### PR TITLE
Fix #1256.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,8 @@ Version 2.5.0
   (fixes #1326)
 - Default font in the ``ImageFormatter`` has been updated (#928, PR#1245)
 - Test suite switched to py.test, removed nose dependency (#1490)
+- Reduce ``TeraTerm`` lexer score -- it used to match nearly all languages
+  (#1256)
 
 
 Version 2.4.2

--- a/pygments/lexers/teraterm.py
+++ b/pygments/lexers/teraterm.py
@@ -154,5 +154,5 @@ class TeraTermLexer(RegexLexer):
     def analyse_text(text):
         result = 0.0
         if re.search(TeraTermLexer.tokens['commands'][0][0], text):
-            result += 0.60
+            result += 0.01
         return result

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -9,8 +9,10 @@
 
 import pytest
 
-from pygments.lexers import CppLexer
+from pygments.lexers import CppLexer, CLexer
 from pygments.token import Token
+
+from pygments.lexers import guess_lexer
 
 
 @pytest.fixture(scope='module')
@@ -33,3 +35,21 @@ def test_open_comment(lexer):
         (Token.Comment.Multiline, u'/* foo\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_guess_c_lexer():
+    code = '''
+    #include <stdio.h>
+    #include <stdlib.h>
+
+    int main(void);
+
+    int main(void) {
+        uint8_t x = 42;
+        uint8_t y = x + 1;
+
+        /* exit 1 for success! */
+        return 1;
+    }
+    '''
+    lexer = guess_lexer(code)
+    assert isinstance(lexer, CLexer)


### PR DESCRIPTION
Reduce TeraTerm.analyze_text score to 0.01. This resolves the
conflict with Turtle, but doesn't take over nearly all other
languages.

Added a test as provided in the bug report to ensure this won't
regress again.