### PR TITLE
JuttleLexer: Fix duplicate 'juttle' occurance in lexer aliases.

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -234,7 +234,7 @@ LEXERS = {
     'JspLexer': ('pygments.lexers.templates', 'Java Server Page', ('jsp',), ('*.jsp',), ('application/x-jsp',)),
     'JuliaConsoleLexer': ('pygments.lexers.julia', 'Julia console', ('jlcon',), (), ()),
     'JuliaLexer': ('pygments.lexers.julia', 'Julia', ('julia', 'jl'), ('*.jl',), ('text/x-julia', 'application/x-julia')),
-    'JuttleLexer': ('pygments.lexers.javascript', 'Juttle', ('juttle', 'juttle'), ('*.juttle',), ('application/juttle', 'application/x-juttle', 'text/x-juttle', 'text/juttle')),
+    'JuttleLexer': ('pygments.lexers.javascript', 'Juttle', ('juttle',), ('*.juttle',), ('application/juttle', 'application/x-juttle', 'text/x-juttle', 'text/juttle')),
     'KalLexer': ('pygments.lexers.javascript', 'Kal', ('kal',), ('*.kal',), ('text/kal', 'application/kal')),
     'KconfigLexer': ('pygments.lexers.configs', 'Kconfig', ('kconfig', 'menuconfig', 'linux-config', 'kernel-config'), ('Kconfig*', '*Config.in*', 'external.in*', 'standard-modules.in'), ('text/x-kconfig',)),
     'KernelLogLexer': ('pygments.lexers.textfmts', 'Kernel log', ('kmsg', 'dmesg'), ('*.kmsg', '*.dmesg'), ()),

--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -1481,7 +1481,7 @@ class JuttleLexer(RegexLexer):
     """
 
     name = 'Juttle'
-    aliases = ['juttle', 'juttle']
+    aliases = ['juttle']
     filenames = ['*.juttle']
     mimetypes = ['application/juttle', 'application/x-juttle',
                  'text/x-juttle', 'text/juttle']


### PR DESCRIPTION
The output from pygments.lexers.get_all_lexers() contains 'juttle'
twice in the aliases section for the Juttle lexer entry.

This could be reproduced using:

```
>>> from pygments.lexers import get_all_lexers
>>> lexers = get_all_lexers()
>>> {alias[0]: alias[1] for alias in lexers}.get('Juttle')
('juttle', 'juttle')
```

This patch fixes the duplicate entry and generates the associated
_mapping.py file.

Fixes: #1604