### PR TITLE
Improve HTML formatter output.

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -677,7 +677,8 @@ class HtmlFormatter(Formatter):
                 else:
                     style = ''
 
-            line = '<pre%s>%s</pre>' % (style, line)
+            if style:
+                line = '<span%s>%s</span>' % (style, line)
 
             lines.append(line)
 
@@ -688,8 +689,8 @@ class HtmlFormatter(Formatter):
         # some configurations seem to mess up the formatting...
         yield 0, (
             '<table class="%stable">' % self.cssclass +
-            '<tr><td class="linenos"><div class="linenodiv">' +
-            ls + '</div></td><td class="code">'
+            '<tr><td class="linenos"><div class="linenodiv"><pre>' +
+            ls + '</pre></div></td><td class="code">'
         )
         yield 0, dummyoutfile.getvalue()
         yield 0, '</td></tr></table>'
@@ -723,7 +724,10 @@ class HtmlFormatter(Formatter):
                 else:
                     style = ' class="linenos"'
 
-            yield 1, '<span%s>%s</span>' % (style, line) + inner_line
+            if style:
+                yield 1, '<span%s>%s</span>' % (style, line) + inner_line
+            else:
+                yield 1, line +  inner_line
             num += 1
 
     def _wrap_lineanchors(self, inner):

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos">1</span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos">3</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos">3</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos">1</span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos">3</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos">3</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos">1</span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos special">3</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special">3</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos">1</span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos special">3</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special">3</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos"> 9</span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos"> 9</span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos special"> 9</span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos special"> 9</span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> </span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos"> </span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos"> </span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> </span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos"> </span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos"> </span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> </span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos special"> </span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special"> </span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> </span><span class="c1"># a</span>
-    <span class="linenos">2</span><span class="c1"># b</span>
-    <span class="linenos special"> </span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special"> </span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos">  </span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos">  </span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos special">  </span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight">
-  <pre>
-    <span></span>
-    <span class="linenos"> 8</span><span class="c1"># a</span>
-    <span class="linenos special">  </span><span class="c1"># b</span>
-    <span class="linenos">10</span><span class="c1"># c</span>
-  </pre>
+ <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor.html
@@ -1,8 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
-  <pre style="line-height: 125%; margin: 0;">
-    <span></span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-    <span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-    <span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
-  </pre>
+ <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+</pre>
 </div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-1">1</a></pre>
-        <pre><a href="#-2">2</a></pre>
-        <pre><a href="#-3">3</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-1">1</a>
+<a href="#-2">2</a>
+<a href="#-3">3</a></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre>1</pre>
-        <pre>2</pre>
-        <pre>3</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre>1
+2
+3</pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-1">1</a></pre>
-        <pre><a href="#-2">2</a></pre>
-        <pre class="special"><a href="#-3">3</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-1">1</a>
+<a href="#-2">2</a>
+<span class="special"><a href="#-3">3</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre>1</pre>
-        <pre>2</pre>
-        <pre class="special">3</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre>1
+2
+<span class="special">3</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-8"> 8</a></pre>
-        <pre><a href="#-9"> 9</a></pre>
-        <pre><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-8"> 8</a>
+<a href="#-9"> 9</a>
+<a href="#-10">10</a></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> 8</pre>
-        <pre> 9</pre>
-        <pre>10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 8
+ 9
+10</pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-8"> 8</a></pre>
-        <pre class="special"><a href="#-9"> 9</a></pre>
-        <pre><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-8"> 8</a>
+<span class="special"><a href="#-9"> 9</a></span>
+<a href="#-10">10</a></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> 8</pre>
-        <pre class="special"> 9</pre>
-        <pre>10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 8
+<span class="special"> 9</span>
+10</pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> </pre>
-        <pre><a href="#-2">2</a></pre>
-        <pre> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 
+<a href="#-2">2</a>
+ </pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> </pre>
-        <pre>2</pre>
-        <pre> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 
+2
+ </pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> </pre>
-        <pre><a href="#-2">2</a></pre>
-        <pre class="special"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 
+<a href="#-2">2</a>
+<span class="special"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> </pre>
-        <pre>2</pre>
-        <pre class="special"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 
+2
+<span class="special"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-8"> 8</a></pre>
-        <pre>  </pre>
-        <pre><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-8"> 8</a>
+  
+<a href="#-10">10</a></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> 8</pre>
-        <pre>  </pre>
-        <pre>10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 8
+  
+10</pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre><a href="#-8"> 8</a></pre>
-        <pre class="special">  </pre>
-        <pre><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><a href="#-8"> 8</a>
+<span class="special">  </span>
+<a href="#-10">10</a></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre> 8</pre>
-        <pre class="special">  </pre>
-        <pre>10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight">
-        <pre>
-          <span></span>
-          <span class="c1"># a</span>
-          <span class="c1"># b</span>
-          <span class="c1"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre> 8
+<span class="special">  </span>
+10</pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight">
+    <pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-1">1</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-3">3</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-1">1</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-3">3</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">3</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-1">1</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"><a href="#-3">3</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-1">1</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"><a href="#-3">3</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">1</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">3</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-9"> 9</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-9"> 9</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 9</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"><a href="#-9"> 9</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"><a href="#-9"> 9</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> 9</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-2">2</a></span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">2</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;"> </span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">  </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-8"> 8</a></span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"><a href="#-10">10</a></span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor.html
@@ -1,21 +1,19 @@
 <table class="highlighttable">
-  <tr>
-    <td class="linenos">
-      <div class="linenodiv">
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</pre>
-        <pre style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </pre>
-        <pre style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</pre>
-      </div>
-    </td>
-    <td class="code">
-      <div class="highlight" style="background: #f8f8f8">
-        <pre style="line-height: 125%; margin: 0;">
-          <span></span>
-          <span style="color: #408080; font-style: italic"># a</span>
-          <span style="color: #408080; font-style: italic"># b</span>
-          <span style="color: #408080; font-style: italic"># c</span>
-        </pre>
-      </div>
-    </td>
-  </tr>
+ <tr>
+  <td class="linenos">
+   <div class="linenodiv">
+    <pre><span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;"> 8</span>
+<span style="color: #000000; background-color: #ffffc0; padding: 0 5px 0 5px;">  </span>
+<span style="color: #000000; background-color: #f0f0f0; padding: 0 5px 0 5px;">10</span></pre>
+   </div>
+  </td>
+  <td class="code">
+   <div class="highlight" style="background: #f8f8f8">
+    <pre style="line-height: 125%; margin: 0;"><span></span><span style="color: #408080; font-style: italic"># a</span>
+<span style="color: #408080; font-style: italic"># b</span>
+<span style="color: #408080; font-style: italic"># c</span>
+</pre>
+   </div>
+  </td>
+ </tr>
 </table>


### PR DESCRIPTION
With the previous changes, we started to emit one <pre> per line for
line numbers. This breaks for instance the Sphinx-RTD-Theme, which
expects the line numbers to be formatted the same way as the normal
content. This commit makes the following changes:

* Emit a single <pre> inside the linenos div
* Wrap individual lines into <span> as needed
* Update all tests
* Don't yield empty <span> elements when no style is specified

This also makes the .html test files look correct when looked at with a
browser, as there is no extra whitespace in them which needs stripping.