### PR TITLE
D: remove typedef from keywords

### DIFF
--- a/pygments/lexers/d.py
+++ b/pygments/lexers/d.py
@@ -47,7 +47,7 @@ class DLexer(RegexLexer):
                 'module', 'new', 'nothrow', 'out', 'override', 'package', 'pragma',
                 'private', 'protected', 'public', 'pure', 'ref', 'return', 'scope',
                 'shared', 'static', 'struct', 'super', 'switch', 'synchronized',
-                'template', 'this', 'throw', 'try', 'typedef', 'typeid', 'typeof',
+                'template', 'this', 'throw', 'try', 'typeid', 'typeof',
                 'union', 'unittest', 'version', 'volatile', 'while', 'with',
                 '__gshared', '__traits', '__vector', '__parameters'),
                 suffix=r'\b'),


### PR DESCRIPTION
ref: https://dlang.org/deprecate.html#typedef