### PR TITLE
python3: make "import" in the "fromimport" context match python2 

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -389,7 +389,7 @@ class Python3Lexer(RegexLexer):
         default('#pop')  # all else: go back
     ]
     tokens['fromimport'] = [
-        (r'(\s+)(import)\b', bygroups(Text, Keyword), '#pop'),
+        (r'(\s+)(import)\b', bygroups(Text, Keyword.Namespace), '#pop'),
         (r'\.', Name.Namespace),
         (uni_name, Name.Namespace),
         default('#pop'),


### PR DESCRIPTION
i.e. make it Keyword.Namespace