### PR TITLE
Make HttpLexer compatible with RFC 7230 (section 3.1.2).

### DIFF
--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -179,7 +179,7 @@ class HttpLexer(RegexLexer):
              bygroups(Name.Function, Text, Name.Namespace, Text,
                       Keyword.Reserved, Operator, Number, Text),
              'headers'),
-            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(?:( +)([^\r\n]+))?(\r?\n|\Z)',
+            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(?:( +)([^\r\n]*))?(\r?\n|\Z)',
              bygroups(Keyword.Reserved, Operator, Number, Text, Number, Text,
                       Name.Exception, Text),
              'headers'),

--- a/tests/test_textfmts.py
+++ b/tests/test_textfmts.py
@@ -46,6 +46,20 @@ def test_http_status_line_without_reason_phrase(lexer):
     assert list(lexer.get_tokens(fragment)) == tokens
 
 
+def test_http_status_line_without_reason_phrase_rfc_7230(lexer):
+    fragment = u'HTTP/1.1 200 \n'
+    tokens = [
+        (Token.Keyword.Reserved, u'HTTP'),
+        (Token.Operator, u'/'),
+        (Token.Number, u'1.1'),
+        (Token.Text, u' '),
+        (Token.Number, u'200'),
+        (Token.Text, u' '),
+        (Token.Text, u'\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
 def test_application_xml(lexer):
     fragment = u'GET / HTTP/1.0\nContent-Type: application/xml\n\n<foo>\n'
     tokens = [


### PR DESCRIPTION
Specifically this addresses for the case where only a numeric HTTP status code is returned (eg. 200) and no textual reason phrase (eg. OK).  Strictly according to RFC 7230, the white space just after the status code number is NOT optional, and in fact Tomcat 8.5 behaves this way, emitting status lines like "HTTP/1.1 200 \n" (note the white space after the 200).