### PR TITLE
testing turtle prefix names where reference starts with number

### DIFF
--- a/pygments/lexers/rdf.py
+++ b/pygments/lexers/rdf.py
@@ -299,7 +299,7 @@ class TurtleLexer(RegexLexer):
             (r'.', String, '#pop'),
         ],
         'end-of-string': [
-            (r'(@)([a-zA-z]+(:?-[a-zA-Z0-9]+)*)',
+            (r'(@)([a-zA-Z]+(?:-[a-zA-Z0-9]+)*)',
              bygroups(Operator, Generic.Emph), '#pop:2'),
 
             (r'(\^\^)%(IRIREF)s' % patterns, bygroups(Operator, Generic.Emph), '#pop:2'),

--- a/pygments/lexers/rdf.py
+++ b/pygments/lexers/rdf.py
@@ -234,10 +234,8 @@ class TurtleLexer(RegexLexer):
                 '(?:(?:[' + PN_CHARS_GRP + '.:]|' + PLX + ')*(?:[' +
                 PN_CHARS_GRP + ':]|' + PLX + '))?')
 
-    flags = re.IGNORECASE
-
     patterns = {
-        'PNAME_NS': r'((?:[a-z][\w-]*)?\:)',  # Simplified character range
+        'PNAME_NS': r'((?:[a-zA-Z][\w-]*)?\:)',  # Simplified character range
         'IRIREF': r'(<[^<>"{}|^`\\\x00-\x20]*>)'
     }
 
@@ -301,7 +299,7 @@ class TurtleLexer(RegexLexer):
             (r'.', String, '#pop'),
         ],
         'end-of-string': [
-            (r'(@)([a-z]+(:?-[a-z0-9]+)*)',
+            (r'(@)([a-zA-z]+(:?-[a-zA-Z0-9]+)*)',
              bygroups(Operator, Generic.Emph), '#pop:2'),
 
             (r'(\^\^)%(IRIREF)s' % patterns, bygroups(Operator, Generic.Emph), '#pop:2'),

--- a/tests/examplefiles/example.ttl
+++ b/tests/examplefiles/example.ttl
@@ -2,14 +2,14 @@
 @prefix dcterms: <http://purl.org/dc/terms/>. @prefix xs: <http://www.w3.org/2001/XMLSchema> .
 @prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@PREFIX dc: <http://purl.org/dc/elements/1.1/>  # SPARQL-like syntax is OK
+PREFIX dc: <http://purl.org/dc/elements/1.1/>  # SPARQL-like syntax is OK
 @prefix : <http://xmlns.com/foaf/0.1/> .  # empty prefix is OK
 
 <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
 
-<#doc1> a <#document>
+<#doc1> a <#document>;
 	dc:creator "Smith", "Jones"; 
-	:knows <http://getopenid.com/jsmith>
+	:knows <http://getopenid.com/jsmith>;
 	dcterms:hasPart [ # A comment
 		dc:title "Some title", "Some other title";
 		dc:creator "برشت، برتولد"@ar;
@@ -23,8 +23,8 @@
 
 <http://data.ub.uio.no/realfagstermer/006839> a mads:Topic,
     skos:Concept ;
-    dcterms:created "2014-08-25"^^xsd:date ;
-    dcterms:modified "2014-11-12"^^xsd:date ;
+    dcterms:created "2014-08-25"^^xs:date ;
+    dcterms:modified "2014-11-12"^^xs:date ;
     dcterms:identifier "REAL006839" ;
     skos:prefLabel "Flerbørstemarker"@nb,
         "Polychaeta"@la ;
@@ -33,7 +33,7 @@
         "Mangebørsteormer"@nb,
         "Havbørsteormer"@nb,
         "Havbørstemarker"@nb,
-        "Polycheter"@nb.
+        "Polycheter"@nb ;
     skos:inScheme <http://data.ub.uio.no/realfagstermer/> ;
     skos:narrower <http://data.ub.uio.no/realfagstermer/018529>,
         <http://data.ub.uio.no/realfagstermer/024538>,

--- a/tests/test_rdf.py
+++ b/tests/test_rdf.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+    Basic RubyLexer Test
+    ~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2020 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments.token import Name, Punctuation, Text
+from pygments.lexers import TurtleLexer, ShExCLexer
+
+
+@pytest.fixture(scope='module')
+def turtle_lexer():
+    yield TurtleLexer()
+
+@pytest.fixture(scope='module')
+def shexc_lexer():
+    yield ShExCLexer()
+
+def test_turtle_prefixed_name_starting_with_number(turtle_lexer):
+    fragment = 'alice:6f6e4241-75a2-4780-9b2a-40da53082e54\n'
+    tokens = [
+        (Name.Namespace, 'alice'),
+        (Punctuation, ':'),
+        (Name.Tag, '6f6e4241-75a2-4780-9b2a-40da53082e54'),
+        (Text, '\n'),
+    ]
+    assert list(turtle_lexer.get_tokens(fragment)) == tokens
+
+def test_shexc_prefixed_name_starting_with_number(shexc_lexer):
+    fragment = 'alice:6f6e4241-75a2-4780-9b2a-40da53082e54\n'
+    tokens = [
+        (Name.Namespace, 'alice'),
+        (Punctuation, ':'),
+        (Name.Tag, '6f6e4241-75a2-4780-9b2a-40da53082e54'),
+        (Text, '\n'),
+    ]
+    assert list(shexc_lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
closes #1553

I don't work with python myself but I hope changes here are reasonable. ShExC lexer handles prefixed names where part after `:` starts with number correctly. This change should only copy that part of ShExC lexer to Turtle lexer.