### PR TITLE
Add __END_LINE__ to Crystal syntax highlighting

### DIFF
--- a/pygments/lexers/crystal.py
+++ b/pygments/lexers/crystal.py
@@ -171,6 +171,7 @@ class CrystalLexer(ExtendedRegexLexer):
             '''.split(), suffix=r'\b'), Keyword),
             (words('''
                 previous_def forall out uninitialized __DIR__ __FILE__ __LINE__
+                __END_LINE__
             '''.split(), prefix=r'(?<!\.)', suffix=r'\b'), Keyword.Pseudo),
             # https://crystal-lang.org/docs/syntax_and_semantics/is_a.html
             (r'\.(is_a\?|nil\?|responds_to\?|as\?|as\b)', Keyword.Pseudo),


### PR DESCRIPTION
I found `__END_LINE__` magic constant is missing in syntax highlighting for Crystal language.

https://crystal-lang.org/reference/syntax_and_semantics/constants.html