### PR TITLE
Add E-mail and MIME lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -255,6 +255,7 @@ LEXERS = {
     'LogosLexer': ('pygments.lexers.objective', 'Logos', ('logos',), ('*.x', '*.xi', '*.xm', '*.xmi'), ('text/x-logos',)),
     'LogtalkLexer': ('pygments.lexers.prolog', 'Logtalk', ('logtalk',), ('*.lgt', '*.logtalk'), ('text/x-logtalk',)),
     'LuaLexer': ('pygments.lexers.scripting', 'Lua', ('lua',), ('*.lua', '*.wlua'), ('text/x-lua', 'application/x-lua')),
+    'MIMELexer': ('pygments.lexers.mime', 'MIME', ('mime',), (), ('multipart/mixed', 'multipart/related', 'multipart/alternative')),
     'MOOCodeLexer': ('pygments.lexers.scripting', 'MOOCode', ('moocode', 'moo'), ('*.moo',), ('text/x-moocode',)),
     'MSDOSSessionLexer': ('pygments.lexers.shell', 'MSDOS Session', ('doscon',), (), ()),
     'MakefileLexer': ('pygments.lexers.make', 'Makefile', ('make', 'makefile', 'mf', 'bsdmake'), ('*.mak', '*.mk', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'), ('text/x-makefile',)),

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -146,6 +146,7 @@ LEXERS = {
     'ElixirLexer': ('pygments.lexers.erlang', 'Elixir', ('elixir', 'ex', 'exs'), ('*.ex', '*.exs'), ('text/x-elixir',)),
     'ElmLexer': ('pygments.lexers.elm', 'Elm', ('elm',), ('*.elm',), ('text/x-elm',)),
     'EmacsLispLexer': ('pygments.lexers.lisp', 'EmacsLisp', ('emacs', 'elisp', 'emacs-lisp'), ('*.el',), ('text/x-elisp', 'application/x-elisp')),
+    'EmailLexer': ('pygments.lexers.email', 'E-mail', ('email', 'eml'), ('*.eml',), ('message/rfc822',)),
     'ErbLexer': ('pygments.lexers.templates', 'ERB', ('erb',), (), ('application/x-ruby-templating',)),
     'ErlangLexer': ('pygments.lexers.erlang', 'Erlang', ('erlang',), ('*.erl', '*.hrl', '*.es', '*.escript'), ('text/x-erlang',)),
     'ErlangShellLexer': ('pygments.lexers.erlang', 'Erlang erl session', ('erl',), ('*.erl-sh',), ('text/x-erl-shellsession',)),

--- a/pygments/lexers/email.py
+++ b/pygments/lexers/email.py
@@ -43,7 +43,7 @@ class EmailHeaderLexer(RegexLexer):
 
     tokens = {
         "root": [
-            (r"^(?:[A-WYZ]|X400)[\w\-]*:", Name.Tag, ("header")),
+            (r"^(?:[A-WYZ]|X400)[\w\-]*:", Name.Tag, "header"),
             (r"^(X-(?:\w[\w\-]*:))([\s\S]*?\n)(?![ \t])", get_x_header_tokens),
         ],
         "header": [
@@ -120,6 +120,10 @@ class EmailHeaderLexer(RegexLexer):
                     String.Affix
                 )
             ),
+
+            # others
+            (r'[\s]+', Text.Whitespace),
+            (r'[\S]', Text),
         ],
     }
 

--- a/pygments/lexers/email.py
+++ b/pygments/lexers/email.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.email
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the raw E-mail.
+
+    :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, DelegatingLexer, bygroups
+from pygments.lexers.mime import MIMELexer
+from pygments.token import Text, Keyword, Name, String, Number, Comment
+from pygments.util import get_bool_opt
+
+__all__ = ["EmailLexer"]
+
+
+class EmailHeaderLexer(RegexLexer):
+    """
+    Sub-lexer for raw E-mail. This lexer only process header part of e-mail.
+    """
+
+    def __init__(self, **options):
+        super(EmailHeaderLexer, self).__init__(**options)
+        self.highlight_x = get_bool_opt(options, "highlight-X-header", False)
+
+    def get_x_header_tokens(self, match):
+        if self.highlight_x:
+            # field
+            yield match.start(1), Name.Tag, match.group(1)
+
+            # content
+            default_actions = self.get_tokens_unprocessed(
+                match.group(2), stack=("root", "header"))
+            for item in default_actions:
+                yield item
+        else:
+            # lowlight
+            yield match.start(1), Comment.Special, match.group(1)
+            yield match.start(2), Comment.Multiline, match.group(2)
+
+    tokens = {
+        "root": [
+            (r"^(?:[A-WYZ]|X400)[\w\-]*:", Name.Tag, ("header")),
+            (r"^(X-(?:\w[\w\-]*:))([\s\S]*?\n)(?![ \t])", get_x_header_tokens),
+        ],
+        "header": [
+            # folding
+            (r"\n[ \t]", Text.Whitespace),
+            (r"\n(?![ \t])", Text.Whitespace, "#pop"),
+
+            # keywords
+            (r"\bE?SMTPS?\b", Keyword),
+            (r"\b(?:HE|EH)LO\b", Keyword),
+
+            # mailbox
+            (r"[\w\.\-\+=]+@[\w\.\-]+", Name.Label),
+            (r"<[\w\.\-\+=]+@[\w\.\-]+>", Name.Label),
+
+            # domain
+            (r"\b(\w[\w\.-]*\.[\w\.-]*\w[a-zA-Z]+)\b", Name.Function),
+
+            # IPv4
+            (
+                r"(?<=\b)(?:(?:25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\.){3}(?:25[0"
+                r"-5]|2[0-4][0-9]|1?[0-9][0-9]?)(?=\b)",
+                Number.Integer,
+            ),
+
+            # IPv6
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,7}:(?!\b)", Number.Hex),
+            (r"(?<=\b):((:[0-9a-fA-F]{1,4}){1,7}|:)(?=\b)", Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}(?=\b)", Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}(?=\b)", Number.Hex),
+            (r"(?<=\b)[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})(?=\b)", Number.Hex),
+            (r"(?<=\b)fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}(?=\b)", Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}(?=\b)", Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}(?=\b)",
+             Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}(?=\b)",
+             Number.Hex),
+            (r"(?<=\b)([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}(?=\b)",
+             Number.Hex),
+            (
+                r"(?<=\b)::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}"
+                r"[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}"
+                r"[0-9])(?=\b)",
+                Number.Hex,
+            ),
+            (
+                r"(?<=\b)([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-"
+                r"9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-"
+                r"9])(?=\b)",
+                Number.Hex,
+            ),
+
+            # Date time
+            (
+                r"(?:(Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s+)?(0[1-9]|[1-2]?[0-9]|3["
+                r"01])\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+("
+                r"19[0-9]{2}|[2-9][0-9]{3})\s+(2[0-3]|[0-1][0-9]):([0-5][0-9])"
+                r"(?::(60|[0-5][0-9]))?(?:\.\d{1,5})?\s+([-\+][0-9]{2}[0-5][0-"
+                r"9]|\(?(?:UTC?|GMT|(?:E|C|M|P)(?:ST|ET|DT)|[A-IK-Z])\)?)",
+                Name.Decorator,
+            ),
+
+            # RFC-2047 encoded string
+            (
+                r"(=\?)([\w-]+)(\?)([BQ])(\?)([\[\w!\"#$%&\'()*+,-./:;<=>@[\\"
+                r"\]^_`{|}~]+)(\?=)",
+                bygroups(
+                    String.Affix,
+                    Name.Constant,
+                    String.Affix,
+                    Keyword.Constant,
+                    String.Affix,
+                    Number.Hex,
+                    String.Affix
+                )
+            ),
+        ],
+    }
+
+
+class EmailLexer(DelegatingLexer):
+    """
+    Lexer for raw E-mail.
+
+    Additional options accepted:
+
+    `highlight-X-header`
+        Highlight the fields of ``X-`` user-defined email header. (default:
+        ``False``).
+    """
+
+    name = "E-mail"
+    aliases = ["email", "eml"]
+    filenames = ["*.eml"]
+    mimetypes = ["message/rfc822"]
+
+    def __init__(self, **options):
+        super(EmailLexer, self).__init__(
+            EmailHeaderLexer, MIMELexer, Comment, **options
+        )

--- a/pygments/lexers/email.py
+++ b/pygments/lexers/email.py
@@ -108,7 +108,7 @@ class EmailHeaderLexer(RegexLexer):
 
             # RFC-2047 encoded string
             (
-                r"(=\?)([\w-]+)(\?)([BQ])(\?)([\[\w!\"#$%&\'()*+,-./:;<=>@[\\"
+                r"(=\?)([\w-]+)(\?)([BbQq])(\?)([\[\w!\"#$%&\'()*+,-./:;<=>@[\\"
                 r"\]^_`{|}~]+)(\?=)",
                 bygroups(
                     String.Affix,

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -51,10 +51,9 @@ class MIMELexer(RegexLexer):
 
     def __init__(self, **options):
         RegexLexer.__init__(self, **options)
-        self.content_type = options.get("Content_Type")
         self.boundary = options.get("boundary")
         self.content_transfer_encoding = options.get("Content_Transfer_Encoding")
-
+        self.content_type = options.get("Content_Type", "text/plain")
         self.max_nested_level = get_int_opt(options, "MIME-max-level", -1)
 
     def analyse_text(text):
@@ -194,7 +193,8 @@ class MIMELexer(RegexLexer):
                 r"|message)/([\w-]+))",
                 store_content_type,
             ),
-            (r"boundary=(?:\"([\w=-]+)\"|([\w=-]+)\b)", store_boundary),
+            (r"boundary=(?:\"([\w'()+,.\/:? =-]+)\"|([\w'()+,.\/:? =-]+)\b)",
+             store_boundary),
         ],
         "content-transfer-encoding": [
             include("header"),

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -20,9 +20,13 @@ __all__ = ["MIMELexer"]
 
 
 class MIMELexer(RegexLexer):
-    """Lexer for Multipurpose Internet Mail Extensions (MIME) data. It assumes
-    that the given data contains both header and body. If no valid header is
-    found, it would treat entire data as body.
+    """
+    Lexer for Multipurpose Internet Mail Extensions (MIME) data. This lexer is
+    designed to process the nested mulitpart data.
+
+    It assumes that the given data contains both header and body (and is
+    splitted by empty line). If no valid header is found, then the entire data
+    would be treated as body.
 
     Additional options accepted:
 
@@ -31,12 +35,12 @@ class MIMELexer(RegexLexer):
         would treated as unlimited. (default: -1)
 
     `Content-Type`
-        Treat this data as specific content type. Useful when header is
-        missing, or it would try to parse from header. (default: None)
+        Treat the data as specific content type. Useful when header is
+        missing, or this lexer would try to parse from header. (default: None)
 
     `Content-Transfer-Encoding`
-        Treat this data as specific encoding. Or it would try to parse from
-        header by default. (default: None)
+        Treat the data as specific encoding. Or this lexer would try to parse
+        from header by default. (default: None)
     """
 
     name = "MIME"

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -56,7 +56,7 @@ class MIMELexer(RegexLexer):
                  "multipart/alternative"]
 
     def __init__(self, **options):
-        RegexLexer.__init__(self, **options)
+        super(MIMELexer, self).__init__(**options)
         self.boundary = options.get("Multipart-Boundary")
         self.content_transfer_encoding = options.get("Content_Transfer_Encoding")
         self.content_type = options.get("Content_Type", "text/plain")
@@ -90,9 +90,9 @@ class MIMELexer(RegexLexer):
                 yield pos + i, t, v
 
         else:
-            yield match.start(1), Comment.Special, field + ":"
+            yield match.start(1), Comment, field + ":"
             yield match.start(2), Text.Whitespace, match.group(2)
-            yield match.start(3), Comment.Multiline, match.group(3)
+            yield match.start(3), Comment, match.group(3)
 
     def get_body_tokens(self, match):
         pos_body_start = match.start()

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -36,7 +36,13 @@ class MIMELexer(RegexLexer):
 
     `Content-Type`
         Treat the data as specific content type. Useful when header is
-        missing, or this lexer would try to parse from header. (default: None)
+        missing, or this lexer would try to parse from header. (default:
+        `text/plain`)
+
+    `Multipart-Boundary`
+        Set the default multipart boundary delimiter. This option is only used
+        when `Content-Type` is `multipart` and header is missing. This lexer
+        would try to parse from header by default. (default: None)
 
     `Content-Transfer-Encoding`
         Treat the data as specific encoding. Or this lexer would try to parse
@@ -51,7 +57,7 @@ class MIMELexer(RegexLexer):
 
     def __init__(self, **options):
         RegexLexer.__init__(self, **options)
-        self.boundary = options.get("boundary")
+        self.boundary = options.get("Multipart-Boundary")
         self.content_transfer_encoding = options.get("Content_Transfer_Encoding")
         self.content_type = options.get("Content_Type", "text/plain")
         self.max_nested_level = get_int_opt(options, "MIME-max-level", -1)

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -117,7 +117,7 @@ class MIMELexer(RegexLexer):
         if m:
             pos_part_start = pos_body_start + m.end()
             pos_iter_start = lpos_end = m.end()
-            yield pos_body_start, Other, entire_body[:m.start()]
+            yield pos_body_start, Text, entire_body[:m.start()]
             yield pos_body_start + lpos_end, String.Delimiter, m.group()
         else:
             pos_part_start = pos_body_start
@@ -139,7 +139,7 @@ class MIMELexer(RegexLexer):
         # some data has suffix text after last boundary
         lpos_start = pos_part_start - pos_body_start
         if lpos_start != len(entire_body):
-            yield pos_part_start, Other, entire_body[lpos_start:]
+            yield pos_part_start, Text, entire_body[lpos_start:]
 
     def get_bodypart_tokens(self, text):
         # return if:

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""
+    pygments.lexers.mime
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for Multipurpose Internet Mail Extensions (MIME) data.
+
+    :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, include, do_insertions
+from pygments.lexers import get_lexer_for_mimetype
+from pygments.token import Text, Whitespace, Name, String, Comment, Other
+from pygments.util import get_int_opt, ClassNotFound
+
+__all__ = ["MIMELexer"]
+
+
+class MIMELexer(RegexLexer):
+    """Lexer for Multipurpose Internet Mail Extensions (MIME) data. It assumes
+    that the given data contains both header and body. If no valid header is
+    found, it would treat entire data as body.
+
+    Additional options accepted:
+
+    `MIME-max-level`
+        Max recurssion level for nested MIME structure. Any negative number
+        would treated as unlimited. (default: -1)
+
+    `Content-Type`
+        Treat this data as specific content type. Useful when header is
+        missing, or it would try to parse from header. (default: None)
+
+    `Content-Transfer-Encoding`
+        Treat this data as specific encoding. Or it would try to parse from
+        header by default. (default: None)
+    """
+
+    name = "MIME"
+    aliases = ["mime"]
+    mimetypes = ["multipart/mixed",
+                 "multipart/related",
+                 "multipart/alternative"]
+
+    def __init__(self, **options):
+        RegexLexer.__init__(self, **options)
+        self.content_type = options.get("Content_Type")
+        self.boundary = options.get("boundary")
+        self.content_transfer_encoding = options.get("Content_Transfer_Encoding")
+
+        self.max_nested_level = get_int_opt(options, "MIME-max-level", -1)
+
+    def analyse_text(text):
+        try:
+            header, body = text.strip().split("\n\n", 1)
+            if not body.strip():
+                return 0.1
+
+            invalid_headers = MIMELexer.tokens["header"].sub("", header)
+            if invalid_headers.strip():
+                return 0.1
+            else:
+                return 1
+
+        except ValueError:
+            return 0.1
+
+    def get_header_tokens(self, match):
+        field = match.group(1)
+
+        if field.lower() in self.attention_headers:
+            yield match.start(1), Name.Tag, field + ":"
+            yield match.start(2), Whitespace, match.group(2)
+
+            pos = match.end(2)
+            body = match.group(3)
+            for i, t, v in self.get_tokens_unprocessed(body, ("root", field.lower())):
+                yield pos + i, t, v
+
+        else:
+            yield match.start(1), Comment.Special, field + ":"
+            yield match.start(2), Whitespace, match.group(2)
+            yield match.start(3), Comment.Multiline, match.group(3)
+
+    def get_body_tokens(self, match):
+        pos_body_start = match.start()
+        entire_body = match.group()
+
+        # if it is not a mulitpart
+        if not self.content_type.startswith("multipart") or not self.boundary:
+            for i, t, v in self.get_bodypart_tokens(entire_body):
+                yield pos_body_start + i, t, v
+            return
+
+        # find boundary
+        bdry_pattern = r"^--%s(--)?\n" % re.escape(self.boundary)
+        bdry_matcher = re.compile(bdry_pattern, re.MULTILINE)
+
+        # process tokens of each body part
+        pos_part_start = pos_body_start
+        for m in bdry_matcher.finditer(entire_body):
+            # bodypart
+            lpos_start = pos_part_start - pos_body_start
+            lpos_end = m.start()
+            part = entire_body[lpos_start:lpos_end]
+            for i, t, v in self.get_bodypart_tokens(part):
+                yield pos_part_start + i, t, v
+
+            # boundary
+            yield pos_body_start + m.start(), String.Delimiter, m.group()
+            pos_part_start = pos_body_start + m.end()
+
+        # check for tailing context
+        lpos_start = pos_part_start - pos_body_start
+        if lpos_start != len(entire_body):
+            yield pos_part_start, Other, entire_body[lpos_start:]
+
+    def get_bodypart_tokens(self, text):
+        # return if:
+        #  * no content
+        #  * no content type specific
+        #  * content encoding is not readable
+        #  * max recurrsion exceed
+        if not text.strip() or not self.content_type:
+            return [(0, Other, text)]
+
+        cte = self.content_transfer_encoding
+        if cte and cte not in {"8bit", "7bit", "quoted-printable"}:
+            return [(0, Other, text)]
+
+        if self.max_nested_level == 0:
+            return [(0, Other, text)]
+
+        # get lexer
+        try:
+            lexer = get_lexer_for_mimetype(self.content_type)
+        except ClassNotFound:
+            return [(0, Other, text)]
+
+        if isinstance(lexer, type(self)):
+            lexer.max_nested_level = self.max_nested_level - 1
+
+        return lexer.get_tokens_unprocessed(text)
+
+    def store_content_type(self, match):
+        self.content_type = match.group(1)
+
+        prefix_len = match.start(1) - match.start(0)
+        yield match.start(0), Whitespace, match.group(0)[:prefix_len]
+        yield match.start(1), Name.Label, match.group(2)
+        yield match.end(2), String.Delimiter, "/"
+        yield match.start(3), Name.Label, match.group(3)
+
+    def store_boundary(self, match):
+        if match.group(1):
+            prefix_len = match.start(1) - match.start(0)
+            yield match.start(0), Text, match.group(0)[:prefix_len]
+            yield match.start(1), String.Delimiter, match.group(1)
+            yield match.end(1), Text, '"'
+            self.boundary = match.group(1)
+        else:
+            prefix_len = match.start(2) - match.start(0)
+            yield match.start(0), Text, match.group(0)[:prefix_len]
+            yield match.start(2), String.Delimiter, match.group(2)
+            self.boundary = match.group(2)
+
+    def store_content_transfer_encoding(self, match):
+        self.content_transfer_encoding = match.group(0).lower()
+        yield match.start(0), Text, match.group(0)
+
+    attention_headers = {"content-type", "content-transfer-encoding"}
+
+    tokens = {
+        "root": [
+            (r"^([\w-]+):( *)([\s\S]*?\n)(?![ \t])", get_header_tokens),
+            (r"^$[\s\S]+", get_body_tokens),
+        ],
+        "header": [
+            # folding
+            (r"\n[ \t]", Whitespace),
+            (r"\n(?![ \t])", Whitespace, "#pop"),
+        ],
+        "content-type": [
+            include("header"),
+            (
+                r"^\s*((multipart|application|audio|font|image|model|text|video"
+                r"|message)/([\w-]+))",
+                store_content_type,
+            ),
+            (r"boundary=(?:\"([\w=-]+)\"|([\w=-]+)\b)", store_boundary),
+        ],
+        "content-transfer-encoding": [
+            include("header"),
+            (r"([\w-]+)", store_content_transfer_encoding),
+        ],
+    }

--- a/pygments/lexers/mime.py
+++ b/pygments/lexers/mime.py
@@ -195,6 +195,8 @@ class MIMELexer(RegexLexer):
             ),
             (r"boundary=(?:\"([\w'()+,.\/:? =-]+)\"|([\w'()+,.\/:? =-]+)\b)",
              store_boundary),
+            (r'\S+', Text),
+            (r'[ \t]+', Whitespace),
         ],
         "content-transfer-encoding": [
             include("header"),

--- a/tests/examplefiles/MIME_example.eml
+++ b/tests/examplefiles/MIME_example.eml
@@ -1,0 +1,34 @@
+From: Some One <someone@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+        boundary="+Testboundary text"
+
+This is a multipart message in MIME format.
+
+--+Testboundary text
+Content-Type: multipart/alternative;
+        boundary="hello, boundary"
+
+--hello, boundary
+Content-Type: text/plain
+
+this is the body text
+
+--hello, boundary
+Content-Type: text/html;
+       charset="utf-8"
+Content-Transfer-Encoding: quoted-printable
+
+<font color=3D"#FF0000">This is the body text</font>
+
+--hello, boundary--
+--+Testboundary text
+Content-Type: text/plain;
+Content-Disposition: attachment;
+        filename="test.bin"
+Content-Transfer-Encoding: quoted-printable
+
+dGhpcyBpcyB0aGUgYXR0YWNobWVudCB0ZXh0
+
+--+Testboundary text--
+Some additional content here.

--- a/tests/examplefiles/MIME_example.eml
+++ b/tests/examplefiles/MIME_example.eml
@@ -25,8 +25,8 @@ Content-Transfer-Encoding: quoted-printable
 --+Testboundary text
 Content-Type: text/plain;
 Content-Disposition: attachment;
-        filename="test.bin"
-Content-Transfer-Encoding: quoted-printable
+        filename="test.txt"
+Content-Transfer-Encoding: base64
 
 dGhpcyBpcyB0aGUgYXR0YWNobWVudCB0ZXh0
 

--- a/tests/examplefiles/example.eml
+++ b/tests/examplefiles/example.eml
@@ -1,0 +1,92 @@
+Mime-Version: 1.0 (Apple Message framework v730)
+Content-Type: multipart/mixed; boundary=Apple-Mail-13-196941151
+Message-Id: <9169D984-4E0B-45EF-82D4-8F5E53AD7012@example.com>
+From: foo@example.com
+Subject: testing
+Date: Mon, 6 Jun 2005 22:21:22 +0200
+To: blah@example.com
+
+
+--Apple-Mail-13-196941151
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain;
+	charset=ISO-8859-1;
+	delsp=yes;
+	format=flowed
+
+This is the first part.
+
+--Apple-Mail-13-196941151
+Content-Type: message/rfc822;
+  name="ForwardedMessage.eml";
+
+Return-Path: <xxxx@xxxx.com>
+X-Original-To: xxxx@xxxx.com
+Delivered-To: xxxx@xxxx.com
+Received: from localhost (localhost [127.0.0.1])
+	by xxx.xxxxx.com (Postfix) with ESMTP id 50FD3A96F
+	for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:50 +0000 (GMT)
+Received: from xxx.xxxxx.com ([127.0.0.1])
+ by localhost (xxx.xxxxx.com [127.0.0.1]) (amavisd-new, port 10024)
+ with LMTP id 70060-03 for <xxxx@xxxx.com>;
+ Tue, 10 May 2005 17:26:49 +0000 (GMT)
+Received: from xxx.xxxxx.com (xxx.xxxxx.com [69.36.39.150])
+	by xxx.xxxxx.com (Postfix) with ESMTP id 8B957A94B
+	for <xxxx@xxxx.com>; Tue, 10 May 2005 17:26:48 +0000 (GMT)
+Received: from xxx.xxxxx.com (xxx.xxxxx.com [64.233.184.203])
+	by xxx.xxxxx.com (Postfix) with ESMTP id 9972514824C
+	for <xxxx@xxxx.com>; Tue, 10 May 2005 12:26:40 -0500 (CDT)
+Received: by xxx.xxxxx.com with SMTP id 68so1694448wri
+        for <xxxx@xxxx.com>; Tue, 10 May 2005 10:26:40 -0700 (PDT)
+DomainKey-Signature: a=rsa-sha1; q=dns; c=nofws;
+        s=beta; d=xxxxx.com;
+        h=received:message-id:date:from:reply-to:to:subject:mime-version:content-type;
+        b=g8ZO5ttS6GPEMAz9WxrRk9+9IXBUfQIYsZLL6T88+ECbsXqGIgfGtzJJFn6o9CE3/HMrrIGkN5AisxVFTGXWxWci5YA/7PTVWwPOhJff5BRYQDVNgRKqMl/SMttNrrRElsGJjnD1UyQ/5kQmcBxq2PuZI5Zc47u6CILcuoBcM+A=
+Received: by 10.54.96.19 with SMTP id t19mr621017wrb;
+        Tue, 10 May 2005 10:26:39 -0700 (PDT)
+Received: by 10.54.110.5 with HTTP; Tue, 10 May 2005 10:26:39 -0700 (PDT)
+Message-ID: <xxxx@xxxx.com>
+Date: Tue, 10 May 2005 11:26:39 -0600
+From: Test Tester <xxxx@xxxx.com>
+Reply-To: Test Tester <xxxx@xxxx.com>
+To: xxxx@xxxx.com, xxxx@xxxx.com
+Subject: Another PDF
+Mime-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_2192_32400445.1115745999735"
+X-Virus-Scanned: amavisd-new at textdrive.com
+
+------=_Part_2192_32400445.1115745999735
+Content-Type: text/plain; charset=ISO-8859-1
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+Just attaching another PDF, here, to see what the message looks like,
+and to see if I can figure out what is going wrong here.
+
+------=_Part_2192_32400445.1115745999735
+Content-Type: application/pdf; name="broken.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="broken.pdf"
+
+JVBERi0xLjQNCiXk9tzfDQoxIDAgb2JqDQo8PCAvTGVuZ3RoIDIgMCBSDQogICAvRmlsdGVyIC9G
+bGF0ZURlY29kZQ0KPj4NCnN0cmVhbQ0KeJy9Wt2KJbkNvm/od6jrhZxYln9hWEh2p+8HBvICySaE
+ycLuTV4/1ifJ9qnq09NpSBimu76yLUuy/qzqcPz7+em3Ixx/CDc6CsXxs3b5+fvfjr/8cPz6/BRu
+rbfAx/n3739/fuJylJ5u5fjX81OuDr4deK4Bz3z/aDP+8fz0yw8g0Ofq7ktr1Mn+u28rvhy/jVeD
+QSa+9YNKHP/pxjvDNfVAx/m3MFz54FhvTbaseaxiDoN2LeMVMw+yA7RbHSCDzxZuaYB2E1Yay7QU
+x89vz0+tyFDKMlAHK5yqLmnjF+c4RjEiQIUeKwblXMe+AsZjN1J5yGQL5DHpDHksurM81rF6PKab
+gK6zAarIDzIiUY23rJsN9iorAE816aIu6lsgAdQFsuhhkHOUFgVjp2GjMqSewITXNQ27jrMeamkg
+1rPI3iLWG2CIaSBB+V1245YVRICGbbpYKHc2USFDl6M09acQVQYhlwIrkBNLISvXhGlF1wi5FHCw
+wxZkoGNJlVeJCEsqKA+3YAV5AMb6KkeaqEJQmFKKQU8T1pRi2ihE1Y4CDrqoYFFXYjJJOatsyzuI
+8SIlykuxKTMibWK8H1PgEvqYgs4GmQSrEjJAalgGirIhik+p4ZQN9E3ETFPAHE1b8pp1l/0Rc1gl
+fQs0ABWvyoZZzU8VnPXwVVcO9BEsyjEJaO6eBoZRyKGlrKoYoOygA8BGIzgwN3RQ15ouigG5idZQ
+fx2U4Db2CqiLO0WHAZoylGiCAqhniNQjFjQPSkmjwfNTgQ6M1Ih+eWo36wFmjIxDJZiGUBiWsAyR
+xX3EekGOizkGI96Ol9zVZTAivikURhRsHh2E3JhWMpSTZCnnonrLhMCodgrNcgo4uyJUJc6qnVss
+nrGd1Ptr0YwisCOYyIbUwVjV4xBUNLbguSO2YHujonAMJkMdSI7bIw91Akq2AUlMUWGFTMAOamjU
+OvZQCxIkY2pCpMFo/IwLdVLHs6nddwTRrgoVbvLU9eB0G4EMndV0TNoxHbt3JBWwK6hhv3iHfDtF
+yokB302IpEBTnWICde4uYc/1khDbSIkQopO6lcqamGBu1OSE3N5IPSsZX00CkSHRiiyx6HQIShsS
+HSVNswdVsaOUSAWq9aYhDtGDaoG5a3lBGkYt/lFlBFt1UqrYnzVtUpUQnLiZeouKgf1KhRBViRRk
+ExepJCzTwEmFDalIRbLEGtw0gfpESOpIAF/NnpPzcVCG86s0g2DuSyd41uhNGbEgaSrWEXORErbw
+------=_Part_2192_32400445.1115745999735--
+
+--Apple-Mail-13-196941151--


### PR DESCRIPTION
This PR add lexer to parse raw E-mail source and MIME data.

It was originally designed for E-mail, but MIME format is common used in E-mail.
So a minimal MIME lexer is provided, it could handle the nested `multipart` format but it only processes few headers.
(Currently it only supports `Content-Type` and `Content-Transfer-Encoding`, which are necessary to recognize the data in the payload.)

Also, the `multipart/form-data` format, which is common used in HTTP transfer is not handled.


