### PR TITLE
Javascript: Add 'async', 'await' keywords

### DIFF
--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -81,7 +81,7 @@ class JavascriptLexer(RegexLexer):
             (r'[{(\[;,]', Punctuation, 'slashstartsregex'),
             (r'[})\].]', Punctuation),
             (r'(for|in|while|do|break|return|continue|switch|case|default|if|else|'
-             r'throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|'
+             r'throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|await|async|'
              r'this|of)\b', Keyword, 'slashstartsregex'),
             (r'(var|let|with|function)\b', Keyword.Declaration, 'slashstartsregex'),
             (r'(abstract|boolean|byte|char|class|const|debugger|double|enum|export|'


### PR DESCRIPTION
## Changes
* Add keywords `async` and `await` to the Javascript lexer.
