### PR TITLE
Added '*.markdown' file extension to 'markdown' lexer

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -508,7 +508,7 @@ class MarkdownLexer(RegexLexer):
     """
     name = 'markdown'
     aliases = ['md']
-    filenames = ['*.md']
+    filenames = ['*.md', '*.markdown']
     mimetypes = ["text/x-markdown"]
     flags = re.MULTILINE
 


### PR DESCRIPTION
Some people use the full name of the markup.