### PR TITLE
Improve SystemVerilog class/endclass lexer rules

### DIFF
--- a/pygments/lexers/hdl.py
+++ b/pygments/lexers/hdl.py
@@ -191,15 +191,15 @@ class SystemVerilogLexer(RegexLexer):
                 'always_latch', 'and', 'assert', 'assign', 'assume', 'automatic',
                 'before', 'begin', 'bind', 'bins', 'binsof', 'break', 'buf',
                 'bufif0', 'bufif1', 'case', 'casex', 'casez', 'cell',
-                'checker', 'class', 'clocking', 'cmos', 'config',
+                'checker', 'clocking', 'cmos', 'config',
                 'constraint', 'context', 'continue', 'cover', 'covergroup',
                 'coverpoint', 'cross', 'deassign', 'default', 'defparam', 'design',
                 'disable', 'do', 'edge', 'else', 'end', 'endcase',
-                'endchecker', 'endclass', 'endclocking', 'endconfig', 'endfunction',
+                'endchecker', 'endclocking', 'endconfig', 'endfunction',
                 'endgenerate', 'endgroup', 'endinterface', 'endmodule', 'endpackage',
                 'endprimitive', 'endprogram', 'endproperty', 'endsequence',
                 'endspecify', 'endtable', 'endtask', 'enum', 'eventually',
-                'expect', 'export', 'extends', 'extern', 'final', 'first_match',
+                'expect', 'export', 'extern', 'final', 'first_match',
                 'for', 'force', 'foreach', 'forever', 'fork', 'forkjoin', 'function',
                 'generate', 'genvar', 'global', 'highz0', 'highz1', 'if', 'iff',
                 'ifnone', 'ignore_bins', 'illegal_bins', 'implies', 'implements', 'import',
@@ -229,6 +229,13 @@ class SystemVerilogLexer(RegexLexer):
                 'xnor', 'xor'),
                 suffix=r'\b'),
              Keyword),
+
+            (r'(class)(\s+)([a-zA-Z_]\w*)',
+             bygroups(Keyword.Declaration, Text, Name.Class)),
+            (r'(extends)(\s+)([a-zA-Z_]\w*)',
+             bygroups(Keyword.Declaration, Text, Name.Class)),
+            (r'(endclass\b)((\s*)(:)(\s*)([a-zA-Z_]\w*))?',
+             bygroups(Keyword.Declaration, None, Text, Punctuation, Text, Name.Class)),
 
             (words((
                 # Variable types
@@ -331,14 +338,9 @@ class SystemVerilogLexer(RegexLexer):
                 ), suffix=r'\b'),
              Name.Builtin),
 
-            (r'(class)(\s+)', bygroups(Keyword, Text), 'classname'),
-
             (r'[a-zA-Z_]\w*:(?!:)', Name.Label),
             (r'\$?[a-zA-Z_]\w*', Name),
             (r'\\(\S+)', Name),
-        ],
-        'classname': [
-            (r'[a-zA-Z_]\w*', Name.Class, '#pop'),
         ],
         'string': [
             (r'"', String, '#pop'),

--- a/tests/test_hdl.py
+++ b/tests/test_hdl.py
@@ -592,3 +592,96 @@ def test_systemverilog_operators(lexer):
     """Test various operators"""
     tokens = list(lexer.get_tokens(SYSTEMVERILOG_OPERATORS_TEXT))
     assert tokens == SYSTEMVERILOG_OPERATORS_TOKENS
+
+
+# Most of the interesting types of class declarations
+SYSTEMVERILOG_CLASSES_TEXT = """
+class Foo;
+endclass
+
+class Bar;
+endclass : Bar
+
+class Fiz extends Buz;
+endclass : Fiz
+
+class Free #(parameter type T = byte) extends Beer #(T);
+endclass : Free
+"""
+
+SYSTEMVERILOG_CLASSES_TOKENS = [
+    (Keyword.Declaration, 'class'),
+    (Text,                ' '),
+    (Name.Class,          'Foo'),
+    (Punctuation,         ';'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'endclass'),
+    (Text,                '\n'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'class'),
+    (Text,                ' '),
+    (Name.Class,          'Bar'),
+    (Punctuation,         ';'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'endclass'),
+    (Text,                ' '),
+    (Punctuation,         ':'),
+    (Text,                ' '),
+    (Name.Class,          'Bar'),
+    (Text,                '\n'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'class'),
+    (Text,                ' '),
+    (Name.Class,          'Fiz'),
+    (Text,                ' '),
+    (Keyword.Declaration, 'extends'),
+    (Text,                ' '),
+    (Name.Class,          'Buz'),
+    (Punctuation,         ';'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'endclass'),
+    (Text,                ' '),
+    (Punctuation,         ':'),
+    (Text,                ' '),
+    (Name.Class,          'Fiz'),
+    (Text,                '\n'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'class'),
+    (Text,                ' '),
+    (Name.Class,          'Free'),
+    (Text,                ' '),
+    (Punctuation,         '#'),
+    (Punctuation,         '('),
+    (Keyword,             'parameter'),
+    (Text,                ' '),
+    (Keyword.Type,        'type'),
+    (Text,                ' '),
+    (Name,                'T'),
+    (Text,                ' '),
+    (Operator,            '='),
+    (Text,                ' '),
+    (Keyword.Type,        'byte'),
+    (Punctuation,         ')'),
+    (Text,                ' '),
+    (Keyword.Declaration, 'extends'),
+    (Text,                ' '),
+    (Name.Class,          'Beer'),
+    (Text,                ' '),
+    (Punctuation,         '#'),
+    (Punctuation,         '('),
+    (Name,                'T'),
+    (Punctuation,         ')'),
+    (Punctuation,         ';'),
+    (Text,                '\n'),
+    (Keyword.Declaration, 'endclass'),
+    (Text,                ' '),
+    (Punctuation,         ':'),
+    (Text,                ' '),
+    (Name.Class,          'Free'),
+    (Text,                '\n'),
+]
+
+def test_systemverilog_classes(lexer):
+    """Test class/extends/endclass group captures"""
+    tokens = list(lexer.get_tokens(SYSTEMVERILOG_CLASSES_TEXT))
+    assert tokens == SYSTEMVERILOG_CLASSES_TOKENS


### PR DESCRIPTION
The class looks like:

class class_identifier [#(param_decls)] [extends class_identifier #(params)];
    ...
endclass [: class_identifier]

Using the same Java convention of Keyword.Declaration and Name.Class.

Add a test_systemverilog_classes unit test to test_hdl.