### PR TITLE
consider trailing whitespace a part of the prompt, making copy/paste more straight forward

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -232,7 +232,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _innerLexerCls = BashLexer
     _ps1rgx = re.compile(
         r'^((?:(?:\[.*?\])|(?:\(\S+\))?(?:| |sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)' \
-        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%])(.*\n?)')
+        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%]\s*)(.*\n?)')
     _ps2 = '>'
 
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -142,9 +142,8 @@ def test_end_of_line_nums(lexer_bash):
 def test_newline_in_echo(lexer_session):
     fragment = '$ echo \\\nhi\nhi\n'
     tokens = [
-        (Token.Text, ''),
-        (Token.Generic.Prompt, '$'),
-        (Token.Text, ' '),
+        (Token.Name.Builtin, ''),
+        (Token.Generic.Prompt, '$ '),
         (Token.Name.Builtin, 'echo'),
         (Token.Text, ' '),
         (Token.Literal.String.Escape, '\\\n'),
@@ -217,8 +216,7 @@ def test_virtualenv(lexer_session):
         (Token.Text, ''),
         (Token.Text, ' '),
         (Token.Text, ''),
-        (Token.Generic.Prompt, '[~/project]$'),
-        (Token.Text, ' '),
+        (Token.Generic.Prompt, '[~/project]$ '),
         (Token.Text, 'foo'),
         (Token.Text, ' '),
         (Token.Text, '-h'),

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -154,6 +154,31 @@ def test_newline_in_echo(lexer_session):
     assert list(lexer_session.get_tokens(fragment)) == tokens
 
 
+def test_newline_in_ls(lexer_session):
+    fragment = '$ ls \\\nhi\nhi\n'
+    tokens = [
+        (Token.Text, ''),
+        (Token.Generic.Prompt, '$ '),
+        (Token.Text, 'ls'),
+        (Token.Text, ' '),
+        (Token.Literal.String.Escape, '\\\n'),
+        (Token.Text, 'hi'),
+        (Token.Text, '\n'),
+        (Token.Generic.Output, 'hi\n'),
+    ]
+    assert list(lexer_session.get_tokens(fragment)) == tokens
+
+
+def test_comment_after_prompt(lexer_session):
+    fragment = '$# comment'
+    tokens = [
+        (Token.Comment.Single, ''),
+        (Token.Generic.Prompt, '$'),
+        (Token.Comment.Single, '# comment\n'),
+    ]
+    assert list(lexer_session.get_tokens(fragment)) == tokens
+
+
 def test_msdos_gt_only(lexer_msdos):
     fragment = '> py\nhi\n'
     tokens = [


### PR DESCRIPTION
Consider white space between prompt and command to be part of the prompt. this usually makes copy/paste more straight forward.

For example, if highlighting this shell session:

```
user@host:~$ ls --many-parameters-here
```

Before the patch, attempting to select the command with the mouse for copy & paste will include the space between `$` and `ls`. With the patch, any number of spaces will be considered part of the prompt is now not selected any more. This is convenient because the space will cause (at least) bash to not add the command to the history of commands.

According to man (1) bash, the default PS1 is `\s-\v\$ ` and Debian sets  `${debian_chroot:+($debian_chroot)}\u@\h:\w\$ `. I believe the vast majority of real world prompts will include a space. 

An alternative implementation could make spaces an extra special token that cannot be selected. but I don't know the right class for that. Another variation could be to really consider only the first space as part of the prompt. Please let me know if you prefer any of that.

Regarding tests: I don't quite get why the first element in `test_end_of_line_nums` changes to `Token.Name.Builtin`, but the output at least for HTML otherwise looks fine. Please let me know if this is somehow a problem (and I appreciate pointers on how to fix this ;-))

