### PR TITLE
ImgFormatter: Use the start position based on the length of text

### DIFF
--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -209,6 +209,12 @@ class FontManager:
         """
         return self.fonts['NORMAL'].getsize('M')
 
+    def get_text_size(self, text):
+        """
+        Get the text size(width, height).
+        """
+        return self.fonts['NORMAL'].getsize(text)
+
     def get_font(self, bold, oblique):
         """
         Get the font based on bold and italic flags.
@@ -419,17 +425,17 @@ class ImageFormatter(Formatter):
         """
         return self.fontw
 
-    def _get_char_x(self, charno):
+    def _get_char_x(self, linelength):
         """
         Get the X coordinate of a character position.
         """
-        return charno * self.fontw + self.image_pad + self.line_number_width
+        return linelength + self.image_pad + self.line_number_width
 
-    def _get_text_pos(self, charno, lineno):
+    def _get_text_pos(self, linelength, lineno):
         """
         Get the actual position for a character and line position.
         """
-        return self._get_char_x(charno), self._get_line_y(lineno)
+        return self._get_char_x(linelength), self._get_line_y(lineno)
 
     def _get_linenumber_pos(self, lineno):
         """
@@ -453,11 +459,11 @@ class ImageFormatter(Formatter):
         """
         return self.fonts.get_font(style['bold'], style['italic'])
 
-    def _get_image_size(self, maxcharno, maxlineno):
+    def _get_image_size(self, maxlinelength, maxlineno):
         """
         Get the required image size.
         """
-        return (self._get_char_x(maxcharno) + self.image_pad,
+        return (self._get_char_x(maxlinelength) + self.image_pad,
                 self._get_line_y(maxlineno + 0) + self.image_pad)
 
     def _draw_linenumber(self, posno, lineno):
@@ -483,6 +489,7 @@ class ImageFormatter(Formatter):
         Create drawables for the token content.
         """
         lineno = charno = maxcharno = 0
+        maxlinelength = linelength = 0
         for ttype, value in tokensource:
             while ttype not in self.styles:
                 ttype = ttype.parent
@@ -497,17 +504,22 @@ class ImageFormatter(Formatter):
                 temp = line.rstrip('\n')
                 if temp:
                     self._draw_text(
-                        self._get_text_pos(charno, lineno),
+                        self._get_text_pos(linelength, lineno),
                         temp,
                         font = self._get_style_font(style),
                         fill = self._get_text_color(style)
                     )
+                    temp_width, temp_hight = self.fonts.get_text_size(temp)
+                    linelength += temp_width
+                    maxlinelength = max(maxlinelength, linelength)
                     charno += len(temp)
                     maxcharno = max(maxcharno, charno)
                 if line.endswith('\n'):
                     # add a line for each extra line in the value
+                    linelength = 0
                     charno = 0
                     lineno += 1
+        self.maxlinelength = maxlinelength
         self.maxcharno = maxcharno
         self.maxlineno = lineno
 
@@ -551,7 +563,7 @@ class ImageFormatter(Formatter):
         self._draw_line_numbers()
         im = Image.new(
             'RGB',
-            self._get_image_size(self.maxcharno, self.maxlineno),
+            self._get_image_size(self.maxlinelength, self.maxlineno),
             self.background_color
         )
         self._paint_line_number_bg(im)


### PR DESCRIPTION
Related #1213 

Changed from calculating the start position as the number of characters multiplied by the number of widths of the letter "M" to using the `get_size` method of the `PIL.ImageFont.ImageFont` class and drawing the token from the calculated position for each token.