### PR TITLE
Fix cmake header

### DIFF
--- a/pygments/lexers/make.py
+++ b/pygments/lexers/make.py
@@ -196,7 +196,12 @@ class CMakeLexer(RegexLexer):
     }
 
     def analyse_text(text):
-        exp = r'^ *CMAKE_MINIMUM_REQUIRED *\( *VERSION *\d(\.\d)* *( FATAL_ERROR)? *\) *$'
+        exp = (
+            r'^[ \t]*CMAKE_MINIMUM_REQUIRED[ \t]*'
+            r'\([ \t]*VERSION[ \t]*\d+(\.\d+)*[ \t]*'
+            r'([ \t]FATAL_ERROR)?[ \t]*\)[ \t]*'
+            r'(#.*)?$'
+       )
         if re.search(exp, text, flags=re.MULTILINE | re.IGNORECASE):
             return 0.8
         return 0.0

--- a/pygments/lexers/make.py
+++ b/pygments/lexers/make.py
@@ -200,7 +200,7 @@ class CMakeLexer(RegexLexer):
             r'^[ \t]*CMAKE_MINIMUM_REQUIRED[ \t]*'
             r'\([ \t]*VERSION[ \t]*\d+(\.\d+)*[ \t]*'
             r'([ \t]FATAL_ERROR)?[ \t]*\)[ \t]*'
-            r'(#.*)?$'
+            r'(#[^\n]*)?$'
        )
         if re.search(exp, text, flags=re.MULTILINE | re.IGNORECASE):
             return 0.8

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+    CMake Tests
+    ~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexers import CMakeLexer, guess_lexer
+
+
+def test_guess_cmake_lexer_from_header():
+    headers = [
+        "CMAKE_MINIMUM_REQUIRED(VERSION 2.6 FATAL_ERROR)",
+        "cmake_minimum_required(version 3.13)  # CMake version check",
+        " CMAKE_MINIMUM_REQUIRED\t( VERSION 2.6 FATAL_ERROR ) ",
+    ]
+    for header in headers:
+        code = '\n'.join([
+            header,
+            'project(example)',
+            'set(CMAKE_CXX_STANDARD 14)',
+            'set(SOURCE_FILES main.cpp)',
+            'add_executable(example ${SOURCE_FILES})',
+        ])
+        lexer = guess_lexer(code)
+        assert isinstance(lexer, CMakeLexer), \
+            "header must be detected as CMake: %r" % header


### PR DESCRIPTION
The current regex to guess CMake by header has several flaws this patch fixes:

* Version number can have multiple digits.
* Tabs are handled as white space.
* Trailing comments are ignored.

Reference: https://cmake.org/cmake/help/v3.13/manual/cmake-language.7.html#syntax