### PR TITLE
Rust lexer: bug fix with rust macros

### DIFF
--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -52,7 +52,7 @@ class RustLexer(RegexLexer):
         'module_path!', 'option_env!', 'panic!', 'print!', 'println!',
         'stringify!', 'thread_local!', 'todo!', 'trace_macros!',
         'unimplemented!', 'unreachable!', 'vec!', 'write!', 'writeln!',
-    )), Name.Builtin)
+    )), Name.Function.Magic)
 
     tokens = {
         'root': [

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -40,11 +40,10 @@ class RustLexer(RegexLexer):
         'ExactSizeIterator', 'Option', 'Result',
         'Box', 'ToOwned', 'String', 'ToString', 'Vec',
         'Clone', 'Copy', 'Default', 'Eq', 'Hash', 'Ord', 'PartialEq',
-        'PartialOrd', 'Ord',
+        'PartialOrd', 'Ord', 'drop', 'Some', 'None', 'Ok', 'Err',
     ), suffix=r'\b'), Name.Builtin)
 
     builtin_funcs_macros = (words((
-        'drop', 'Some', 'None', 'Ok', 'Err',
         'asm!', 'assert!', 'assert_eq!', 'assert_ne!', 'cfg!', 'column!',
         'compile_error!', 'concat!', 'concat_idents!', 'dbg!', 'debug_assert!',
         'debug_assert_eq!', 'debug_assert_ne!', 'env!', 'eprint!', 'eprintln!',

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -52,7 +52,7 @@ class RustLexer(RegexLexer):
         'module_path!', 'option_env!', 'panic!', 'print!', 'println!',
         'stringify!', 'thread_local!', 'todo!', 'trace_macros!',
         'unimplemented!', 'unreachable!', 'vec!', 'write!', 'writeln!',
-    ), suffix=r'\b'), Name.Builtin)
+    )), Name.Builtin)
 
     tokens = {
         'root': [


### PR DESCRIPTION
Rust macros would not be recognized/formatted, as they end with a '!', which does not count as word boundary. This was required by the suffix r'\b' (after the '!').
A typical macro call like `"println!("test");"` would not be matched by the associated regex `r"println!\b"` (it would instead be matched by `r"println\b!"`).

To fix this problem, the suffix is removed. As every macro ends with an '!' (which implicitely includes a word boundary before), it's not necessary anyway for the macros.

There were also several keywords which are not macros (as far as I know) listed in this category. They were moved to the correct section. As both categories used the same token anyway, it doesn't really matter.

Lastly, the token type for macros was changed. Rust macros seem to fit more into the *magic function* (`Name.Function.Magic`) category than into the *builtin* (`Name.Builtin`) one.