### PR TITLE
[Scala] Fix type highlighting

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -271,8 +271,7 @@ class ScalaLexer(RegexLexer):
             # method names
             (r'(class|trait|object)(\s+)', bygroups(Keyword, Text), 'class'),
             (r'[^\S\n]+', Text),
-            (r'//.*?\n', Comment.Single),
-            (r'/\*', Comment.Multiline, 'comment'),
+            include('comments'),
             (u'@%s' % idrest, Name.Decorator),
             (u'(abstract|ca(?:se|tch)|d(?:ef|o)|e(?:lse|xtends)|'
              u'f(?:inal(?:ly)?|or(?:Some)?)|i(?:f|mplicit)|'
@@ -307,15 +306,16 @@ class ScalaLexer(RegexLexer):
         ],
         'class': [
             (u'(%s|%s|`[^`]+`)(\\s*)(\\[)' % (idrest, op),
-             bygroups(Name.Class, Text, Operator), 'typeparam'),
+             bygroups(Name.Class, Text, Operator), ('#pop', 'typeparam')),
             (r'\s+', Text),
+            include('comments'),
             (r'\{', Operator, '#pop'),
             (r'\(', Operator, '#pop'),
-            (r'//.*?\n', Comment.Single, '#pop'),
             (u'%s|%s|`[^`]+`' % (idrest, op), Name.Class, '#pop'),
         ],
         'type': [
             (r'\s+', Text),
+            include('comments'),
             (r'<[%:]|>:|[#_]|forSome|type', Keyword),
             (u'([,);}]|=>|=|\u21d2)(\\s*)', bygroups(Operator, Text), '#pop'),
             (r'[({]', Operator, '#push'),
@@ -325,15 +325,20 @@ class ScalaLexer(RegexLexer):
             (u'((?:%s|%s|`[^`]+`)(?:\\.(?:%s|%s|`[^`]+`))*)(\\s*)$' %
              (idrest, op, idrest, op),
              bygroups(Keyword.Type, Text), '#pop'),
-            (r'//.*?\n', Comment.Single, '#pop'),
             (u'\\.|%s|%s|`[^`]+`' % (idrest, op), Keyword.Type)
         ],
         'typeparam': [
-            (r'[\s,]+', Text),
+            (r'\s+', Text),
+            include('comments'),
+            (r',+', Punctuation),
             (u'<[%:]|=>|>:|[#_\u21D2]|forSome|type', Keyword),
             (r'([\])}])', Operator, '#pop'),
             (r'[(\[{]', Operator, '#push'),
             (u'\\.|%s|%s|`[^`]+`' % (idrest, op), Keyword.Type)
+        ],
+        'comments': [
+            (r'//.*?\n', Comment.Single),
+            (r'/\*', Comment.Multiline, 'comment'),
         ],
         'comment': [
             (r'[^/*]+', Comment.Multiline),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -316,7 +316,7 @@ class ScalaLexer(RegexLexer):
         'type': [
             (r'\s+', Text),
             include('comments'),
-            (r'<[%:]|>:|[#_]|forSome|type', Keyword),
+            (r'<[%:]|>:|[#_]|forSome|\btype\b', Keyword),
             (u'([,);}]|=>|=|\u21d2)(\\s*)', bygroups(Operator, Text), '#pop'),
             (r'[({]', Operator, '#push'),
             (u'((?:%s|%s|`[^`]+`)(?:\\.(?:%s|%s|`[^`]+`))*)(\\s*)(\\[)' %
@@ -331,7 +331,7 @@ class ScalaLexer(RegexLexer):
             (r'\s+', Text),
             include('comments'),
             (r',+', Punctuation),
-            (u'<[%:]|=>|>:|[#_\u21D2]|forSome|type', Keyword),
+            (u'<[%:]|=>|>:|[#_\u21D2]|forSome|\btype\b', Keyword),
             (r'([\])}])', Operator, '#pop'),
             (r'[(\[{]', Operator, '#push'),
             (u'\\.|%s|%s|`[^`]+`' % (idrest, op), Keyword.Type)

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -316,7 +316,7 @@ class ScalaLexer(RegexLexer):
         'type': [
             (r'\s+', Text),
             include('comments'),
-            (r'<[%:]|>:|[#_]|forSome|\btype\b', Keyword),
+            (r'<[%:]|>:|[#_]|\bforSome\b|\btype\b', Keyword),
             (u'([,);}]|=>|=|\u21d2)(\\s*)', bygroups(Operator, Text), '#pop'),
             (r'[({]', Operator, '#push'),
             (u'((?:%s|%s|`[^`]+`)(?:\\.(?:%s|%s|`[^`]+`))*)(\\s*)(\\[)' %
@@ -331,7 +331,7 @@ class ScalaLexer(RegexLexer):
             (r'\s+', Text),
             include('comments'),
             (r',+', Punctuation),
-            (u'<[%:]|=>|>:|[#_\u21D2]|forSome|\btype\b', Keyword),
+            (u'<[%:]|=>|>:|[#_\u21D2]|\bforSome\b|\btype\b', Keyword),
             (r'([\])}])', Operator, '#pop'),
             (r'[(\[{]', Operator, '#push'),
             (u'\\.|%s|%s|`[^`]+`' % (idrest, op), Keyword.Type)


### PR DESCRIPTION
On top of #1314, fix the following issue: `type` is recognized as a keyword even if inside a word, which isn't correct. To wit, below `types` is an identifier, not the `type` keyword followed by an `s`:

```
trait Symbol(val tpe: types.Type)
trait Symbol(val tpe: Option[types.Type])
```

![image](https://user-images.githubusercontent.com/289960/69831639-8e16b280-122a-11ea-813e-4f9bfc5df870.png)

I expect `forSome` needs the same treatment, but I haven't tested that.

Also, I'm a Scala dev, not a Python one, and I might be doing something silly.