### PR TITLE
Djangojavascriptlexerfix

### DIFF
--- a/pygments/lexers/templates.py
+++ b/pygments/lexers/templates.py
@@ -338,7 +338,7 @@ class DjangoLexer(RegexLexer):
             (r'[^{]+', Other),
             (r'\{\{', Comment.Preproc, 'var'),
             # jinja/django comments
-            (r'\{[*#].*?[*#]\}', Comment),
+            (r'\{#.*?#\}', Comment),
             # django comments
             (r'(\{%)(-?\s*)(comment)(\s*-?)(%\})(.*?)'
              r'(\{%)(-?\s*)(endcomment)(\s*-?)(%\})',

--- a/tests/test_djangojavascript_lexer.py
+++ b/tests/test_djangojavascript_lexer.py
@@ -10,6 +10,10 @@ def lexer():
 
 
 def test_do_not_mistake_JSDoc_for_django_comment(lexer):
+    """
+    Test to make sure the lexer doesn't mistake
+    {* ... *} to be a django comment
+    """
     text = """/**
                * @param {*} cool
                */

--- a/tests/test_djangojavascript_lexer.py
+++ b/tests/test_djangojavascript_lexer.py
@@ -1,0 +1,37 @@
+import pytest
+
+from pygments.lexers.templates import JavascriptDjangoLexer
+from pygments.token import Comment
+
+
+@pytest.fixture(scope="module")
+def lexer():
+    yield JavascriptDjangoLexer()
+
+
+def test_do_not_mistake_JSDoc_for_django_comment(lexer):
+    text = """/**
+               * @param {*} cool
+               */
+              func = function(cool) {
+              };
+               
+              /**
+               * @param {*} stuff
+               */
+              fun = function(stuff) {
+              };"""
+    tokens = list(lexer.get_tokens(text))
+    assert (
+        (
+            Comment,
+            """{*} cool
+               */
+              func = function(cool) {
+              };
+               
+              /**
+               * @param {*}""",
+        )
+        not in tokens
+    )


### PR DESCRIPTION
Fixes #1588. Only needed to change the one line of code the Django lexer to remove `{* .. *}` from being thought as a Django comment.