### PR TITLE
llvm lexer: add poison keyword

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -418,7 +418,7 @@ class LlvmLexer(RegexLexer):
                 'nonlazybind', 'nonnull', 'norecurse', 'noRecurse', 'noredzone', 'noreturn',
                 'notail', 'notEligibleToImport', 'nounwind', 'nsw', 'nsz', 'null', 'nuw', 'oeq',
                 'offset', 'oge', 'ogt', 'ole', 'olt', 'one', 'opaque', 'optforfuzzing',
-                'optnone', 'optsize', 'or', 'ord', 'path', 'personality', 'phi',
+                'optnone', 'optsize', 'or', 'ord', 'path', 'personality', 'phi', 'poison',
                 'prefix', 'preserve_allcc', 'preserve_mostcc', 'private', 'prologue',
                 'protected', 'ptrtoint', 'ptx_device', 'ptx_kernel', 'readnone', 'readNone',
                 'readonly', 'readOnly', 'reassoc', 'refs', 'relbf', 'release', 'resByArg',


### PR DESCRIPTION
New 'poison' keyword coming with LLVM 12: http://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20201123/856253.html