### PR TITLE
Fix a Windows/PyPy3 test failure

### DIFF
--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -515,7 +515,11 @@ def main_inner(popts, args, usage):
     # ... and do it!
     if '-s' not in opts:
         # process whole input as per normal...
-        highlight(code, lexer, fmter, outfile)
+        try:
+            highlight(code, lexer, fmter, outfile)
+        finally:
+            if outfn:
+                outfile.close()
         return 0
     else:
         # line by line processing of stdin (eg: for 'tail -f')...
@@ -532,6 +536,9 @@ def main_inner(popts, args, usage):
             return 0
         except KeyboardInterrupt:  # pragma: no cover
             return 0
+        finally:
+            if outfn:
+                outfile.close()
 
 
 def main(args=sys.argv):


### PR DESCRIPTION
PyPy3 on Windows has a test failure in `test_cmdline:test_outfile()`
when trying to unlink the temporary output file. The root cause is that
`cmdline:inner_main()` does not explicitly close the file that it opens,
and PyPy3 isn't auto-closing the file when `inner_main()` returns.
This prevents the file from being unlinked, and the test case fails.