### PR TITLE
Fix glob patterns when absolute paths are used

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -313,7 +313,7 @@ class ApacheConfLexer(RegexLexer):
             (r'[^\S\n]+', Text),
             (r'\d+\.\d+\.\d+\.\d+(?:/\d+)?', Number),
             (r'\d+', Number),
-            (r'/([a-z0-9][\w./-]+)', String.Other),
+            (r'/([\*a-z0-9][\*\w./-]+)', String.Other),
             (r'(on|off|none|any|all|double|email|dns|min|minimal|'
              r'os|productonly|full|emerg|alert|crit|error|warn|'
              r'notice|info|debug|registry|script|inetd|standalone|'

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -313,7 +313,7 @@ class ApacheConfLexer(RegexLexer):
             (r'[^\S\n]+', Text),
             (r'\d+\.\d+\.\d+\.\d+(?:/\d+)?', Number),
             (r'\d+', Number),
-            (r'/([\*a-z0-9][\*\w./-]+)', String.Other),
+            (r'/([*a-z0-9][*\w./-]+)', String.Other),
             (r'(on|off|none|any|all|double|email|dns|min|minimal|'
              r'os|productonly|full|emerg|alert|crit|error|warn|'
              r'notice|info|debug|registry|script|inetd|standalone|'

--- a/tests/test_apache_conf.py
+++ b/tests/test_apache_conf.py
@@ -54,3 +54,48 @@ def test_directive_no_args(lexer):
             (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_include_globs(lexer):
+    fragment = 'Include /etc/httpd/conf.d/*.conf'
+    tokens = [
+            (Token.Name.Builtin, 'Include'),
+            (Token.Text, ' '),
+            (Token.String.Other, '/etc/httpd/conf.d/*.conf'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_multi_include_globs(lexer):
+    fragment = 'Include /etc/httpd/conf.d/*/*.conf'
+    tokens = [
+            (Token.Name.Builtin, 'Include'),
+            (Token.Text, ' '),
+            (Token.String.Other, '/etc/httpd/conf.d/*/*.conf'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_multi_include_globs_root(lexer):
+    fragment = 'Include /*conf/*.conf'
+    tokens = [
+            (Token.Name.Builtin, 'Include'),
+            (Token.Text, ' '),
+            (Token.String.Other, '/*conf/*.conf'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_fix_lock_absolute_path(lexer):
+    fragment = 'LockFile /var/lock/apache2/accept.lock'
+    tokens = [
+            (Token.Name.Builtin, 'LockFile'),
+            (Token.Text, ' '),
+            (Token.String.Other, '/var/lock/apache2/accept.lock'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
When lexing an apache config the following example illustrates the issue of lexing a glob pattern which is also an absolute path:
```
Include /etc/httpd/conf.d/*.conf
```

This lexs to:
```
(Token.Name.Builtin, 'Include')
(Token.Text, ' ')
(Token.Literal.String.Other, '/etc/httpd/conf.d/')
(Token.Text, '*.conf')
(Token.Text, '')
(Token.Text, '\n')
```

The ```(Token.Text, '*.conf')``` seems like it should really be part of the String.Other, like so ```(Token.Literal.String.Other, '/etc/httpd/conf.d/*.conf')```

This PR adds the '*' to the acceptable character list for these type of absolute file path/glob patterns. Tests have been included to address:
- one original absolute file path from the examplefiles/apache2.conf
- one basic glob pattern
- one multi-glob pattern
- one root level multi-glob pattern