### PR TITLE
GAS: Add support for C style comments.

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -55,9 +55,9 @@ class GasLexer(RegexLexer):
             (number, Number.Integer),
             (register, Name.Variable),
             (r'[\r\n]+', Text, '#pop'),
-            (r'([;#]|//).*?\n', Comment, '#pop'),
-            (r'/[*].*?[*]/', Comment),
-            (r'/[*].*?\n[\w\W]*?[*]/', Comment, '#pop'),
+            (r'([;#]|//).*?\n', Comment.Single, '#pop'),
+            (r'/[*].*?[*]/', Comment.Multiline),
+            (r'/[*].*?\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -81,9 +81,9 @@ class GasLexer(RegexLexer):
             ('$'+number, Number.Integer),
             (r"$'(.|\\')'", String.Char),
             (r'[\r\n]+', Text, '#pop'),
-            (r'([;#]|//).*?\n', Comment, '#pop'),
-            (r'/[*].*?[*]/', Comment),
-            (r'/[*].*?\n[\w\W]*?[*]/', Comment, '#pop'),
+            (r'([;#]|//).*?\n', Comment.Single, '#pop'),
+            (r'/[*].*?[*]/', Comment.Multiline),
+            (r'/[*].*?\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -91,8 +91,8 @@ class GasLexer(RegexLexer):
         'whitespace': [
             (r'\n', Text),
             (r'\s+', Text),
-            (r'([;#]|//).*?\n', Comment),
-            (r'/[*][\w\W]*?[*]/', Comment)
+            (r'([;#]|//).*?\n', Comment.Single),
+            (r'/[*][\w\W]*?[*]/', Comment.Multiline)
         ],
         'punctuation': [
             (r'[-*,.()\[\]!:]+', Punctuation)

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -55,7 +55,9 @@ class GasLexer(RegexLexer):
             (number, Number.Integer),
             (register, Name.Variable),
             (r'[\r\n]+', Text, '#pop'),
-            (r'[;#].*?\n', Comment, '#pop'),
+            (r'([;#]|//).*?\n', Comment, '#pop'),
+            (r'/[*].*?[*]/', Comment),
+            (r'/[*].*?\n[\w\W]*?[*]/', Comment, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -79,7 +81,9 @@ class GasLexer(RegexLexer):
             ('$'+number, Number.Integer),
             (r"$'(.|\\')'", String.Char),
             (r'[\r\n]+', Text, '#pop'),
-            (r'[;#].*?\n', Comment, '#pop'),
+            (r'([;#]|//).*?\n', Comment, '#pop'),
+            (r'/[*].*?[*]/', Comment),
+            (r'/[*].*?\n[\w\W]*?[*]/', Comment, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -87,7 +91,8 @@ class GasLexer(RegexLexer):
         'whitespace': [
             (r'\n', Text),
             (r'\s+', Text),
-            (r'[;#].*?\n', Comment)
+            (r'([;#]|//).*?\n', Comment),
+            (r'/[*][\w\W]*?[*]/', Comment)
         ],
         'punctuation': [
             (r'[-*,.()\[\]!:]+', Punctuation)

--- a/tests/test_asm.py
+++ b/tests/test_asm.py
@@ -1,30 +1,68 @@
 # -*- coding: utf-8 -*-
 """
-    Basic ColdfusionHtmlLexer Test
+    Basic GasLexer/NasmLexer Test
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
 
-import unittest
-import os
+import pytest
 
 from pygments.token import Token
-from pygments.lexers import NasmLexer
+from pygments.lexers import NasmLexer, GasLexer
 
 
-class NasmLexerTest(unittest.TestCase):
+@pytest.fixture(scope='module')
+def lexer_gas():
+    yield GasLexer()
 
-    def setUp(self):
-        self.lexer = NasmLexer()
+@pytest.fixture(scope='module')
+def lexer_nasm():
+    yield NasmLexer()
 
-    def testCPUID(self):
-        # CPU is a valid directive, and we don't want to parse this as
-        # cpu id, but as a single token. See bug #1517
-        fragment = 'cpuid'
-        expected = [
-            (Token.Name.Function, u'cpuid'),
-            (Token.Text, u'\n'),
-        ]
-        self.assertEqual(expected, list(self.lexer.get_tokens(fragment)))
+
+def test_comments(lexer_gas):
+    fragment = '''
+    lock addq $0, /* comments */ (%rsp) /*
+    // comments
+    */ xorq %rax, %rax // comments
+    '''
+    tokens = [
+        (Token.Text, '    '),
+        (Token.Name.Attribute, 'lock'),
+        (Token.Text, ' '),
+        (Token.Name.Function, 'addq'),
+        (Token.Text, ' '),
+        (Token.Name.Constant, '$0'),
+        (Token.Punctuation, ','),
+        (Token.Text, ' '),
+        (Token.Comment.Multiline, '/* comments */'),
+        (Token.Text, ' '),
+        (Token.Punctuation, '('),
+        (Token.Name.Variable, '%rsp'),
+        (Token.Punctuation, ')'),
+        (Token.Text, ' '),
+        (Token.Comment.Multiline, '/*\n    // comments\n    */'),
+        (Token.Text, ' '),
+        (Token.Name.Function, 'xorq'),
+        (Token.Text, ' '),
+        (Token.Name.Variable, '%rax'),
+        (Token.Punctuation, ','),
+        (Token.Text, ' '),
+        (Token.Name.Variable, '%rax'),
+        (Token.Text, ' '),
+        (Token.Comment.Single, '// comments\n'),
+        (Token.Text, '    \n')
+    ]
+    assert list(lexer_gas.get_tokens(fragment)) == tokens
+
+def test_cpuid(lexer_nasm):
+    # CPU is a valid directive, and we don't want to parse this as
+    # cpu id, but as a single token. See bug #1517
+    fragment = 'cpuid'
+    expected = [
+        (Token.Name.Function, u'cpuid'),
+        (Token.Text, u'\n'),
+    ]
+    assert expected == list(lexer_nasm.get_tokens(fragment))


### PR DESCRIPTION
GNU AS supports C style comments, but some errors occur when I try to highlight them using pygments. So I try to add support for it.

Here are some examples (x64 assembly).

The following code is considered illegal by GNU AS,
```
movq %rax, /* comments
  comments */ %rbx
```
Instead, the following code is considered legal,
```
movq %rax, %rbx /* comments
  comments */ movq %rax, %rbx
```
and
```
movq %rax, /* comments */ %rbx
```
It is corresponding to my pull request code.

In the end, I highlight this code:
```
.section ".text"
.global main
.code64

/*
 * Hello world!
 */

/* comments */ main: // comments
  lock addq $0, /* comments */ (%rsp) /*
    comments
  */ xorq %rax, %rax
  /* comments */retq
```
The result is
![a](https://user-images.githubusercontent.com/41988959/69717044-3ef75180-1146-11ea-92ee-e7d06b8ff9f0.png)
It seems that there are no problems.