### PR TITLE
Jasmin min score for analyse text

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -1615,7 +1615,7 @@ class JasminLexer(RegexLexer):
                      r'inner|interface|limit|set|signature|stack)\b', text,
                      re.MULTILINE):
             score += 0.6
-        return score
+        return min(score, 1.0)
 
 
 class SarlLexer(RegexLexer):


### PR DESCRIPTION
This PR adds `min` to make sure the highest value isn't greater than 1.0. Used the same logic as https://github.com/pygments/pygments/blob/master/pygments/lexers/gdscript.py#L346