### PR TITLE
Add nowrap option to LatexFormatter

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -161,6 +161,8 @@ class LatexFormatter(Formatter):
             \PY{k}{pass}
         \end{Verbatim}
 
+    Wrapping can be disabled using the `nowrap` option.
+
     The special command used here (``\PY``) and all the other macros it needs
     are output by the `get_style_defs` method.
 
@@ -172,6 +174,11 @@ class LatexFormatter(Formatter):
     ``Verbatim`` environments.
 
     Additional options accepted:
+
+    `nowrap`
+        If set to ``True``, don't wrap the tokens at all, not even inside a
+        ``\begin{Verbatim}`` environment. This disables most other options
+        (default: ``False``).
 
     `style`
         The style to use, can be a string or a Style subclass (default:
@@ -250,6 +257,7 @@ class LatexFormatter(Formatter):
 
     def __init__(self, **options):
         Formatter.__init__(self, **options)
+        self.nowrap = get_bool_opt(options, 'nowrap', False)
         self.docclass = options.get('docclass', 'article')
         self.preamble = options.get('preamble', '')
         self.linenos = get_bool_opt(options, 'linenos', False)
@@ -337,17 +345,18 @@ class LatexFormatter(Formatter):
             realoutfile = outfile
             outfile = StringIO()
 
-        outfile.write(u'\\begin{' + self.envname + u'}[commandchars=\\\\\\{\\}')
-        if self.linenos:
-            start, step = self.linenostart, self.linenostep
-            outfile.write(u',numbers=left' +
-                          (start and u',firstnumber=%d' % start or u'') +
-                          (step and u',stepnumber=%d' % step or u''))
-        if self.mathescape or self.texcomments or self.escapeinside:
-            outfile.write(u',codes={\\catcode`\\$=3\\catcode`\\^=7\\catcode`\\_=8}')
-        if self.verboptions:
-            outfile.write(u',' + self.verboptions)
-        outfile.write(u']\n')
+        if not self.nowrap:
+            outfile.write(u'\\begin{' + self.envname + u'}[commandchars=\\\\\\{\\}')
+            if self.linenos:
+                start, step = self.linenostart, self.linenostep
+                outfile.write(u',numbers=left' +
+                              (start and u',firstnumber=%d' % start or u'') +
+                              (step and u',stepnumber=%d' % step or u''))
+            if self.mathescape or self.texcomments or self.escapeinside:
+                outfile.write(u',codes={\\catcode`\\$=3\\catcode`\\^=7\\catcode`\\_=8}')
+            if self.verboptions:
+                outfile.write(u',' + self.verboptions)
+            outfile.write(u']\n')
 
         for ttype, value in tokensource:
             if ttype in Token.Comment:
@@ -410,7 +419,8 @@ class LatexFormatter(Formatter):
             else:
                 outfile.write(value)
 
-        outfile.write(u'\\end{' + self.envname + u'}\n')
+        if not self.nowrap:
+            outfile.write(u'\\end{' + self.envname + u'}\n')
 
         if self.full:
             encoding = self.encoding or 'utf8'

--- a/tests/test_latex_formatter.py
+++ b/tests/test_latex_formatter.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 import os
 import tempfile
 from os import path
+from io import StringIO
 
 import pytest
 
@@ -21,10 +22,20 @@ from pygments.lexers import PythonLexer
 TESTDIR = path.dirname(path.abspath(__file__))
 TESTFILE = path.join(TESTDIR, 'test_latex_formatter.py')
 
+with open(TESTFILE) as fp:
+    tokensource = list(PythonLexer().get_tokens(fp.read()))
+
+
+def test_correct_output():
+    hfmt = LatexFormatter(nowrap=True)
+    houtfile = StringIO()
+    hfmt.format(tokensource, houtfile)
+
+    assert r'\begin{Verbatim}' not in houtfile.getvalue()
+    assert r'\end{Verbatim}' not in houtfile.getvalue()
+
 
 def test_valid_output():
-    with open(TESTFILE) as fp:
-        tokensource = list(PythonLexer().get_tokens(fp.read()))
     fmt = LatexFormatter(full=True, encoding='latin1')
 
     handle, pathname = tempfile.mkstemp('.tex')


### PR DESCRIPTION
At present, LatexFormatter always output `\begin{Verbatim}` macro. As a result, the generated content always becomes block level element. To support to generate inline one, I'd like to add `nowrap` option to LatexFormatter like HtmlFormatter.