### PR TITLE
support added for css variables

### DIFF
--- a/pygments/lexers/css.py
+++ b/pygments/lexers/css.py
@@ -310,6 +310,8 @@ class CssLexer(RegexLexer):
             (words(_vendor_prefixes,), Keyword.Pseudo),
             (r'('+r'|'.join(_css_properties)+r')(\s*)(\:)',
              bygroups(Keyword, Text, Punctuation), 'value-start'),
+            (r'([-]*[a-zA-Z_][\w-]*)(\s*)(\:)', bygroups(Name.Variable, Text, Punctuation),
+             'value-start'),
             (r'([a-zA-Z_][\w-]*)(\s*)(\:)', bygroups(Name, Text, Punctuation),
              'value-start'),
 
@@ -343,6 +345,7 @@ class CssLexer(RegexLexer):
         ],
         'function-start': [
             (r'\s+', Text),
+            (r'[-]+([\w+]+[-]*)+', Name.Variable),
             include('urls'),
             (words(_vendor_prefixes,), Keyword.Pseudo),
             (words(_keyword_values, suffix=r'\b'), Keyword.Constant),

--- a/pygments/lexers/css.py
+++ b/pygments/lexers/css.py
@@ -310,7 +310,7 @@ class CssLexer(RegexLexer):
             (words(_vendor_prefixes,), Keyword.Pseudo),
             (r'('+r'|'.join(_css_properties)+r')(\s*)(\:)',
              bygroups(Keyword, Text, Punctuation), 'value-start'),
-            (r'([-]*[a-zA-Z_][\w-]*)(\s*)(\:)', bygroups(Name.Variable, Text, Punctuation),
+            (r'([-]+[a-zA-Z_][\w-]*)(\s*)(\:)', bygroups(Name.Variable, Text, Punctuation),
              'value-start'),
             (r'([a-zA-Z_][\w-]*)(\s*)(\:)', bygroups(Name, Text, Punctuation),
              'value-start'),


### PR DESCRIPTION
fixes #1060 

I went with Name.Variable for the css vars, I hope that's the correct choice. 

This works for both declaring variables:

```css
--color-pink: HotPink;
```

and getting variables through the var() function:

```css
border: 1px solid var(--button-color)
```