### PR TITLE
Ensure `setup.py` works again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     description = 'Pygments is a syntax highlighting package written in Python.',
     long_description = __doc__,
     keywords = 'syntax highlighting',
-    packages = find_packages(include=['pygments']),
+    packages = find_packages(exclude=['tests']),
     entry_points = {
         'console_scripts': ['pygmentize = pygments.cmdline:main'],
     },


### PR DESCRIPTION
While `pip3 install .` still works, `python3 setup.py install` does not (and
ditto for Python2), because subpackages of `pygments` don't get installed. Even
running `find_packages` on its own has consistent behavior:

```
$ python3
>>> from setuptools import setup, find_packages
>>> find_packages(exclude=['tests'])
['pygments', 'pygments.filters', 'pygments.lexers', 'pygments.formatters', 'pygments.styles']
>>> find_packages(include=['pygments'])
['pygments']
```

The bug seems to have been introduced in
8d0828bbfc5b8deb7525a19e1037704f644563da.

Tested on macOS 10.14 with Homebrew Python 2.7.17 and 3.7.5.

I'm no Python expert, but my fix is based on examples in https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages.

That `packages` does not recurse automatically is made clear by distutils docs:
https://docs.python.org/3.7/distutils/setupscript.html#listing-whole-packages.