### PR TITLE
Add missing prompt color for Solarized style.

### DIFF
--- a/pygments/styles/solarized.py
+++ b/pygments/styles/solarized.py
@@ -58,6 +58,7 @@ def make_style(colors):
 
         Number:              colors['cyan'],
 
+        Generic:             colors['base0'],
         Generic.Deleted:     colors['red'],
         Generic.Emph:        'italic',
         Generic.Error:       colors['red'],

--- a/pygments/styles/solarized.py
+++ b/pygments/styles/solarized.py
@@ -64,6 +64,7 @@ def make_style(colors):
         Generic.Heading:     'bold',
         Generic.Subheading:  'underline',
         Generic.Inserted:    colors['green'],
+        Generic.Output:      colors['base0'],
         Generic.Prompt:      'bold ' + colors['blue'],
         Generic.Strong:      'bold',
         Generic.Traceback:   colors['blue'],

--- a/pygments/styles/solarized.py
+++ b/pygments/styles/solarized.py
@@ -64,6 +64,7 @@ def make_style(colors):
         Generic.Heading:     'bold',
         Generic.Subheading:  'underline',
         Generic.Inserted:    colors['green'],
+        Generic.Prompt:      'bold ' + colors['blue'],
         Generic.Strong:      'bold',
         Generic.Traceback:   colors['blue'],
 


### PR DESCRIPTION
This might fix rendering on dark background as hinted by https://github.com/pygments/pygments/issues/1526.