### PR TITLE
fixed fortran literal regex pattern

### DIFF
--- a/pygments/lexers/fortran.py
+++ b/pygments/lexers/fortran.py
@@ -155,10 +155,10 @@ class FortranLexer(RegexLexer):
         ],
 
         'nums': [
-            (r'\d+(?![.e])(_[a-z]\w+)?', Number.Integer),
-            (r'[+-]?\d*\.\d+([ed][-+]?\d+)?(_[a-z]\w+)?', Number.Float),
-            (r'[+-]?\d+\.\d*([ed][-+]?\d+)?(_[a-z]\w+)?', Number.Float),
-            (r'[+-]?\d+(\.\d*)?[ed][-+]?\d+(_[a-z]\w+)?', Number.Float),
+            (r'\d+(?![.e])(_([1-9]|[a-z]\w*))?', Number.Integer),
+            (r'[+-]?\d*\.\d+([ed][-+]?\d+)?(_([1-9]|[a-z]\w*))?', Number.Float),
+            (r'[+-]?\d+\.\d*([ed][-+]?\d+)?(_([1-9]|[a-z]\w*))?', Number.Float),
+            (r'[+-]?\d+(\.\d*)?[ed][-+]?\d+(_([1-9]|[a-z]\w*))?', Number.Float),
         ],
     }
 


### PR DESCRIPTION
This fix let the fortran lexer properly handle literal expressions with kind parameters specified as follows:
```
  integer :: n = 128_4
  real(8) :: pi = 3.14_8
```

I believe this is part of the fortran standard.