### PR TITLE
Parse HTTP status-line even when reason-phrase not included.

### DIFF
--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -179,9 +179,9 @@ class HttpLexer(RegexLexer):
              bygroups(Name.Function, Text, Name.Namespace, Text,
                       Keyword.Reserved, Operator, Number, Text),
              'headers'),
-            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})( +)([^\r\n]+)(\r?\n|\Z)',
+            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(( +)([^\r\n]+))?(\r?\n|\Z)',
              bygroups(Keyword.Reserved, Operator, Number, Text, Number,
-                      Text, Name.Exception, Text),
+                      None, Text, Name.Exception, Text),
              'headers'),
         ],
         'headers': [

--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -179,9 +179,9 @@ class HttpLexer(RegexLexer):
              bygroups(Name.Function, Text, Name.Namespace, Text,
                       Keyword.Reserved, Operator, Number, Text),
              'headers'),
-            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(( +)([^\r\n]+))?(\r?\n|\Z)',
-             bygroups(Keyword.Reserved, Operator, Number, Text, Number,
-                      None, Text, Name.Exception, Text),
+            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(?:( +)([^\r\n]+))?(\r?\n|\Z)',
+             bygroups(Keyword.Reserved, Operator, Number, Text, Number, Text,
+                      Name.Exception, Text),
              'headers'),
         ],
         'headers': [

--- a/tests/test_textfmts.py
+++ b/tests/test_textfmts.py
@@ -18,6 +18,34 @@ def lexer():
     yield HttpLexer()
 
 
+def test_http_status_line(lexer):
+    fragment = u'HTTP/1.1 200 OK\n'
+    tokens = [
+        (Token.Keyword.Reserved, u'HTTP'),
+        (Token.Operator, u'/'),
+        (Token.Number, u'1.1'),
+        (Token.Text, u' '),
+        (Token.Number, u'200'),
+        (Token.Text, u' '),
+        (Token.Name.Exception, u'OK'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_http_status_line_without_reason_phrase(lexer):
+    fragment = u'HTTP/1.1 200\n'
+    tokens = [
+        (Token.Keyword.Reserved, u'HTTP'),
+        (Token.Operator, u'/'),
+        (Token.Number, u'1.1'),
+        (Token.Text, u' '),
+        (Token.Number, u'200'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
 def test_application_xml(lexer):
     fragment = u'GET / HTTP/1.0\nContent-Type: application/xml\n\n<foo>\n'
     tokens = [


### PR DESCRIPTION
Background: https://github.com/jakubroztocil/httpie/issues/811