### PR TITLE
Revert a private API in the HTML formatter

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -457,20 +457,20 @@ class HtmlFormatter(Formatter):
         return ''
 
     def _get_css_classes(self, ttype):
-        """Generate the opening <span> tag for a given token type using CSS classes."""
+        """Return the CSS classes of this token type prefixed with the classprefix option."""
         cls = self._get_css_class(ttype)
         while ttype not in STANDARD_TYPES:
             ttype = ttype.parent
             cls = self._get_css_class(ttype) + ' ' + cls
-        return cls and '<span class="%s">' % cls or ''
+        return cls or ''
 
     def _get_css_inline_styles(self, ttype):
-        """Generate the opening <span> tag for a given token type using inline CSS styles."""
+        """Return the inline CSS styles for this token type."""
         cclass = self.ttype2class.get(ttype)
         while cclass is None:
             ttype = ttype.parent
             cclass = self.ttype2class.get(ttype)
-        return cclass and '<span style="%s">' % self.class2style[cclass][0] or ''
+        return cclass or ''
 
     def _create_stylesheet(self):
         t2c = self.ttype2class = {Token: ''}
@@ -816,9 +816,12 @@ class HtmlFormatter(Formatter):
                 cspan = self.span_element_openers[ttype]
             except KeyError:
                 if nocls:
-                    cspan = self.span_element_openers[ttype] = self._get_css_inline_styles(ttype)
+                    css_style = self._get_css_inline_styles(ttype)
+                    cspan = css_style and '<span style="%s">' % self.class2style[css_style][0] or ''
                 else:
-                    cspan = self.span_element_openers[ttype] = self._get_css_classes(ttype)
+                    css_class = self._get_css_classes(ttype)
+                    cspan = css_class and '<span class="%s">' % css_class or ''
+                self.span_element_openers[ttype] = cspan
 
             parts = self._translate_parts(value)
 


### PR DESCRIPTION
This should revert the behavior of the function without losing the overall caching behavior that was intended.

In addition to running the unit tests, I confirmed identical SHA1 checksums for before-and-after HTML documents generated with (and without) the `-O noclasses` option.

@asottile, please confirm that this fixes #1644. Thanks!