### PR TITLE
Add execline lexer

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -57,6 +57,7 @@ Programming languages
 * Email
 * Erlang (incl. shell sessions)
 * `Ezhil <http://ezhillang.org>`_
+* `Execline <https://skarnet.org/software/execline>`_
 * Factor
 * Fancy
 * Fantom

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -152,6 +152,7 @@ LEXERS = {
     'EvoqueHtmlLexer': ('pygments.lexers.templates', 'HTML+Evoque', ('html+evoque',), ('*.html',), ('text/html+evoque',)),
     'EvoqueLexer': ('pygments.lexers.templates', 'Evoque', ('evoque',), ('*.evoque',), ('application/x-evoque',)),
     'EvoqueXmlLexer': ('pygments.lexers.templates', 'XML+Evoque', ('xml+evoque',), ('*.xml',), ('application/xml+evoque',)),
+    'ExeclineLexer': ('pygments.lexers.shell', 'execline', ('execline',), ('*.exec',), ()),
     'EzhilLexer': ('pygments.lexers.ezhil', 'Ezhil', ('ezhil',), ('*.n',), ('text/x-ezhil',)),
     'FSharpLexer': ('pygments.lexers.dotnet', 'F#', ('fsharp', 'f#'), ('*.fs', '*.fsi'), ('text/x-fsharp',)),
     'FactorLexer': ('pygments.lexers.factor', 'Factor', ('factor',), ('*.factor',), ('text/x-factor',)),

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -889,6 +889,7 @@ class ExeclineLexer(RegexLexer):
             (r'(?s)"(\\.|[^"\\$])*"', String.Double),
             (r'"', String.Double, 'string'),
             (r'\s+', Text),
+            (r'[^\s{}$"\\]+', Text)
         ],
         'string': [
             (r'"', String.Double, '#pop'),

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -854,7 +854,7 @@ class ExeclineLexer(RegexLexer):
     Lexer for Laurent Bercot's execline language
     (https://skarnet.org/software/execline).
 
-    .. versionadded:: 2.6
+    .. versionadded:: 2.7
     """
 
     name = 'execline'

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -852,6 +852,9 @@ class FishShellLexer(RegexLexer):
 class ExeclineLexer(RegexLexer):
     """
     Lexer for Laurent Bercot's execline language
+    (https://skarnet.org/software/execline).
+
+    .. versionadded:: 2.6
     """
 
     name = 'execline'

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -20,7 +20,8 @@ from pygments.util import shebang_matches
 
 __all__ = ['BashLexer', 'BashSessionLexer', 'TcshLexer', 'BatchLexer',
            'SlurmBashLexer', 'MSDOSSessionLexer', 'PowerShellLexer',
-           'PowerShellSessionLexer', 'TcshSessionLexer', 'FishShellLexer']
+           'PowerShellSessionLexer', 'TcshSessionLexer', 'FishShellLexer',
+           'ExeclineLexer']
 
 line_re = re.compile('.*?\n')
 
@@ -847,3 +848,59 @@ class FishShellLexer(RegexLexer):
             include('root'),
         ],
     }
+
+class ExeclineLexer(RegexLexer):
+    """
+    Lexer for Laurent Bercot's execline language
+    """
+
+    name = 'execline'
+    aliases = ['execline']
+    filenames = ['*.exec']
+
+    tokens = {
+        'root': [
+            include('basic'),
+            include('data'),
+            include('interp')
+        ],
+        'interp': [
+            (r'\$\{', String.Interpol, 'curly'),
+            (r'\$[\w@#]+', Name.Variable),  # user variable
+            (r'\$', Text),
+        ],
+        'basic': [
+            (r'\b(background|backtick|cd|define|dollarat|elgetopt|'
+             r'elgetpositionals|elglob|emptyenv|envfile|exec|execlineb|'
+             r'exit|export|fdblock|fdclose|fdmove|fdreserve|fdswap|'
+             r'forbacktickx|foreground|forstdin|forx|getcwd|getpid|heredoc|'
+             r'homeof|if|ifelse|ifte|ifthenelse|importas|loopwhilex|'
+             r'multidefine|multisubstitute|pipeline|piperw|posix-cd|'
+             r'redirfd|runblock|shift|trap|tryexec|umask|unexport|wait|'
+             r'withstdinas)\b', Name.Builtin),
+            (r'\A#!.+\n', Comment.Hashbang),
+            (r'#.*\n', Comment.Single),
+            (r'[{}]', Operator)
+        ],
+        'data': [
+            (r'(?s)"(\\.|[^"\\$])*"', String.Double),
+            (r'"', String.Double, 'string'),
+            (r'\s+', Text),
+        ],
+        'string': [
+            (r'"', String.Double, '#pop'),
+            (r'(?s)(\\\\|\\.|[^"\\$])+', String.Double),
+            include('interp'),
+        ],
+        'curly': [
+            (r'\}', String.Interpol, '#pop'),
+            (r'[\w#@]+', Name.Variable),
+            include('root')
+        ]
+
+    }
+
+    def analyse_text(text):
+        if shebang_matches(text, r'execlineb'):
+            return 1
+

--- a/tests/examplefiles/example.exec
+++ b/tests/examplefiles/example.exec
@@ -1,0 +1,37 @@
+#!/usr/bin/execlineb
+
+importas -iu SPEC 1
+shift
+elgetpositionals
+
+ifelse -nX {
+    heredoc -d 0 ${SPEC}
+    s6-grep -qE "^([[:alpha:]]+(_[[:digit:]]+)?/)*([[:alpha:]]+(_[[:digit:]]+)?):[[:digit:]]+$"
+} {
+    foreground {
+        fdmove 1 2
+        echo "Bad argument"
+    }
+    exit 1
+}
+
+multidefine -0d: ${SPEC} { QUEUESPEC THREADSPEC }
+
+define -s -d/ QUEUELIST ${QUEUESPEC}
+backtick -ni CMDLINE {
+    forx -o0 QUEUEPAT { ${QUEUELIST} }
+    importas -i Q QUEUEPAT
+    ifelse -X {
+        heredoc -d 0 ${Q}
+        s6-grep -qE "^[[:alpha:]]+_[[:digit:]]+$"
+    } {
+        multidefine -0d_ ${Q} { QNAM QPRIO }
+        echo -n "-q ${QNAM},${QPRIO} "
+    }
+    echo -n "-q ${Q} "
+}
+
+importas -ui CMDLINE CMDLINE
+define -s -d" " ARGS ${CMDLINE}
+${@} ${ARGS} -c ${THREADSPEC}
+


### PR DESCRIPTION
This introduces a lexer for [execline](https://skarnet.org/software/execline), a small scripting language. Execline isn't really a "shell" language per se (like bash, etc.), however the syntax is sufficiently similar that I thought it would be sensible to add it to `pygments.lexers.shell`.