### PR TITLE
fix closing tag for unnamed blocks on MasonLexer

### DIFF
--- a/pygments/lexers/templates.py
+++ b/pygments/lexers/templates.py
@@ -565,7 +565,7 @@ class MasonLexer(RegexLexer):
 
     def analyse_text(text):
         result = 0.0
-        if re.search(r'</%(class|doc|init)%>', text) is not None:
+        if re.search(r'</%(class|doc|init)>', text) is not None:
             result = 1.0
         elif re.search(r'<&.+&>', text, re.DOTALL) is not None:
             result = 0.11

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pygments.lexers.templates import JavascriptDjangoLexer
+from pygments.lexers.templates import JavascriptDjangoLexer, MasonLexer
 from pygments.token import Comment
 
 
@@ -8,6 +8,9 @@ from pygments.token import Comment
 def lexer():
     yield JavascriptDjangoLexer()
 
+@pytest.fixture(scope='module')
+def lexerMason():
+    yield MasonLexer()
 
 def test_do_not_mistake_JSDoc_for_django_comment(lexer):
     """
@@ -27,3 +30,15 @@ def test_do_not_mistake_JSDoc_for_django_comment(lexer):
               };"""
     tokens = lexer.get_tokens(text)
     assert not any(t[0] == Comment for t in tokens)
+
+def test_mason_unnamed_block(lexerMason):
+    text = """
+            <%class>
+            has 'foo';
+            has 'bar' => (required => 1);
+            has 'baz' => (isa => 'Int', default => 17);
+            </%class>
+            """
+    res = lexerMason.analyse_text(text)
+    assert res == 1.0
+    


### PR DESCRIPTION
The regex for unnamed blocks seems to be wrong defined. According to the [official documentation](https://metacpan.org/pod/distribution/Mason/lib/Mason/Manual/Syntax.pod#%3C%class%3E) all unnamed blocks including class/doc/init must be ended by a </%class> and not by </%class%> and subsequently.

Example here:
https://metacpan.org/pod/distribution/Mason/lib/Mason/Manual/Intro.pod#Email-generator-(from-script)