### PR TITLE
Add support for PowerShell Remoting sessions

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -772,7 +772,7 @@ class PowerShellSessionLexer(ShellSessionBaseLexer):
     mimetypes = []
 
     _innerLexerCls = PowerShellLexer
-    _ps1rgx = re.compile(r'^((?:\[[^]]+\]: )?PS [^>]+> )(.*\n?)')
+    _ps1rgx = re.compile(r'^((?:\[[^]]+\]: )?PS [^>]+> ?)(.*\n?)')
     _ps2 = '>> '
 
 

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -772,7 +772,7 @@ class PowerShellSessionLexer(ShellSessionBaseLexer):
     mimetypes = []
 
     _innerLexerCls = PowerShellLexer
-    _ps1rgx = re.compile(r'^(PS [^>]+> )(.*\n?)')
+    _ps1rgx = re.compile(r'^((?:\[[^]]+\]: )?PS [^>]+> )(.*\n?)')
     _ps2 = '>> '
 
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -169,6 +169,17 @@ def test_msdos_gt_only(lexer_msdos):
     assert list(lexer_msdos.get_tokens(fragment)) == tokens
 
 
+def test_powershell_session(lexer_powershell_session):
+    fragment = u'PS C:\\> Get-ChildItem\n'
+    tokens = [
+        (Token.Name.Builtin, u''),
+        (Token.Generic.Prompt, u'PS C:\\> '),
+        (Token.Name.Builtin, u'Get-ChildItem'),
+        (Token.Text, u'\n')
+    ]
+    assert list(lexer_powershell_session.get_tokens(fragment)) == tokens
+
+
 def test_powershell_remoting_session(lexer_powershell_session):
     fragment = u'[Long-NetBIOS-Hostname]: PS C:\\> Get-ChildItem\n'
     tokens = [

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -170,7 +170,7 @@ def test_msdos_gt_only(lexer_msdos):
 
 
 def test_powershell_remoting_session(lexer_powershell_session):
-    fragment = u'[Long-NetBIOS-Hostname]: PS C:\> Get-ChildItem\n'
+    fragment = u'[Long-NetBIOS-Hostname]: PS C:\\> Get-ChildItem\n'
     tokens = [
         (Token.Name.Builtin, u''),
         (Token.Generic.Prompt, u'[Long-NetBIOS-Hostname]: PS C:\\> '),

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -10,7 +10,7 @@
 import pytest
 
 from pygments.token import Token
-from pygments.lexers import BashLexer, BashSessionLexer, MSDOSSessionLexer
+from pygments.lexers import BashLexer, BashSessionLexer, MSDOSSessionLexer, PowerShellSessionLexer
 
 
 @pytest.fixture(scope='module')
@@ -26,6 +26,11 @@ def lexer_session():
 @pytest.fixture(scope='module')
 def lexer_msdos():
     yield MSDOSSessionLexer()
+
+
+@pytest.fixture(scope='module')
+def lexer_powershell_session():
+    yield PowerShellSessionLexer()
 
 
 def test_curly_no_escape_and_quotes(lexer_bash):
@@ -162,6 +167,18 @@ def test_msdos_gt_only(lexer_msdos):
         (Token.Generic.Output, u'hi\n'),
     ]
     assert list(lexer_msdos.get_tokens(fragment)) == tokens
+
+
+def test_powershell_remoting_session(lexer_powershell_session):
+    fragment = u'[Long-NetBIOS-Hostname]: PS C:\> Get-ChildItem\n'
+    tokens = [
+        (Token.Name.Builtin, u''),
+        (Token.Generic.Prompt, u'[Long-NetBIOS-Hostname]: PS C:\\> '),
+        (Token.Name.Builtin, u'Get-ChildItem'),
+        (Token.Text, u'\n')
+    ]
+    assert list(lexer_powershell_session.get_tokens(fragment)) == tokens
+
 
 def test_virtualenv(lexer_session):
     fragment = u'(env) [~/project]$ foo -h\n'


### PR DESCRIPTION
I have added support for PowerShell Remoting (also called WinRM) sessions to the PowerShellSessionLexer. These follow the format below.

```
[Hostname]: PS C:\> Get-ChildItem
```

I have added this by adding an optional non-capturing group to the regex in front of the traditional regex. I hope this follows all the rules and that I did not miss an edge case.