### PR TITLE
Fix a catastrophic backtracking bug in JavaLexer

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -65,7 +65,7 @@ class JavaLexer(RegexLexer):
              'var'),
             (r'(import(?:\s+static)?)(\s+)', bygroups(Keyword.Namespace, Text),
              'import'),
-            (r'"(\\\\|\\"|[^"])*"', String),
+            (r'"', String, 'string'),
             (r"'\\.'|'[^\\]'|'\\u[0-9a-fA-F]{4}'", String.Char),
             (r'(\.)((?:[^\W\d]|\$)[\w$]*)', bygroups(Punctuation,
                                                      Name.Attribute)),
@@ -95,6 +95,13 @@ class JavaLexer(RegexLexer):
         ],
         'import': [
             (r'[\w.]+\*?', Name.Namespace, '#pop')
+        ],
+        'string': [
+            (r'[^\\"]+', String),
+            (r'\\\\', String),  # Escaped backslash
+            (r'\\"', String),  # Escaped quote
+            (r'\\', String),  # Bare backslash
+            (r'"', String, '#pop'),  # Closing quote
         ],
     }
 

--- a/tests/test_java.py
+++ b/tests/test_java.py
@@ -7,9 +7,11 @@
     :license: BSD, see LICENSE for details.
 """
 
+import time
+
 import pytest
 
-from pygments.token import Text, Name, Punctuation, Keyword, Number
+from pygments.token import Keyword, Name, Number, Punctuation, String, Text
 from pygments.lexers import JavaLexer
 
 
@@ -76,3 +78,24 @@ def test_numeric_literals(lexer):
         (Text, '\n')
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+@pytest.mark.parametrize(
+    'text',
+    (
+        '""', '"abc"', '"ひらがな"', '"123"',
+        '"\\\\"', '"\\t"' '"\\""',
+    ),
+)
+def test_string_literals_positive_match(lexer, text):
+    """Test positive matches for string literals."""
+    tokens = list(lexer.get_tokens_unprocessed(text))
+    assert all([token is String for _, token, _ in tokens])
+    assert ''.join([value for _, _, value in tokens]) == text
+
+
+def test_string_literals_backtracking(lexer):
+    """Test catastrophic backtracking for string literals."""
+    start_time = time.time()
+    list(lexer.get_tokens_unprocessed('"' + '\\' * 100))
+    assert time.time() - start_time < 1, 'possible backtracking bug'


### PR DESCRIPTION
This closes #1586, which triggered the bug.

1. Pygments guessed from an input string that it should use SspLexer to lex the file.
2. The SspLexer is a delegating lexer that relies on XmlLexer and JspRootLexer.
3. JspRootLexer relies on regular expressions from the JavaLexer.
4. The JavaLexer has a catastrophic backtracking bug in its string literal regular expression.

This patch addresses the problem by replacing the string literal regex with a sub-state for string literal parsing.