### PR TITLE
[Robot Framework] Add *Task* and *Tasks* table

### DIFF
--- a/pygments/lexers/robotframework.py
+++ b/pygments/lexers/robotframework.py
@@ -123,6 +123,7 @@ class RowTokenizer:
                         'metadata': settings,
                         'variables': variables, 'variable': variables,
                         'testcases': testcases, 'testcase': testcases,
+                        'tasks': testcases, 'task': testcases,
                         'keywords': keywords, 'keyword': keywords,
                         'userkeywords': keywords, 'userkeyword': keywords}
 


### PR DESCRIPTION
Since Robot Framework 3.1 (January 2019), new section `*** Task ***` and `*** Tasks ***` are available. They have the same highlighting as `*** Testcases ***`

This pull request adds 2 new tables for *Task* and *Tasks*. 

I do not know how to test this, though.

Reference: [Release Notes Robot Framework 3.1](https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-3.1.rst#terminology-configuration-to-support-robotic-process-automation-rpa)