### PR TITLE
Exclude tests from distribution -- fix #1280

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description = 'Pygments is a syntax highlighting package written in Python.',
     long_description = __doc__,
     keywords = 'syntax highlighting',
-    packages = find_packages(),
+    packages = find_packages(include=['pygments']),
     entry_points = {
         'console_scripts': ['pygmentize = pygments.cmdline:main'],
     },


### PR DESCRIPTION
As mentioned in #1280, we're polluting the tests directory with the 2.5.0 release. I think this is because to the tests package being found due to presence of `__init__.py`. Use `exclude` on `find_packages` to prevent that from happening.