### PR TITLE
reStructuredText: improve handling of field lists

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -222,10 +222,9 @@ class RstLexer(RegexLexer):
                       Punctuation, Text, using(this, state='inline'))),
             # Comments
             (r'^ *\.\..*(\n( +.*\n|\n)+)?', Comment.Preproc),
-            # Field list
-            (r'^( *)(:[a-zA-Z-]+:)(\s*)$', bygroups(Text, Name.Class, Text)),
-            (r'^( *)(:.*?:)([ \t]+)(.*?)$',
-             bygroups(Text, Name.Class, Text, Name.Function)),
+            # Field list marker
+            (r'^( *)(:(?:\\\\|\\:|[^:\n])+:(?=\s))([ \t]*)',
+             bygroups(Text, Name.Class, Text)),
             # Definition list
             (r'^(\S.*(?<!::)\n)((?:(?: +.*)\n)+)',
              bygroups(using(this, state='inline'), using(this, state='inline'))),


### PR DESCRIPTION
The current field list rules only find a field body if it starts on the same line as the field marker, as shown by this [code sample](http://www.sphinx-doc.org/en/stable/domains.html#the-javascript-domain) in the Sphinx docs. This replacement rule covers any field marker (including colons if escaped) and an optional field body consisting of one or more paragraphs, starting on either the same line or a following line, as long as it's indented more than the marker.