### PR TITLE
Matlab class properties

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -20,6 +20,7 @@ from pygments.lexers import _scilab_builtins
 __all__ = ['MatlabLexer', 'MatlabSessionLexer', 'OctaveLexer', 'ScilabLexer']
 
 
+
 class MatlabLexer(RegexLexer):
     """
     For Matlab source code.
@@ -107,7 +108,11 @@ class MatlabLexer(RegexLexer):
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
             (r'%.*$', Comment),
             (r'(\s*^\s*)(function)\b', bygroups(Whitespace, Keyword), 'deffunc'),
-            (r'(\s*^\s*)(properties)\b', bygroups(Whitespace, Keyword), 'defprops'),
+            (r'(\s*^\s*)(properties)(\s+)(\()',
+             bygroups(Whitespace, Keyword, Whitespace, Punctuation),
+             ('defprops', 'propattrs')),
+            (r'(\s*^\s*)(properties)\b',
+             bygroups(Whitespace, Keyword), 'defprops'),
 
             # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
@@ -148,6 +153,18 @@ class MatlabLexer(RegexLexer):
             # function with no args
             (r'(\s*)([a-zA-Z_]\w*)',
              bygroups(Whitespace, Name.Function), '#pop'),
+        ],
+        'propattrs': [
+            (r'(\w+)(\s*)(=)(\s*)(\d+)',
+             bygroups(Name.Builtin, Whitespace, Punctuation, Whitespace,
+                      Number)),
+            (r'(\w+)(\s*)(=)(\s*)([a-zA-Z]\w*)',
+             bygroups(Name.Builtin, Whitespace, Punctuation, Whitespace,
+                      Keyword)),
+            (r',', Punctuation),
+            (r'\)', Punctuation, '#pop'),
+            (r'\s+', Whitespace),
+            (r'.', Text),
         ],
         'defprops': [
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -81,7 +81,7 @@ class MatlabLexer(RegexLexer):
             (r'^!.*', String.Other),
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
             (r'%.*$', Comment),
-            (r'^\s*function\b', Keyword, 'deffunc'),
+            (r'(\s*^\s*)(function)\b', bygroups(Text, Keyword), 'deffunc'),
 
             # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
@@ -91,8 +91,8 @@ class MatlabLexer(RegexLexer):
                     'global', 'if', 'methods', 'otherwise', 'parfor',
                     'persistent', 'return', 'spmd', 'switch',
                     'try', 'while'),
-                   prefix=r'(?<!\.)', suffix=r'\b'),
-             Keyword),
+                   prefix=r'(?<!\.)(\s*)(', suffix=r')\b'),
+             bygroups(Text, Keyword)),
 
             ("(" + "|".join(elfun + specfun + elmat) + r')\b',  Name.Builtin),
 

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -82,6 +82,7 @@ class MatlabLexer(RegexLexer):
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
             (r'%.*$', Comment),
             (r'(\s*^\s*)(function)\b', bygroups(Text, Keyword), 'deffunc'),
+            (r'(\s*^\s*)(properties)\b', bygroups(Text, Keyword), 'defprops'),
 
             # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
@@ -142,6 +143,13 @@ class MatlabLexer(RegexLexer):
                       Punctuation, Whitespace), '#pop'),
             # function with no args
             (r'(\s*)([a-zA-Z_]\w*)', bygroups(Text, Name.Function), '#pop'),
+        ],
+        'defprops': [
+            (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
+            (r'%.*$', Comment),
+            (r'(?<!\.)end\b', Keyword, '#pop'),
+            (r'\w+', Name),
+            (r'\s*', Text)
         ],
         'string': [
             (r"[^']*'", String, '#pop'),

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -129,8 +129,8 @@ class MatlabLexer(RegexLexer):
             # is recognized if it is either surrounded by spaces or by no
             # spaces on both sides; only the former case matters for us.  (This
             # allows distinguishing `cd ./foo` from `cd ./ foo`.)
-            (r'(?:^|(?<=;))(\s*)(\w+)(\s+)(?!=|\(|(?:%s)\s+)' % _operators,
-             bygroups(Text, Name, Text), 'commandargs'),
+            (r'(?:^|(?<=;))(\s*)(\w+)(\s+)(?!=|\(|(?:%s)\s+|\s)' % _operators,
+             bygroups(Whitespace, Name, Whitespace), 'commandargs'),
 
             include('expressions')
         ],

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -86,9 +86,9 @@ class MatlabLexer(RegexLexer):
             # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
             # names.
-            (words(('break', 'case', 'catch', 'classdef', 'continue', 'else',
-                    'elseif', 'end', 'for', 'function',
-                    'global', 'if', 'otherwise', 'parfor',
+            (words(('break', 'case', 'catch', 'classdef', 'continue',
+                    'dynamicprops', 'else', 'elseif', 'end', 'for', 'function',
+                    'global', 'if', 'methods', 'otherwise', 'parfor',
                     'persistent', 'return', 'spmd', 'switch',
                     'try', 'while'),
                    prefix=r'(?<!\.)', suffix=r'\b'),

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -97,6 +97,7 @@ class MatlabLexer(RegexLexer):
 
             (r'(?<![\w)\].])\'', String, 'string'),
             (r'[a-zA-Z_]\w*', Name),
+            (r'\s+', Whitespace),
             (r'.', Text),
         ],
         'root': [
@@ -105,8 +106,8 @@ class MatlabLexer(RegexLexer):
             (r'^!.*', String.Other),
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
             (r'%.*$', Comment),
-            (r'(\s*^\s*)(function)\b', bygroups(Text, Keyword), 'deffunc'),
-            (r'(\s*^\s*)(properties)\b', bygroups(Text, Keyword), 'defprops'),
+            (r'(\s*^\s*)(function)\b', bygroups(Whitespace, Keyword), 'deffunc'),
+            (r'(\s*^\s*)(properties)\b', bygroups(Whitespace, Keyword), 'defprops'),
 
             # from 'iskeyword' on version 9.4 (R2018a):
             # Check that there is no preceding dot, as keywords are valid field
@@ -117,7 +118,7 @@ class MatlabLexer(RegexLexer):
                     'persistent', 'return', 'spmd', 'switch',
                     'try', 'while'),
                    prefix=r'(?<!\.)(\s*)(', suffix=r')\b'),
-             bygroups(Text, Keyword)),
+             bygroups(Whitespace, Keyword)),
 
             ("(" + "|".join(elfun + specfun + elmat) + r')\b',  Name.Builtin),
 
@@ -145,7 +146,8 @@ class MatlabLexer(RegexLexer):
                       Whitespace, Name.Function, Punctuation, Text,
                       Punctuation, Whitespace), '#pop'),
             # function with no args
-            (r'(\s*)([a-zA-Z_]\w*)', bygroups(Text, Name.Function), '#pop'),
+            (r'(\s*)([a-zA-Z_]\w*)',
+             bygroups(Whitespace, Name.Function), '#pop'),
         ],
         'defprops': [
             (r'%\{\s*\n', Comment.Multiline, 'blockcomment'),
@@ -163,7 +165,7 @@ class MatlabLexer(RegexLexer):
             # equal sign or operator
             (r"=", Punctuation, '#pop'),
             (_operators, Operator, '#pop'),
-            (r"[ \t]+", Text),
+            (r"[ \t]+", Whitespace),
             ("'[^']*'", String),
             (r"[^';\s]+", String),
             (";", Punctuation, '#pop'),
@@ -652,7 +654,8 @@ class OctaveLexer(RegexLexer):
                       Whitespace, Name.Function, Punctuation, Text,
                       Punctuation, Whitespace), '#pop'),
             # function with no args
-            (r'(\s*)([a-zA-Z_]\w*)', bygroups(Text, Name.Function), '#pop'),
+            (r'(\s*)([a-zA-Z_]\w*)',
+             bygroups(Whitespace, Name.Function), '#pop'),
         ],
     }
 

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -149,7 +149,7 @@ class MatlabLexer(RegexLexer):
             (r'%.*$', Comment),
             (r'(?<!\.)end\b', Keyword, '#pop'),
             (r'\w+', Name),
-            (r'\s*', Text)
+            (r'\s+|.', Text)
         ],
         'string': [
             (r"[^']*'", String, '#pop'),

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -36,7 +36,7 @@ def test_single_line(lexer):
         (Token.Literal.Number.Integer, '101325'),
         (Token.Punctuation, ')'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -56,14 +56,14 @@ def test_line_continuation(lexer):
         (Token.Literal.Number.Integer, '300'),
         (Token.Punctuation, ','),
         (Token.Keyword, '...'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
         (Token.Literal.String, "'"),
         (Token.Literal.String, "P'"),
         (Token.Punctuation, ','),
         (Token.Literal.Number.Integer, '101325'),
         (Token.Punctuation, ')'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -73,37 +73,29 @@ def test_keywords_ended_by_newline(lexer):
     fragment = "if x > 100\n    disp('x > 100')\nelse\n    disp('x < 100')\nend\n"
     tokens = [
         (Token.Keyword, 'if'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Name, 'x'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Operator, '>'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Literal.Number.Integer, '100'),
-        (Token.Text, '\n'),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, '\n    '),
         (Token.Name.Builtin, 'disp'),
         (Token.Punctuation, '('),
         (Token.Literal.String, "'"),
         (Token.Literal.String, "x > 100'"),
         (Token.Punctuation, ')'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
         (Token.Keyword, 'else'),
-        (Token.Text, '\n'),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, '\n    '),
         (Token.Name.Builtin, 'disp'),
         (Token.Punctuation, '('),
         (Token.Literal.String, "'"),
         (Token.Literal.String, "x < 100'"),
         (Token.Punctuation, ')'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
         (Token.Keyword, 'end'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -123,14 +115,14 @@ def test_comment_after_continuation(lexer):
         (Token.Punctuation, ','),
         (Token.Keyword, '...'),
         (Token.Comment, ' a comment'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
         (Token.Literal.String, "'"),
         (Token.Literal.String, "P'"),
         (Token.Punctuation, ','),
         (Token.Literal.Number.Integer, '101325'),
         (Token.Punctuation, ')'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -142,13 +134,12 @@ def test_multiple_spaces_variable_assignment(lexer):
     fragment = 'x  = 100;\n'
     tokens = [
         (Token.Name, 'x'),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, '  '),
         (Token.Punctuation, '='),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Literal.Number.Integer, '100'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -160,13 +151,12 @@ def test_operator_multiple_space(lexer):
     fragment = 'x  > 100;\n'
     tokens = [
         (Token.Name, 'x'),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, '  '),
         (Token.Operator, '>'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Literal.Number.Integer, '100'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -176,12 +166,12 @@ def test_one_space_assignment(lexer):
     fragment = 'x = 100;\n'
     tokens = [
         (Token.Name, 'x'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Punctuation, '='),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Literal.Number.Integer, '100'),
         (Token.Punctuation, ';'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -195,9 +185,9 @@ def test_command_mode(lexer):
     fragment = 'help sin\n'
     tokens = [
         (Token.Name, 'help'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Literal.String, 'sin'),
-        (Token.Text, '\n'),
+        (Token.Text.Whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -220,54 +210,48 @@ end
 """.strip()
 
 def test_classes_with_properties(lexer):
+    whitespace = Token.Text.Whitespace
     tokens = [
         (Token.Keyword, 'classdef'),
-        (Token.Text, ' '),
+        (whitespace, ' '),
         (Token.Name, 'Name'),
-        (Token.Text, ' '),
+        (whitespace, ' '),
         (Token.Operator, '<'),
-        (Token.Text, ' '),
+        (whitespace, ' '),
         (Token.Keyword, 'dynamicprops'),
-        (Token.Text, '\n    '),
+        (whitespace, '\n    '),
         (Token.Keyword, 'properties'),
-        (Token.Text, '\n        '),
+        (whitespace, '\n        '),
         (Token.Comment, '% i am a comment'),
-        (Token.Text, '\n        '),
+        (whitespace, '\n        '),
         (Token.Name, 'name1'),
-        (Token.Text, '\n        '),
+        (whitespace, '\n        '),
         (Token.Name, 'name2'),
-        (Token.Text, '\n    '),
+        (whitespace, '\n    '),
         (Token.Keyword, 'end'),
-        (Token.Text, '\n    '),
+        (whitespace, '\n    '),
         (Token.Keyword, 'methods'),
-        (Token.Text, '\n'),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
-        (Token.Text, ' '),
+        (whitespace, '\n        '),
         (Token.Comment, '% i am also a comment'),
-        (Token.Text, '\n        '),
+        (whitespace, '\n        '),
         (Token.Keyword, 'function'),
-        (Token.Text.Whitespace, ' '),
-        (Token.Text, 'self '),
+        (whitespace, ' '),
+        (Token.Text, 'self'),
+        (whitespace, ' '),
         (Token.Punctuation, '='),
-        (Token.Text.Whitespace, ' '),
+        (whitespace, ' '),
         (Token.Name.Function, 'Name'),
         (Token.Punctuation, '('),
         (Token.Punctuation, ')'),
-        (Token.Text.Whitespace, '\n            '),
+        (whitespace, '\n            '),
         (Token.Comment, '% i am a comment inside a constructor'),
-        (Token.Text, '\n        '),
+        (whitespace, '\n        '),
         (Token.Keyword, 'end'),
-        (Token.Text, '\n    '),
+        (whitespace, '\n    '),
         (Token.Keyword, 'end'),
-        (Token.Text, '\n'),
+        (whitespace, '\n'),
         (Token.Keyword, 'end'),
-        (Token.Text, '\n'),
+        (whitespace, '\n'),
     ]
     assert list(lexer.get_tokens(MATLAB_SAMPLE_CLASS)) == tokens
 

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -200,6 +200,11 @@ classdef Name < dynamicprops
         name1
         name2
     end
+    properties (Constant = true, SetAccess = protected)
+        % i too am a comment
+        matrix = [0, 1, 2];
+        string = 'i am a string'
+    end
     methods
         % i am also a comment
         function self = Name()
@@ -227,6 +232,49 @@ def test_classes_with_properties(lexer):
         (Token.Name, 'name1'),
         (whitespace, '\n        '),
         (Token.Name, 'name2'),
+        (whitespace, '\n    '),
+        (Token.Keyword, 'end'),
+        (whitespace, '\n    '),
+        (Token.Keyword, 'properties'),
+        (whitespace, ' '),
+        (Token.Punctuation, '('),
+        (Token.Name.Builtin, 'Constant'),
+        (whitespace, ' '),
+        (Token.Punctuation, '='),
+        (whitespace, ' '),
+        (Token.Keyword, 'true'),
+        (Token.Punctuation, ','),
+        (whitespace, ' '),
+        (Token.Name.Builtin, 'SetAccess'),
+        (whitespace, ' '),
+        (Token.Punctuation, '='),
+        (whitespace, ' '),
+        (Token.Keyword, 'protected'),
+        (Token.Punctuation, ')'),
+        (whitespace, "\n        "),
+        (Token.Comment, '% i too am a comment'),
+        (whitespace, '\n        '),
+        (Token.Name, 'matrix'),
+        (whitespace, ' '),
+        (Token.Punctuation, '='),
+        (whitespace, ' '),
+        (Token.Punctuation, '['),
+        (Token.Literal.Number.Integer, '0'),
+        (Token.Punctuation, ','),
+        (whitespace, ' '),
+        (Token.Literal.Number.Integer, '1'),
+        (Token.Punctuation, ','),
+        (whitespace, ' '),
+        (Token.Literal.Number.Integer, '2'),
+        (Token.Punctuation, ']'),
+        (Token.Punctuation, ';'),
+        (whitespace, '\n        '),
+        (Token.Name, 'string'),
+        (whitespace, ' '),
+        (Token.Punctuation, '='),
+        (whitespace, ' '),
+        (Token.Literal.String, "'"),
+        (Token.Literal.String, "i am a string'"),
         (whitespace, '\n    '),
         (Token.Keyword, 'end'),
         (whitespace, '\n    '),

--- a/tests/test_matlab.py
+++ b/tests/test_matlab.py
@@ -200,3 +200,74 @@ def test_command_mode(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+
+MATLAB_SAMPLE_CLASS = """
+classdef Name < dynamicprops
+    properties
+        % i am a comment
+        name1
+        name2
+    end
+    methods
+        % i am also a comment
+        function self = Name()
+            % i am a comment inside a constructor
+        end
+    end
+end
+""".strip()
+
+def test_classes_with_properties(lexer):
+    tokens = [
+        (Token.Keyword, 'classdef'),
+        (Token.Text, ' '),
+        (Token.Name, 'Name'),
+        (Token.Text, ' '),
+        (Token.Operator, '<'),
+        (Token.Text, ' '),
+        (Token.Keyword, 'dynamicprops'),
+        (Token.Text, '\n    '),
+        (Token.Keyword, 'properties'),
+        (Token.Text, '\n        '),
+        (Token.Comment, '% i am a comment'),
+        (Token.Text, '\n        '),
+        (Token.Name, 'name1'),
+        (Token.Text, '\n        '),
+        (Token.Name, 'name2'),
+        (Token.Text, '\n    '),
+        (Token.Keyword, 'end'),
+        (Token.Text, '\n    '),
+        (Token.Keyword, 'methods'),
+        (Token.Text, '\n'),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Text, ' '),
+        (Token.Comment, '% i am also a comment'),
+        (Token.Text, '\n        '),
+        (Token.Keyword, 'function'),
+        (Token.Text.Whitespace, ' '),
+        (Token.Text, 'self '),
+        (Token.Punctuation, '='),
+        (Token.Text.Whitespace, ' '),
+        (Token.Name.Function, 'Name'),
+        (Token.Punctuation, '('),
+        (Token.Punctuation, ')'),
+        (Token.Text.Whitespace, '\n            '),
+        (Token.Comment, '% i am a comment inside a constructor'),
+        (Token.Text, '\n        '),
+        (Token.Keyword, 'end'),
+        (Token.Text, '\n    '),
+        (Token.Keyword, 'end'),
+        (Token.Text, '\n'),
+        (Token.Keyword, 'end'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(MATLAB_SAMPLE_CLASS)) == tokens
+


### PR DESCRIPTION
Given the following Matlab code,

```matlab
classdef Name < dynamicprops
    properties
        % i am a comment
        name1
        name2
    end
    methods
        % i am also a comment
        function self = Name()
            % i am a comment inside a constructor
        end
    end
end
```

pygments' matlab lexer gets very confused indeed. This attempts to improve the situation. Although it does not capture all of [the properties syntax](https://www.mathworks.com/help/matlab/matlab_oop/defining-properties.html), it special-cases `properties` blocks to prevent the list of names from being misinterpreted as the "command syntax." It also prevents the comments from being mistaken for string literals.

Let me know anything I can do to improve the PR. In particular, if you'd like support for the full properties syntax, I can do that, but I wasn't sure of the best way to re-use token rules from the `'root'` in `'defprops'` while maintaining readability.