### PR TITLE
Simplify markdown strikethrough regex and leave text parsing to lower cases

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -582,7 +582,7 @@ class MarkdownLexer(RegexLexer):
             # italics fenced by '_'
             (r'(\_[^_ \n][^_\n]*\_)', bygroups(Generic.Emph)),
             # strikethrough
-            (r'([^~]*)(~~[^~]+~~)', bygroups(Text, Generic.Deleted)),
+            (r'(~~[^~]+~~)', bygroups(Generic.Deleted)),
             # mentions and topics (twitter and github stuff)
             (r'[@#][\w/:]+', Name.Entity),
             # (image?) links eg: ![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -597,7 +597,7 @@ class MarkdownLexer(RegexLexer):
              bygroups(Text, Name.Label, Text, Name.Attribute)),
 
             # general text, must come last!
-            (r'[^\\\s]+', Text),
+            (r'[^\\\s`~*]+', Text),
             (r'.', Text),
         ],
     }

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -7,6 +7,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import time
+
 import pytest
 from pygments.token import Generic, Token, String, Keyword, Name
 
@@ -390,11 +392,33 @@ def test_bold_fenced_by_asterisk(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
+def test_embedded_bold(lexer):
+    fragment = 'embedded**bold**in text'
+    tokens = [
+        (Token.Text, 'embedded'),
+        (Generic.Strong, '**bold**'),
+        (Token.Text, 'in'),
+        (Token.Text, ' '),
+        (Token.Text, 'text'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
 
 def test_bold_fenced_by_underscore(lexer):
     fragment = '__bold__'
     tokens = [
         (Generic.Strong, '__bold__'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_embedded_underscore_no_bold(lexer):
+    fragment = 'embedded__bold__in text'
+    tokens = [
+        (Token.Text, 'embedded__bold__in'),
+        (Token.Text, ' '),
+        (Token.Text, 'text'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -421,11 +445,34 @@ def test_italics_fenced_by_asterisk(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
+def test_embedded_italics(lexer):
+    fragment = 'embedded*italics*in text'
+    tokens = [
+        (Token.Text, 'embedded'),
+        (Generic.Emph, '*italics*'),
+        (Token.Text, 'in'),
+        (Token.Text, ' '),
+        (Token.Text, 'text'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+
 
 def test_italics_fenced_by_underscore(lexer):
     fragment = '_italics_'
     tokens = [
         (Generic.Emph, '_italics_'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_embedded_underscore_no_italics(lexer):
+    fragment = 'embedded_italics_in text'
+    tokens = [
+        (Token.Text, 'embedded_italics_in'),
+        (Token.Text, ' '),
+        (Token.Text, 'text'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -477,6 +524,20 @@ def test_strikethrough(lexer):
     fragment = '~~striked~~not striked'
     tokens = [
         (Generic.Deleted, '~~striked~~'),
+        (Token.Text, 'not'),
+        (Token.Text, ' '),
+        (Token.Text, 'striked'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_embedded_strikethrough(lexer):
+    fragment = 'not striked~~striked through~~not striked'
+    tokens = [
+        (Token.Text, 'not'),
+        (Token.Text, ' '),
+        (Token.Text, 'striked'),
+        (Generic.Deleted, '~~striked through~~'),
         (Token.Text, 'not'),
         (Token.Text, ' '),
         (Token.Text, 'striked'),

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -559,3 +559,17 @@ def test_reference_style_links(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_simple_text(lexer):
+    fragment = 'this is simple text'
+    tokens = [
+        (Token.Text, 'this'),
+        (Token.Text, ' '),
+        (Token.Text, 'is'),
+        (Token.Text, ' '),
+        (Token.Text, 'simple'),
+        (Token.Text, ' '),
+        (Token.Text, 'text'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -634,3 +634,11 @@ def test_simple_text(lexer):
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_long_line_perf(lexer):
+    # note, this test is weak enough to pass in pypy, so much so that in
+    # cpython it doesn't actually provide much perf regression coverage
+    fragment = "this is text\n"*1024
+    start_time = time.time()
+    assert all(x[0] == Token.Text for x in lexer.get_tokens(fragment))
+    assert time.time() - start_time < 5


### PR DESCRIPTION
the regex: `r'([^~]*)(~~[^~]+~~)'` ends up being expensive looking for essentially a string of any characters (not "~") of any length preceeding the strikethrough case. In the cases that this fails on a long string we might fall back to consuming a single character and then checking again this regex again, only to fail again. In the worst case we might repeat this O(n) regex for every character in the file leading to O(n^2) behavior.

#1617 illustrates how this can cause poor performance in practice on an otherwise "normal" markdown file.

This fix eliminates the `[^~]* ` group so it will only trigger when the next character is "~". I believe this is ok because other cases that will advance lexing are either specific to other cases with reasonable starting and terminating patterns (e.g. image tags or code spans), or are the non-space, non-escape string text case or the single character text matching case. In these cases we'll consume a minimal (in some sense) amount of content until we might possibly come back to the start of the strikethrough. In fact, other than the non-space text case, this is the only "inline" pattern that consumes nearly arbitrary strings prior to matching a specific pattern.

Existing tests pass and I added another simple, happy-path test case just to make sure that text processing isn't messed up. I also tested the old and new logic on the file from #1617 and got the same terminal formatted result, only got there in 400ms instead of 21s.