### PR TITLE
Add Haxe to languages.rst

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -72,6 +72,7 @@ Programming languages
 * Gosu
 * Groovy
 * `Haskell <https://www.haskell.org/>`_ (incl. Literate Haskell)
+* `Haxe <https://haxe.org>`_
 * HLSL
 * `HSpec <https://hackage.haskell.org/package/hspec>`_
 * Hy


### PR DESCRIPTION
Not sure why Haxe wasn't in there. Pygments supports it.