### PR TITLE
Fix PS2 and backslash continuation

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -233,7 +233,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _ps1rgx = re.compile(
         r'^((?:(?:\[.*?\])|(?:\(\S+\))?(?:| |sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)' \
         r'?|\[\S+[@:][^\n]+\].+))\s*[$#%]\s*)(.*\n?)')
-    _ps2 = '>'
+    _ps2 = '> '
 
 
 class BatchLexer(RegexLexer):

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -169,10 +169,6 @@ class ShellSessionBaseLexer(Lexer):
 
         for match in line_re.finditer(text):
             line = match.group()
-            if backslash_continuation:
-                curcode += line
-                backslash_continuation = curcode.endswith('\\\n')
-                continue
 
             venv_match = self._venv.match(line)
             if venv_match:
@@ -197,7 +193,7 @@ class ShellSessionBaseLexer(Lexer):
                                    [(0, Generic.Prompt, m.group(1))]))
                 curcode += m.group(2)
                 backslash_continuation = curcode.endswith('\\\n')
-            elif line.startswith(self._ps2):
+            elif line.startswith(self._ps2) and backslash_continuation:
                 insertions.append((len(curcode),
                                    [(0, Generic.Prompt, line[:len(self._ps2)])]))
                 curcode += line[len(self._ps2):]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -205,6 +205,23 @@ def test_fake_ps2_prompt(lexer_session):
     ]
     assert list(lexer_session.get_tokens(fragment)) == tokens
 
+
+def test_prompt_in_output(lexer_session):
+    """Test that output that looks like a prompt is not detected as such."""
+    fragment = '$ cat \\\n> test.txt\nline1\n> file content, not prompt!'
+    tokens = [
+        (Token.Generic.Prompt, '$ '),
+        (Token.Text, 'cat'),
+        (Token.Text, ' '),
+        (Token.Literal.String.Escape, '\\\n'),
+        (Token.Generic.Prompt, '> '),
+        (Token.Text, 'test.txt'),
+        (Token.Text, '\n'),
+        (Token.Generic.Output, 'line1\n'),
+        (Token.Generic.Output, '> file content, not prompt!\n'),
+    ]
+    assert list(lexer_session.get_tokens(fragment)) == tokens
+
 def test_msdos_gt_only(lexer_msdos):
     fragment = '> py\nhi\n'
     tokens = [

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -177,6 +177,19 @@ def test_comment_after_prompt(lexer_session):
     assert list(lexer_session.get_tokens(fragment)) == tokens
 
 
+def test_ps2_prompt(lexer_session):
+    fragment = '$ ls\n> foo'
+    tokens = [
+        (Token.Generic.Prompt, '$ '),
+        (Token.Text, 'ls'),
+        (Token.Text, '\n'),
+        (Token.Generic.Prompt, '> '),
+        (Token.Text, 'foo'),
+        (Token.Text, '\n'),
+    ]
+    assert list(lexer_session.get_tokens(fragment)) == tokens
+
+
 def test_msdos_gt_only(lexer_msdos):
     fragment = '> py\nhi\n'
     tokens = [


### PR DESCRIPTION
Fix backslash continuation and set PS2 to include a space (so `> ` instead of `>`), which is the default for most (all) shells. Currently, lines that end with a backslash are always rendered verbatim, effectively breaking any actual examples that want to show the PS2 prompt correctly. Using a common bash session, this is how you would split a command into multiple lines:

```
$ ls --many options \
> /some/location
```

... where both `$ ` and `> ` would be the prompt (configured by the PS1 and PS2 environment variables). So naturally, we want these tokens to be shown as prompt (and also not be copy-able).

Current test cases also do not reflect this behavior. For example, the `test_newline_in_echo` has a fragment of `'$ echo \\\nhi\nhi\n'`, which would be impossible to actually create (unless PS2 where configured to an empty string), as a user typing `echo \<enter>` would imediately get a `> ` in the next line.

As an example, here is how this renders without the patch. Note how this is actually inverted: The `>` from the certbot command is **not** detected as a prompt (even though it actually it is), while for the echo command output is detected as a prompt, even though it actually it isn't:

![without-patch](https://user-images.githubusercontent.com/6200103/104124068-eafdfb00-534e-11eb-9102-6837e5605e4b.png)

Now with the patch... it's actually correct:

![with-patch](https://user-images.githubusercontent.com/6200103/104124075-f4876300-534e-11eb-870e-df90774d10eb.png)


