### PR TITLE
Add support for ARM constant notation in GAS lexer

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -37,7 +37,7 @@ class GasLexer(RegexLexer):
     string = r'"(\\"|[^"])*"'
     char = r'[\w$.@-]'
     identifier = r'(?:[a-zA-Z$_]' + char + r'*|\.' + char + '+)'
-    number = r'(?:0[xX][a-zA-Z0-9]+|\d+)'
+    number = r'(?:0[xX][a-fA-F0-9]+|#?-?\d+)'
     register = '%' + identifier
 
     tokens = {


### PR DESCRIPTION
GNU supports ARM syntax which uses notation like `#1` for constants.
Currently this is handled like a comment which is incorrect.

Take the case of:
ldr     r0, [r1, #0]

Right now the #0] would be treated like a comment and looks very poor.
![image](https://user-images.githubusercontent.com/173245/92046490-80510900-ed37-11ea-93ee-657726231a79.png)

After this change:
![image](https://user-images.githubusercontent.com/173245/92046521-952d9c80-ed37-11ea-920a-33f219a99ed0.png)

Was referenced as part of issue #627 