### PR TITLE
Remove generated output/ directory when 'make clean' is called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ check:
 		   -i docs/build -i pygments/formatters/_mapping.py -i pygments/unistring.py
 
 clean: clean-pyc
-	-rm -rf build
+	-rm -rf build tests/examplefiles/output
 	-rm -f codetags.html
 
 clean-pyc:


### PR DESCRIPTION
This minor PR removes the `tests/examplefiles/output/` directory so `make clean` cleans more.

It's done following https://github.com/pygments/pygments/pull/1257#issuecomment-559607557 and https://github.com/pygments/pygments/pull/1257#issuecomment-559664075
