### PR TITLE
Fixing parsing of Ada numeric literals

### DIFF
--- a/pygments/lexers/pascal.py
+++ b/pygments/lexers/pascal.py
@@ -577,7 +577,7 @@ class AdaLexer(RegexLexer):
             (r'\n+', Text),
         ],
         'numbers': [
-            (r'[0-9_]+#[0-9a-f]+#', Number.Hex),
+            (r'[0-9_]+#[0-9a-f_\.]+#', Number.Hex),
             (r'[0-9_]+\.[0-9_]*', Number.Float),
             (r'[0-9_]+', Number.Integer),
         ],


### PR DESCRIPTION
Reasoning: Ada allows formats such as 2#1111_0000# and 2#1111.0000#