### PR TITLE
RawToken{Formatter,Lexer}: support Python 3 and handle exceptions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,6 +41,7 @@ Version 2.8.0
 - Added markdown to MarkdownLexer aliases (#1687)
 - Removed "raw" alias from RawTokenLexer, so that it cannot be
   selected by alias.
+- Fixed RawTokenLexer to work in Python 3 and handle exceptions.
 - Added prompt colors to the Solarized theme (#1529)
 
 Version 2.7.4

--- a/pygments/formatters/other.py
+++ b/pygments/formatters/other.py
@@ -87,34 +87,32 @@ class RawTokenFormatter(Formatter):
             import gzip
             outfile = gzip.GzipFile('', 'wb', 9, outfile)
 
-            def write(text):
-                outfile.write(text.encode())
-            flush = outfile.flush
+            write = outfile.write
+            flush = outfile.close
         elif self.compress == 'bz2':
             import bz2
             compressor = bz2.BZ2Compressor(9)
 
             def write(text):
-                outfile.write(compressor.compress(text.encode()))
+                outfile.write(compressor.compress(text))
 
             def flush():
                 outfile.write(compressor.flush())
                 outfile.flush()
         else:
-            def write(text):
-                outfile.write(text.encode())
+            write = outfile.write
             flush = outfile.flush
 
         if self.error_color:
             for ttype, value in tokensource:
-                line = "%s\t%r\n" % (ttype, value)
+                line = b"%r\t%r\n" % (ttype, value)
                 if ttype is Token.Error:
                     write(colorize(self.error_color, line))
                 else:
                     write(line)
         else:
             for ttype, value in tokensource:
-                write("%s\t%r\n" % (ttype, value))
+                write(b"%r\t%r\n" % (ttype, value))
         flush()
 
 

--- a/pygments/lexers/special.py
+++ b/pygments/lexers/special.py
@@ -8,8 +8,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import ast
 import re
-from io import BytesIO
 
 from pygments.lexer import Lexer
 from pygments.token import Token, Error, Text
@@ -43,9 +43,7 @@ line_re = re.compile('.*?\n')
 
 class RawTokenLexer(Lexer):
     """
-    Recreate a token stream formatted with the `RawTokenFormatter`.  This
-    lexer raises exceptions during parsing if the token stream in the
-    file is malformed.
+    Recreate a token stream formatted with the `RawTokenFormatter`.
 
     Additional options accepted:
 
@@ -67,13 +65,16 @@ class RawTokenLexer(Lexer):
         if self.compress:
             if isinstance(text, str):
                 text = text.encode('latin1')
-            if self.compress == 'gz':
-                import gzip
-                gzipfile = gzip.GzipFile('', 'rb', 9, BytesIO(text))
-                text = gzipfile.read()
-            elif self.compress == 'bz2':
-                import bz2
-                text = bz2.decompress(text)
+            try:
+                if self.compress == 'gz':
+                    import gzip
+                    text = gzip.decompress(text)
+                elif self.compress == 'bz2':
+                    import bz2
+                    text = bz2.decompress(text)
+            except OSError:
+                yield Error, text.decode('latin1')
+        if isinstance(text, bytes):
             text = text.decode('latin1')
 
         # do not call Lexer.get_tokens() because stripping is not optional.
@@ -86,10 +87,6 @@ class RawTokenLexer(Lexer):
         for match in line_re.finditer(text):
             try:
                 ttypestr, val = match.group().rstrip().split('\t', 1)
-            except ValueError:
-                val = match.group()
-                ttype = Error
-            else:
                 ttype = _ttype_cache.get(ttypestr)
                 if not ttype:
                     ttype = Token
@@ -99,6 +96,11 @@ class RawTokenLexer(Lexer):
                             raise ValueError('malformed token name')
                         ttype = getattr(ttype, ttype_)
                     _ttype_cache[ttypestr] = ttype
-                val = val[1:-1].encode().decode('unicode-escape')
+                val = ast.literal_eval(val)
+                if not isinstance(val, str):
+                    raise ValueError('expected str')
+            except (SyntaxError, ValueError):
+                val = match.group()
+                ttype = Error
             yield length, ttype, val
             length += len(val)

--- a/tests/test_raw_token.py
+++ b/tests/test_raw_token.py
@@ -1,0 +1,68 @@
+import bz2
+import gzip
+
+from pygments import highlight
+from pygments.formatters import HtmlFormatter, RawTokenFormatter
+from pygments.lexers import PythonLexer, RawTokenLexer
+
+
+def test_raw_token():
+    code = "2 + α"
+    raw = highlight(code, PythonLexer(), RawTokenFormatter())
+    html = highlight(code, PythonLexer(), HtmlFormatter())
+
+    assert highlight(raw, RawTokenLexer(), RawTokenFormatter()) == raw
+    assert highlight(raw, RawTokenLexer(), HtmlFormatter()) == html
+    assert highlight(raw.decode(), RawTokenLexer(), HtmlFormatter()) == html
+
+    raw_gz = highlight(code, PythonLexer(), RawTokenFormatter(compress="gz"))
+    assert gzip.decompress(raw_gz) == raw
+    assert highlight(raw_gz, RawTokenLexer(compress="gz"), RawTokenFormatter()) == raw
+    assert (
+        highlight(
+            raw_gz.decode("latin1"), RawTokenLexer(compress="gz"), RawTokenFormatter()
+        )
+        == raw
+    )
+
+    raw_bz2 = highlight(code, PythonLexer(), RawTokenFormatter(compress="bz2"))
+    assert bz2.decompress(raw_bz2) == raw
+    assert highlight(raw_bz2, RawTokenLexer(compress="bz2"), RawTokenFormatter()) == raw
+    assert (
+        highlight(
+            raw_bz2.decode("latin1"), RawTokenLexer(compress="bz2"), RawTokenFormatter()
+        )
+        == raw
+    )
+
+
+def test_invalid_raw_token():
+    # These should not throw exceptions.
+    assert (
+        highlight("Tolkien", RawTokenLexer(), RawTokenFormatter())
+        == b"Token.Error\t'Tolkien\\n'\n"
+    )
+    assert (
+        highlight("Tolkien\t'x'", RawTokenLexer(), RawTokenFormatter())
+        == b"Token\t'x'\n"
+    )
+    assert (
+        highlight("Token.Text\t42", RawTokenLexer(), RawTokenFormatter())
+        == b"Token.Error\t'Token.Text\\t42\\n'\n"
+    )
+    assert (
+        highlight("Token.Text\t'", RawTokenLexer(), RawTokenFormatter())
+        == b'Token.Error\t"Token.Text\\t\'\\n"\n'
+    )
+    assert (
+        highlight("Token.Text\t'α'", RawTokenLexer(), RawTokenFormatter())
+        == b"Token.Text\t'\\u03b1'\n"
+    )
+    assert (
+        highlight("Token.Text\tu'α'", RawTokenLexer(), RawTokenFormatter())
+        == b"Token.Text\t'\\u03b1'\n"
+    )
+    assert (
+        highlight(b"Token.Text\t'\xff'", RawTokenLexer(), RawTokenFormatter())
+        == b"Token.Text\t'\\xff'\n"
+    )


### PR DESCRIPTION
In Python 3, `RawTokenFormatter` would output non-ASCII for non-ASCII input, and `RawTokenLexer` would throw Unicode-related exceptions for ASCII or non-ASCII input; fix them. Also, handle all exceptions, so that callers who find `RawTokenLexer` via `get_lexer_by_name` on user input don’t unexpectedly get a lexer that throws exceptions.