### PR TITLE
Add support for (System)Verilog escaped identifiers

### DIFF
--- a/pygments/lexers/hdl.py
+++ b/pygments/lexers/hdl.py
@@ -110,6 +110,7 @@ class VerilogLexer(RegexLexer):
              Keyword.Type),
             (r'[a-zA-Z_]\w*:(?!:)', Name.Label),
             (r'\$?[a-zA-Z_]\w*', Name),
+            (r'\\(\S+)', Name),
         ],
         'string': [
             (r'"', String, '#pop'),
@@ -316,6 +317,7 @@ class SystemVerilogLexer(RegexLexer):
              Keyword.Type),
             (r'[a-zA-Z_]\w*:(?!:)', Name.Label),
             (r'\$?[a-zA-Z_]\w*', Name),
+            (r'\\(\S+)', Name),
         ],
         'classname': [
             (r'[a-zA-Z_]\w*', Name.Class, '#pop'),


### PR DESCRIPTION
The escaped identifiers start with a backslash, end with whitespace, and can include any character that is not whitespace.

See IEEE 1364-2005 §3.7.1 and IEEE 1800-2017 §5.6.1.