### PR TITLE
Speed up JSON and reduce HTML formatter consumption

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -9,6 +9,7 @@
     :license: BSD, see LICENSE for details.
 """
 
+import functools
 import os
 import sys
 import os.path
@@ -794,6 +795,11 @@ class HtmlFormatter(Formatter):
         yield from inner
         yield 0, '</code>'
 
+    @functools.lru_cache(maxsize=100)
+    def _translate_parts(self, value):
+        """HTML-escape a value and split it by newlines."""
+        return value.translate(_escape_html_table).split('\n')
+
     def _format_lines(self, tokensource):
         """
         Just format the tokens, without any wrapping tags.
@@ -801,7 +807,6 @@ class HtmlFormatter(Formatter):
         """
         nocls = self.noclasses
         lsep = self.lineseparator
-        escape_table = _escape_html_table
         tagsfile = self.tagsfile
 
         lspan = ''
@@ -815,7 +820,7 @@ class HtmlFormatter(Formatter):
                 else:
                     cspan = self.span_element_openers[ttype] = self._get_css_classes(ttype)
 
-            parts = value.translate(escape_table).split('\n')
+            parts = self._translate_parts(value)
 
             if tagsfile and ttype in Token.Name:
                 filename, linenumber = self._lookup_ctag(value)

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -541,7 +541,7 @@ class JsonBareObjectLexer(JsonLexer):
 
 class JsonLdLexer(JsonLexer):
     """
-    For `JSON-LD <http://json-ld.org/>`_ linked data.
+    For `JSON-LD <https://json-ld.org/>`_ linked data.
 
     .. versionadded:: 2.0
     """
@@ -551,11 +551,38 @@ class JsonLdLexer(JsonLexer):
     filenames = ['*.jsonld']
     mimetypes = ['application/ld+json']
 
-    tokens = {
-        'objectvalue': [
-            (r'"@(context|id|value|language|type|container|list|set|'
-             r'reverse|index|base|vocab|graph)"', Name.Decorator,
-             'objectattribute'),
-            inherit,
-        ],
+    json_ld_keywords = {
+        '"@%s"' % keyword
+        for keyword in (
+            'base',
+            'container',
+            'context',
+            'direction',
+            'graph',
+            'id',
+            'import',
+            'included',
+            'index',
+            'json',
+            'language',
+            'list',
+            'nest',
+            'none',
+            'prefix',
+            'propagate',
+            'protected',
+            'reverse',
+            'set',
+            'type',
+            'value',
+            'version',
+            'vocab',
+        )
     }
+
+    def get_tokens_unprocessed(self, text, stack=('root',)):
+        for start, token, value in super(JsonLdLexer, self).get_tokens_unprocessed(text, stack):
+            if token is Name.Tag and value in self.json_ld_keywords:
+                yield start, Name.Decorator, value
+            else:
+                yield start, token, value

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -448,6 +448,14 @@ class JsonLexer(Lexer):
     filenames = ['*.json', 'Pipfile.lock']
     mimetypes = ['application/json']
 
+    # No validation of integers, floats, or constants is done.
+    # As long as the characters are members of the following
+    # sets, the token will be considered valid. For example,
+    #
+    #     "--1--" is parsed as an integer
+    #     "1...eee" is parsed as a float
+    #     "trustful" is parsed as a constant
+    #
     integers = set('-0123456789')
     floats = set('.eE+')
     constants = set('truefalsenull')  # true|false|null

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -479,10 +479,13 @@ class JsonLexer(Lexer):
         # an object key; any other character indicates the string is a
         # regular string value.
         #
-        # The queue holds tuples of slice indices and the token type.
-        # The token type will be replaced if necessary. For example:
+        # The queue holds tuples that contain the following data:
         #
-        #     (1, 7, Name.Tag)
+        #     (start_index, token_type, text)
+        #
+        # By default the token type of text in double quotes is
+        # String.Double. The token type will be replaced if a colon
+        # is encountered after the string closes.
         #
         queue = []
 

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -11,7 +11,7 @@
 
 import re
 
-from pygments.lexer import RegexLexer, ExtendedRegexLexer, LexerContext, \
+from pygments.lexer import Lexer, RegexLexer, ExtendedRegexLexer, LexerContext, \
     include, bygroups, inherit
 from pygments.token import Text, Comment, Keyword, Name, String, Number, \
     Punctuation, Literal, Error
@@ -436,7 +436,7 @@ class YamlLexer(ExtendedRegexLexer):
         return super().get_tokens_unprocessed(text, context)
 
 
-class JsonLexer(RegexLexer):
+class JsonLexer(Lexer):
     """
     For JSON data structures.
 
@@ -448,71 +448,177 @@ class JsonLexer(RegexLexer):
     filenames = ['*.json', 'Pipfile.lock']
     mimetypes = ['application/json']
 
-    flags = re.DOTALL
+    integers = set('-0123456789')
+    floats = set('.eE+')
+    constants = set('truefalsenull')  # true|false|null
+    hexadecimals = set('0123456789abcdefABCDEF')
+    punctuations = set('{}[],')
+    whitespaces = {'\u0020', '\u000a', '\u000d', '\u0009'}
 
-    # integer part of a number
-    int_part = r'-?(0|[1-9]\d*)'
+    def get_tokens_unprocessed(self, text):
+        """Parse JSON data."""
 
-    # fractional part of a number
-    frac_part = r'\.\d+'
+        in_string = False
+        in_escape = False
+        in_unicode_escape = 0
+        in_whitespace = False
+        in_constant = False
+        in_number = False
+        in_float = False
+        in_punctuation = False
 
-    # exponential part of a number
-    exp_part = r'[eE](\+|-)?\d+'
+        start = 0
 
-    tokens = {
-        'whitespace': [
-            (r'\s+', Text),
-        ],
+        # The queue is used to store data that may need to be tokenized
+        # differently based on what follows. In particular, JSON object
+        # keys are tokenized differently than string values, but cannot
+        # be distinguished until punctuation is encountered outside the
+        # string.
+        #
+        # A ":" character after the string indicates that the string is
+        # an object key; any other character indicates the string is a
+        # regular string value.
+        #
+        # The queue holds tuples of slice indices and the token type.
+        # The token type will be replaced if necessary. For example:
+        #
+        #     (1, 7, Name.Tag)
+        #
+        queue = []
 
-        # represents a simple terminal value
-        'simplevalue': [
-            (r'(true|false|null)\b', Keyword.Constant),
-            (('%(int_part)s(%(frac_part)s%(exp_part)s|'
-              '%(exp_part)s|%(frac_part)s)') % vars(),
-             Number.Float),
-            (int_part, Number.Integer),
-            (r'"(\\(["\\/bfnrt]|u[a-fA-F0-9]{4})|[^\\"])*"', String.Double),
-        ],
+        for stop, character in enumerate(text):
+            if in_string:
+                if in_unicode_escape:
+                    if character in self.hexadecimals:
+                        in_unicode_escape -= 1
+                        if not in_unicode_escape:
+                            in_escape = False
+                    else:
+                        in_unicode_escape = 0
+                        in_escape = False
 
+                elif in_escape:
+                    if character == 'u':
+                        in_unicode_escape = 4
+                    else:
+                        in_escape = False
 
-        # the right hand side of an object, after the attribute name
-        'objectattribute': [
-            include('value'),
-            (r':', Punctuation),
-            # comma terminates the attribute but expects more
-            (r',', Punctuation, '#pop'),
-            # a closing bracket terminates the entire object, so pop twice
-            (r'\}', Punctuation, '#pop:2'),
-        ],
+                elif character == '\\':
+                    in_escape = True
 
-        # a json object - { attr, attr, ... }
-        'objectvalue': [
-            include('whitespace'),
-            (r'"(\\(["\\/bfnrt]|u[a-fA-F0-9]{4})|[^\\"])*"', Name.Tag, 'objectattribute'),
-            (r'\}', Punctuation, '#pop'),
-        ],
+                elif character == '"':
+                    queue.append((start, String.Double, text[start:stop + 1]))
+                    in_string = False
+                    in_escape = False
+                    in_unicode_escape = 0
 
-        # json array - [ value, value, ... }
-        'arrayvalue': [
-            include('whitespace'),
-            include('value'),
-            (r',', Punctuation),
-            (r'\]', Punctuation, '#pop'),
-        ],
+                continue
 
-        # a json value - either a simple value or a complex value (object or array)
-        'value': [
-            include('whitespace'),
-            include('simplevalue'),
-            (r'\{', Punctuation, 'objectvalue'),
-            (r'\[', Punctuation, 'arrayvalue'),
-        ],
+            elif in_whitespace:
+                if character in self.whitespaces:
+                    continue
 
-        # the root of a json document whould be a value
-        'root': [
-            include('value'),
-        ],
-    }
+                if queue:
+                    queue.append((start, Text, text[start:stop]))
+                else:
+                    yield start, Text, text[start:stop]
+                in_whitespace = False
+                # Fall through so the new character can be evaluated.
+
+            elif in_constant:
+                if character in self.constants:
+                    continue
+
+                yield start, Keyword.Constant, text[start:stop]
+                in_constant = False
+                # Fall through so the new character can be evaluated.
+
+            elif in_number:
+                if character in self.integers:
+                    continue
+                elif character in self.floats:
+                    in_float = True
+                    continue
+
+                if in_float:
+                    yield start, Number.Float, text[start:stop]
+                else:
+                    yield start, Number.Integer, text[start:stop]
+                in_number = False
+                in_float = False
+                # Fall through so the new character can be evaluated.
+
+            elif in_punctuation:
+                if character in self.punctuations:
+                    continue
+
+                yield start, Punctuation, text[start:stop]
+                in_punctuation = False
+                # Fall through so the new character can be evaluated.
+
+            start = stop
+
+            if character == '"':
+                in_string = True
+
+            elif character in self.whitespaces:
+                in_whitespace = True
+
+            elif character in {'f', 'n', 't'}:  # The first letters of true|false|null
+                # Exhaust the queue. Accept the existing token types.
+                yield from queue
+                queue.clear()
+
+                in_constant = True
+
+            elif character in self.integers:
+                # Exhaust the queue. Accept the existing token types.
+                yield from queue
+                queue.clear()
+
+                in_number = True
+
+            elif character == ':':
+                # Yield from the queue. Replace string token types.
+                for _start, _token, _text in queue:
+                    if _token is Text:
+                        yield _start, _token, _text
+                    elif _token is String.Double:
+                        yield _start, Name.Tag, _text
+                    else:
+                        yield _start, Error, _text
+                queue.clear()
+
+                in_punctuation = True
+
+            elif character in self.punctuations:
+                # Exhaust the queue. Accept the existing token types.
+                yield from queue
+                queue.clear()
+
+                in_punctuation = True
+
+            else:
+                # Exhaust the queue. Accept the existing token types.
+                yield from queue
+                queue.clear()
+
+                yield start, Error, character
+
+        # Yield any remaining text.
+        yield from queue
+        if in_string:
+            yield start, Error, text[start:]
+        elif in_float:
+            yield start, Number.Float, text[start:]
+        elif in_number:
+            yield start, Number.Integer, text[start:]
+        elif in_constant:
+            yield start, Keyword.Constant, text[start:]
+        elif in_whitespace:
+            yield start, Text, text[start:]
+        elif in_punctuation:
+            yield start, Punctuation, text[start:]
 
 
 class JsonBareObjectLexer(JsonLexer):
@@ -526,17 +632,6 @@ class JsonBareObjectLexer(JsonLexer):
     aliases = ['json-object']
     filenames = []
     mimetypes = ['application/json-object']
-
-    tokens = {
-        'root': [
-            (r'\}', Error),
-            include('objectvalue'),
-        ],
-        'objectattribute': [
-            (r'\}', Error),
-            inherit,
-        ],
-    }
 
 
 class JsonLdLexer(JsonLexer):
@@ -580,8 +675,8 @@ class JsonLdLexer(JsonLexer):
         )
     }
 
-    def get_tokens_unprocessed(self, text, stack=('root',)):
-        for start, token, value in super(JsonLdLexer, self).get_tokens_unprocessed(text, stack):
+    def get_tokens_unprocessed(self, text):
+        for start, token, value in super(JsonLdLexer, self).get_tokens_unprocessed(text):
             if token is Name.Tag and value in self.json_ld_keywords:
                 yield start, Name.Decorator, value
             else:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import time
+
 import pytest
 
 from pygments.lexers.data import JsonLexer, JsonBareObjectLexer, JsonLdLexer, YamlLexer
@@ -134,6 +136,19 @@ def test_json_round_trip_errors(lexer_json, text):
 
     tokens = list(lexer_json.get_tokens_unprocessed(text))
     assert ''.join(t[2] for t in tokens) == text
+
+
+def test_json_escape_backtracking(lexer_json):
+    """Confirm that there is no catastrophic backtracking in the lexer.
+
+    This no longer applies because the JSON lexer doesn't use regular expressions,
+    but the test is included to ensure no loss of functionality now or in the future.
+    """
+
+    fragment = r'{"\u00D0000\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\63CD'
+    start_time = time.time()
+    list(lexer_json.get_tokens(fragment))
+    assert time.time() - start_time < 1, 'The JSON lexer may have catastrophic backtracking'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In #1425, the author of an app that depends on Pygments reported slowness when running Pygments against large JSON files.

I investigated by generating a 118MB JSON file as input, using the inputs reported by the author of that app. I found that the regex parser's `.get_tokens_unprocessed()` took ~63 seconds to lex the entire file. I then rewrote the parser in Python and found that the time was reduced to only ~22 seconds.

I also found that Pygments was consuming ~3GB of memory when formatting the 118MB JSON file in HTML. It appears that the buffered file I/O is caching everything in memory before finally writing to the file all at once as Pygments exits. While I wasn't able to stop the buffering from waiting until the entire file was in memory, I was able to shave off an entire gigabyte of memory consumption by caching the opening span classes that are generated per-token (like `<span class="s2">` or `<span style="whatever">`). I didn't find similar memory consumption issues in the Terminal256 formatter.

For the Terminal256 formatter, this patch cuts the total runtime almost in half, dropping from 2:02 to 1:09 total processing time (as measured by Powershell's Measure-Command).

For the HTML formatter, the gains are more significant:

* Memory consumption drops by ~33%
* The HTML formatter with default options drops from 1:56 to 1:04 total processing time.
* The HTML formatter with the `noclasses` option drops from 2:59 to 1:03 total processing time.

All output from the HTML and Terminal256 formatters is 100% byte-for-byte identical between master branch and this branch.