### PR TITLE
MATLAB allows keywords to be used as field names.

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -84,11 +84,14 @@ class MatlabLexer(RegexLexer):
             (r'^\s*function\b', Keyword, 'deffunc'),
 
             # from 'iskeyword' on version 7.11 (R2010):
-            (words((
-                'break', 'case', 'catch', 'classdef', 'continue', 'else', 'elseif',
-                'end', 'enumerated', 'events', 'for', 'function', 'global', 'if',
-                'methods', 'otherwise', 'parfor', 'persistent', 'properties',
-                'return', 'spmd', 'switch', 'try', 'while'), suffix=r'\b'),
+            # Check that there is no preceding dot, as keywords are valid field
+            # names.
+            (words(('break', 'case', 'catch', 'classdef', 'continue', 'else',
+                    'elseif', 'end', 'enumerated', 'events', 'for', 'function',
+                    'global', 'if', 'methods', 'otherwise', 'parfor',
+                    'persistent', 'properties', 'return', 'spmd', 'switch',
+                    'try', 'while'),
+                   prefix=r'(?<!\.)', suffix=r'\b'),
              Keyword),
 
             ("(" + "|".join(elfun + specfun + elmat) + r')\b',  Name.Builtin),


### PR DESCRIPTION
... so don't highlight them as keywords in that position.

Example MATLAB session showcasing this "feature":

    >> x.for = 42

    x =

    struct with fields:

        for: 42

    >> x

    x =

    struct with fields:

        for: 42

    >> x.for

    ans =

        42