### PR TITLE
Support anchored line numbers in inline mode

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -710,6 +710,8 @@ class HtmlFormatter(Formatter):
         st = self.linenostep
         num = self.linenostart
         mw = len(str(len(inner_lines) + num - 1))
+        la = self.lineanchors
+        aln = self.anchorlinenos
         nocls = self.noclasses
 
         for _, inner_line in inner_lines:
@@ -733,9 +735,15 @@ class HtmlFormatter(Formatter):
                     style = ' class="linenos"'
 
             if style:
-                yield 1, '<span%s>%s</span>' % (style, line) + inner_line
+                linenos = '<span%s>%s</span>' % (style, line)
             else:
-                yield 1, line +  inner_line
+                linenos = line
+
+            if aln:
+                yield 1, ('<a href="#%s-%d">%s</a>' % (la, num, linenos) +
+                          inner_line)
+            else:
+                yield 1, linenos + inner_line
             num += 1
 
     def _wrap_lineanchors(self, inner):

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
-<span class="linenos">2</span><span class="c1"># b</span>
-<span class="linenos">3</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos">3</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
-<span class="linenos">2</span><span class="c1"># b</span>
-<span class="linenos special">3</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special">3</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
-<span class="linenos"> 9</span><span class="c1"># b</span>
-<span class="linenos">10</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
-<span class="linenos special"> 9</span><span class="c1"># b</span>
-<span class="linenos">10</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
-<span class="linenos">2</span><span class="c1"># b</span>
-<span class="linenos"> </span><span class="c1"># c</span>
+ <pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos"> </span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
-<span class="linenos">2</span><span class="c1"># b</span>
-<span class="linenos special"> </span><span class="c1"># c</span>
+ <pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special"> </span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
-<span class="linenos">  </span><span class="c1"># b</span>
-<span class="linenos">10</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight">
- <pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
-<span class="linenos special">  </span><span class="c1"># b</span>
-<span class="linenos">10</span><span class="c1"># c</span>
+ <pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-2"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-2"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-10"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-10"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-2"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-2"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-10"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8">
- <pre style="line-height: 125%;"><span></span><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #408080; font-style: italic"># a</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #408080; font-style: italic"># b</span>
-<span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #408080; font-style: italic"># c</span>
+ <pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #408080; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #408080; font-style: italic"># b</span>
+<a href="#-10"><span style="color: #000000; background-color: #f0f0f0; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #408080; font-style: italic"># c</span>
 </pre>
 </div>


### PR DESCRIPTION
In `table` mode, line numbers can be anchored. See how each line anchor (in the form`<a name="L-1"></a>`) gets their corresponding `<a href="#L-1"> 1</a>` link tied to their line number: 

```shell-session
$ pygmentize -f html -O linenos=table,linespans=coderow,lineanchors=L,anchorlinenos=True,wrapcode=True ./dummy.py
```

```html
<table class="highlighttable">
    <tr>
        <td class="linenos">
            <div class="linenodiv">
                <pre>
                    <a href="#L-1"> 1</a>
                    <a href="#L-2"> 2</a>
                    (...)
                </pre>
            </div>
        </td>
        <td class="code">
            <div class="highlight">
                <pre>
                    <span></span>
                    <code>
                        <span id="coderow-1">
                            <a name="L-1"></a>
                            <span class="ch">#!/usr/bin/env python</span>
                         </span>
                         <span id="coderow-2">
                             <a name="L-2"></a>
                         </span>
                         (...)
                    </code>
                </pre>
            </div>
        </td>
    </tr>
</table>
```

This is perfect. But does not work in `inline` mode, for which no link are prodduced at all:

```shell-session
$ pygmentize -f html -O linenos=inline,linespans=coderow,lineanchors=L,anchorlinenos=True,wrapcode=True ./dummy.py
```

```html
<div class="highlight">
    <pre>
        <span></span>
        <code>
            <span id="coderow-1">
                <a name="L-1"></a>
                <span class="linenos"> 1</span>
                <span class="ch">#!/usr/bin/env python</span>
            </span>
            <span id="coderow-2">
                <a name="L-2"></a>
                <span class="linenos"> 2</span>
            </span>
            (...)
        </code>
    </pre>
</div>
```

This PR fixes this difference by generating proper line number link to their anchor in `inline`, as Pygments does in `table` mode:

```shell-session
$ pygmentize -f html -O linenos=inline,linespans=coderow,lineanchors=L,anchorlinenos=True,wrapcode=True ./dummy.py
```

```html
<div class="highlight">
    <pre>
        <span></span>
        <code>
            <span id="coderow-1">
                <a name="L-1"></a>
                <a href="#L-1">
                    <span class="linenos"> 1</span>
                </a>
                <span class="ch">#!/usr/bin/env python</span>
            </span>
            <span id="coderow-2">
                <a name="L-2"></a>
                <a href="#L-2">
                    <span class="linenos"> 2</span>
                </a>
                (...)
            </code>
    </pre>
</div>
```