### PR TITLE
Multiline flag does not work with re.match

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -101,9 +101,9 @@ class GasLexer(RegexLexer):
     }
 
     def analyse_text(text):
-        if re.match(r'^\.(text|data|section)', text, re.M):
+        if re.search(r'^\.(text|data|section)', text, re.M):
             return True
-        elif re.match(r'^\.\w+', text, re.M):
+        elif re.search(r'^\.\w+', text, re.M):
             return 0.1
 
 
@@ -883,7 +883,7 @@ class Ca65Lexer(RegexLexer):
 
     def analyse_text(self, text):
         # comments in GAS start with "#"
-        if re.match(r'^\s*;', text, re.MULTILINE):
+        if re.search(r'^\s*;', text, re.MULTILINE):
             return 0.9
 
 

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -162,10 +162,10 @@ class MatlabLexer(RegexLexer):
                 and '{' not in first_non_comment):
             return 1.
         # comment
-        elif re.match(r'^\s*%', text, re.M):
+        elif re.search(r'^\s*%', text, re.M):
             return 0.2
         # system cmd
-        elif re.match(r'^!\w+', text, re.M):
+        elif re.search(r'^!\w+', text, re.M):
             return 0.2
 
 

--- a/pygments/util.py
+++ b/pygments/util.py
@@ -173,7 +173,7 @@ def doctype_matches(text, regex):
     Note that this method only checks the first part of a DOCTYPE.
     eg: 'html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"'
     """
-    m = doctype_lookup_re.match(text)
+    m = doctype_lookup_re.search(text)
     if m is None:
         return False
     doctype = m.group(2)
@@ -196,7 +196,7 @@ def looks_like_xml(text):
     try:
         return _looks_like_xml_cache[key]
     except KeyError:
-        m = doctype_lookup_re.match(text)
+        m = doctype_lookup_re.search(text)
         if m is not None:
             return True
         rv = tag_re.search(text[:1000]) is not None


### PR DESCRIPTION
Replace `re.match` with `re.search` whenever the `re.MULTILINE` / `re.M` flag is present. Fixes #1056.