### PR TITLE
LaTeX: avoid uneven baselines in case highlighting uses \fcolorbox

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -299,8 +299,8 @@ class LatexFormatter(Formatter):
                 cmndef += (r'\def\$$@tc##1{\textcolor[rgb]{%s}{##1}}' %
                            rgbcolor(ndef['color']))
             if ndef['border']:
-                cmndef += (r'\def\$$@bc##1{\setlength{\fboxsep}{0pt}'
-                           r'\fcolorbox[rgb]{%s}{%s}{\strut ##1}}' %
+                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{-\fboxrule}'
+                           r'\fcolorbox[rgb]{%s}{%s}{\strut ##1}}}' %
                            (rgbcolor(ndef['border']),
                             rgbcolor(ndef['bgcolor'])))
             elif ndef['bgcolor']:


### PR DESCRIPTION
Without this, the \strut causes the background color to apply to a full
baseline height, then the framing done by \fcolorbox augments beyond
that the box height and as a result the line where this happens will
have extra distance from previous and next lines.

Correct that by reducing the apparent box size by exactly the width of
the frame (\fboxrule).

Also, make the change to \fboxsep local. Reason: if texcomments is True,
some arbitrary LaTeX mark-up can be executed in a later part and the
setting of \fboxsep could modify output; macro ``\<cmdprefix>@bc`` is
executed at top level, cf. ``\<cmdprefix>@do``.


Related:
- https://github.com/sphinx-doc/sphinx/issues/4249

But the https://github.com/sphinx-doc/sphinx/issues/4250 fix is not satisfying, cf https://github.com/sphinx-doc/sphinx/issues/8874, hence this PR.