### PR TITLE
Add regexlint to tox so linting can be done during development

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,5 @@ commands = py.test {posargs}
 
 [testenv:lint]
 deps =
-    regexlint
+    git+https://github.com/pygments/regexlint.git@master
 commands = regexlint pygments.lexers

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,14 @@
 [tox]
-envlist = py35, py36, py37, py38, pypy3
+envlist = py35, py36, py37, py38, pypy3, lint
 
 [testenv]
 deps =
     pytest
     pytest-cov
 commands = py.test {posargs}
+
+
+[testenv:lint]
+deps =
+    regexlint
+commands = regexlint pygments.lexers


### PR DESCRIPTION
Tested on Windows.

Closes #1556