### PR TITLE
Markdown lexer improvements

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -558,7 +558,7 @@ class MarkdownLexer(RegexLexer):
             # quote
             (r'^(\s*>\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
             # code block fenced by 3 backticks
-            (r'^(\s*```\n(.+\n)+\s*```$)', String.Backtick),
+            (r'^(\s*```\n[\w\W]*?^\s*```$)', String.Backtick),
             # code block with language
             (r'^(\s*```)(\w+)(\n)([\w\W]*?)(^\s*```$)', _handle_codeblock),
             # code block indented with 4 spaces or 1 tab

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -561,8 +561,6 @@ class MarkdownLexer(RegexLexer):
             (r'^(\s*```\n[\w\W]*?^\s*```$\n)', String.Backtick),
             # code block with language
             (r'^(\s*```)(\w+)(\n)([\w\W]*?)(^\s*```$\n)', _handle_codeblock),
-            # code block indented with 4 spaces or 1 tab
-            (r'(\n\n)((\ {4}|\t)(.+\n)+)', bygroups(Text, String.Backtick)),
 
             include('inline'),
         ],

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -558,9 +558,9 @@ class MarkdownLexer(RegexLexer):
             # quote
             (r'^(\s*>\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
             # code block fenced by 3 backticks
-            (r'^(\s*```\n[\w\W]*?^\s*```$)', String.Backtick),
+            (r'^(\s*```\n[\w\W]*?^\s*```$\n)', String.Backtick),
             # code block with language
-            (r'^(\s*```)(\w+)(\n)([\w\W]*?)(^\s*```$)', _handle_codeblock),
+            (r'^(\s*```)(\w+)(\n)([\w\W]*?)(^\s*```$\n)', _handle_codeblock),
             # code block indented with 4 spaces or 1 tab
             (r'(\n\n)((\ {4}|\t)(.+\n)+)', bygroups(Text, String.Backtick)),
 
@@ -570,7 +570,7 @@ class MarkdownLexer(RegexLexer):
             # escape
             (r'\\.', Text),
             # inline code
-            (r'([^`])(`[^`\n]+`)', bygroups(Text, String.Backtick)),
+            (r'([^`]*)(`[^`\n]+`)', bygroups(Text, String.Backtick)),
             # warning: the following rules eat outer tags.
             # eg. **foo _bar_ baz** => foo and baz are not recognized as bold
             # bold fenced by '**'

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -570,19 +570,19 @@ class MarkdownLexer(RegexLexer):
             # escape
             (r'\\.', Text),
             # inline code
-            (r'([^`]*)(`[^`\n]+`)', bygroups(Text, String.Backtick)),
+            (r'([^`]?)(`[^`\n]+`)', bygroups(Text, String.Backtick)),
             # warning: the following rules eat outer tags.
             # eg. **foo _bar_ baz** => foo and baz are not recognized as bold
             # bold fenced by '**'
-            (r'(\*\*[^* \n][^*\n]*\*\*)', bygroups(Generic.Strong)),
-            # # bold fenced by '__'
-            (r'(\_\_[^_ \n][^_\n]*\_\_)', bygroups(Generic.Strong)),
+            (r'([^\*]?)(\*\*[^* \n][^*\n]*\*\*)', bygroups(Text, Generic.Strong)),
+            # bold fenced by '__'
+            (r'([^_]?)(__[^_ \n][^_\n]*__)', bygroups(Text, Generic.Strong)),
             # italics fenced by '*'
-            (r'(\*[^* \n][^*\n]*\*)', bygroups(Generic.Emph)),
+            (r'([^\*]?)(\*[^* \n][^*\n]*\*)', bygroups(Text, Generic.Emph)),
             # italics fenced by '_'
-            (r'(\_[^_ \n][^_\n]*\_)', bygroups(Generic.Emph)),
+            (r'([^_]?)(_[^_ \n][^_\n]*_)', bygroups(Text, Generic.Emph)),
             # strikethrough
-            (r'([^~]*)(~~[^~]+~~)', bygroups(Text, Generic.Deleted)),
+            (r'([^~]?)(~~[^~ \n][^~\n]*~~)', bygroups(Text, Generic.Deleted)),
             # mentions and topics (twitter and github stuff)
             (r'[@#][\w/:]+', Name.Entity),
             # (image?) links eg: ![Image of Yaktocat](https://octodex.github.com/images/yaktocat.png)

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -329,44 +329,6 @@ def test_code_block_with_language(lexer):
         assert list(lexer.get_tokens(fragment)) == tokens
 
 
-def test_code_indented_with_spaces(lexer):
-    fragments = (
-        'sample:\n\n    code\n',
-    )
-    for fragment in fragments:
-        tokens = [
-            (Token.Text, 'sample:'),
-            (Token.Text, '\n\n'),
-            (String.Backtick, '    code\n'),
-        ]
-        assert list(lexer.get_tokens(fragment)) == tokens
-
-    fragments = (
-        'sample:\n\n\tcode\n',
-    )
-    for fragment in fragments:
-        tokens = [
-            (Token.Text, 'sample:'),
-            (Token.Text, '\n\n'),
-            (String.Backtick, '\tcode\n'),
-        ]
-        assert list(lexer.get_tokens(fragment)) == tokens
-
-    fragments = (
-        'sample:\n    code\nsome\n\nmore code',
-    )
-    for fragment in fragments:
-        tokens = [
-            (Token.Text, 'sample:'),
-            (Token.Text, '\n'),
-            (String.Backtick, '    code\n'),
-            (String.Backtick, '    some\n'),
-            (Token.Text, '\n'),
-            (String.Backtick, '    more code\n'),
-        ]
-        assert list(lexer.get_tokens(fragment)) == tokens
-
-
 def test_inline_code(lexer):
     fragment = 'code: `code`'
     tokens = [

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -246,6 +246,20 @@ def test_bulleted_list(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
+    fragment = '```\ncode\n```\n* *foo*\n* bar'
+    tokens = [
+        (String.Backtick, '```\ncode\n```\n'),
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Generic.Emph, '*foo*'),
+        (Token.Text, '\n'),
+        (Keyword, '*'),
+        (Token.Text, ' '),
+        (Token.Text, 'bar'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
 
 def test_numbered_list(lexer):
     fragment = '1. foo\n2. bar'
@@ -287,20 +301,19 @@ def test_invalid_code_block(lexer):
 
 def test_code_block_fenced_by_backticks(lexer):
     fragments = (
-        '```\ncode\n```',
-        '```\nmulti\n`line`\ncode\n```',
+        '```\ncode\n```\n',
+        '```\nmulti\n`line`\ncode\n```\n',
     )
     for fragment in fragments:
         tokens = [
             (String.Backtick, fragment),
-            (Token.Text, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
 
 def test_code_block_with_language(lexer):
     fragments = (
-        '```python\nimport this\n```',
+        '```python\nimport this\n```\n',
     )
     for fragment in fragments:
         tokens = [
@@ -311,8 +324,7 @@ def test_code_block_with_language(lexer):
             (Token.Text, ' '),
             (Token.Name.Namespace, 'this'),
             (Token.Text, '\n'),
-            (String.Backtick, '```'),
-            (Token.Text, '\n'),
+            (String.Backtick, '```\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -344,8 +356,7 @@ def test_code_indented_with_spaces(lexer):
 def test_inline_code(lexer):
     fragment = 'code: `code`'
     tokens = [
-        (Token.Text, 'code:'),
-        (Token.Text, ' '),
+        (Token.Text, 'code: '),
         (String.Backtick, '`code`'),
         (Token.Text, '\n'),
     ]
@@ -363,6 +374,56 @@ def test_inline_code(lexer):
     tokens = [
         (Token.Text, '('),
         (String.Backtick, '`code`'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '* `code`'
+    tokens = [
+        (Token.Keyword, '*'),
+        (Token.Text, ' '),
+        (String.Backtick, '`code`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '```\ncode\n```\n* nocode\n* `code`'
+    tokens = [
+        (String.Backtick, '```\ncode\n```\n'),
+        (Token.Keyword, '*'),
+        (Token.Text, ' '),
+        (Token.Text, 'nocode'),
+        (Token.Text, '\n'),
+        (Token.Keyword, '*'),
+        (Token.Text, ' '),
+        (String.Backtick, '`code`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '- `code`'
+    tokens = [
+        (Token.Keyword, '-'),
+        (Token.Text, ' '),
+        (String.Backtick, '`code`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '1. `code`'
+    tokens = [
+        (Token.Keyword, '1.'),
+        (Token.Text, ' '),
+        (String.Backtick, '`code`'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = 'code (`in brackets`)'
+    tokens = [
+        (Token.Text, 'code ('),
+        (String.Backtick, '`in brackets`'),
         (Token.Text, ')'),
         (Token.Text, '\n'),
     ]

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -352,11 +352,26 @@ def test_code_indented_with_spaces(lexer):
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
+    fragments = (
+        'sample:\n    code\nsome\n\nmore code',
+    )
+    for fragment in fragments:
+        tokens = [
+            (Token.Text, 'sample:'),
+            (Token.Text, '\n'),
+            (String.Backtick, '    code\n'),
+            (String.Backtick, '    some\n'),
+            (Token.Text, '\n'),
+            (String.Backtick, '    more code\n'),
+        ]
+        assert list(lexer.get_tokens(fragment)) == tokens
+
 
 def test_inline_code(lexer):
     fragment = 'code: `code`'
     tokens = [
-        (Token.Text, 'code: '),
+        (Token.Text, 'code:'),
+        (Token.Text, ' '),
         (String.Backtick, '`code`'),
         (Token.Text, '\n'),
     ]
@@ -422,7 +437,9 @@ def test_inline_code(lexer):
 
     fragment = 'code (`in brackets`)'
     tokens = [
-        (Token.Text, 'code ('),
+        (Token.Text, 'code'),
+        (Token.Text, ' '),
+        (Token.Text, '('),
         (String.Backtick, '`in brackets`'),
         (Token.Text, ')'),
         (Token.Text, '\n'),
@@ -451,11 +468,29 @@ def test_bold_fenced_by_asterisk(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
+    fragment = '(**bold**)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Strong, '**bold**'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
 
 def test_bold_fenced_by_underscore(lexer):
     fragment = '__bold__'
     tokens = [
         (Generic.Strong, '__bold__'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(__bold__)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Strong, '__bold__'),
+        (Token.Text, ')'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
@@ -482,11 +517,29 @@ def test_italics_fenced_by_asterisk(lexer):
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
 
+    fragment = '(*italics*)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Emph, '*italics*'),
+        (Token.Text, ')'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
 
 def test_italics_fenced_by_underscore(lexer):
     fragment = '_italics_'
     tokens = [
         (Generic.Emph, '_italics_'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+    fragment = '(_italics_)'
+    tokens = [
+        (Token.Text, '('),
+        (Generic.Emph, '_italics_'),
+        (Token.Text, ')'),
         (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
This is a series of improvements to the Markdown Lexer:

* Fenced code was not recognized when it contained empty lines
* Inline code was not recognized after bulleted list entry (e.g. ```* `code` ```)
* Bold and italics were not recognized when surrounded with non-space char (e.g. `(**foo**)`)
* There is no way to recognize code indented by 4 spaces using regex only - so remove the error-prone detection