### PR TITLE
image formatter supports background color

### DIFF
--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -434,6 +434,16 @@ class ImageFormatter(Formatter):
             fill = '#000'
         return fill
 
+    def _get_text_bg_color(self, style):
+        """
+        Get the correct background color for the token from the style.
+        """
+        if style['bgcolor'] is not None:
+            bg_color = '#' + style['bgcolor']
+        else:
+            bg_color = None
+        return bg_color
+
     def _get_style_font(self, style):
         """
         Get the correct font for the style.
@@ -456,14 +466,15 @@ class ImageFormatter(Formatter):
             str(lineno).rjust(self.line_number_chars),
             font=self.fonts.get_font(self.line_number_bold,
                                      self.line_number_italic),
-            fill=self.line_number_fg,
+            text_fg=self.line_number_fg,
+            text_bg=None,
         )
 
-    def _draw_text(self, pos, text, font, **kw):
+    def _draw_text(self, pos, text, font, text_fg, text_bg):
         """
         Remember a single drawable tuple to paint later.
         """
-        self.drawables.append((pos, text, font, kw))
+        self.drawables.append((pos, text, font, text_fg, text_bg))
 
     def _create_drawables(self, tokensource):
         """
@@ -487,7 +498,8 @@ class ImageFormatter(Formatter):
                         self._get_text_pos(charno, lineno),
                         temp,
                         font = self._get_style_font(style),
-                        fill = self._get_text_color(style)
+                        text_fg = self._get_text_color(style),
+                        text_bg = self._get_text_bg_color(style),
                     )
                     charno += len(temp)
                     maxcharno = max(maxcharno, charno)
@@ -552,8 +564,11 @@ class ImageFormatter(Formatter):
                 y = self._get_line_y(linenumber - 1)
                 draw.rectangle([(x, y), (x + rectw, y + recth)],
                                fill=self.hl_color)
-        for pos, value, font, kw in self.drawables:
-            draw.text(pos, value, font=font, **kw)
+        for pos, value, font, text_fg, text_bg in self.drawables:
+            if text_bg:
+                text_size = draw.textsize(text=value, font=font)
+                draw.rectangle([pos[0], pos[1], pos[0] + text_size[0], pos[1] + text_size[1]], fill=text_bg)
+            draw.text(pos, value, font=font, fill=text_fg)
         im.save(outfile, self.image_format.upper())
 
 


### PR DESCRIPTION
Extend Image formatters in img.py to support background colors.

* New function to get the background color for a given token type, optionally None
* The self.drawables list used the fill keyword, stuffed into a **kwrgs, for the color of the token; since tokens can have foreground and background colors, that list now uses two explicit names, passing one to the PIL/Pillow text draw call, the other to the rectangle draw call.
* When iterating over the `drawables` list, the presence of a background color triggers the drawing of a rectangle beneath the text.
* Dimensions of background rectangle calculated by PIL based on the rendered text and font.
* If input string is multiline, PIL will use multiline for draw and size internally.