### PR TITLE
Fix HttpLexer to allow HTTP/2.0 as preface

### DIFF
--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -175,11 +175,11 @@ class HttpLexer(RegexLexer):
     tokens = {
         'root': [
             (r'(GET|POST|PUT|DELETE|HEAD|OPTIONS|TRACE|PATCH)( +)([^ ]+)( +)'
-             r'(HTTP)(/)(1\.[01]|2|3)(\r?\n|\Z)',
+             r'(HTTP)(/)(1\.[01]|2(?:\.0)|3)(\r?\n|\Z)',
              bygroups(Name.Function, Text, Name.Namespace, Text,
                       Keyword.Reserved, Operator, Number, Text),
              'headers'),
-            (r'(HTTP)(/)(1\.[01]|2|3)( +)(\d{3})(?:( +)([^\r\n]*))?(\r?\n|\Z)',
+            (r'(HTTP)(/)(1\.[01]|2(?:\.0)|3)( +)(\d{3})(?:( +)([^\r\n]*))?(\r?\n|\Z)',
              bygroups(Keyword.Reserved, Operator, Number, Text, Number, Text,
                       Name.Exception, Text),
              'headers'),

--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -175,11 +175,11 @@ class HttpLexer(RegexLexer):
     tokens = {
         'root': [
             (r'(GET|POST|PUT|DELETE|HEAD|OPTIONS|TRACE|PATCH)( +)([^ ]+)( +)'
-             r'(HTTP)(/)(1\.[01]|2(?:\.0)|3)(\r?\n|\Z)',
+             r'(HTTP)(/)(1\.[01]|2(?:\.0)?|3)(\r?\n|\Z)',
              bygroups(Name.Function, Text, Name.Namespace, Text,
                       Keyword.Reserved, Operator, Number, Text),
              'headers'),
-            (r'(HTTP)(/)(1\.[01]|2(?:\.0)|3)( +)(\d{3})(?:( +)([^\r\n]*))?(\r?\n|\Z)',
+            (r'(HTTP)(/)(1\.[01]|2(?:\.0)?|3)( +)(\d{3})(?:( +)([^\r\n]*))?(\r?\n|\Z)',
              bygroups(Keyword.Reserved, Operator, Number, Text, Number, Text,
                       Name.Exception, Text),
              'headers'),


### PR DESCRIPTION
According to [RFC7540 (section 3.5)](https://tools.ietf.org/html/rfc7540#section-3.5), if I interpret it correctly, it actually even _has to_ start with `2.0` and not `2`.

As HTTP/3 is also defined there, I have not looked into how that has to be used/started. (i.e. that _may_ need to be fixed as well)

Fixes https://github.com/pygments/pygments/issues/1520