### PR TITLE
Add a check for CR/LF in files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export PYTHONPATH = $(shell echo "$$PYTHONPATH"):$(shell python -c 'import os; p
 all: clean-pyc check test
 
 check:
-	@$(PYTHON) scripts/check_crlf.py pygments build external || true
+	@$(PYTHON) scripts/check_crlf.py pygments build external
 	@$(PYTHON) scripts/detect_missing_analyse_text.py || true
 	@pyflakes pygments | grep -v 'but unused' || true
 	@$(PYTHON) scripts/check_sources.py -i build -i dist -i pygments/lexers/_mapping.py \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ export PYTHONPATH = $(shell echo "$$PYTHONPATH"):$(shell python -c 'import os; p
 all: clean-pyc check test
 
 check:
+	@$(PYTHON) scripts/check_crlf.py pygments dist || true
 	@$(PYTHON) scripts/detect_missing_analyse_text.py || true
 	@pyflakes pygments | grep -v 'but unused' || true
 	@$(PYTHON) scripts/check_sources.py -i build -i dist -i pygments/lexers/_mapping.py \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ export PYTHONPATH = $(shell echo "$$PYTHONPATH"):$(shell python -c 'import os; p
 all: clean-pyc check test
 
 check:
-	@$(PYTHON) scripts/check_crlf.py pygments dist || true
+	@$(PYTHON) scripts/check_crlf.py pygments build external || true
 	@$(PYTHON) scripts/detect_missing_analyse_text.py || true
 	@pyflakes pygments | grep -v 'but unused' || true
 	@$(PYTHON) scripts/check_sources.py -i build -i dist -i pygments/lexers/_mapping.py \

--- a/scripts/check_crlf.py
+++ b/scripts/check_crlf.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Checker for line endings
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Make sure each Python does not use Windows-style file endings.
+
+    :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import sys
+import os
+
+if __name__ == '__main__':
+    for directory in sys.argv[1:]:
+        if not os.path.exists(directory):
+            continue
+
+        for root, dirs, files in os.walk(directory):
+            for filename in files:
+                if not filename.endswith('.py'):
+                    continue
+
+                with open(os.path.join(root, filename), 'rb') as f:
+                    if b'\r\n' in f.read():
+                        sys.exit(1)
+    
+    sys.exit(0)

--- a/scripts/check_crlf.py
+++ b/scripts/check_crlf.py
@@ -4,7 +4,8 @@
     Checker for line endings
     ~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Make sure each Python does not use Windows-style file endings.
+    Make sure Python (.py) and Bash completition (.bashcomp) files do not
+    contain CR/LF newlines.
 
     :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -23,8 +24,10 @@ if __name__ == '__main__':
                 if not filename.endswith('.py') and not filename.endswith('.bashcomp'):
                     continue
 
-                with open(os.path.join(root, filename), 'rb') as f:
+                full_path = os.path.join(root, filename)
+                with open(full_path, 'rb') as f:
                     if b'\r\n' in f.read():
+                        print('CR/LF found in', full_path)
                         sys.exit(1)
 
     sys.exit(0)

--- a/scripts/check_crlf.py
+++ b/scripts/check_crlf.py
@@ -20,11 +20,11 @@ if __name__ == '__main__':
 
         for root, dirs, files in os.walk(directory):
             for filename in files:
-                if not filename.endswith('.py'):
+                if not filename.endswith('.py') and not filename.endswith('.bashcomp'):
                     continue
 
                 with open(os.path.join(root, filename), 'rb') as f:
                     if b'\r\n' in f.read():
                         sys.exit(1)
-    
+
     sys.exit(0)


### PR DESCRIPTION
This can occur when checking out things on Windows, and it breaks the
tarball. This adds a script to check for the presence of CR/LF which
exits early if anything gets found.