### PR TITLE
Fix coq analyze text logic

### DIFF
--- a/pygments/lexers/theorem.py
+++ b/pygments/lexers/theorem.py
@@ -154,7 +154,7 @@ class CoqLexer(RegexLexer):
     }
 
     def analyse_text(text):
-        if 'qed' in text and 'tauto' in text:
+        if re.search(r'[qQ]ed', text) and 'tauto' in text:
             return 1
 
 

--- a/tests/test_theorem.py
+++ b/tests/test_theorem.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pygments.lexers.theorem import CoqLexer
+
+@pytest.fixture(scope="module")
+def lexer():
+    yield CoqLexer()
+
+def test_coq_analyze_text(lexer):
+    text = r"""
+            Theorem demorgan : forall (P Q : Prop),
+              ~(P \/ Q) -> ~P /\ ~Q.
+            Proof.
+              tauto.
+            Qed.
+            """
+    res = lexer.analyse_text(text)
+    assert res == 1.0


### PR DESCRIPTION
the current Coq analysis the actual value for completing a proof is `Qed` but also `qed` can appear on it. So I applied a regex to validate it.

https://coq.inria.fr/refman/proof-engine/proof-handling.html?highlight=qed#coq:cmd.qed
https://coq.inria.fr/refman/proof-engine/tactics.html#coq:tacn.tauto
