### PR TITLE
Updated languages and templates list with more links

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -8,205 +8,205 @@ Pygments supports an ever-growing range of languages. Watch this space...
 Programming languages
 ---------------------
 
-* ActionScript
-* Ada
-* Agda (incl. literate)
+* `ActionScript <https://www.adobe.com/devnet/actionscript/articles/actionscript3_overview.html>`_
+* `Ada <https://www.adaic.org/>`_
+* `Agda <https://wiki.portal.chalmers.se/agda>`_ (incl. literate)
 * `Alloy <https://alloytools.org/>`_
 * `AMPL <https://ampl.com/>`_
-* ANTLR
-* APL
-* AppleScript
-* Assembly (various)
-* Asymptote
-* `Augeas <http://augeas.net>`_
-* AutoIt
-* Awk
-* BBC Basic
-* Befunge
-* BlitzBasic
+* `ANTLR <https://www.antlr.org/>`_
+* `APL <https://tryapl.org/>`_
+* `AppleScript <https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/introduction/ASLR_intro.html>`_
+* `Assembly <https://en.wikipedia.org/wiki/Assembly_language>`_ (various)
+* `Asymptote <https://asymptote.sourceforge.io/>`_
+* `Augeas <https://augeas.net/>`_
+* `AutoIt <https://www.autoitscript.com/site/autoit/>`_
+* `Awk <https://en.wikipedia.org/wiki/AWK>`_
+* `BBC Basic <http://www.bbcbasic.co.uk/bbcbasic.html>`_
+* `Befunge <https://github.com/catseye/Befunge-93>`_
+* `BlitzBasic <https://en.wikipedia.org/wiki/Blitz_BASIC>`_
 * `Boa <https://boa.cs.iastate.edu/docs/>`_
-* Boo
+* `Boo <https://boo-language.github.io/>`_
 * `Boogie <https://boogie.codeplex.com/>`_
-* BrainFuck
-* C, C++ (incl. dialects like Arduino)
-* C#
+* `BrainFuck <https://en.wikipedia.org/wiki/Brainfuck>`_
+* `C <http://www.open-std.org/jtc1/sc22/wg14/>`_, `C++ <https://isocpp.org/>`_ (incl. dialects like Arduino)
+* `C# <https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/>`_
 * `Chapel <https://chapel-lang.org/>`_
 * `Charm++ CI <http://charmplusplus.org/>`_
-* Cirru
-* Clay
+* `Cirru <http://cirru.org/>`_
+* `Clay <https://github.com/jckarter/clay>`_
 * `Clean <https://clean.cs.ru.nl/Clean>`_
-* Clojure
-* CoffeeScript
-* ColdFusion
-* Common Lisp
-* Component Pascal
+* `Clojure <https://clojure.org/>`_
+* `CoffeeScript <https://coffeescript.org/>`_
+* `ColdFusion <https://www.adobe.com/products/coldfusion-family.html>`_
+* `Common Lisp <https://common-lisp.net/>`_
+* `Component Pascal <https://en.wikipedia.org/wiki/Component_Pascal>`_
 * `Coq <https://coq.inria.fr/>`_
-* Croc (MiniD)
-* Cryptol (incl. Literate Cryptol)
+* `Croc <http://www.croc-lang.org/>`_ (MiniD)
+* `Cryptol <https://cryptol.net/>`_ (incl. Literate Cryptol)
 * `Crystal <https://crystal-lang.org>`_
-* Cypher
+* `Cypher <https://neo4j.com/developer/cypher-query-language/>`_
 * `Cython <https://cython.org>`_
 * `D <https://dlang.org>`_
-* Dart
+* `Dart <https://dart.dev/>`_
 * DCPU-16
-* Delphi
+* `Delphi <https://www.embarcadero.com/products/delphi>`_
 * `Devicetree <https://www.devicetree.org/>`_
-* Dylan (incl. console)
-* Eiffel
+* `Dylan <https://opendylan.org/>`_ (incl. console)
+* `Eiffel <https://www.eiffel.org/>`_
 * `Elm <https://elm-lang.org/>`_
-* Emacs Lisp
+* `Emacs Lisp <https://www.gnu.org/software/emacs/manual/html_node/elisp/>`_
 * Email
-* Erlang (incl. shell sessions)
+* `Erlang <https://www.erlang.org/>`_ (incl. shell sessions)
 * `Ezhil <http://ezhillang.org>`_
 * `Execline <https://skarnet.org/software/execline>`_
-* Factor
-* Fancy
-* Fantom
+* `Factor <https://factorcode.org/>`_
+* `Fancy <http://www.fancy-lang.org/>`_
+* `Fantom <https://fantom-lang.org/>`_
 * `Fennel <https://fennel-lang.org/>`_
 * `FloScript <https://ioflo.com/>`_
-* Fortran
+* `Fortran <https://fortran-lang.org/>`_
 * `FreeFEM++ <https://freefem.org/>`_
-* F#
+* `F# <https://fsharp.org/>`_
 * `F* <https://www.fstar-lang.org/>`_
-* GAP
-* GDScript
-* Gherkin (Cucumber)
-* GLSL shaders
+* `GAP <https://www.gap-system.org/>`_
+* `GDScript <https://docs.godotengine.org/>`_
+* `Gherkin <https://cucumber.io/docs/gherkin/>`_ (Cucumber)
+* `GLSL <https://www.khronos.org/registry/OpenGL/index_gl.php>`_ shaders
+* `GnuCOBOL <https://www.gnu.org/software/gnucobol/>`_ (OpenCOBOL)
 * `Golo <https://golo-lang.org/>`_
-* Gosu
-* Groovy
+* `Gosu <https://gosu-lang.github.io/>`_
+* `Groovy <https://groovy-lang.org/>`_
 * `Haskell <https://www.haskell.org/>`_ (incl. Literate Haskell)
 * `Haxe <https://haxe.org>`_
-* HLSL
+* `HLSL <https://docs.microsoft.com/en-gb/windows/win32/direct3dhlsl/dx-graphics-hlsl>`_ shaders
 * `HSpec <https://hackage.haskell.org/package/hspec>`_
-* Hy
-* IDL
-* Idris (incl. Literate Idris)
-* Igor Pro
-* Io
-* Jags
-* Java
-* JavaScript
-* Jasmin
-* Jcl
+* `Hy <https://hylang.org>`_
+* `IDL <https://www.harrisgeospatial.com/Software-Technology/IDL>`_
+* `Idris <https://www.idris-lang.org/>`_ (incl. Literate Idris)
+* `Igor Pro <https://www.wavemetrics.com/products/igorpro/programming>`_
+* `Io <http://iolanguage.com/>`_
+* `Jags <http://mcmc-jags.sourceforge.net/>`_
+* `Java <https://www.oracle.com/java/>`_
+* `JavaScript <https://en.wikipedia.org/wiki/JavaScript>`_
+* `Jasmin <http://jasmin.sourceforge.net/>`_
+* `Jcl <https://en.wikipedia.org/wiki/Job_Control_Language>`_
 * `Julia <https://julialang.org>`_
-* Kotlin
-* Lasso (incl. templating)
-* Limbo
-* LiveScript
+* `Kotlin <https://kotlinlang.org/>`_
+* `Lasso <http://www.lassosoft.com/>`_ (incl. templating)
+* `Limbo <http://www.vitanuova.com/inferno/limbo.html>`_
+* `LiveScript <https://livescript.net/>`_
 * `LLVM MIR <https://llvm.org/docs/MIRLangRef.html>`_
-* Logtalk
-* Logos
+* `Logtalk <https://logtalk.org/>`_
+* `Logos <https://en.wikipedia.org/wiki/Logo_(programming_language)>`_
 * `Lua <https://lua.org>`_
-* Mathematica
-* Matlab
+* `Mathematica <https://www.wolfram.com/mathematica/>`_
+* `Matlab <https://www.mathworks.com/products/matlab.html>`_
 * `MiniScript <https://miniscript.org>`_
-* Modelica
-* Modula-2
-* Monkey
+* `Modelica <https://www.modelica.org/>`_
+* `Modula-2 <https://www.modula2.org/>`_
+* `Monkey <https://monkeylang.org/>`_
 * `Monte <https://monte.readthedocs.io/>`_
-* MoonScript
-* Mosel
-* MuPad
-* NASM
-* Nemerle
-* NesC
-* NewLISP
-* Nimrod
+* `MoonScript <https://moonscript.org/>`_
+* `Mosel <https://www.maths.ed.ac.uk/hall/Xpress/FICO_Docs/mosel/mosel_lang/dhtml/moselreflang.html>`_
+* `MuPad <https://www.mathworks.com/discovery/mupad.html>`_
+* `NASM <https://www.nasm.us/>`_
+* `Nemerle <http://nemerle.org/>`_
+* `NesC <http://nescc.sourceforge.net/>`_
+* `NewLISP <http://www.newlisp.org/>`_
+* `Nim <https://nim-lang.org/>`_
 * `Nit <https://nitlanguage.org/>`_
-* Notmuch
-* NuSMV
-* Objective-C
-* Objective-J
-* Octave
-* OCaml
-* Opa
-* OpenCOBOL
+* `Notmuch <https://notmuchmail.org/>`_
+* `NuSMV <http://nusmv.fbk.eu/NuSMV/papers/sttt_j/html/node7.html>`_
+* `Objective-C <https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/Introduction/Introduction.html>`_
+* `Objective-J <https://www.cappuccino.dev/learn/objective-j.html>`_
+* `Octave <https://www.gnu.org/software/octave/>`_
+* `OCaml <https://ocaml.org/>`_
+* `Opa <http://opalang.org/>`_
 * `ParaSail <https://www.parasail-lang.org/>`_
-* Pawn
-* PHP
+* `Pawn <https://www.compuphase.com/pawn/pawn.htm>`_
+* `PHP <https://www.php.net/>`_
 * `Perl 5 <https://perl.org>`_
-* Pike
+* `Pike <https://pike.lysator.liu.se/>`_
 * `Pony <https://www.ponylang.io/>`_
-* PovRay
-* PostScript
-* PowerShell
+* `PovRay <http://www.povray.org/>`_
+* `PostScript <https://en.wikipedia.org/wiki/PostScript>`_
+* `PowerShell <https://microsoft.com/powershell>`_
 * `Praat <http://www.praat.org>`_
-* Prolog
+* `Prolog <https://en.wikipedia.org/wiki/Prolog>`_
 * `Python <https://python.org/>`_ 2.x and 3.x (incl. console sessions and
   tracebacks)
-* QBasic
+* `QBasic <https://en.wikipedia.org/wiki/QBasic>`_
 * `Racket <https://racket-lang.org/>`_
 * `Raku <https://www.raku.org/>`_ a.k.a. Perl 6
 * `ReasonML <https://reasonml.github.io/>`_
 * `REBOL <http://www.rebol.com>`_
 * `Red <https://www.red-lang.org>`_
-* Redcode
-* Rexx
-* Ride
+* `Redcode <https://esolangs.org/wiki/Redcode>`_
+* `Rexx <https://www.ibm.com/rexx/>`_
+* `Ride <https://docs.wavesprotocol.org/en/ride/>`_
 * `Ruby <https://www.ruby-lang.org>`_ (incl. irb sessions)
 * `Rust <https://rust-lang.org>`_
-* S, S-Plus, R
-* Scala
+* S, S-Plus, `R <https://www.r-project.org/>`_
+* `Scala <https://scala-lang.org/>`_
 * `Scdoc <https://git.sr.ht/~sircmpwn/scdoc>`_
-* Scheme
-* Scilab
+* `Scheme <http://www.scheme-reports.org/>`_
+* `Scilab <https://www.scilab.org/>`_
 * `SGF <https://www.red-bean.com/sgf/>`_
-* Shell scripts (Bash, Tcsh, Fish)
+* Shell scripts (`Bash <https://www.gnu.org/software/bash/>`_, `Tcsh <https://www.tcsh.org/>`_, `Fish <https://fishshell.com/>`_)
 * `Shen <http://shenlanguage.org/>`_
-* Silver
+* `Silver <https://elementscompiler.com/elements/silver/>`_
 * `Slash <https://github.com/arturadib/Slash-A>`_
 * `Slurm <https://slurm.schedmd.com/overview.html>`_
-* Smalltalk
-* SNOBOL
+* `Smalltalk <https://en.wikipedia.org/wiki/Smalltalk>`_
+* `SNOBOL <http://www.snobol4.org/>`_
 * `Snowball <https://snowballstem.org/>`_
 * `Solidity <https://solidity.readthedocs.io/>`_
-* SourcePawn
+* `SourcePawn <https://github.com/alliedmodders/sourcepawn>`_
 * `Stan <https://mc-stan.org/>`_
-* Standard ML
-* Stata
-* Swift
-* Swig
+* `Standard ML <https://smlfamily.github.io/>`_
+* `Stata <https://www.stata.com/features/programming-language/>`_
+* `Swift <https://swift.org/>`_
+* `Swig <http://swig.org/>`_
 * `SuperCollider <https://supercollider.github.io/>`_
-* Tcl
+* `Tcl <https://www.tcl.tk/about/language.html>`_
 * `Tera Term language <https://ttssh2.osdn.jp/>`_
-* TypeScript
-* TypoScript
+* `TypeScript <https://www.typescriptlang.org/>`_
+* `TypoScript <https://typo3.org/>`_
 * `USD <https://graphics.pixar.com/usd/docs/index.html>`_
-* Unicon
-* Urbiscript
-* Vala
-* VBScript
-* Verilog, SystemVerilog
-* VHDL
-* Visual Basic.NET
-* Visual FoxPro
+* `Unicon <https://unicon.sourceforge.io/>`_
+* `Urbiscript <https://github.com/urbiforge/urbi>`_
+* `Vala <https://wiki.gnome.org/Projects/Vala>`_
+* `VBScript <https://docs.microsoft.com/en-us/previous-versions/t0aew7h6(v=vs.85)>`_
+* Verilog, `SystemVerilog <https://en.wikipedia.org/wiki/SystemVerilog>`_
+* `VHDL <http://www.eda-twiki.org/cgi-bin/view.cgi/P1076/WebHome>`_
+* `Visual Basic.NET <https://docs.microsoft.com/dotnet/visual-basic/>`_
+* `Visual FoxPro <https://msdn.microsoft.com/vfoxpro>`_
 * `Whiley <http://whiley.org/>`_
 * `Xtend <https://www.eclipse.org/xtend/>`_
-* XQuery
+* `XQuery <http://www.w3.org/XML/Query/>`_
 * `Zeek <https://www.zeek.org>`_
-* Zephir
+* `Zephir <https://zephir-lang.com/en>`_
 * `Zig <https://ziglang.org/>`_
 
 Template languages
 ------------------
 
-* Angular templates
-* Cheetah templates
-* ColdFusion
+* `Angular templates <https://angular.io/guide/template-syntax>`_
+* `Cheetah templates <https://cheetahtemplate.org/>`_
+* `ColdFusion <https://www.adobe.com/products/coldfusion-family.html>`_
 * `Django <https://www.djangoproject.com>`_ / `Jinja
   <https://jinja.pocoo.org/jinja>`_ templates
-* ERB (Ruby templating)
+* `ERB <https://en.wikipedia.org/wiki/ERuby>`_ (Ruby templating)
 * Evoque
 * `Genshi <https://genshi.edgewall.org>`_ (the Trac template language)
-* Handlebars
-* JSP (Java Server Pages)
-* Liquid
+* `Handlebars <https://handlebarsjs.com/>`_
+* `JSP <https://www.oracle.com/java/technologies/jspt.html>`_ (Java Server Pages)
+* `Liquid <https://shopify.github.io/liquid/>`_
 * `Myghty <https://pypi.org/project/Myghty/>`_ (the HTML::Mason based framework)
 * `Mako <https://www.makotemplates.org>`_ (the Myghty successor)
-* Slim
+* `Slim <http://slim-lang.com/>`_
 * `Smarty <https://www.smarty.net>`_ templates (PHP templating)
-* Tea
+* `Tea <https://github.com/teatrove/teatrove/wiki/Tea-Template-Language>`_
 * `Twig <https://twig.symfony.com/>`_
 
 Other markup


### PR DESCRIPTION
I tried to comprehensively fill out the list of language and template links in the documentation.

For each one I verified that every link works at the time of submission, and used my best judgement on whether the link points the best place to go and read about whatever the link represents, be it a programming language, programming system, language family of some kind, ISO or IEEE standard, etc.

If I couldn't find a good live link that I felt described the thing well, I fell back to English language Wikipedia. In some cases Wikipedia is all that's left for a language or system. One or two were just http -> https promotions. If there's a better name now for a language or system than was in the list, I changed it (at least Nimrod -> Nim, maybe others).