### PR TITLE
Fix directives that have 0 arguments when lexing apache configs

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -303,8 +303,7 @@ class ApacheConfLexer(RegexLexer):
             (r'#(.*\\\n)+.*$|(#.*?)$', Comment),
             (r'(<[^\s>]+)(?:(\s+)(.*))?(>)',
              bygroups(Name.Tag, Text, String, Name.Tag)),
-            (r'([a-z]\w*)(\s+)',
-             bygroups(Name.Builtin, Text), 'value'),
+            (r'[a-z]\w*', Name.Builtin, 'value'),
             (r'\.+', Text),
         ],
         'value': [

--- a/tests/test_apache_conf.py
+++ b/tests/test_apache_conf.py
@@ -40,3 +40,17 @@ def test_multiline_argument(lexer):
             (Token.Text, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_directive_no_args(lexer):
+    fragment = 'Example\nServerName localhost'
+    tokens = [
+            (Token.Name.Builtin, 'Example'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+            (Token.Name.Builtin, 'ServerName'),
+            (Token.Text, ' '),
+            (Token.Text, 'localhost'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
When parsing Apache Configuration files, a Directive that has 0 arguments, e.g. the [Example Directive](https://httpd.apache.org/docs/2.4/mod/mod_example_hooks.html#example), causes the next observed directive to lex to a Token.Text instead of a Token.Name.Builtin.

Some examples: 
'Example\nServerName localhost' yields:
```
(Token.Name.Builtin, 'Example'),
(Token.Text, '\n'),
(Token.Text, 'ServerName'),
(Token.Text, ' '),
(Token.Text, 'localhost'),
(Token.Text, '')
(Token.Text, '\n')
```

Similarly this affects other elements as well, e.g. Comments,
 'Example\n# Comment' yields:
```
(Token.Name.Builtin, 'Example'),
(Token.Text, '\n'),
(Token.Text, '#'),
(Token.Text, ' '),
(Token.Text, 'Comment'),
(Token.Text, '')
(Token.Text, '\n')
```

The proposed changes modify this behavior to present more accurate representation of the data.
'Example\nServerName localhost' yields:
```
(Token.Name.Builtin, 'Example'),
(Token.Text, ''),
(Token.Text, '\n'),
(Token.Name.Builtin, 'ServerName'),
(Token.Text, ' '),
(Token.Text, 'localhost'),
(Token.Text, ''),
(Token.Text, '\n')
```

And this time I was able to understand/include a unit tests as well.

Happy lexing :)
