### PR TITLE
Added support for the Kappa language.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -133,6 +133,7 @@ Other contributors, listed alphabetically, are:
 * Brian McKenna -- F# lexer
 * Charles McLaughlin -- Puppet lexer
 * Kurt McKee -- Tera Term macro lexer
+* Hector Medina -- Kappa lexer and styles
 * Lukas Meuser -- BBCode formatter, Lua lexer
 * Cat Miller -- Pig lexer
 * Paul Miller -- LiveScript lexer

--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -165,6 +165,10 @@ Other markup
 * XSLT
 * YAML
 
+Other languages
+---------------
+* `Kappa <http://kappalanguage.org>`_ (biochemical signaling simulation via graph transformation)
+
 ... that's all?
 ---------------
 

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -232,6 +232,7 @@ LEXERS = {
     'JuliaLexer': ('pygments.lexers.julia', 'Julia', ('julia', 'jl'), ('*.jl',), ('text/x-julia', 'application/x-julia')),
     'JuttleLexer': ('pygments.lexers.javascript', 'Juttle', ('juttle', 'juttle'), ('*.juttle',), ('application/juttle', 'application/x-juttle', 'text/x-juttle', 'text/juttle')),
     'KalLexer': ('pygments.lexers.javascript', 'Kal', ('kal',), ('*.kal',), ('text/kal', 'application/kal')),
+    'KappaLexer': ('pygments.lexers.kappa', 'Kappa', ('kappa',), ('*.ka',), ()),
     'KconfigLexer': ('pygments.lexers.configs', 'Kconfig', ('kconfig', 'menuconfig', 'linux-config', 'kernel-config'), ('Kconfig', '*Config.in*', 'external.in*', 'standard-modules.in'), ('text/x-kconfig',)),
     'KokaLexer': ('pygments.lexers.haskell', 'Koka', ('koka',), ('*.kk', '*.kki'), ('text/x-koka',)),
     'KotlinLexer': ('pygments.lexers.jvm', 'Kotlin', ('kotlin',), ('*.kt',), ('text/x-kotlin',)),

--- a/pygments/lexers/kappa.py
+++ b/pygments/lexers/kappa.py
@@ -1,0 +1,144 @@
+#! /usr/bin/env python3
+
+from pygments.lexer import RegexLexer, bygroups, words
+from pygments.token_kappa import *
+
+__all__ = ['KappaLexer']
+
+
+class KappaLexer(RegexLexer):
+    """Pygments lexer for the Kappa language (https://kappalanguage.org)"""
+    name = 'Kappa'
+    aliases = ['kappa']
+    filenames = ['*.ka']
+
+    integer = r'[0-9]+'
+    real = r'([0-9]+[eE][+-]?[0-9+])|((([0-9]+\.[0-9]*)|(\.[0-9]+))([eE][+-]?[0-9]+)?)'
+    ident = r'[_~][a-zA-Z0-9~+_]+|[a-zA-Z][a-zA-Z0-9_~+-]*'
+
+    tokens = {
+        'root': [
+            # comments
+            (r'//.*?$', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+            (r'\s+', Whitespace),
+            # agent name
+            (r'(' + ident + ')(\()', bygroups(Agent_Name, Agent_Decor), 'agent_rule'),
+            # various keywords
+            (r'(%agent:)(\s*)(' + ident + ')(\()', bygroups(Dec_Keyword, Whitespace, Dec_Ag_Name, Dec_Ag_Decor),
+             'agent_declaration'),
+            (r'(%token:)(\s*)(' + ident + ')', bygroups(Dec_Keyword, Whitespace, String)),
+            (words(('obs', 'init', 'var', 'plot', 'def'),
+                   prefix='%', suffix=':'), Misc_Keyword),
+            (words(('?', ':', 'log', 'sin', 'cos', 'tan', 'exp', 'int', 'mod', 'sqrt', 'pi', 'max', 'min'),
+                   prefix='\[\s*', suffix='\s*\]'), Misc_Func),
+            # perturbation language
+            (r'%mod:', Pert_Keyword),
+            (r';', Pert_Keyword),
+            (words(('INF', 'inf', 'alarm'),
+                   prefix=r'\b', suffix=r'\b'), Pert_Constructs),
+            (words(('true', 'false', 'not', 'E', 'E+', 'T', 'Tsim', 'Emax', 'Tmax'),
+                   prefix='\[\s*', suffix='\s*\]'), Pert_Constructs),
+            (words(('do', 'repeat'),
+                   prefix=r'\b', suffix=r'\b'), Pert_Decor),
+            (words(('APPLY', 'DEL', 'ADD', 'SNAPSHOT', 'STOP', 'DIN', 'TRACK', 'UPDATE', 'PRINT', 'PRINTF', 'RUN',
+                    'SPECIES_OF'),
+                   prefix=r'\$', suffix=r'\b'), Pert_Oper),
+            (words(('&&', '||')), Pert_Constructs),
+            # double-quoted, unquoted, and single-quoted strings
+            (r'"[^"]+"', Pert_FileName),
+            (r"([_~][a-zA-Z0-9~+_]+|[a-zA-Z][a-zA-Z0-9_~+-]*)|('[^']*')", String),
+            # numbers
+            (integer, Number),
+            (real, Number),
+            # rule decorations & markers
+            (r'@|<->|->|{|}|:', Rule_Decor),
+            (r',', Rule_Decor),
+            (r'[-+/*^|><=()]', Alge_Oper),
+            (r'\.', Rule_Decor)             # chemical notation placeholder marking agent creation/destruction
+        ],
+        'comment': [
+            (r'[^*/]', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline)
+        ],
+        'agent_rule': [
+            # comments
+            (r'//.*?$', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+            # end of expression, agent edit operation
+            (r'(\))([+-]?)', bygroups(Agent_Decor, Agent_Oper), '#pop'),
+            # bond states
+            (r'(\[\s*)(\d+|_|#|\.)(\s*\])',                                          # [99]
+             bygroups(Site_Bond_Decor, Site_Bond_State, Site_Bond_Decor)),
+            (r'(\[\s*)(' + ident + ')(.)(' + ident + ')(\s*\])',                     # [site.Agent]
+             bygroups(Site_Bond_Decor, Site_Bond_State_Site, Site_Bond_Decor, Site_Bond_State_Agent, Site_Bond_Decor)),
+            (r'(\[\s*)(\d+|_|#|\.)(\s*/\s*)(\d+|\.)(\s*\])',                         # [99/56]
+             bygroups(Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor)),
+            (r'(\[\s*)(' + ident + ')(.)(' + ident + ')(\s*/\s*)(\d+|\.)(\s*\])',    # [site.Agent/.]
+             bygroups(Site_Bond_Oper_Decor, Site_Bond_Oper_State_Site, Site_Bond_Oper_Decor, Site_Bond_Oper_State_Agent, Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor)),
+             # internal states
+            (r'({\s*)(' + ident + '|#)(\s*})',                                       # {ph}
+             bygroups(Site_Int_Decor, Site_Int_State, Site_Int_Decor)),
+            (r'({\s*)(' + ident + '|#)(\s*/\s*)(' + ident + ')(\s*})',               # {ph/un}
+             bygroups(Site_Int_Oper_Decor, Site_Int_Oper_State, Site_Int_Oper_Decor, Site_Int_Oper_State, Site_Int_Oper_Decor)),
+            # counter states
+            (r'({\s*(?:>=|>|=)\s*)(\d+)(\s*})',                                     # {>55}
+             bygroups(Site_Count_Decor, Site_Count_State, Site_Count_Decor)),
+            (r'({\s*=\s*)(' + ident + ')(\s*})',                                    # {=x}
+             bygroups(Site_Count_Decor, Site_Count_State, Site_Count_Decor)),
+            (r'({\s*[-+]=\s*)(-?\d+)(\s*})',                                        # {+= -55}
+             bygroups(Site_Count_Oper_Decor, Site_Count_Oper_State, Site_Count_Oper_Decor)),
+            (r'({\s*=\s*)(\d+)(\s*/\s*[+-]=\s*)(-?\d+)(\s*})',                      # {= 55 / += -3}
+             bygroups(Site_Count_Oper_Decor, Site_Count_Oper_State, Site_Count_Oper_Decor, Site_Count_Oper_State, Site_Count_Oper_Decor)),
+            # rest of components
+            (r'\s', Agent_Sign),
+            (r',', Agent_Sign_Decor),
+            (ident, Site_Name)
+        ],
+        # the declaration pods exists because counter syntax is identical for edit notation in rules and for declaration
+        # statements in %agent:
+        # With it, I avoid issuing the wrong tokens (e.g. highlighting as edit operation statements in agent declaration
+        # statement), at the expense of more token types.
+        'agent_declaration' : [
+            # comments
+            (r'//.*?$', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+            # kappa
+            (r'\)', Dec_Ag_Decor, '#pop'),                                  # end of expression
+            (r'({\s*=\s*)(\d+)(\s*/\s*[+-]=\s*)(-?\d+)(\s*})',              # {= 55 / += 3} :: counters
+             bygroups(Dec_Ag_Sign_Site_Ct_d, Dec_Ag_Sign_Site_Ct_s, Dec_Ag_Sign_Site_Ct_d, Dec_Ag_Sign_Site_Ct_s, Dec_Ag_Sign_Site_Ct_d)),
+            (r'({\s*=\s*)(\d+)(\s*})',                                      # {= 55 } :: counters_cont
+             bygroups(Dec_Ag_Sign_Site_Ct_d, Dec_Ag_Sign_Site_Ct_s, Dec_Ag_Sign_Site_Ct_d)),
+            (r'\[', Dec_Ag_Sign_Site_Bd_d, 'declaration_bond_type'),        # change state
+            (r'{', Dec_Ag_Sign_Site_In_d, 'declaration_internal_list'),     # change state
+            # rest of components
+            (r'\s+', Dec_Ag_Sign_Decor),
+            (r',', Dec_Ag_Sign_Decor),
+            (ident, Dec_Ag_Sign_Site_Name)
+        ],
+        'declaration_bond_type' : [
+            # comments
+            (r'//.*?$', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+            # bond data
+            (r'\]', Dec_Ag_Sign_Site_Bd_d, '#pop'),
+            (r'(' + ident + ')(\.)(' + ident + ')', bygroups(Dec_Ag_Sign_Site_Bd_s, Dec_Ag_Sign_Site_Bd_d, Dec_Ag_Sign_Site_Bd_a)),
+            (r'\s+', Dec_Ag_Sign_Site_Bd_d),
+            (r',', Dec_Ag_Sign_Site_Bd_d)
+        ],
+        'declaration_internal_list' : [
+            # comments
+            (r'//.*?$', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+            # internal state data
+            (r'}', Dec_Ag_Sign_Site_In_d, '#pop'),
+            (ident, Dec_Ag_Sign_Site_In_s),
+            (r'\s+', Dec_Ag_Sign_Site_In_d),
+            (r',', Dec_Ag_Sign_Site_In_d)
+        ],
+    }
+
+
+

--- a/pygments/lexers/kappa.py
+++ b/pygments/lexers/kappa.py
@@ -124,7 +124,7 @@ class KappaLexer(RegexLexer):
             (r'/\*', Comment.Multiline, 'comment'),
             # bond data
             (r'\]', Dec_Ag_Sign_Site_Bd_d, '#pop'),
-            (r'(' + ident + ')(\.)(' + ident + ')', bygroups(Dec_Ag_Sign_Site_Bd_s, Dec_Ag_Sign_Site_Bd_d, Dec_Ag_Sign_Site_Bd_a)),
+            (r'(' + ident + r')(\.)(' + ident + r')', bygroups(Dec_Ag_Sign_Site_Bd_s, Dec_Ag_Sign_Site_Bd_d, Dec_Ag_Sign_Site_Bd_a)),
             (r'\s+', Dec_Ag_Sign_Site_Bd_d),
             (r',', Dec_Ag_Sign_Site_Bd_d)
         ],

--- a/pygments/lexers/kappa.py
+++ b/pygments/lexers/kappa.py
@@ -23,7 +23,7 @@ class KappaLexer(RegexLexer):
             (r'/\*', Comment.Multiline, 'comment'),
             (r'\s+', Whitespace),
             # agent name
-            (r'(' + ident + ')(\()', bygroups(Agent_Name, Agent_Decor), 'agent_rule'),
+            (r'(' + ident + r')(\()', bygroups(Agent_Name, Agent_Decor), 'agent_rule'),
             # various keywords
             (r'(%agent:)(\s*)(' + ident + ')(\()', bygroups(Dec_Keyword, Whitespace, Dec_Ag_Name, Dec_Ag_Decor),
              'agent_declaration'),

--- a/pygments/lexers/kappa.py
+++ b/pygments/lexers/kappa.py
@@ -25,20 +25,20 @@ class KappaLexer(RegexLexer):
             # agent name
             (r'(' + ident + r')(\()', bygroups(Agent_Name, Agent_Decor), 'agent_rule'),
             # various keywords
-            (r'(%agent:)(\s*)(' + ident + ')(\()', bygroups(Dec_Keyword, Whitespace, Dec_Ag_Name, Dec_Ag_Decor),
+            (r'(%agent:)(\s*)(' + ident + r')(\()', bygroups(Dec_Keyword, Whitespace, Dec_Ag_Name, Dec_Ag_Decor),
              'agent_declaration'),
-            (r'(%token:)(\s*)(' + ident + ')', bygroups(Dec_Keyword, Whitespace, String)),
+            (r'(%token:)(\s*)(' + ident + r')', bygroups(Dec_Keyword, Whitespace, String)),
             (words(('obs', 'init', 'var', 'plot', 'def'),
                    prefix='%', suffix=':'), Misc_Keyword),
             (words(('?', ':', 'log', 'sin', 'cos', 'tan', 'exp', 'int', 'mod', 'sqrt', 'pi', 'max', 'min'),
-                   prefix='\[\s*', suffix='\s*\]'), Misc_Func),
+                   prefix=r'\[\s*', suffix=r'\s*\]'), Misc_Func),
             # perturbation language
             (r'%mod:', Pert_Keyword),
             (r';', Pert_Keyword),
             (words(('INF', 'inf', 'alarm'),
                    prefix=r'\b', suffix=r'\b'), Pert_Constructs),
             (words(('true', 'false', 'not', 'E', 'E+', 'T', 'Tsim', 'Emax', 'Tmax'),
-                   prefix='\[\s*', suffix='\s*\]'), Pert_Constructs),
+                   prefix=r'\[\s*', suffix=r'\s*\]'), Pert_Constructs),
             (words(('do', 'repeat'),
                    prefix=r'\b', suffix=r'\b'), Pert_Decor),
             (words(('APPLY', 'DEL', 'ADD', 'SNAPSHOT', 'STOP', 'DIN', 'TRACK', 'UPDATE', 'PRINT', 'PRINTF', 'RUN',
@@ -72,21 +72,21 @@ class KappaLexer(RegexLexer):
             # bond states
             (r'(\[\s*)(\d+|_|#|\.)(\s*\])',                                          # [99]
              bygroups(Site_Bond_Decor, Site_Bond_State, Site_Bond_Decor)),
-            (r'(\[\s*)(' + ident + ')(.)(' + ident + ')(\s*\])',                     # [site.Agent]
+            (r'(\[\s*)(' + ident + r')(.)(' + ident + r')(\s*\])',                     # [site.Agent]
              bygroups(Site_Bond_Decor, Site_Bond_State_Site, Site_Bond_Decor, Site_Bond_State_Agent, Site_Bond_Decor)),
             (r'(\[\s*)(\d+|_|#|\.)(\s*/\s*)(\d+|\.)(\s*\])',                         # [99/56]
              bygroups(Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor)),
-            (r'(\[\s*)(' + ident + ')(.)(' + ident + ')(\s*/\s*)(\d+|\.)(\s*\])',    # [site.Agent/.]
+            (r'(\[\s*)(' + ident + r')(.)(' + ident + r')(\s*/\s*)(\d+|\.)(\s*\])',    # [site.Agent/.]
              bygroups(Site_Bond_Oper_Decor, Site_Bond_Oper_State_Site, Site_Bond_Oper_Decor, Site_Bond_Oper_State_Agent, Site_Bond_Oper_Decor, Site_Bond_Oper_State, Site_Bond_Oper_Decor)),
              # internal states
-            (r'({\s*)(' + ident + '|#)(\s*})',                                       # {ph}
+            (r'({\s*)(' + ident + r'|#)(\s*})',                                       # {ph}
              bygroups(Site_Int_Decor, Site_Int_State, Site_Int_Decor)),
-            (r'({\s*)(' + ident + '|#)(\s*/\s*)(' + ident + ')(\s*})',               # {ph/un}
+            (r'({\s*)(' + ident + r'|#)(\s*/\s*)(' + ident + r')(\s*})',               # {ph/un}
              bygroups(Site_Int_Oper_Decor, Site_Int_Oper_State, Site_Int_Oper_Decor, Site_Int_Oper_State, Site_Int_Oper_Decor)),
             # counter states
             (r'({\s*(?:>=|>|=)\s*)(\d+)(\s*})',                                     # {>55}
              bygroups(Site_Count_Decor, Site_Count_State, Site_Count_Decor)),
-            (r'({\s*=\s*)(' + ident + ')(\s*})',                                    # {=x}
+            (r'({\s*=\s*)(' + ident + r')(\s*})',                                    # {=x}
              bygroups(Site_Count_Decor, Site_Count_State, Site_Count_Decor)),
             (r'({\s*[-+]=\s*)(-?\d+)(\s*})',                                        # {+= -55}
              bygroups(Site_Count_Oper_Decor, Site_Count_Oper_State, Site_Count_Oper_Decor)),

--- a/pygments/styles/__init__.py
+++ b/pygments/styles/__init__.py
@@ -51,6 +51,9 @@ STYLE_MAP = {
     'stata-light': 'stata_light::StataLightStyle',
     'stata-dark':  'stata_dark::StataDarkStyle',
     'inkpot':      'inkpot::InkPotStyle',
+    'kappa':               'kappa_styles::KaSimInBrowserStyle',
+    'kasim-in-browser':    'kappa_styles::KaSimInBrowserStyle',
+    'kappa-edit-notation': 'kappa_styles::EditNotationDeltasStyle',
 }
 
 

--- a/pygments/styles/kappa_styles.py
+++ b/pygments/styles/kappa_styles.py
@@ -1,0 +1,73 @@
+#! /usr/bin/env python3
+
+from pygments.style import Style
+from pygments.token import Comment, Number, String, Operator
+from pygments.token_kappa import *
+
+"""Kappa has a lot of idiosyncratic components; a lot of those have a Pygments-token associated to them.
+Refer to those defined in kappa_tokens.py for documentation and hierarchy."""
+
+class DemoStyle(Style):
+    """This style showcases some of the subtleties in the lexer."""
+    default_style = ''
+    styles = {
+        Agent_Name: 'bold',
+        Site_Bond_State_Agent: 'bold',
+        Agent_Oper: 'underline #f00',
+        Site_Bond: '#cc00cc',
+        Site_Int: '#0000ff',
+        Site_Count: '#009999',
+        String: 'italic',
+        Site_Bond_Oper: 'underline',
+        Site_Int_Oper: 'underline',
+        Site_Count_Oper: 'underline',
+        Dec_Ag_Sign_Site_Bd: '#999999',
+        Pert_Keyword: 'bold',
+        Pert_Decor: 'italic',
+        Pert_Oper: 'bg:#ffcccc',
+        Comment: 'bg:#f2f2f2 italic',
+        Number: '#cc7a00',
+        Dec_Keyword: 'bold',
+        Misc_Keyword: 'bold',
+        Rule_Decor: '#009900',
+        # Comment: '#f00',
+        # Number: '#f00',
+        # String: '#f00',
+        # Number: '#f00',
+        # Operator: '#f00'
+    }
+
+
+class KaSimInBrowserStyle(Style):
+    """This style mimics the CodeMirror interface used in the GUI / KappApp."""
+    default_style = ''
+    styles = {
+        Comment: '#a50',
+        Misc_Keyword: '#708',
+        Dec_Keyword: '#708',
+        Pert_Keyword: '#708',
+        Agent_Decor: '#05a',
+        Dec_Ag_Decor: '#05a',
+        Rule_Decor: '#05a',
+        Number: '#164',
+        Operator: '#05a',
+        Misc_Func: '#05a',
+        Pert_Oper: '#05a',
+        Pert_Decor: '#05a',
+        Pert_FileName: '#a11',
+        Pert_Constructs: '#708',
+    }
+
+class EditNotationDeltasStyle(Style):
+    """This style highlights edit notation operations."""
+    default_style = ''
+    styles = {
+        String: '#808080 italic',
+        Agent_Name: 'bold',
+        Site_Bond_Oper: 'bg:#c9f2d6',
+        Site_Int_Oper: 'bg:#c9e4f2',
+        Agent_Oper: 'bg:#f2c9e4',
+        Site_Count_Oper: 'bg:#f2d6c9',
+        Rule_Decor: '#cc0000',
+        Comment: 'bg:#b3b3b3'
+    }

--- a/pygments/token_kappa.py
+++ b/pygments/token_kappa.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python3
+
+from pygments.token import Token
+
+
+# rule components
+Rule                        = Token.Kappa.Rule
+Rule_Decor                  = Token.Kappa.Rule.Decor        # e.g. commas between agents
+Rule_Agent                  = Token.Kappa.Rule.Agent        # whole agent
+Agent_Name                  = Token.Kappa.Rule.Agent.Name       # agent's name
+Agent_Oper                  = Token.Kappa.Rule.Agent.Operation  # edit operation following the parenthesis
+Agent_Decor                 = Token.Kappa.Rule.Agent.Decorators # e.g. the parenthesis themselves
+Agent_Sign                  = Token.Kappa.Rule.Agent.Signature  # the whole signature, sites plus commas
+Agent_Sign_Decor            = Token.Kappa.Rule.Agent.Signature.Decorators   # the commas between sites
+
+Agent_Site                  = Token.Kappa.Rule.Agent.Signature.Site         # a single site
+Site_Name                   = Token.Kappa.Rule.Agent.Signature.Site.Name        # the site's name
+Site_Bond                   = Token.Kappa.Rule.Agent.Signature.Site.Bond        # the site's bond data
+Site_Bond_Decor             = Token.Kappa.Rule.Agent.Signature.Site.Bond.Decorators     # e.g. square brackets
+Site_Bond_State             = Token.Kappa.Rule.Agent.Signature.Site.Bond.State          # bond identifier, or typing
+Site_Bond_State_Agent       = Token.Kappa.Rule.Agent.Signature.Site.Bond.State.Agent    # agent in site.Agent
+Site_Bond_State_Site        = Token.Kappa.Rule.Agent.Signature.Site.Bond.State.Site     # site in site.Agent
+Site_Bond_Oper              = Token.Kappa.Rule.Agent.Signature.Site.Bond.Operation      # if edit operation, whole operation
+Site_Bond_Oper_Decor        = Token.Kappa.Rule.Agent.Signature.Site.Bond.Operation.Decorators   # e.g. the slash
+Site_Bond_Oper_State        = Token.Kappa.Rule.Agent.Signature.Site.Bond.Operation.States       # the before slash, and after slash components
+Site_Bond_Oper_State_Agent  = Token.Kappa.Rule.Agent.Signature.Site.Bond.Operation.States.Agent # when typing in edit operation, the agent
+Site_Bond_Oper_State_Site   = Token.Kappa.Rule.Agent.Signature.Site.Bond.Operation.States.Site  # when typing in edit operation, the site
+
+Site_Int                    = Token.Kappa.Rule.Agent.Signature.Site.Internal    # the site's internal state data
+Site_Int_Decor              = Token.Kappa.Rule.Agent.Signature.Site.Internal.Decorators # e.g. curly brackets
+Site_Int_State              = Token.Kappa.Rule.Agent.Signature.Site.Internal.State      # internal state data
+Site_Int_Oper               = Token.Kappa.Rule.Agent.Signature.Site.Internal.Operation  # if edit operation, whole expression
+Site_Int_Oper_Decor         = Token.Kappa.Rule.Agent.Signature.Site.Internal.Operation.Decorators   # e.g. the slash
+Site_Int_Oper_State         = Token.Kappa.Rule.Agent.Signature.Site.Internal.Operation.States       # the before slash, and after slash components
+
+Site_Count                  = Token.Kappa.Rule.Agent.Signature.Site.Counter     # the site's counter data
+Site_Count_Decor            = Token.Kappa.Rule.Agent.Signature.Site.Counter.Decorators  # e.g. curly brackets
+Site_Count_State            = Token.Kappa.Rule.Agent.Signature.Site.Counter.State       # the counter state data
+Site_Count_Oper             = Token.Kappa.Rule.Agent.Signature.Site.Counter.Operation   # if operation, whole expression
+Site_Count_Oper_Decor       = Token.Kappa.Rule.Agent.Signature.Site.Counter.Operation.Decorators    # e.g. the slash
+Site_Count_Oper_State       = Token.Kappa.Rule.Agent.Signature.Site.Counter.Operation.States        # the before slash, and after slash components
+
+# declaration components
+Declaration             = Token.Kappa.Declaration
+Dec_Keyword             = Token.Kappa.Declaration.Keyword       # either %agent: or %token:
+Dec_Ag                  = Token.Kappa.Declaration.Agent         # the kappa agent being declared
+Dec_Ag_Name             = Token.Kappa.Declaration.Agent.Name            # the agent's name
+Dec_Ag_Decor            = Token.Kappa.Declaration.Agent.Decoration      # the parenthesis
+Dec_Ag_Sign             = Token.Kappa.Declaration.Agent.Signature       # the agent's signature
+Dec_Ag_Sign_Decor       = Token.Kappa.Declaration.Agent.Signature.Decorator     # inter-site commas
+Dec_Ag_Sign_Site        = Token.Kappa.Declaration.Agent.Signature.Site          # a site, with internal/bond/counter data
+Dec_Ag_Sign_Site_Name   = Token.Kappa.Declaration.Agent.Signature.Site.Name         # a site's name
+Dec_Ag_Sign_Site_Bd     = Token.Kappa.Declaration.Agent.Signature.Site.Bond         # type specifier, i.e: [site.Agent]
+Dec_Ag_Sign_Site_Bd_s   = Token.Kappa.Declaration.Agent.Signature.Site.Bond.Site        # site in [site.Agent]
+Dec_Ag_Sign_Site_Bd_a   = Token.Kappa.Declaration.Agent.Signature.Site.Bond.Agent       # Agent in [site.Agent]
+Dec_Ag_Sign_Site_Bd_d   = Token.Kappa.Declaration.Agent.Signature.Site.Bond.Decorator   # brackets and period in [site.Agent]
+Dec_Ag_Sign_Site_In_s   = Token.Kappa.Declaration.Agent.Signature.Site.Internal.State       # un ph in {un, ph}
+Dec_Ag_Sign_Site_In_d   = Token.Kappa.Declaration.Agent.Signature.Site.Internal.Decorator   # comma and curlies in {un, ph}
+Dec_Ag_Sign_Site_Ct_s   = Token.Kappa.Declaration.Agent.Signature.Site.Counter.State            # 1 and 5 in {=1/+=5}
+Dec_Ag_Sign_Site_Ct_d   = Token.Kappa.Declaration.Agent.Signature.Site.Counter.Decorator        # equals, slash, curlies in {=1/+=5}
+
+# perturbations
+Perturbation    = Token.Kappa.Perturbation              # the whole perturbation syntax (minus agent usage)
+Pert_Keyword    = Token.Kappa.Perturbation.Keyword      # %mod:
+Pert_Decor      = Token.Kappa.Perturbation.Decorators   # do, repeat
+Pert_Oper       = Token.Kappa.Perturbation.Operation    # e.g. STOP, SNAPSHOT, ADD
+Pert_Constructs = Token.Kappa.Perturbation.Constructs   # e.g. [E], [T], alarm
+Pert_FileName   = Token.Kappa.Perturbation.FileName     # double-quoted string used for filenames
+
+# other script components
+Alge_Oper       = Token.Kappa.Operand               # algebraic operations: + - * / ^
+Misc_Keyword    = Token.Kappa.Miscelaneous          # e.g. %obs:, %init:, %var:
+Misc_Func       = Token.Kappa.Function              # e.g. exp, sqrt, max, cos
+Comment         = Token.Kappa.Comment               # comments
+Whitespace      = Token.Kappa.Whitespace
+Number          = Token.Kappa.Number
+String          = Token.Kappa.String                # Unquoted and single-quoted identifiers, like rule names

--- a/tests/examplefiles/example.ka
+++ b/tests/examplefiles/example.ka
@@ -1,0 +1,58 @@
+/*** some glorious header
+spanning multiple lines ***/
+
+
+%agent: A(x[~x.~B], c[_1._C, x2._C])				// in-line comment
+%agent: ~B(~x[x.A])
+%agent: _C(_1{u p}[c.A] /*some comment*/ x2{~a _p _55}[c.A])
+%agent: ~9(c{=1 / +=5})
+%token: Bob
+
+
+'99' A(x[.]),~B(~x[.]) -> A(x[1]),~B(~x[1]) @ 'on_rate' * [tan] 3
+
+A(x[1/.]),~B(~x[1/.]) @ 'off_rate'
+
+A(x[_],c[.]),_C(_1{u}[.]) -> A(x[_],c[2]),_C(_1{u}[2])
+       @ 'on_rate'
+
+_C(_1{u}[1]),A(c[1]) -> _C(_1[.]{p}),A(c[.]) @ 'mod_rate'
+_C(_1{u/p}) @ 'mod_rate'
+
+'a.c' A(x[.],c[.]),_C(_1{p}[.],x2[.]{~a}) ->
+      A(x[.],c[1]),_C(_1{p}[.],x2[1]{~a}) @ 'on_rate'
+
+A(x[.],c[1]),_C(_1{p},x2{~a}[1]) ->
+         A(x[.],c[.]),_C(_1{p},x2{_p}[.]) @ 'mod_rate'
+
+~9()+ @ 1.0 {'mod_rate'}
+
+~9()- @ .1 { 'mod_rate' * 'on_rate' }
+
+~9(c{=1}) -> ~9(c{+=1}) @ 'on_rate' * 'off_rate' / 'mod_rate' {1.0}
+
+~9(c{=1 / +=1}) @ 1
+
+A() -> . | 1 Bob @ 1
+
+%var: 'on_rate' 1.0E-3
+%var: 'off_rate' 0.1
+%var: 'mod_rate' 1
+%obs: 'AB' |A(x[~x.~B])|
+%obs: 'Cuu' |_C(_1{u},x2{~a})|
+%var: 'n_ab' 1000 * [tan] 3
+%obs: 'n_c' 0
+%var: 'C' |_C()|
+%init: 'n_ab' A(),~B()
+%init: 'n_c' _C()
+%init: 5 ~9()
+%init: 55 Bob
+
+%mod: alarm 10.0 do $ADD 10^2 * |~9()| _C();
+%mod: [T] > 50 do $SNAPSHOT "my_snap.ka";
+%mod: [E] > 1 do $STOP ;
+/* open1 /* open2 close 2*/
+close */
+/* bla blaa */
+/* bla / bla */
+/* bla * bla */


### PR DESCRIPTION
Kappa is a rule transformation language for simulating biochemical signaling cascades. The tokens used in other languages were not suitable for Kappa, so I created new ones. This necessitated a new style-sheet, for which two are presented.

If it would be desirable to declare the tokens elsewhere, please advise.

[this PR is taking up where the old mercurial PR-811 left off]