### PR TITLE
Change Verilog 'wo' to 'wor'

### DIFF
--- a/pygments/lexers/hdl.py
+++ b/pygments/lexers/hdl.py
@@ -105,7 +105,7 @@ class VerilogLexer(RegexLexer):
             (words((
                 'byte', 'shortint', 'int', 'longint', 'integer', 'time',
                 'bit', 'logic', 'reg', 'supply0', 'supply1', 'tri', 'triand',
-                'trior', 'tri0', 'tri1', 'trireg', 'uwire', 'wire', 'wand', 'wo'
+                'trior', 'tri0', 'tri1', 'trireg', 'uwire', 'wire', 'wand', 'wor'
                 'shortreal', 'real', 'realtime'), suffix=r'\b'),
              Keyword.Type),
             (r'[a-zA-Z_]\w*:(?!:)', Name.Label),


### PR DESCRIPTION
There is no 'wo' keyword.
This was probably supposed to be 'wor', short for "wired OR".