### PR TITLE
Matlabsession line continuation

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -97,7 +97,7 @@ class MatlabLexer(RegexLexer):
             ("(" + "|".join(elfun + specfun + elmat) + r')\b',  Name.Builtin),
 
             # line continuation with following comment:
-            (r'\.\.\..*$', Comment),
+            (r'(\.\.\.)(.*)$', bygroups(Keyword, Comment)),
 
             # command form:
             # "How MATLAB Recognizes Command Syntax" specifies that an operator

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -147,6 +147,12 @@ class MatlabLexer(RegexLexer):
             (r"[^']*'", String, '#pop'),
         ],
         'commandargs': [
+            # If an equal sign or other operator is encountered, this
+            # isn't a command. It might be a variable assignment or
+            # comparison operation with multiple spaces before the
+            # equal sign or operator
+            (r"=", Punctuation, '#pop'),
+            (_operators, Operator, '#pop'),
             (r"[ \t]+", Text),
             ("'[^']*'", String),
             (r"[^';\s]+", String),

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -45,30 +45,30 @@ class MatlabLexer(RegexLexer):
     # specfun: Special Math functions
     # elmat: Elementary matrices and matrix manipulation
     #
-    # taken from Matlab version 7.4.0.336 (R2007a)
+    # taken from Matlab version 9.4 (R2018a)
     #
     elfun = ("sin", "sind", "sinh", "asin", "asind", "asinh", "cos", "cosd", "cosh",
              "acos", "acosd", "acosh", "tan", "tand", "tanh", "atan", "atand", "atan2",
-             "atanh", "sec", "secd", "sech", "asec", "asecd", "asech", "csc", "cscd",
+             "atan2d", "atanh", "sec", "secd", "sech", "asec", "asecd", "asech", "csc", "cscd",
              "csch", "acsc", "acscd", "acsch", "cot", "cotd", "coth", "acot", "acotd",
-             "acoth", "hypot", "exp", "expm1", "log", "log1p", "log10", "log2", "pow2",
+             "acoth", "hypot", "deg2rad", "rad2deg", "exp", "expm1", "log", "log1p", "log10", "log2", "pow2",
              "realpow", "reallog", "realsqrt", "sqrt", "nthroot", "nextpow2", "abs",
              "angle", "complex", "conj", "imag", "real", "unwrap", "isreal", "cplxpair",
              "fix", "floor", "ceil", "round", "mod", "rem", "sign")
     specfun = ("airy", "besselj", "bessely", "besselh", "besseli", "besselk", "beta",
-               "betainc", "betaln", "ellipj", "ellipke", "erf", "erfc", "erfcx",
-               "erfinv", "expint", "gamma", "gammainc", "gammaln", "psi", "legendre",
+               "betainc", "betaincinv", "betaln", "ellipj", "ellipke", "erf", "erfc", "erfcx",
+               "erfinv", "erfcinv", "expint", "gamma", "gammainc", "gammaincinv", "gammaln", "psi", "legendre",
                "cross", "dot", "factor", "isprime", "primes", "gcd", "lcm", "rat",
                "rats", "perms", "nchoosek", "factorial", "cart2sph", "cart2pol",
                "pol2cart", "sph2cart", "hsv2rgb", "rgb2hsv")
-    elmat = ("zeros", "ones", "eye", "repmat", "rand", "randn", "linspace", "logspace",
+    elmat = ("zeros", "ones", "eye", "repmat", "repelem", "linspace", "logspace",
              "freqspace", "meshgrid", "accumarray", "size", "length", "ndims", "numel",
-             "disp", "isempty", "isequal", "isequalwithequalnans", "cat", "reshape",
-             "diag", "blkdiag", "tril", "triu", "fliplr", "flipud", "flipdim", "rot90",
+             "disp", "isempty", "isequal", "isequaln", "cat", "reshape",
+             "diag", "blkdiag", "tril", "triu", "fliplr", "flipud", "flip", "rot90",
              "find", "end", "sub2ind", "ind2sub", "bsxfun", "ndgrid", "permute",
              "ipermute", "shiftdim", "circshift", "squeeze", "isscalar", "isvector",
-             "ans", "eps", "realmax", "realmin", "pi", "i", "inf", "nan", "isnan",
-             "isinf", "isfinite", "j", "why", "compan", "gallery", "hadamard", "hankel",
+             "isrow", "iscolumn", "ismatrix", "eps", "realmax", "realmin", "intmax", "intmin", "flintmax", "pi", "i", "inf", "nan", "isnan",
+             "isinf", "isfinite", "j", "true", "false", "compan", "gallery", "hadamard", "hankel",
              "hilb", "invhilb", "magic", "pascal", "rosser", "toeplitz", "vander",
              "wilkinson")
 
@@ -83,13 +83,13 @@ class MatlabLexer(RegexLexer):
             (r'%.*$', Comment),
             (r'^\s*function\b', Keyword, 'deffunc'),
 
-            # from 'iskeyword' on version 7.11 (R2010):
+            # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
             # names.
             (words(('break', 'case', 'catch', 'classdef', 'continue', 'else',
-                    'elseif', 'end', 'enumerated', 'events', 'for', 'function',
-                    'global', 'if', 'methods', 'otherwise', 'parfor',
-                    'persistent', 'properties', 'return', 'spmd', 'switch',
+                    'elseif', 'end', 'for', 'function',
+                    'global', 'if', 'otherwise', 'parfor',
+                    'persistent', 'return', 'spmd', 'switch',
                     'try', 'while'),
                    prefix=r'(?<!\.)', suffix=r'\b'),
              Keyword),

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""
+    MATLAB Tests
+    ~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments.token import Token
+from pygments.lexers import MatlabLexer
+
+
+@pytest.fixture(scope='module')
+def lexer():
+    yield MatlabLexer()
+
+
+def test_single_line(lexer):
+    """
+    Test that a single line with strings, a method, and numbers is parsed correctly.
+    """
+    fragment = "set('T',300,'P',101325);\n"
+    tokens = [
+        (Token.Name, 'set'),
+        (Token.Punctuation, '('),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "T'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '300'),
+        (Token.Punctuation, ','),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "P'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '101325'),
+        (Token.Punctuation, ')'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_line_continuation(lexer):
+    """
+    Test that line continuation by ellipses does not produce generic
+    output on the second line.
+    """
+    fragment = "set('T',300,...\n'P',101325);\n"
+    tokens = [
+        (Token.Name, 'set'),
+        (Token.Punctuation, '('),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "T'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '300'),
+        (Token.Punctuation, ','),
+        (Token.Keyword, '...'),
+        (Token.Text, '\n'),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "P'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '101325'),
+        (Token.Punctuation, ')'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_keywords_ended_by_newline(lexer):
+    """Test that keywords on their own line are marked as keywords."""
+    fragment = "if x > 100\n    disp('x > 100')\nelse\n    disp('x < 100')\nend\n"
+    tokens = [
+        (Token.Keyword, 'if'),
+        (Token.Text, ' '),
+        (Token.Name, 'x'),
+        (Token.Text, ' '),
+        (Token.Operator, '>'),
+        (Token.Text, ' '),
+        (Token.Literal.Number.Integer, '100'),
+        (Token.Text, '\n'),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Name.Builtin, 'disp'),
+        (Token.Punctuation, '('),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "x > 100'"),
+        (Token.Punctuation, ')'),
+        (Token.Text, '\n'),
+        (Token.Keyword, 'else'),
+        (Token.Text, '\n'),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Name.Builtin, 'disp'),
+        (Token.Punctuation, '('),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "x < 100'"),
+        (Token.Punctuation, ')'),
+        (Token.Text, '\n'),
+        (Token.Keyword, 'end'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_comment_after_continuation(lexer):
+    """
+    Test that text after the line continuation ellipses is marked as a comment.
+    """
+    fragment = "set('T',300,... a comment\n'P',101325);\n"
+    tokens = [
+        (Token.Name, 'set'),
+        (Token.Punctuation, '('),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "T'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '300'),
+        (Token.Punctuation, ','),
+        (Token.Keyword, '...'),
+        (Token.Comment, ' a comment'),
+        (Token.Text, '\n'),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "P'"),
+        (Token.Punctuation, ','),
+        (Token.Literal.Number.Integer, '101325'),
+        (Token.Punctuation, ')'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_multiple_spaces_variable_assignment(lexer):
+    """
+    Test that multiple spaces with an equal sign doesn't get formatted to a string.
+    """
+    fragment = 'x  = 100;\n'
+    tokens = [
+        (Token.Name, 'x'),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Punctuation, '='),
+        (Token.Text, ' '),
+        (Token.Literal.Number.Integer, '100'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_operator_multiple_space(lexer):
+    """
+    Test that multiple spaces with an operator doesn't get formatted to a string.
+    """
+    fragment = 'x  > 100;\n'
+    tokens = [
+        (Token.Name, 'x'),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Operator, '>'),
+        (Token.Text, ' '),
+        (Token.Literal.Number.Integer, '100'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_one_space_assignment(lexer):
+    """Test that one space before an equal sign is formatted correctly."""
+    fragment = 'x = 100;\n'
+    tokens = [
+        (Token.Name, 'x'),
+        (Token.Text, ' '),
+        (Token.Punctuation, '='),
+        (Token.Text, ' '),
+        (Token.Literal.Number.Integer, '100'),
+        (Token.Punctuation, ';'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_command_mode(lexer):
+    """
+    MATLAB allows char function arguments to not be enclosed by parentheses
+    or contain quote characters, as long as they are space separated. Test
+    that one common such function is formatted appropriately.
+    """
+    fragment = 'help sin\n'
+    tokens = [
+        (Token.Name, 'help'),
+        (Token.Text, ' '),
+        (Token.Literal.String, 'sin'),
+        (Token.Punctuation, ''),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
There are a few changes wrapped up here:

1. Allow explicit line continuation in the `matlabsession` lexer. This allows this syntax:
   ```matlab
   set('T', 100.0, ...
   'P', 1.0e5);
   ```
   Previously, the second line was marked as generic output.
2. ~Keywords previously could only be ended by a word boundary, which does not include a newline. However, some keywords (`else`, `end`) are often on their own line. These keywords are now highlighted correctly.~
3. The ellipses used for line continuations are now highlighted as a Keyword, which better matches the built-in Matlab highlighter.
4. The functions and keywords which should be highlighted have been updated from Matlab R2018a. I removed the old keywords that did not appear in the output of the included bash script, but they could be retained for backwards compatibility. I could also update the lists from Matlab R2020a, but since I had R2018a handy, I just used that. Let me know!

Thank you!