### PR TITLE
Add Python 3.9 as a supported version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py35, py36, py37, py38, py39, pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
This patch adds Python 3.9 as a tested tox version and lists it as a trove classifier in `setup.py`.

I didn't try to add it as a GitHub workflow because I'm not sure if Python 3.9 is supported yet. That piece still needs to be done.