### PR TITLE
haskell: Fix highlighting of promoted type operators

### DIFF
--- a/pygments/lexers/haskell.py
+++ b/pygments/lexers/haskell.py
@@ -66,6 +66,7 @@ class HaskellLexer(RegexLexer):
             (r"(')[" + uni.Lu + r"][\w\']*", Keyword.Type),
             (r"(')\[[^\]]*\]", Keyword.Type),  # tuples and lists get special treatment in GHC
             (r"(')\([^)]*\)", Keyword.Type),  # ..
+            (r"(')[:!#$%&*+.\\/<=>?@^|~-]+", Keyword.Type),  # promoted type operators
             #  Operators
             (r'\\(?![:!#$%&*+.\\/<=>?@^|~-]+)', Name.Function),  # lambda operator
             (r'(<-|::|->|=>|=)(?![:!#$%&*+.\\/<=>?@^|~-]+)', Operator.Word),  # specials

--- a/tests/examplefiles/example.hs
+++ b/tests/examplefiles/example.hs
@@ -39,3 +39,6 @@ type family Fam (a :: Type) = r :: Type where
 type IntChar = '[Int, Char]
 type Falsy = 'False
 type Falsy = '(10, 20, 30)
+type EmptyList = '[]
+type TypeCons = 1 ': '[]
+type Times = 1 '* 2

--- a/tests/test_haskell.py
+++ b/tests/test_haskell.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+    Haskell Tests
+    ~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2019 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments.lexers import HaskellLexer
+from pygments.token import Token
+
+
+@pytest.fixture(scope='module')
+def lexer():
+    yield HaskellLexer()
+
+
+def test_promoted_names(lexer):
+    fragment = "'x ': '[]\n"
+    tokens = [
+        (Token.Name, '\'x'),
+        (Token.Text, ' '),
+        (Token.Keyword.Type, '\':'),
+        (Token.Text, ' '),
+        (Token.Keyword.Type, '\'[]'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
Closes #527 

Are there tests I'm supposed to run/update after changing the examples?