### PR TITLE
Update Csound built-ins for v6.14.0

### DIFF
--- a/pygments/lexers/_csound_builtins.py
+++ b/pygments/lexers/_csound_builtins.py
@@ -7,7 +7,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-# Opcodes in Csound 6.13.0 using:
+# Opcodes in Csound 6.14.0 using:
 #   python3 -c "
 #   import re
 #   from subprocess import Popen, PIPE
@@ -265,11 +265,19 @@ chn_k
 chnclear
 chnexport
 chnget
+chngeta
+chngeti
+chngetk
 chngetks
+chngets
 chnmix
 chnparams
 chnset
+chnseta
+chnseti
+chnsetk
 chnsetks
+chnsets
 chuap
 clear
 clfilt
@@ -467,6 +475,7 @@ ftaudio
 ftchnls
 ftconv
 ftcps
+ftexists
 ftfree
 ftgen
 ftgenonce
@@ -748,6 +757,7 @@ la_k_upper_solve_mc
 la_k_upper_solve_mr
 la_k_vc_set
 la_k_vr_set
+lastcycle
 lenarray
 lfo
 limit
@@ -838,6 +848,7 @@ mdelay
 median
 mediank
 metro
+metro2
 mfb
 midglobal
 midiarp
@@ -1192,6 +1203,7 @@ qinf
 qnan
 r2c
 rand
+randc
 randh
 randi
 random
@@ -1252,6 +1264,7 @@ scanu
 schedkwhen
 schedkwhennamed
 schedule
+schedulek
 schedwhen
 scoreline
 scoreline_i
@@ -1362,6 +1375,7 @@ strlowerk
 strrindex
 strrindexk
 strset
+strstrip
 strsub
 strsubk
 strtod

--- a/pygments/lexers/csound.py
+++ b/pygments/lexers/csound.py
@@ -189,8 +189,8 @@ class CsoundScoreLexer(CsoundLexer):
             include('root')
         ],
 
-        # Braced strings are not allowed in Csound scores, but this is needed
-        # because the superclass includes it.
+        # Braced strings are not allowed in Csound scores, but this is needed because the
+        # superclass includes it.
         'braced string': [
             (r'\}\}', String, '#pop'),
             (r'[^}]|\}(?!\})', String)
@@ -337,8 +337,8 @@ class CsoundOrchestraLexer(CsoundLexer):
         #   prints          https://csound.com/docs/manual/prints.html
         #   sprintf         https://csound.com/docs/manual/sprintf.html
         #   sprintfk        https://csound.com/docs/manual/sprintfk.html
-        # work with strings that contain format specifiers. In addition, these
-        # opcodes’ handling of format specifiers is inconsistent:
+        # work with strings that contain format specifiers. In addition, these opcodes’
+        # handling of format specifiers is inconsistent:
         #   - fprintks, fprints, printks, and prints do accept %a and %A
         #     specifiers, but can’t accept %s specifiers.
         #   - printf, printf_i, sprintf, and sprintfk don’t accept %a and %A


### PR DESCRIPTION
This pull request updates Csound built-ins for Csound 6.14.0. (It also fixes a style nit in csound.py.)