### PR TITLE
Fix regexs to support somes flags

### DIFF
--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -53,7 +53,7 @@ class JavascriptLexer(RegexLexer):
         'slashstartsregex': [
             include('commentsandwhitespace'),
             (r'/(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gimuy]+\b|\B)', String.Regex, '#pop'),
+             r'([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'(?=/)', Text, ('#pop', 'badregex')),
             default('#pop')
         ],
@@ -160,7 +160,7 @@ class KalLexer(RegexLexer):
         'root': [
             include('commentsandwhitespace'),
             (r'/(?! )(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gim]+\b|\B)', String.Regex),
+             r'([gimuys]+\b|\B)', String.Regex),
             (r'\?|:|_(?=\n)|==?|!=|-(?!>)|[<>+*/-]=?',
              Operator),
             (r'\b(and|or|isnt|is|not|but|bitwise|mod|\^|xor|exists|'
@@ -474,7 +474,7 @@ class TypeScriptLexer(RegexLexer):
         'slashstartsregex': [
             include('commentsandwhitespace'),
             (r'/(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gim]+\b|\B)', String.Regex, '#pop'),
+             r'([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'(?=/)', Text, ('#pop', 'badregex')),
             default('#pop')
         ],
@@ -1496,7 +1496,7 @@ class JuttleLexer(RegexLexer):
         'slashstartsregex': [
             include('commentsandwhitespace'),
             (r'/(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gim]+\b|\B)', String.Regex, '#pop'),
+             r'([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'(?=/)', Text, ('#pop', 'badregex')),
             default('#pop')
         ],

--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -255,7 +255,7 @@ class LiveScriptLexer(RegexLexer):
         ],
         'multilineregex': [
             include('commentsandwhitespace'),
-            (r'//([gim]+\b|\B)', String.Regex, '#pop'),
+            (r'//([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'/', String.Regex),
             (r'[^/#]+', String.Regex)
         ],
@@ -263,7 +263,7 @@ class LiveScriptLexer(RegexLexer):
             include('commentsandwhitespace'),
             (r'//', String.Regex, ('#pop', 'multilineregex')),
             (r'/(?! )(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gim]+\b|\B)', String.Regex, '#pop'),
+             r'([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'/', Operator, '#pop'),
             default('#pop'),
         ],
@@ -1054,7 +1054,7 @@ class CoffeeScriptLexer(RegexLexer):
         ],
         'multilineregex': [
             (r'[^/#]+', String.Regex),
-            (r'///([gim]+\b|\B)', String.Regex, '#pop'),
+            (r'///([gimuys]+\b|\B)', String.Regex, '#pop'),
             (r'#\{', String.Interpol, 'interpoling_string'),
             (r'[/#]', String.Regex),
         ],
@@ -1062,7 +1062,7 @@ class CoffeeScriptLexer(RegexLexer):
             include('commentsandwhitespace'),
             (r'///', String.Regex, ('#pop', 'multilineregex')),
             (r'/(?! )(\\.|[^[/\\\n]|\[(\\.|[^\]\\\n])*])+/'
-             r'([gim]+\b|\B)', String.Regex, '#pop'),
+             r'([gimuys]+\b|\B)', String.Regex, '#pop'),
             # This isn't really guarding against mishighlighting well-formed
             # code, just the ability to infinite-loop between root and
             # slashstartsregex.


### PR DESCRIPTION
Resolves #1646

Some of the flags (e.g., `u`, `y`, `s`) are not supported by the lexer while they are supported by the language.
https://pygments.org/demo/?lexer=js&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi
https://pygments.org/demo/?lexer=ts&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi
https://pygments.org/demo/?lexer=livescript&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi
https://pygments.org/demo/?lexer=coffeescript&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi
https://pygments.org/demo/?lexer=kal&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi
https://pygments.org/demo/?lexer=juttle&code=%2Fx%2Fgmiuys%0A%2Fx%2Fgmiuy%0A%2Fx%2Fgmiu%0A%2Fx%2Fgmi