### PR TITLE
Detect malformed closing tags as errors in ApacheConfLexer

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -302,8 +302,10 @@ class ApacheConfLexer(RegexLexer):
         'root': [
             (r'\s+', Text),
             (r'#(.*\\\n)+.*$|(#.*?)$', Comment),
-            (r'(<[^\s>]+)(?:(\s+)(.*))?(>)',
+            (r'(<[^\s>/][^\s>]*)(?:(\s+)(.*))?(>)',
              bygroups(Name.Tag, Text, String, Name.Tag)),
+            (r'(</[^\s>]+)(>)',
+             bygroups(Name.Tag, Name.Tag)),
             (r'[a-z]\w*', Name.Builtin, 'value'),
             (r'\.+', Text),
         ],

--- a/tests/test_apache_conf.py
+++ b/tests/test_apache_conf.py
@@ -99,3 +99,36 @@ def test_fix_lock_absolute_path(lexer):
             (Token.Text, '\n'),
     ]
     assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_normal_scoped_directive(lexer):
+    fragment = '<VirtualHost "test">\n</VirtualHost>'
+    tokens = [
+            (Token.Name.Tag, '<VirtualHost'),
+            (Token.Text, ' '),
+            (Token.Literal.String, '"test"'),
+            (Token.Name.Tag, '>'),
+            (Token.Text, '\n'),
+            (Token.Name.Tag, '</VirtualHost'),
+            (Token.Name.Tag, '>'),
+            (Token.Text, '\n')
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+
+def test_malformed_scoped_directive_closing_tag(lexer):
+    fragment = '<VirtualHost "test">\n</VirtualHost\n>'
+    tokens = [
+            (Token.Name.Tag, '<VirtualHost'),
+            (Token.Text, ' '),
+            (Token.Literal.String, '"test"'),
+            (Token.Name.Tag, '>'),
+            (Token.Text, '\n'),
+            (Token.Error, '<'),
+            (Token.Error, '/'),
+            (Token.Name.Builtin, 'VirtualHost'),
+            (Token.Text, ''),
+            (Token.Text, '\n'),
+            (Token.Error, '>'),
+            (Token.Text, '\n')
+    ]
+    assert list(lexer.get_tokens(fragment)) == tokens
+


### PR DESCRIPTION
Discovered this issue while fuzzing a parser I've been working on. When a scoped directive's closing tag is malformed with whitespace/newlines prior to the '>' this will generate an error during httpd's config test.

e.g.
```
<VirtualHost "test"
</VirtualHost
>
```
or
```
<VirtualHost "test"
</VirtualHost >
```

Will cause this error:

> httpd: Syntax error on line 2 of /usr/local/apache2/conf/httpd.conf: \</VirtualHost> directive missing closing '>'

This patch aligns the token stream to more accurately detect this error. I identify open tags vs. closing tags by the absence or presence of the '/' after the '<', respectively. The opening tags should maintain all previous functionality. The closing tags will now be restricted to non-whitespace characters within.

I've included a positive test and negative test related to this specific issue. The negative test (test_malformed_scoped_directive_closing_tag) token stream was derived *after* the patches. The positive test (test_normal_scoped_directive) is present to ensure expected functionality is maintained.