### PR TITLE
Add lexer for LLVM's MIR format

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -253,6 +253,8 @@ LEXERS = {
     'LiterateIdrisLexer': ('pygments.lexers.haskell', 'Literate Idris', ('lidr', 'literate-idris', 'lidris'), ('*.lidr',), ('text/x-literate-idris',)),
     'LiveScriptLexer': ('pygments.lexers.javascript', 'LiveScript', ('live-script', 'livescript'), ('*.ls',), ('text/livescript',)),
     'LlvmLexer': ('pygments.lexers.asm', 'LLVM', ('llvm',), ('*.ll',), ('text/x-llvm',)),
+    'LlvmMirBodyLexer': ('pygments.lexers.asm', 'LLVM-MIR Body', ('llvm-mir-body',), (), ()),
+    'LlvmMirLexer': ('pygments.lexers.asm', 'LLVM-MIR', ('llvm-mir',), ('*.mir',), ()),
     'LogosLexer': ('pygments.lexers.objective', 'Logos', ('logos',), ('*.x', '*.xi', '*.xm', '*.xmi'), ('text/x-logos',)),
     'LogtalkLexer': ('pygments.lexers.prolog', 'Logtalk', ('logtalk',), ('*.lgt', '*.logtalk'), ('text/x-logtalk',)),
     'LuaLexer': ('pygments.lexers.scripting', 'Lua', ('lua',), ('*.lua', '*.wlua'), ('text/x-lua', 'application/x-lua')),

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -12,15 +12,16 @@
 import re
 
 from pygments.lexer import RegexLexer, include, bygroups, using, words, \
-    DelegatingLexer
+    DelegatingLexer, default
 from pygments.lexers.c_cpp import CppLexer, CLexer
 from pygments.lexers.d import DLexer
 from pygments.token import Text, Name, Number, String, Comment, Punctuation, \
-    Other, Keyword, Operator
+    Other, Keyword, Operator, Literal
 
 __all__ = ['GasLexer', 'ObjdumpLexer', 'DObjdumpLexer', 'CppObjdumpLexer',
-           'CObjdumpLexer', 'HsailLexer', 'LlvmLexer', 'NasmLexer',
-           'NasmObjdumpLexer', 'TasmLexer', 'Ca65Lexer', 'Dasm16Lexer']
+           'CObjdumpLexer', 'HsailLexer', 'LlvmLexer', 'LlvmMirBodyLexer',
+           'LlvmMirLexer', 'NasmLexer', 'NasmObjdumpLexer', 'TasmLexer',
+           'Ca65Lexer', 'Dasm16Lexer']
 
 
 class GasLexer(RegexLexer):
@@ -440,7 +441,7 @@ class LlvmLexer(RegexLexer):
                 'win64cc', 'within', 'wpdRes', 'wpdResolutions', 'writeonly', 'x',
                 'x86_64_sysvcc', 'x86_fastcallcc', 'x86_fp80', 'x86_intrcc', 'x86_mmx',
                 'x86_regcallcc', 'x86_stdcallcc', 'x86_thiscallcc', 'x86_vectorcallcc', 'xchg',
-                'xor', 'zeroext', 'zeroinitializer', 'zext'),
+                'xor', 'zeroext', 'zeroinitializer', 'zext', 'immarg', 'willreturn'),
                 suffix=r'\b'), Keyword),
 
             # Types
@@ -450,6 +451,217 @@ class LlvmLexer(RegexLexer):
             # Integer types
             (r'i[1-9]\d*', Keyword)
         ]
+    }
+
+class LlvmMirBodyLexer(RegexLexer):
+    """
+    For LLVM MIR examples without the YAML wrapper
+
+    For more information on LLVM MIR see https://llvm.org/docs/MIRLangRef.html.
+
+    .. versionadded:: 2.6
+    """
+    name = 'LLVM-MIR Body'
+    aliases = ['llvm-mir-body']
+    filenames = []
+    mimetypes = []
+
+    tokens = {
+        'root': [
+            # Attributes on basic blocks
+            (words(('liveins', 'successors'), suffix=':'), Keyword),
+            # Basic Block Labels
+            (r'bb\.[0-9]+(\.[0-9a-zA-Z_.-]+)?( \(address-taken\))?:', Name.Label),
+            (r'bb\.[0-9]+ \(%[0-9a-zA-Z_.-]+\)( \(address-taken\))?:', Name.Label),
+            (r'%bb\.[0-9]+(\.\w+)?', Name.Label),
+            # Stack references
+            (r'%stack\.[0-9]+(\.\w+\.addr)?', Name),
+            # Subreg indices
+            (r'%subreg\.\w+', Name),
+            # Virtual registers
+            (r'%[0-9a-zA-Z_]+ *', Name.Variable, 'vreg'),
+            # Reference to LLVM-IR global
+            include('global'),
+            # Reference to Intrinsic
+            (r'intrinsic\(\@[0-9a-zA-Z_.]+\)', Name.Variable.Global),
+            # Comparison predicates
+            (words(('eq', 'ne', 'sgt', 'sge', 'slt', 'sle', 'ugt', 'uge', 'ult',
+                    'ule'), prefix=r'intpred\(', suffix=r'\)'), Name.Builtin),
+            (words(('oeq', 'one', 'ogt', 'oge', 'olt', 'ole', 'ugt', 'uge',
+                    'ult', 'ule'), prefix=r'floatpred\(', suffix=r'\)'),
+             Name.Builtin),
+            # Physical registers
+            (r'\$\w+', String.Single),
+            # Assignment operator
+            (r'[=]', Operator),
+            # gMIR Opcodes
+            (r'(G_ANYEXT|G_[SZ]EXT|G_SEXT_INREG|G_TRUNC|G_IMPLICIT_DEF|G_PHI|'
+             r'G_FRAME_INDEX|G_GLOBAL_VALUE|G_INTTOPTR|G_PTRTOINT|G_BITCAST|'
+             r'G_CONSTANT|G_FCONSTANT|G_VASTART|G_VAARG|G_CTLZ|G_CTLZ_ZERO_UNDEF|'
+             r'G_CTTZ|G_CTTZ_ZERO_UNDEF|G_CTPOP|G_BSWAP|G_BITREVERSE|'
+             r'G_ADDRSPACE_CAST|G_BLOCK_ADDR|G_JUMP_TABLE|G_DYN_STACKALLOC|'
+             r'G_ADD|G_SUB|G_MUL|G_[SU]DIV|G_[SU]REM|G_AND|G_OR|G_XOR|G_SHL|'
+             r'G_[LA]SHR|G_[IF]CMP|G_SELECT|G_GEP|G_PTR_MASK|G_SMIN|G_SMAX|'
+             r'G_UMIN|G_UMAX|G_[US]ADDO|G_[US]ADDE|G_[US]SUBO|G_[US]SUBE|'
+             r'G_[US]MULO|G_[US]MULH|G_FNEG|G_FPEXT|G_FPTRUNC|G_FPTO[US]I|'
+             r'G_[US]ITOFP|G_FABS|G_FCOPYSIGN|G_FCANONICALIZE|G_FMINNUM|'
+             r'G_FMAXNUM|G_FMINNUM_IEEE|G_FMAXNUM_IEEE|G_FMINIMUM|G_FMAXIMUM|'
+             r'G_FADD|G_FSUB|G_FMUL|G_FMA|G_FMAD|G_FDIV|G_FREM|G_FPOW|G_FEXP|'
+             r'G_FEXP2|G_FLOG|G_FLOG2|G_FLOG10|G_FCEIL|G_FCOS|G_FSIN|G_FSQRT|'
+             r'G_FFLOOR|G_FRINT|G_FNEARBYINT|G_INTRINSIC_TRUNC|'
+             r'G_INTRINSIC_ROUND|G_LOAD|G_[ZS]EXTLOAD|G_INDEXED_LOAD|'
+             r'G_INDEXED_[ZS]EXTLOAD|G_STORE|G_INDEXED_STORE|'
+             r'G_ATOMIC_CMPXCHG_WITH_SUCCESS|G_ATOMIC_CMPXCHG|'
+             r'G_ATOMICRMW_(XCHG|ADD|SUB|AND|NAND|OR|XOR|MAX|MIN|UMAX|UMIN|FADD|'
+                           r'FSUB)'
+             r'|G_FENCE|G_EXTRACT|G_UNMERGE_VALUES|G_INSERT|G_MERGE_VALUES|'
+             r'G_BUILD_VECTOR|G_BUILD_VECTOR_TRUNC|G_CONCAT_VECTORS|'
+             r'G_INTRINSIC|G_INTRINSIC_W_SIDE_EFFECTS|G_BR|G_BRCOND|'
+             r'G_BRINDIRECT|G_BRJT|G_INSERT_VECTOR_ELT|G_EXTRACT_VECTOR_ELT|'
+             r'G_SHUFFLE_VECTOR)\b',
+             Name.Builtin),
+            # Target independent opcodes
+            (r'(COPY|PHI|INSERT_SUBREG|EXTRACT_SUBREG|REG_SEQUENCE)\b',
+             Name.Builtin),
+            # Flags
+            (words(('killed', 'implicit')), Keyword),
+            # ConstantInt values
+            (r'[i][0-9]+ +', Keyword.Type, 'constantint'),
+            # ConstantFloat values
+            (r'(half|float|double) +', Keyword.Type, 'constantfloat'),
+            # Bare immediates
+            include('integer'),
+            # MMO's
+            (r':: *', Operator, 'mmo'),
+            # MIR Comments
+            (r';.*', Comment),
+            # If we get here, assume it's a target instruction
+            (r'[0-9a-zA-Z_]+', Name),
+            # Everything else that isn't highlighted
+            (r'[(), \n]+', Text),
+        ],
+        # The integer constant from a ConstantInt value
+        'constantint': [
+            include('integer'),
+            (r'(?=.)', Text, '#pop'),
+        ],
+        # The floating point constant from a ConstantFloat value
+        'constantfloat': [
+            include('float'),
+            (r'(?=.)', Text, '#pop'),
+        ],
+        'vreg': [
+            # The bank or class if there is one
+            (r' *:(?!:)', Keyword, ('#pop', 'vreg_bank_or_class')),
+            # The LLT if there is one
+            (r' *\(', Text, 'vreg_type'),
+            (r'(?=.)', Text, '#pop'),
+        ],
+        'vreg_bank_or_class': [
+            # The unassigned bank/class
+            (r' *_', Name.Variable.Magic),
+            (r' *[0-9a-zA-Z_]+', Name.Variable),
+            # The LLT if there is one
+            (r' *\(', Text, 'vreg_type'),
+            (r'(?=.)', Text, '#pop'),
+        ],
+        'vreg_type': [
+            # Scalar and pointer types
+            (r' *[sp][0-9]+', Keyword.Type),
+            (r' *<[0-9]+ *x *[sp][0-9]+>', Keyword.Type),
+            (r'\)', Text, '#pop'),
+            (r'(?=.)', Text, '#pop'),
+        ],
+        'mmo': [
+            (r'\(', Text),
+            (r' +', Text),
+            (words(('load', 'store', 'on', 'into', 'from', 'align', 'monotonic',
+                    'acquire', 'release', 'acq_rel', 'seq_cst')),
+             Keyword),
+            # IR references
+            (r'%ir\.[0-9a-zA-Z_.-]+', Name),
+            (r'%ir-block\.[0-9a-zA-Z_.-]+', Name),
+            (r'[-+]', Operator),
+            include('integer'),
+            include('global'),
+            (r',', Punctuation),
+            (r'\), \(', Text),
+            (r'\)', Text, '#pop'),
+        ],
+        'integer': [(r'-?[0-9]+', Number.Integer),],
+        'float': [(r'-?[0-9]+\.[0-9]+(e[+-][0-9]+)?', Number.Float)],
+        'global': [(r'\@[0-9a-zA-Z_.]+', Name.Variable.Global)],
+    }
+
+class LlvmMirLexer(RegexLexer):
+    """
+    Lexer for the overall LLVM MIR document format
+
+    MIR is a human readable serialization format that's used to represent LLVM's
+    machine specific intermediate representation. It allows LLVM's developers to
+    see the state of the compilation process at various points, as well as test
+    individual pieces of the compiler.
+
+    For more information on LLVM MIR see https://llvm.org/docs/MIRLangRef.html.
+
+    .. versionadded:: 2.6
+    """
+    name = 'LLVM-MIR'
+    aliases = ['llvm-mir']
+    filenames = ['*.mir']
+
+    tokens = {
+        'root': [
+            # Comments are hashes at the YAML level
+            (r'#.*', Comment),
+            # Documents starting with | are LLVM-IR
+            (r'--- \|$', Keyword, 'llvm_ir'),
+            # Other documents are MIR
+            (r'---', Keyword, 'llvm_mir'),
+            # Consume everything else in one token for efficiency
+            (r'[^-#]+|.', Text),
+        ],
+        'llvm_ir': [
+            # Documents end with '...' or '---'
+            (r'(\.\.\.|(?=---))', Keyword, '#pop'),
+            # Delegate to the LlvmLexer
+            (r'((?:.|\n)+?)(?=(\.\.\.|---))', bygroups(using(LlvmLexer))),
+        ],
+        'llvm_mir': [
+            # Comments are hashes at the YAML level
+            (r'#.*', Comment),
+            # Documents end with '...' or '---'
+            (r'(\.\.\.|(?=---))', Keyword, '#pop'),
+            # Handle the simple attributes
+            (r'name:', Keyword, 'name'),
+            (words(('alignment', ),
+                   suffix=':'), Keyword, 'number'),
+            (words(('legalized', 'regBankSelected', 'tracksRegLiveness',
+                    'selected', 'exposesReturnsTwice'),
+                   suffix=':'), Keyword, 'boolean'),
+            # Handle the attributes don't highlight inside
+            (words(('registers', 'stack', 'fixedStack', 'liveins', 'frameInfo',
+                    'machineFunctionInfo'),
+                   suffix=':'), Keyword),
+            # Delegate the body block to the LlvmMirBodyLexer
+            (r'body: *\|', Keyword, 'llvm_mir_body'),
+            # Consume everything else
+            (r'.+', Text),
+            (r'\n', Text),
+        ],
+        'name': [ (r'[^\n]+', Name), default('#pop') ],
+        'boolean': [ (r' *(true|false)', Name.Builtin), default('#pop') ],
+        'number': [ (r' *[0-9]+', Number), default('#pop') ],
+        'llvm_mir_body': [
+            # Documents end with '...' or '---'.
+            # We have to pop llvm_mir_body and llvm_mir
+            (r'(\.\.\.|(?=---))', Keyword, '#pop:2'),
+            # Delegate the body block to the LlvmMirBodyLexer
+            (r'((?:.|\n)+?)(?=\.\.\.|---)', bygroups(using(LlvmMirBodyLexer))),
+            # The '...' is optional. If we didn't already find it then it isn't
+            # there. There might be a '---' instead though.
+            (r'(?!\.\.\.|---)((.|\n)+)', bygroups(using(LlvmMirBodyLexer), Keyword)),
+        ],
     }
 
 

--- a/tests/examplefiles/llvm-mir.mir
+++ b/tests/examplefiles/llvm-mir.mir
@@ -1,0 +1,32 @@
+# YAML line comment
+
+--- |
+  ; LLVM-IR line comment
+  define void @myfunction() { ret void }
+...
+
+---
+name: myfunction
+legalized: true
+registers:
+  - { id: 0, class: gpr }
+body: |
+  bb.0.named (address-taken):
+    liveins: $r0, $r1
+    successors: %bb.1.alsonamed
+
+    ; MIR line comment
+    %0:gpr(s64) = COPY $r0
+    %1(s32) = COPY $r1
+  bb.1.alsonamed:
+    successors: %bb.2
+
+    %2(s32) = EXTRACT_SUBREG %1(s32), %subreg.sub0
+    %3(s32) = G_ADD %0:gpr(s32), %2(s32) killed
+    %4(s32) = G_CONSTANT i32 1
+    %5(s32) = G_FCONSTANT float 1.0
+    %6(p0) = G_LOAD %6(p0) :: (load 4 from %ir.myvar + 4)
+
+  bb.2:
+    $r0 = COPY %3
+...


### PR DESCRIPTION
MIR is a human readable serialization format that's used to represent LLVM's
machine specific intermediate representation. It allows LLVM's developers to
see the state of the compilation process at various points, as well as test
individual pieces of the compiler. Our documentation for the format can be
found at https://llvm.org/docs/MIRLangRef.html.

Adding a lexer for this format will allow the LLVM documentation to contain
syntax highlighted examples of LLVM-MIR. Two lexers are included in this
change. 'llvm-mir' lexes the overall document format and delegates to 'llvm' and
'llvm-mir-body' as appropriate. 'llvm-mir-body' lexes the contents of the 'body:'
attribute and can be used directly to syntax highlight code examples without
including the document boilerplate.

Since the 'llvm-mir' lexer delegates to the 'llvm' lexer at times, this change
also adds the 'immarg' and 'willreturn' keywords to the 'llvm' lexer as these
were missing.