### PR TITLE
fix ecl analyze text logic

### DIFF
--- a/pygments/lexers/ecl.py
+++ b/pygments/lexers/ecl.py
@@ -126,10 +126,10 @@ class ECLLexer(RegexLexer):
 
     def analyse_text(text):
         """This is very difficult to guess relative to other business languages.
-        <- in conjuction with BEGIN/END seems relatively rare though."""
+        -> in conjuction with BEGIN/END seems relatively rare though."""
         result = 0
 
-        if '<-' in text:
+        if '->' in text:
             result += 0.01
         if 'BEGIN' in text:
             result += 0.01

--- a/tests/test_ecl.py
+++ b/tests/test_ecl.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pygments.lexers.ecl import ECLLexer
+
+@pytest.fixture(scope="module")
+def lexer():
+    yield ECLLexer()
+
+def test_ecl_analyze_text(lexer):
+    text = r"""
+            STRING  ABC -> size32_t lenAbc, const char * abc;
+            """
+    res = lexer.analyse_text(text)
+    assert res == 0.01


### PR DESCRIPTION
the current ECL analysis looks for a `<-` and I haven't seem any mention to this special structure in the documentation. In the other hand I see a lot of `->`. Is it maybe a flaw?

https://hpccsystems.com/training/documentation/ecl-language-reference/html/Special_Structures.html