### PR TITLE
Fix eiffel regex performance

### DIFF
--- a/pygments/lexers/eiffel.py
+++ b/pygments/lexers/eiffel.py
@@ -45,7 +45,7 @@ class EiffelLexer(RegexLexer):
                 'require', 'rescue', 'retry', 'select', 'separate', 'then',
                 'undefine', 'until', 'variant', 'when'), prefix=r'(?i)\b', suffix=r'\b'),
              Keyword.Reserved),
-            (r'"\[(([^\]%]|\n)|%(.|\n)|\][^"])*?\]"', String),
+            (r'"\[([^\]%]|%(.|\n)|\][^"])*?\]"', String),
             (r'"([^"%\n]|%.)*?"', String),
             include('numbers'),
             (r"'([^'%]|%'|%%)'", String.Char),


### PR DESCRIPTION
I encountered a certain eiffel file that performed extremely poorly with this regex.  (I can share an example if desired, I'm not sure what proper etiquette is).

This change avoids the performance problem, and output is unchanged for the `example.e` file and a few other .e files I tested.  I am not very experienced with eiffel language syntax, but as far as I can tell this is an okay change to make.