### PR TITLE
Remove Python 2 environments from the tox environment list (py27, pypy)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37, py38, pypy, pypy3
+envlist = py35, py36, py37, py38, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
This patch removes Python 2.7 and PyPY 2.7 from the tox environments list.

This appears to bring the tox env list in line with Pygments' list of target Python environments in `setup.py`.