### PR TITLE
Fix valid_name regex for SLexer

### DIFF
--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -80,7 +80,7 @@ class SLexer(RegexLexer):
     mimetypes = ['text/S-plus', 'text/S', 'text/x-r-source', 'text/x-r',
                  'text/x-R', 'text/x-r-history', 'text/x-r-profile']
 
-    valid_name = r'(?:`[^`\\]*(?:\\.[^`\\]*)*`)|(?:(?:[a-zA-Z]|[_.][^0-9])[\w_.]*)'
+    valid_name = r'`[^`\\]*(?:\\.[^`\\]*)*`|(?:[a-zA-Z]|\.[A-Za-z_.])[\w_.]*|\.'
     tokens = {
         'comments': [
             (r'#.*$', Comment.Single),

--- a/tests/test_r.py
+++ b/tests/test_r.py
@@ -73,3 +73,40 @@ def test_custom_operator(lexer):
         (Token.Text, u'\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_indexing(lexer):
+    fragment = u'a[1]'
+    tokens = [
+        (Token.Name, u'a'),
+        (Token.Punctuation, u'['),
+        (Token.Literal.Number, u'1'),
+        (Token.Punctuation, u']'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_dot_name(lexer):
+    fragment = u'. <- 1'
+    tokens = [
+        (Token.Name, '.'),
+        (Token.Text, ' '),
+        (Token.Operator, '<-'),
+        (Token.Text, ' '),
+        (Token.Literal.Number, '1'),
+        (Token.Text, '\n')
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_dot_indexing(lexer):
+    fragment = u'.[1]'
+    tokens = [
+        (Token.Name, u'.'),
+        (Token.Punctuation, u'['),
+        (Token.Literal.Number, u'1'),
+        (Token.Punctuation, u']'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
This fixes #1331
All modifications to regex:
1. Delete 2 useless non-capturing groups
2. Variables can not start with underscore (_)
3. Only letters, dot (.) and underscore (_) can go after first dot (.) in name
4. Name from only one symbol dot (.) is possible