### PR TITLE
Add a PEG (Parsing Expression Grammar) lexer

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -248,6 +248,7 @@ Other markup
 * `Nix language <https://nixos.org/nix/>`_
 * NSIS scripts
 * Notmuch
+* `PEG <https://bford.info/packrat/>`_
 * POV-Ray scenes
 * `Puppet <https://puppet.com/>`_
 * QML

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -324,6 +324,7 @@ LEXERS = {
     'PanLexer': ('pygments.lexers.dsls', 'Pan', ('pan',), ('*.pan',), ()),
     'ParaSailLexer': ('pygments.lexers.parasail', 'ParaSail', ('parasail',), ('*.psi', '*.psl'), ('text/x-parasail',)),
     'PawnLexer': ('pygments.lexers.pawn', 'Pawn', ('pawn',), ('*.p', '*.pwn', '*.inc'), ('text/x-pawn',)),
+    'PegLexer': ('pygments.lexers.grammar_notation', 'PEG', ('peg',), ('*.peg',), ('text/x-peg',)),
     'Perl6Lexer': ('pygments.lexers.perl', 'Perl6', ('perl6', 'pl6', 'raku'), ('*.pl', '*.pm', '*.nqp', '*.p6', '*.6pl', '*.p6l', '*.pl6', '*.6pm', '*.p6m', '*.pm6', '*.t', '*.raku', '*.rakumod', '*.rakutest', '*.rakudoc'), ('text/x-perl6', 'application/x-perl6')),
     'PerlLexer': ('pygments.lexers.perl', 'Perl', ('perl', 'pl'), ('*.pl', '*.pm', '*.t'), ('text/x-perl', 'application/x-perl')),
     'PhpLexer': ('pygments.lexers.php', 'PHP', ('php', 'php3', 'php4', 'php5'), ('*.php', '*.php[345]', '*.inc'), ('text/x-php',)),

--- a/pygments/lexers/grammar_notation.py
+++ b/pygments/lexers/grammar_notation.py
@@ -230,6 +230,8 @@ class PegLexer(RegexLexer):
     * A single `a-z` character immediately before a string, or
       multiple `a-z` characters following a string, are part of the
       string (e.g., `r"..."` or `"..."ilmsuxa`).
+
+    .. versionadded:: 2.6
     """
 
     name = 'PEG'

--- a/pygments/lexers/grammar_notation.py
+++ b/pygments/lexers/grammar_notation.py
@@ -15,7 +15,7 @@ from pygments.lexer import RegexLexer, bygroups, include, this, using, words
 from pygments.token import Comment, Keyword, Literal, Name, Number, \
     Operator, Punctuation, String, Text
 
-__all__ = ['BnfLexer', 'AbnfLexer', 'JsgfLexer']
+__all__ = ['BnfLexer', 'AbnfLexer', 'JsgfLexer', 'PegLexer']
 
 
 class BnfLexer(RegexLexer):
@@ -209,5 +209,60 @@ class JsgfLexer(RegexLexer):
             (r'\n\s*\*', Comment.Multiline),
             include('non-comments'),
             (r'.', Comment.Multiline),
+        ],
+    }
+
+
+class PegLexer(RegexLexer):
+    """
+    This lexer is for `Parsing Expression Grammars
+    <https://bford.info/pub/lang/peg.pdf>`_ (PEG).
+
+    Various implementations of PEG have made different decisions
+    regarding the syntax, so let's try to be accommodating:
+
+    * `<-`, `←`, `:`, and `=` are all accepted as rule operators.
+
+    * Both `|` and `/` are choice operators.
+
+    * `^`, `↑`, and `~` are cut operators.
+
+    * A single `a-z` character immediately before a string, or
+      multiple `a-z` characters following a string, are part of the
+      string (e.g., `r"..."` or `"..."ilmsuxa`).
+    """
+
+    name = 'PEG'
+    aliases = ['peg']
+    filenames = ['*.peg']
+    mimetypes = ['text/x-peg']
+
+    tokens = {
+        'root': [
+            # Comments
+            (r'#.*', Comment.Single),
+
+            # All operators
+            (r'<-|[←:=/|&!?*+^↑~]', Operator),
+
+            # Other punctuation
+            (r'[()]', Punctuation),
+
+            # Keywords
+            (r'\.', Keyword),
+
+            # Character classes
+            (r'(\[)([^\]]*(?:\\.[^\]\\]*)*)(\])',
+             bygroups(Punctuation, String, Punctuation)),
+
+            # Single and double quoted strings (with optional modifiers)
+            (r'[a-z]?"[^"\\]*(?:\\.[^"\\]*)*"[a-z]*', String.Double),
+            (r"[a-z]?'[^'\\]*(?:\\.[^'\\]*)*'[a-z]*", String.Single),
+
+            # Nonterminals are not whitespace, operators, or punctuation
+            (r'[^\s<←:=/|&!?*+\^↑~()\[\]"\'#]+', Name.Class),
+
+            # Fallback
+            (r'.', Text),
         ],
     }

--- a/tests/test_grammar_notation.py
+++ b/tests/test_grammar_notation.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+    Basic Grammar Notation Tests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments.token import Token
+from pygments.lexers import PegLexer
+
+
+@pytest.fixture(scope='module')
+def lexer_peg():
+    yield PegLexer()
+
+
+def test_peg_basic(lexer_peg):
+    fragment = u'rule<-("terminal"/nonterminal/[cls])*\n'
+    tokens = [
+        (Token.Name.Class, u'rule'),
+        (Token.Operator, u'<-'),
+        (Token.Punctuation, u'('),
+        (Token.String.Double, u'"terminal"'),
+        (Token.Operator, u'/'),
+        (Token.Name.Class, u'nonterminal'),
+        (Token.Operator, u'/'),
+        (Token.Punctuation, u'['),
+        (Token.String, u'cls'),
+        (Token.Punctuation, u']'),
+        (Token.Punctuation, u')'),
+        (Token.Operator, u'*'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer_peg.get_tokens(fragment)) == tokens
+
+
+def test_peg_operators(lexer_peg):
+    # see for example:
+    # - https://github.com/gvanrossum/pegen
+    # - https://nim-lang.org/docs/pegs.html
+    fragment = u"rule = 'a' | 'b'\n"
+    tokens = [
+        (Token.Name.Class, u'rule'),
+        (Token.Text, u' '),
+        (Token.Operator, u'='),
+        (Token.Text, u' '),
+        (Token.String.Single, u"'a'"),
+        (Token.Text, u' '),
+        (Token.Operator, u'|'),
+        (Token.Text, u' '),
+        (Token.String.Single, u"'b'"),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer_peg.get_tokens(fragment)) == tokens
+    fragment = u"rule: 'a' ~ 'b'\n"
+    tokens = [
+        (Token.Name.Class, u'rule'),
+        (Token.Operator, u':'),
+        (Token.Text, u' '),
+        (Token.String.Single, u"'a'"),
+        (Token.Text, u' '),
+        (Token.Operator, u'~'),
+        (Token.Text, u' '),
+        (Token.String.Single, u"'b'"),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer_peg.get_tokens(fragment)) == tokens
+
+
+def test_peg_modified_strings(lexer_peg):
+    # see for example:
+    # - http://textx.github.io/Arpeggio/
+    # - https://nim-lang.org/docs/pegs.html
+    # - https://github.com/erikrose/parsimonious
+    fragment = u'~"regex" i"insensitive" "multimod"ilx ("not modified")\n'
+    tokens = [
+        # can't handle parsimonious-style regex while ~ is a cut operator
+        (Token.Operator, u'~'),
+        (Token.String.Double, u'"regex"'),
+        (Token.Text, u' '),
+        (Token.String.Double, u'i"insensitive"'),
+        (Token.Text, u' '),
+        (Token.String.Double, u'"multimod"ilx'),
+        (Token.Text, u' '),
+        (Token.Punctuation, u'('),
+        (Token.String.Double, u'"not modified"'),
+        (Token.Punctuation, u')'),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer_peg.get_tokens(fragment)) == tokens


### PR DESCRIPTION
[Parsing Expression Grammars](https://en.wikipedia.org/wiki/Parsing_expression_grammar) (PEGs) have been around for about 15 years and they are fairly popular these days for describing non-ambiguous grammars, such as for programming languages and data formats.

This lexer (`pygments.lexers.grammar_notation.PegLexer`) builds on the original PEG syntax described by Bryan Ford (see [here](https://bford.info/pub/lang/peg.pdf)) with some common extensions seen in various implementations of PEG, such as (optionally) using `|` for choices instead of `/`, `=` or `:` instead of `<-` for rule definitions, cut operators (`^` or `~`), and string modifiers, such as `r"a regex"`.

I've added `tests/test_grammar_notation.py`, but only included tests relevant to this PR instead of going back and adding tests for `BnfLexer`, etc.