### PR TITLE
Apache Config multi-line comments & multi-line arguments

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -300,7 +300,7 @@ class ApacheConfLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Text),
-            (r'(#.*?)$', Comment),
+            (r'#(.*\\\n)+.*$|(#.*?)$', Comment),
             (r'(<[^\s>]+)(?:(\s+)(.*))?(>)',
              bygroups(Name.Tag, Text, String, Name.Tag)),
             (r'([a-z]\w*)(\s+)',
@@ -319,7 +319,7 @@ class ApacheConfLexer(RegexLexer):
              r'os|productonly|full|emerg|alert|crit|error|warn|'
              r'notice|info|debug|registry|script|inetd|standalone|'
              r'user|group)\b', Keyword),
-            (r'"([^"\\]*(?:\\.[^"\\]*)*)"', String.Double),
+            (r'"([^"\\]*(?:\\(.|[\n])[^"\\]*)*)"', String.Double),
             (r'[^\s"\\]+', Text)
         ],
     }


### PR DESCRIPTION

When lexing modsecurity configs I noticed multi-line arguments and comments were not generating token streams I would expect from the lexer.

I apologize, I did attempt to build the test case but I had difficulties figuring out what the process for pickling the expected results to integrate the test properly, that said hopefully someone from the team can integrate these test cases into the apache2.conf file for future testing.

Examples of configuration patterns that operate unexpectedly which can be tested:

Multi-line comment.
```apache
#SecAction \
  "id:'900004', \
  phase:1, \
  t:none, \
  setvar:tx.anomaly_score_blocking=on, \
  nolog, \
  pass"
```

Before patch:
```
(Token.Error, '"') on the quote that begins "id:'900004'
```
After patch:
```
(Token.Comment, '#SecAction \\\n  "id:\'900004\', \\\n  phase:1, \\\n  t:none, \\\n  setvar:tx.anomaly_score_blocking=on, \\\n  nolog, \\\n  pass"')
```

Multi-line arguments:
```apache
SecAction \
  "id:'900001', \
  phase:1, \
  t:none, \
  setvar:tx.critical_anomaly_score=5, \
  setvar:tx.error_anomaly_score=4, \
  setvar:tx.warning_anomaly_score=3, \
  setvar:tx.notice_anomaly_score=2, \
  nolog, \
  pass"
```

Before patch:
```
(Token.Error, '"') on the quote that begins "id:'90001'
```
After patch:
```
(Token.Name.Builtin, 'SecAction'), (Token.Text, ' '), (Token.Text, '\\\n'), (Token.Text, '  '), (Token.Literal.String.Double, '"id:\'900001\', \\\n  phase:1, \\\n  t:none, \\\n  setvar:tx.critical_anomaly_score=5, \\\n  setvar:tx.error_anomaly_score=4, \\\n  setvar:tx.warning_anomaly_score=3, \\\n  setvar:tx.notice_anomaly_score=2, \\\n  nolog, \\\n  pass"'), (Token.Text, '')
```

Some other variations I looked at as well:
```
SecAction arg1\
arg2
```
```
(Token.Name.Builtin, 'SecAction'), (Token.Text, ' '), (Token.Text, 'arg1'), (Token.Text, '\\\n'), (Token.Text, 'arg2'), (Token.Text, '')
```

```
SecAction arg1 \
\
arg2
```
```plaintext
(Token.Name.Builtin, 'SecAction'), (Token.Text, ' '), (Token.Text, 'arg1'), (Token.Text, ' '), (Token.Text, '\\\n'), (Token.Text, '\\\n'), (Token.Text, 'arg2'), (Token.Text, '')
```