### PR TITLE
Improve Markdown lexer

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -576,7 +576,7 @@ class MarkdownLexer(RegexLexer):
             (r'\\.', Text),
             # inline code
             (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
-            # warning: the following rules for italics & bold eat internal tags.
+            # warning: the following rules eat internal tags.
             # eg. **foo _bar_ baz** => bar is not recognized as italics
             # italics fenced by '*'
             (r'([^\*]*)(\*[^\*].+\*)', bygroups(Text, Generic.Emph)),
@@ -586,9 +586,8 @@ class MarkdownLexer(RegexLexer):
             (r'([^\*]*)(\*\*[^\*].+\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'
             (r'([^\_]*)(\_\_[^\_].+\_\_)', bygroups(Text, Generic.Strong)),
-
             # strikethrough
-            (r'(\s)(~~[^~]+~~)((?=\W|\n))', bygroups(Text, Generic.Deleted, Text)),
+            (r'([^~]*)(~~[^~].+~~)', bygroups(Text, Generic.Deleted)),
             # mentions and topics (twitter and github stuff)
             (r'[@#][\w/:]+', Name.Entity),
             # (image?) links eg: ![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -580,8 +580,6 @@ class MarkdownLexer(RegexLexer):
             # "proper way" (r'(\s)([*_]{2}[^*_]+[*_]{2})((?=\W|\n))', bygroups(Text, Generic.Strong, Text)),
             # strikethrough
             (r'(\s)(~~[^~]+~~)((?=\W|\n))', bygroups(Text, Generic.Deleted, Text)),
-            # inline code
-            (r'`[^`]+`', String.Backtick),
             # mentions and topics (twitter and github stuff)
             (r'[@#][\w/:]+', Name.Entity),
             # (image?) links eg: ![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)
@@ -591,6 +589,8 @@ class MarkdownLexer(RegexLexer):
             #   [id]: http://example.com/
             (r'(\[)([^]]+)(\])(\[)([^]]*)(\])', bygroups(Text, Name.Tag, Text, Text, Name.Label, Text)),
             (r'^(\s*\[)([^]]*)(\]:\s*)(.+)', bygroups(Text, Name.Label, Text, Name.Attribute)),
+            # inline code
+            (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
 
             # general text, must come last!
             (r'[^\\\s]+', Text),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -543,9 +543,14 @@ class MarkdownLexer(RegexLexer):
 
     tokens = {
         'root': [
-            # heading with pound prefix
-            (r'^(#)([^#].+\n)', bygroups(Generic.Heading, Text)),
-            (r'^(#{2,6})(.+\n)', bygroups(Generic.Subheading, Text)),
+            # heading with '#' prefix (atx-style)
+            (r'(^#[^#].+)(\n)', bygroups(Generic.Heading, Text)),
+            # subheading with '#' prefix (atx-style)
+            (r'(^#{2,6}[^#].+)(\n)', bygroups(Generic.Subheading, Text)),
+            # heading with '=' underlines (Setext-style)
+            (r'^(.+)(\n)(=+)(\n)', bygroups(Generic.Heading, Text, Generic.Heading, Text)),
+            # subheading with '-' underlines (Setext-style)
+            (r'^(.+)(\n)(-+)(\n)', bygroups(Generic.Subheading, Text, Generic.Subheading, Text)),
             # task list
             (r'^(\s*)([*-] )(\[[ xX]\])( .+\n)',
             bygroups(Text, Keyword, Keyword, using(this, state='inline'))),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -576,6 +576,8 @@ class MarkdownLexer(RegexLexer):
             (r'\\.', Text),
             # inline code
             (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
+            # warning: the following rules for italics & bold eat internal tags.
+            # eg. **foo _bar_ baz** => bar is not recognized as italics
             # italics fenced by '*'
             (r'([^\*]*)(\*[^\*].+\*)', bygroups(Text, Generic.Emph)),
             # italics fenced by '_'
@@ -585,10 +587,6 @@ class MarkdownLexer(RegexLexer):
             # bold fenced by '__'
             (r'([^\_]*)(\_\_[^\_].+\_\_)', bygroups(Text, Generic.Strong)),
 
-            # TODO
-            # # warning: the following rule eats internal tags. eg. **foo _bar_ baz** bar is not italics
-            # (r'(\s)((\*\*|__).*\3)((?=\W|\n))', bygroups(Text, Generic.Strong, None, Text)),
-            # "proper way" (r'(\s)([*_]{2}[^*_]+[*_]{2})((?=\W|\n))', bygroups(Text, Generic.Strong, Text)),
             # strikethrough
             (r'(\s)(~~[^~]+~~)((?=\W|\n))', bygroups(Text, Generic.Deleted, Text)),
             # mentions and topics (twitter and github stuff)

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -581,9 +581,9 @@ class MarkdownLexer(RegexLexer):
             # italics fenced by '_'
             (r'([^\_]*)(\_[^\_].+\_)', bygroups(Text, Generic.Emph)),
             # bold fenced by '**'
-            (r'([^\*\*]*)(\*\*[^\*\*].+\*\*)', bygroups(Text, Generic.Strong)),
+            (r'([^\*]*)(\*\*[^\*].+\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'
-            (r'([^\_\_]*)(\_\_[^\_\_].+\_\_)', bygroups(Text, Generic.Strong)),
+            (r'([^\_]*)(\_\_[^\_].+\_\_)', bygroups(Text, Generic.Strong)),
 
             # TODO
             # # warning: the following rule eats internal tags. eg. **foo _bar_ baz** bar is not italics

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -575,17 +575,17 @@ class MarkdownLexer(RegexLexer):
             # escape
             (r'\\.', Text),
             # inline code
-            (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
+            (r'([^`\n]*)(`[^`\n]+`)', bygroups(Text, String.Backtick)),
             # warning: the following rules eat internal tags.
             # eg. **foo _bar_ baz** => bar is not recognized as italics
             # italics fenced by '*'
-            (r'([^\*]*)(\*[^\*]+\*)', bygroups(Text, Generic.Emph)),
+            (r'([^\*]*)(\*[^\*\n]+\*)', bygroups(Text, Generic.Emph)),
             # italics fenced by '_'
-            (r'([^\_]*)(\_[^\_]+\_)', bygroups(Text, Generic.Emph)),
+            (r'([^\_]*)(\_[^\_\n].+\_)', bygroups(Text, Generic.Emph)),
             # bold fenced by '**'
-            (r'([^\*]*)(\*\*[^\*]+\*\*)', bygroups(Text, Generic.Strong)),
+            (r'([^\*]*)(\*\*[^\*\n].+\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'
-            (r'([^\_]*)(\_\_[^\_]+\_\_)', bygroups(Text, Generic.Strong)),
+            (r'([^\_]*)(\_\_[^\_\n].+\_\_)', bygroups(Text, Generic.Strong)),
             # strikethrough
             (r'([^~]*)(~~[^~]+~~)', bygroups(Text, Generic.Deleted)),
             # mentions and topics (twitter and github stuff)

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -574,11 +574,20 @@ class MarkdownLexer(RegexLexer):
         'inline': [
             # escape
             (r'\\.', Text),
-            # italics
-            (r'(\s)([*_][^*_]+[*_])(\W|\n)', bygroups(Text, Generic.Emph, Text)),
-            # bold
-            # warning: the following rule eats internal tags. eg. **foo _bar_ baz** bar is not italics
-            (r'(\s)((\*\*|__).*\3)((?=\W|\n))', bygroups(Text, Generic.Strong, None, Text)),
+            # inline code
+            (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
+            # italics fenced by '*'
+            (r'([^\*]*)(\*[^\*].+\*)', bygroups(Text, Generic.Emph)),
+            # italics fenced by '_'
+            (r'([^\_]*)(\_[^\_].+\_)', bygroups(Text, Generic.Emph)),
+            # bold fenced by '**'
+            (r'([^\*\*]*)(\*\*[^\*\*].+\*\*)', bygroups(Text, Generic.Strong)),
+            # bold fenced by '__'
+            (r'([^\_\_]*)(\_\_[^\_\_].+\_\_)', bygroups(Text, Generic.Strong)),
+
+            # TODO
+            # # warning: the following rule eats internal tags. eg. **foo _bar_ baz** bar is not italics
+            # (r'(\s)((\*\*|__).*\3)((?=\W|\n))', bygroups(Text, Generic.Strong, None, Text)),
             # "proper way" (r'(\s)([*_]{2}[^*_]+[*_]{2})((?=\W|\n))', bygroups(Text, Generic.Strong, Text)),
             # strikethrough
             (r'(\s)(~~[^~]+~~)((?=\W|\n))', bygroups(Text, Generic.Deleted, Text)),
@@ -591,8 +600,6 @@ class MarkdownLexer(RegexLexer):
             #   [id]: http://example.com/
             (r'(\[)([^]]+)(\])(\[)([^]]*)(\])', bygroups(Text, Name.Tag, Text, Text, Name.Label, Text)),
             (r'^(\s*\[)([^]]*)(\]:\s*)(.+)', bygroups(Text, Name.Label, Text, Name.Attribute)),
-            # inline code
-            (r'([^`\n]*)(`[^`]+`)', bygroups(Text, String.Backtick)),
 
             # general text, must come last!
             (r'[^\\\s]+', Text),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -562,8 +562,10 @@ class MarkdownLexer(RegexLexer):
             bygroups(Text, Keyword, using(this, state='inline'))),
             # quote
             (r'^(\s*>\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
-            # text block
-            (r'^(```\n)([\w\W]*?)(^```$)', bygroups(String, Text, String)),
+            # code block fenced by 3 backticks
+            (r'^(```\n[\w\W]*?^```$)', String.Backtick),
+            # code block indented with 4 spaces or 1 tab
+            (r'^(\ {4}|\t)([\w\W]*?)(\n)', bygroups(Text, String.Backtick, Text)),
             # code block with language
             (r'^(```)(\w+)(\n)([\w\W]*?)(^```$)', _handle_codeblock),
 

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -579,15 +579,15 @@ class MarkdownLexer(RegexLexer):
             # warning: the following rules eat internal tags.
             # eg. **foo _bar_ baz** => bar is not recognized as italics
             # italics fenced by '*'
-            (r'([^\*]*)(\*[^\*].+\*)', bygroups(Text, Generic.Emph)),
+            (r'([^\*]*)(\*[^\*]+\*)', bygroups(Text, Generic.Emph)),
             # italics fenced by '_'
-            (r'([^\_]*)(\_[^\_].+\_)', bygroups(Text, Generic.Emph)),
+            (r'([^\_]*)(\_[^\_]+\_)', bygroups(Text, Generic.Emph)),
             # bold fenced by '**'
-            (r'([^\*]*)(\*\*[^\*].+\*\*)', bygroups(Text, Generic.Strong)),
+            (r'([^\*]*)(\*\*[^\*]+\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'
-            (r'([^\_]*)(\_\_[^\_].+\_\_)', bygroups(Text, Generic.Strong)),
+            (r'([^\_]*)(\_\_[^\_]+\_\_)', bygroups(Text, Generic.Strong)),
             # strikethrough
-            (r'([^~]*)(~~[^~].+~~)', bygroups(Text, Generic.Deleted)),
+            (r'([^~]*)(~~[^~]+~~)', bygroups(Text, Generic.Deleted)),
             # mentions and topics (twitter and github stuff)
             (r'[@#][\w/:]+', Name.Entity),
             # (image?) links eg: ![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -397,3 +397,23 @@ def test_task_list(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_italic_and_bold(lexer):
+    fragment = '**bold** and *italics*'
+    tokens = [
+        (Generic.Strong, '**bold**'),
+        (Token.Text, ' and '),
+        (Generic.Emph, '*italics*'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '*italics* and **bold**'
+    tokens = [
+        (Generic.Emph, '*italics*'),
+        (Token.Text, ' and '),
+        (Generic.Strong, '**bold**'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -8,7 +8,7 @@
 """
 
 import pytest
-from pygments.token import Generic, Token, String
+from pygments.token import Generic, Token, String, Keyword
 
 from pygments.lexers.markup import MarkdownLexer
 
@@ -356,6 +356,44 @@ def test_bold_fenced_by_underscore(lexer):
         (Token.Text, '('),
         (Generic.Strong, '__bold__'),
         (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_strikethrough(lexer):
+    fragment = '~~striked~~not striked'
+    tokens = [
+        (Generic.Deleted, '~~striked~~'),
+        (Token.Text, 'not'),
+        (Token.Text, ' '),
+        (Token.Text, 'striked'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_task_list(lexer):
+    fragment = '- [ ] sample task'
+    tokens = [
+        (Keyword, '- '),
+        (Keyword, '[ ]'),
+        (Token.Text, ' '),
+        (Token.Text, 'sample'),
+        (Token.Text, ' '),
+        (Token.Text, 'task'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '* [ ] sample task'
+    tokens = [
+        (Keyword, '* '),
+        (Keyword, '[ ]'),
+        (Token.Text, ' '),
+        (Token.Text, 'sample'),
+        (Token.Text, ' '),
+        (Token.Text, 'task'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -8,7 +8,7 @@
 """
 
 import pytest
-from pygments.token import Generic, Token, String, Keyword
+from pygments.token import Generic, Token, String, Keyword, Name
 
 from pygments.lexers.markup import MarkdownLexer
 
@@ -167,36 +167,108 @@ def test_setext_subheading(lexer):
         assert list(lexer.get_tokens(fragment)) == tokens
 
 
-def test_inline_code(lexer):
-    fragment = '`code`'
+def test_task_list(lexer):
+    fragment = '- [ ] sample task'
     tokens = [
-        (String.Backtick, '`code`'),
+        (Keyword, '- '),
+        (Keyword, '[ ]'),
+        (Token.Text, ' '),
+        (Token.Text, 'sample'),
+        (Token.Text, ' '),
+        (Token.Text, 'task'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '(`code`)'
+    fragment = '* [ ] sample task'
     tokens = [
-        (Token.Text, '('),
-        (String.Backtick, '`code`'),
-        (Token.Text, ')'),
+        (Keyword, '* '),
+        (Keyword, '[ ]'),
+        (Token.Text, ' '),
+        (Token.Text, 'sample'),
+        (Token.Text, ' '),
+        (Token.Text, 'task'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = 'inline `code`!'
+    fragment = '  * [ ] sample task'
     tokens = [
-        (Token.Text, 'inline '),
-        (String.Backtick, '`code`'),
-        (Token.Text, '!'),
+        (Token.Text, '  '),
+        (Keyword, '* '),
+        (Keyword, '[ ]'),
+        (Token.Text, ' '),
+        (Token.Text, 'sample'),
+        (Token.Text, ' '),
+        (Token.Text, 'task'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '`**code**`'
+
+def test_bulleted_list(lexer):
+    fragment = '* foo\n* bar'
     tokens = [
-        (String.Backtick, '`**code**`'),
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Token.Text, 'foo'),
         (Token.Text, '\n'),
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Token.Text, 'bar'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '- foo\n- bar'
+    tokens = [
+        (Keyword, '-'),
+        (Token.Text, ' '),
+        (Token.Text, 'foo'),
+        (Token.Text, '\n'),
+        (Keyword, '-'),
+        (Token.Text, ' '),
+        (Token.Text, 'bar'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '* *foo*\n* bar'
+    tokens = [
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Generic.Emph, '*foo*'),
+        (Token.Text, '\n'),
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Token.Text, 'bar'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_numbered_list(lexer):
+    fragment = '1. foo\n2. bar'
+    tokens = [
+        (Keyword, '1.'),
+        (Token.Text, ' '),
+        (Token.Text, 'foo'),
+        (Token.Text, '\n'),
+        (Keyword, '2.'),
+        (Token.Text, ' '),
+        (Token.Text, 'bar'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_quote(lexer):
+    fragment = '> a\n> quote'
+    tokens = [
+        (Keyword, '> '),
+        (Generic.Emph, 'a\n'),
+        (Keyword, '> '),
+        (Generic.Emph, 'quote\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -226,27 +298,103 @@ def test_code_block_fenced_by_backticks(lexer):
         assert list(lexer.get_tokens(fragment)) == tokens
 
 
-def test_code_block_indented_by_spaces(lexer):
-    fragment = '    code'
+def test_code_block_with_language(lexer):
+    fragments = (
+        '```python\nimport this\n```',
+    )
+    for fragment in fragments:
+        tokens = [
+            (String.Backtick, '```'),
+            (String.Backtick, 'python'),
+            (Token.Text, '\n'),
+            (Token.Keyword.Namespace, 'import'),
+            (Token.Text, ' '),
+            (Token.Name.Namespace, 'this'),
+            (Token.Text, '\n'),
+            (String.Backtick, '```'),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_code_indented_with_spaces(lexer):
+    fragments = (
+        'sample:\n\n    code\n',
+    )
+    for fragment in fragments:
+        tokens = [
+            (Token.Text, 'sample:'),
+            (Token.Text, '\n\n'),
+            (String.Backtick, '    code\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragments = (
+        'sample:\n\n\tcode\n',
+    )
+    for fragment in fragments:
+        tokens = [
+            (Token.Text, 'sample:'),
+            (Token.Text, '\n\n'),
+            (String.Backtick, '\tcode\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_inline_code(lexer):
+    fragment = 'code: `code`'
     tokens = [
-        (Token.Text, '    '),
-        (String.Backtick, 'code'),
+        (Token.Text, 'code:'),
+        (Token.Text, ' '),
+        (String.Backtick, '`code`'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '      this is also **code**'
+    fragment = ' `**code**`'
     tokens = [
-        (Token.Text, '    '),
-        (String.Backtick, '  this is also **code**'),
+        (Token.Text, ' '),
+        (String.Backtick, '`**code**`'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '\tcode'
+    fragment = '(`code`)'
     tokens = [
-        (Token.Text, '\t'),
-        (String.Backtick, 'code'),
+        (Token.Text, '('),
+        (String.Backtick, '`code`'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_bold(lexer):
+    fragments = (
+        '**no bold__',
+        '__no bold**',
+        '*no bold*',
+        '_no bold_',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Strong
+
+
+def test_bold_fenced_by_asterisk(lexer):
+    fragment = '**bold**'
+    tokens = [
+        (Generic.Strong, '**bold**'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_bold_fenced_by_underscore(lexer):
+    fragment = '__bold__'
+    tokens = [
+        (Generic.Strong, '__bold__'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -273,29 +421,11 @@ def test_italics_fenced_by_asterisk(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '(*italics*)'
-    tokens = [
-        (Token.Text, '('),
-        (Generic.Emph, '*italics*'),
-        (Token.Text, ')'),
-        (Token.Text, '\n'),
-    ]
-    assert list(lexer.get_tokens(fragment)) == tokens
-
 
 def test_italics_fenced_by_underscore(lexer):
     fragment = '_italics_'
     tokens = [
         (Generic.Emph, '_italics_'),
-        (Token.Text, '\n'),
-    ]
-    assert list(lexer.get_tokens(fragment)) == tokens
-
-    fragment = '(_italics_)'
-    tokens = [
-        (Token.Text, '('),
-        (Generic.Emph, '_italics_'),
-        (Token.Text, ')'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -312,50 +442,32 @@ def test_escape_italics(lexer):
             assert token != Generic.Emph
 
 
-def test_invalid_bold(lexer):
-    fragments = (
-        '**no bold__',
-        '__no bold**',
-        '*no bold*',
-        '_no bold_',
-    )
+def test_italics_no_multiline(lexer):
+    fragment = '*no\nitalics*'
 
-    for fragment in fragments:
-        for token, _ in lexer.get_tokens(fragment):
-            assert token != Generic.Strong
+    for token, _ in lexer.get_tokens(fragment):
+        assert token != Generic.Emph
 
 
-def test_bold_fenced_by_asterisk(lexer):
-    fragment = '**bold**'
+def test_italics_and_bold(lexer):
+    fragment = '**bold** and *italics*'
     tokens = [
         (Generic.Strong, '**bold**'),
+        (Token.Text, ' '),
+        (Token.Text, 'and'),
+        (Token.Text, ' '),
+        (Generic.Emph, '*italics*'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '(**bold**)'
+    fragment = '*italics* and **bold**'
     tokens = [
-        (Token.Text, '('),
+        (Generic.Emph, '*italics*'),
+        (Token.Text, ' '),
+        (Token.Text, 'and'),
+        (Token.Text, ' '),
         (Generic.Strong, '**bold**'),
-        (Token.Text, ')'),
-        (Token.Text, '\n'),
-    ]
-    assert list(lexer.get_tokens(fragment)) == tokens
-
-
-def test_bold_fenced_by_underscore(lexer):
-    fragment = '__bold__'
-    tokens = [
-        (Generic.Strong, '__bold__'),
-        (Token.Text, '\n'),
-    ]
-    assert list(lexer.get_tokens(fragment)) == tokens
-
-    fragment = '(__bold__)'
-    tokens = [
-        (Token.Text, '('),
-        (Generic.Strong, '__bold__'),
-        (Token.Text, ')'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -373,47 +485,77 @@ def test_strikethrough(lexer):
     assert list(lexer.get_tokens(fragment)) == tokens
 
 
-def test_task_list(lexer):
-    fragment = '- [ ] sample task'
+def test_mentions(lexer):
+    fragment = 'note for @me:'
     tokens = [
-        (Keyword, '- '),
-        (Keyword, '[ ]'),
+        (Token.Text, 'note'),
         (Token.Text, ' '),
-        (Token.Text, 'sample'),
+        (Token.Text, 'for'),
         (Token.Text, ' '),
-        (Token.Text, 'task'),
-        (Token.Text, '\n'),
-    ]
-    assert list(lexer.get_tokens(fragment)) == tokens
-
-    fragment = '* [ ] sample task'
-    tokens = [
-        (Keyword, '* '),
-        (Keyword, '[ ]'),
-        (Token.Text, ' '),
-        (Token.Text, 'sample'),
-        (Token.Text, ' '),
-        (Token.Text, 'task'),
+        (Name.Entity, '@me:'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
 
-def test_italic_and_bold(lexer):
-    fragment = '**bold** and *italics*'
+def test_topics(lexer):
+    fragment = 'message to #you:'
     tokens = [
-        (Generic.Strong, '**bold**'),
-        (Token.Text, ' and '),
-        (Generic.Emph, '*italics*'),
+        (Token.Text, 'message'),
+        (Token.Text, ' '),
+        (Token.Text, 'to'),
+        (Token.Text, ' '),
+        (Name.Entity, '#you:'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
-    fragment = '*italics* and **bold**'
+
+def test_links(lexer):
+    fragment = '[text](link)'
     tokens = [
-        (Generic.Emph, '*italics*'),
-        (Token.Text, ' and '),
-        (Generic.Strong, '**bold**'),
+        (Token.Text, '['),
+        (Token.Name.Tag, 'text'),
+        (Token.Text, ']'),
+        (Token.Text, '('),
+        (Token.Name.Attribute, 'link'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '![Image of foo](https://bar.baz)'
+    tokens = [
+        (Token.Text, '!['),
+        (Token.Name.Tag, 'Image of foo'),
+        (Token.Text, ']'),
+        (Token.Text, '('),
+        (Token.Name.Attribute, 'https://bar.baz'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_reference_style_links(lexer):
+    fragment = '[an example][id]'
+    tokens = [
+        (Token.Text, '['),
+        (Token.Name.Tag, 'an example'),
+        (Token.Text, ']'),
+        (Token.Text, '['),
+        (Token.Name.Label, 'id'),
+        (Token.Text, ']'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '[id]: http://example.com'
+    tokens = [
+        (Token.Text, '['),
+        (Token.Name.Label, 'id'),
+        (Token.Text, ']: '),
+        (Token.Name.Attribute, 'http://example.com'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -8,6 +8,7 @@
 """
 
 import pytest
+from pygments.token import Generic, Token
 
 from pygments.lexers.markup import MarkdownLexer
 
@@ -34,3 +35,133 @@ def test_code_fence_gsm(lexer):
 
 def test_code_fence_gsm_with_no_lexer(lexer):
     assert_same_text(lexer, r'```invalid-lexer\nfoo\n```\n')
+
+
+def test_invalid_atx_heading(lexer):
+    fragments = (
+        '#',
+        'a #',
+        '*#',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Heading
+
+
+def test_atx_heading(lexer):
+    fragments = (
+        '#Heading',
+        '# Heading',
+        '# Another heading',
+        '# Another # heading',
+        '# Heading #',
+    )
+
+    for fragment in fragments:
+        tokens = [
+            (Generic.Heading, fragment),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_atx_subheading(lexer):
+    fragments = (
+        '##',
+        'a ##',
+        '*##',
+        '####### too many hashes'
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Subheading
+
+
+def test_atx_subheading(lexer):
+    fragments = (
+        '##Subheading',
+        '## Subheading',
+        '### Subheading',
+        '#### Subheading',
+        '##### Subheading',
+        '###### Subheading',
+        '## Another subheading',
+        '## Another ## subheading',
+        '###### Subheading #',
+        '###### Subheading ######',
+    )
+
+    for fragment in fragments:
+        tokens = [
+            (Generic.Subheading, fragment),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_setext_heading(lexer):
+    fragments = (
+        'Heading\n',
+        'Heading\n_',
+        'Heading\n =====',
+        'Heading\na=====',
+        '=====',
+        '\n=\n',
+        'Heading\n=====Text'
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Heading
+
+
+def test_setext_heading(lexer):
+    fragments = (
+        'Heading\n=',
+        'Heading\n=======',
+        'Heading\n==========',
+    )
+
+    for fragment in fragments:
+        tokens = [
+            (Generic.Heading, fragment.split('\n')[0]),
+            (Token.Text, '\n'),
+            (Generic.Heading, fragment.split('\n')[1]),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_setext_subheading(lexer):
+    fragments = (
+        'Subheading\n',
+        'Subheading\n_',
+        'Subheading\n -----',
+        'Subheading\na-----',
+        '-----',
+        '\n-\n',
+        'Subheading\n-----Text'
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Subheading
+
+
+def test_setext_subheading(lexer):
+    fragments = (
+        'Subheading\n-',
+        'Subheading\n----------',
+        'Subheading\n-----------',
+    )
+
+    for fragment in fragments:
+        tokens = [
+            (Generic.Subheading, fragment.split('\n')[0]),
+            (Token.Text, '\n'),
+            (Generic.Subheading, fragment.split('\n')[1]),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -8,7 +8,7 @@
 """
 
 import pytest
-from pygments.token import Generic, Token
+from pygments.token import Generic, Token, String
 
 from pygments.lexers.markup import MarkdownLexer
 
@@ -165,3 +165,37 @@ def test_setext_subheading(lexer):
             (Token.Text, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_inline_code(lexer):
+    fragment = '`code`'
+    tokens = [
+        (String.Backtick, '`code`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(`code`)'
+    tokens = [
+        (Token.Text, '('),
+        (String.Backtick, '`code`'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = 'inline `code`!'
+    tokens = [
+        (Token.Text, 'inline '),
+        (String.Backtick, '`code`'),
+        (Token.Text, '!'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '`**code**`'
+    tokens = [
+        (String.Backtick, '`**code**`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -312,26 +312,6 @@ def test_escape_italics(lexer):
             assert token != Generic.Emph
 
 
-# def test_inline_italics(lexer):
-#     fragment = '***bold** in italics*'
-#     tokens = [
-#         (Generic.Emph, '*'),
-#         (Generic.Strong, '**bold**'),
-#         (Generic.Emph, ' in italics*'),
-#         (Token.Text, '\n'),
-#     ]
-#     assert list(lexer.get_tokens(fragment)) == tokens
-#
-#     fragment = '*in the **middle** of italics*'
-#     tokens = [
-#         (Generic.Emph, '*in the '),
-#         (Generic.Strong, '**middle**'),
-#         (Generic.Emph, ' of italics*'),
-#         (Token.Text, '\n'),
-#     ]
-#     assert list(lexer.get_tokens(fragment)) == tokens
-
-
 def test_invalid_bold(lexer):
     fragments = (
         '**no bold__',
@@ -379,23 +359,3 @@ def test_bold_fenced_by_underscore(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
-
-
-# def test_inline_bold(lexer):
-#     fragment = '***italics* in bold**'
-#     tokens = [
-#         (Generic.Strong, '**'),
-#         (Generic.Emph, '*italics*'),
-#         (Generic.Strong, ' in bold**'),
-#         (Token.Text, '\n'),
-#     ]
-#     assert list(lexer.get_tokens(fragment)) == tokens
-#
-#     fragment = '**in the *middle* of bold**'
-#     tokens = [
-#         (Generic.Strong, '**in the '),
-#         (Generic.Emph, '*middle*'),
-#         (Generic.Strong, ' of bold**'),
-#         (Token.Text, '\n'),
-#     ]
-#     assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -250,3 +250,152 @@ def test_code_block_indented_by_spaces(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_italics(lexer):
+    fragments = (
+        '*no italics_',
+        '_no italics*',
+        '**no italics**',
+        '__no italics__',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Emph
+
+
+def test_italics_fenced_by_asterisk(lexer):
+    fragment = '*italics*'
+    tokens = [
+        (Generic.Emph, '*italics*'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(*italics*)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Emph, '*italics*'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_italics_fenced_by_underscore(lexer):
+    fragment = '_italics_'
+    tokens = [
+        (Generic.Emph, '_italics_'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(_italics_)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Emph, '_italics_'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_escape_italics(lexer):
+    fragments = (
+        r'\*no italics\*',
+        r'\_ no italics \_',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Emph
+
+
+# def test_inline_italics(lexer):
+#     fragment = '***bold** in italics*'
+#     tokens = [
+#         (Generic.Emph, '*'),
+#         (Generic.Strong, '**bold**'),
+#         (Generic.Emph, ' in italics*'),
+#         (Token.Text, '\n'),
+#     ]
+#     assert list(lexer.get_tokens(fragment)) == tokens
+#
+#     fragment = '*in the **middle** of italics*'
+#     tokens = [
+#         (Generic.Emph, '*in the '),
+#         (Generic.Strong, '**middle**'),
+#         (Generic.Emph, ' of italics*'),
+#         (Token.Text, '\n'),
+#     ]
+#     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_bold(lexer):
+    fragments = (
+        '**no bold__',
+        '__no bold**',
+        '*no bold*',
+        '_no bold_',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != Generic.Strong
+
+
+def test_bold_fenced_by_asterisk(lexer):
+    fragment = '**bold**'
+    tokens = [
+        (Generic.Strong, '**bold**'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(**bold**)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Strong, '**bold**'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_bold_fenced_by_underscore(lexer):
+    fragment = '__bold__'
+    tokens = [
+        (Generic.Strong, '__bold__'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(__bold__)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Strong, '__bold__'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
+# def test_inline_bold(lexer):
+#     fragment = '***italics* in bold**'
+#     tokens = [
+#         (Generic.Strong, '**'),
+#         (Generic.Emph, '*italics*'),
+#         (Generic.Strong, ' in bold**'),
+#         (Token.Text, '\n'),
+#     ]
+#     assert list(lexer.get_tokens(fragment)) == tokens
+#
+#     fragment = '**in the *middle* of bold**'
+#     tokens = [
+#         (Generic.Strong, '**in the '),
+#         (Generic.Emph, '*middle*'),
+#         (Generic.Strong, ' of bold**'),
+#         (Token.Text, '\n'),
+#     ]
+#     assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -199,3 +199,54 @@ def test_inline_code(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_invalid_code_block(lexer):
+    fragments = (
+        '```code```',
+        'prefix not allowed before ```\ncode block\n```'
+        '   code',
+    )
+
+    for fragment in fragments:
+        for token, _ in lexer.get_tokens(fragment):
+            assert token != String.Backtick
+
+
+def test_code_block_fenced_by_backticks(lexer):
+    fragments = (
+        '```\ncode\n```',
+        '```\nmulti\n`line`\ncode\n```',
+    )
+    for fragment in fragments:
+        tokens = [
+            (String.Backtick, fragment),
+            (Token.Text, '\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
+
+def test_code_block_indented_by_spaces(lexer):
+    fragment = '    code'
+    tokens = [
+        (Token.Text, '    '),
+        (String.Backtick, 'code'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '      this is also **code**'
+    tokens = [
+        (Token.Text, '    '),
+        (String.Backtick, '  this is also **code**'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '\tcode'
+    tokens = [
+        (Token.Text, '\t'),
+        (String.Backtick, 'code'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
This is a fix for https://github.com/pygments/pygments/issues/1492 where some fragments were only recognized when prefixed with whitespace characters. 

On top of that the following improvements have been made to the **Markdown** lexer:
* Added Unit Tests
* Added rule to recognize code indented by 4 Spaces or Tab Character
* Recognize Heading Text as `Generic.Heading` instead of `Token.Text`
* Recognize Subheading Text as `Generic.Subheading` instead of `Token.Text`
* Support for [Setext-Style headings](https://daringfireball.net/projects/markdown/syntax#header)
  Example:
  ```
  This is a Heading
  =================
 
  Some text...

  This is a Subheading
  --------------------
  ```
  Renders like this:

  This is a Heading
  ============

  Some text...

  This is a Subheading
  ----------------------