### PR TITLE
Update lexer for the Chapel programming language

### DIFF
--- a/pygments/lexers/chapel.py
+++ b/pygments/lexers/chapel.py
@@ -48,7 +48,7 @@ class ChapelLexer(RegexLexer):
                 'defer', 'delete', 'dmapped', 'do', 'domain',
                 'else', 'enum', 'except', 'export', 'extern',
                 'for', 'forall', 'forwarding',
-                'if', 'index', 'init', 'inline',
+                'if', 'import', 'index', 'init', 'inline',
                 'label', 'lambda', 'let', 'lifetime', 'local', 'locale'
                 'new', 'noinit',
                 'on', 'only', 'otherwise', 'override', 'owned',

--- a/pygments/lexers/chapel.py
+++ b/pygments/lexers/chapel.py
@@ -18,7 +18,7 @@ __all__ = ['ChapelLexer']
 
 class ChapelLexer(RegexLexer):
     """
-    For `Chapel <http://chapel.cray.com/>`_ source.
+    For `Chapel <https://chapel-lang.org/>`_ source.
 
     .. versionadded:: 2.0
     """


### PR DESCRIPTION
This change adds a new keyword, `import`, to the list of keywords.

It also updates the website link at the top of the class, as it is a few
years out of date - the old link will redirect to the new one, but we should
still use the new one instead. 