### PR TITLE
more explicitly define escape sequencies in JsonLexer (fix #1065)

### DIFF
--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -471,7 +471,7 @@ class JsonLexer(RegexLexer):
               '%(exp_part)s|%(frac_part)s)') % vars(),
              Number.Float),
             (int_part, Number.Integer),
-            (r'"(\\\\|\\"|[^"])*"', String.Double),
+            (r'"(\\(["\\/bfnrt]|u[a-fA-F0-9]]{4})|[^\\"])*"', String.Double),
         ],
 
 
@@ -488,7 +488,7 @@ class JsonLexer(RegexLexer):
         # a json object - { attr, attr, ... }
         'objectvalue': [
             include('whitespace'),
-            (r'"(\\\\|\\"|[^"])*"', Name.Tag, 'objectattribute'),
+            (r'"(\\(["\\/bfnrt]|u[a-fA-F0-9]]{4})|[^\\"])*"', Name.Tag, 'objectattribute'),
             (r'\}', Punctuation, '#pop'),
         ],
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -56,6 +56,34 @@ def test_basic_json(lexer_json):
     assert list(lexer_json.get_tokens(fragment)) == tokens
 
 
+def test_json_escape_backtracking(lexer_json):
+    # This tests that an (invalid) sequence of escapes doesn't cause the lexer
+    # to fall into catastrophic backtracking. unfortunately, if it's broken
+    # this test will hang and that's how we know it's broken :(
+    fragment = r'{"\u00D0000\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\63CD'
+    tokens = (
+        [(Token.Punctuation, u'{'),
+        (Token.Error, r'"'),
+        (Token.Error, '\\'),
+        (Token.Error, r'u'),
+        (Token.Error, r'0'),
+        (Token.Error, r'0'),
+        (Token.Error, r'D'),
+        (Token.Error, r'0'),
+        (Token.Error, r'0'),
+        (Token.Error, r'0'),
+        (Token.Error, r'0')]
+        + [(Token.Error, '\\')] * 178
+        + [(Token.Error, r'6'),
+        (Token.Error, r'3'),
+        (Token.Error, r'C'),
+        (Token.Error, r'D'),
+        (Token.Text, '\n')]
+    )
+
+    assert list(lexer_json.get_tokens(fragment)) == tokens
+
+
 def test_basic_bare(lexer_bare):
     # This is the same as testBasic for JsonLexer above, except the
     # enclosing curly braces are removed.


### PR DESCRIPTION
As discussed in #1065 the existing regex for matching strings suffers from catastrophic backtracking on some strings. This updated regex is more explicit (and less forgiving) about handling escape sequences.

Tests pass and the https://github.com/simdjson/simdjson/blob/master/jsonchecker/adversarial/issue150/1005.json example doesn't cause a hang.