### PR TITLE
Support Ruby method names and operator overrides, including Unicode

### DIFF
--- a/pygments/lexers/ruby.py
+++ b/pygments/lexers/ruby.py
@@ -328,11 +328,11 @@ class RubyLexer(ExtendedRegexLexer):
         ],
         'funcname': [
             (r'\(', Punctuation, 'defexpr'),
-            (r'(?:([a-zA-Z_]\w*)(\.))?'  # optional scope name, like "self."
+            ('(?:([a-zA-Z_]\\w*)(\\.))?'  # optional scope name, like "self."
              '('
                 '[a-zA-Z\u0080-\uffff][a-zA-Z0-9_\u0080-\uffff]*[!?=]?'  # method name
                 '|!=|!~|=~|\\*\\*?|[-+!~]@?|[/%&|^]|<=>|<[<=]?|>[>=]?|===?'  # or operator override
-                r'|\[\]=?'  # or element reference/assignment override
+                '|\\[\\]=?'  # or element reference/assignment override
                 '|`'  # or the undocumented backtick override
              ')',
              bygroups(Name.Class, Operator, Name.Function), '#pop'),

--- a/pygments/lexers/ruby.py
+++ b/pygments/lexers/ruby.py
@@ -328,9 +328,13 @@ class RubyLexer(ExtendedRegexLexer):
         ],
         'funcname': [
             (r'\(', Punctuation, 'defexpr'),
-            (r'(?:([a-zA-Z_]\w*)(\.))?'
-             r'([a-zA-Z_]\w*[!?]?|\*\*?|[-+]@?|'
-             r'[/%&|^`~]|\[\]=?|<<|>>|<=?>|>=?|===?)',
+            (r'(?:([a-zA-Z_]\w*)(\.))?'  # optional scope name, like "self."
+             '('
+                '[a-zA-Z\u0080-\uffff][a-zA-Z0-9_\u0080-\uffff]*[!?=]?'  # method name
+                '|!=|!~|=~|\\*\\*?|[-+!~]@?|[/%&|^]|<=>|<[<=]?|>[>=]?|===?'  # or operator override
+                r'|\[\]=?'  # or element reference/assignment override
+                '|`'  # or the undocumented backtick override
+             ')',
              bygroups(Name.Class, Operator, Name.Function), '#pop'),
             default('#pop')
         ],

--- a/pygments/lexers/ruby.py
+++ b/pygments/lexers/ruby.py
@@ -328,13 +328,13 @@ class RubyLexer(ExtendedRegexLexer):
         ],
         'funcname': [
             (r'\(', Punctuation, 'defexpr'),
-            ('(?:([a-zA-Z_]\\w*)(\\.))?'  # optional scope name, like "self."
-             '('
-                '[a-zA-Z\u0080-\uffff][a-zA-Z0-9_\u0080-\uffff]*[!?=]?'  # method name
-                '|!=|!~|=~|\\*\\*?|[-+!~]@?|[/%&|^]|<=>|<[<=]?|>[>=]?|===?'  # or operator override
-                '|\\[\\]=?'  # or element reference/assignment override
-                '|`'  # or the undocumented backtick override
-             ')',
+            (r'(?:([a-zA-Z_]\w*)(\.))?'  # optional scope name, like "self."
+             r'('
+                r'[a-zA-Z\u0080-\uffff][a-zA-Z0-9_\u0080-\uffff]*[!?=]?'  # method name
+                r'|!=|!~|=~|\*\*?|[-+!~]@?|[/%&|^]|<=>|<[<=]?|>[>=]?|===?'  # or operator override
+                r'|\[\]=?'  # or element reference/assignment override
+                r'|`'  # or the undocumented backtick override
+             r')',
              bygroups(Name.Class, Operator, Name.Function), '#pop'),
             default('#pop')
         ],


### PR DESCRIPTION
Fixes #253

This patch contains these changes:

* Add 50+ new Ruby tests for method name/operator override matching.
* Unicode method names are now supported (#253).
* `=` method name postfixes are now supported.
* These operator overrides are now supported:
  `<`, `<=`, `!` `!@`, `~@`, `!`, `!=`, `!~`, `=~`
* The `<>` "operator" override is removed. It appears that this was
  a typo in the regular expression (`<=?>` should have been `<=>?`).

Syntax verified with https://docs.ruby-lang.org/en/2.7.0/syntax/methods_rdoc.html