### PR TITLE
APL lexer: Include latest APL primitives

### DIFF
--- a/pygments/lexers/apl.py
+++ b/pygments/lexers/apl.py
@@ -77,8 +77,8 @@ class APLLexer(RegexLexer):
             #
             # Operators
             # ==========
-            (u'[\\.\\\\\\/⌿⍀¨⍣⍨⍠⍤∘]', Name.Attribute),  # closest token type
-            (u'[+\\-×÷⌈⌊∣|⍳?*⍟○!⌹<≤=>≥≠≡≢∊⍷∪∩~∨∧⍱⍲⍴,⍪⌽⊖⍉↑↓⊂⊃⌷⍋⍒⊤⊥⍕⍎⊣⊢⍁⍂≈⌸⍯↗]',
+            (u'[\\.\\\\\\/⌿⍀¨⍣⍨⍠⍤∘⌸&⌶@⌺⍥⍛⍢]', Name.Attribute),  # closest token type
+            (u'[+\\-×÷⌈⌊∣|⍳?*⍟○!⌹<≤=>≥≠≡≢∊⍷∪∩~∨∧⍱⍲⍴,⍪⌽⊖⍉↑↓⊂⊃⌷⍋⍒⊤⊥⍕⍎⊣⊢⍁⍂≈⌸⍯↗⊆⊇⍸√⌾…⍮]',
              Operator),
             #
             # Constant


### PR DESCRIPTION
The current lexer treats the APL primitive *functions* as `Operator` and primitive *operators* as `Name.Attribute`. This PR adds seven new primitive functions `⊆⊇⍸√⌾…⍮` and eight new primitive operators `⌸&⌶@⌺⍥⍛⍢` to support the latest version of [Dyalog APL](https://www.dyalog.com/) and other cutting-edge APL implementations.