### PR TITLE
Nasm: Update register syntax for 64-bit

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -686,7 +686,7 @@ class NasmLexer(RegexLexer):
     floatn = decn + r'\.e?' + decn
     string = r'"(\\"|[^"\n])*"|' + r"'(\\'|[^'\n])*'|" + r"`(\\`|[^`\n])*`"
     declkw = r'(?:res|d)[bwdqt]|times'
-    register = (r'r[0-9][0-5]?[bwd]|'
+    register = (r'r[0-9][0-5]?[bwd]?|'
                 r'[a-d][lh]|[er]?[a-d]x|[er]?[sb]p|[er]?[sd]i|[c-gs]s|st[0-7]|'
                 r'mm[0-7]|cr[0-4]|dr[0-367]|tr[3-7]')
     wordop = r'seg|wrt|strict'


### PR DESCRIPTION
x86_64 has 8 registers r8-r15. The current syntax only accepts them with
a trailing letter. The letter is used to indicate the register size.
However, r8 is also a valid register, for a 64 bit wide register.

For reference on the register names see https://www.cs.uaf.edu/2017/fall/cs301/reference/x86_64.html