### PR TITLE
Fix broken link in doc/_templates/indexsidebar.html

### DIFF
--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -20,5 +20,5 @@
 <p>You can also open an issue at the
   <a href="https://github.com/pygments/pygments/issues">tracker</a>.</p>
 
-<p class="logo">A <a href="https://pocoo.org/">
+<p class="logo">A <a href="https://www.pocoo.org/">
     <img src="{{ pathto("_static/pocoo.png", 1) }}" /></a> project</a></p>


### PR DESCRIPTION
Was looking at the online documentation and found a broken link 🙃 

```console
(black-rHKUX7ap) R:\Programming\black\docs>curl -i https://pocoo.org
HTTP/1.1 400 Bad Request
Server: nginx
Date: Thu, 20 Aug 2020 18:36:55 GMT
Content-Type: text/html
Content-Length: 166
Connection: close

<html>
<head><title>400 Bad Request</title></head>
<body bgcolor="white">
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx</center>
</body>
</html>

(black-rHKUX7ap) R:\Programming\black\docs>curl -i https://www.pocoo.org
HTTP/1.1 200 OK
Server: nginx
Date: Thu, 20 Aug 2020 18:37:07 GMT
Content-Type: text/html
Content-Length: 1975
Last-Modified: Wed, 23 May 2018 10:05:28 GMT
Connection: keep-alive
ETag: "5b053ce8-7b7"
Accept-Ranges: bytes

[snip]
```