### PR TITLE
LaTeX: keep scope of \fboxsep local

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -304,8 +304,8 @@ class LatexFormatter(Formatter):
                            (rgbcolor(ndef['border']),
                             rgbcolor(ndef['bgcolor'])))
             elif ndef['bgcolor']:
-                cmndef += (r'\def\$$@bc##1{\setlength{\fboxsep}{0pt}'
-                           r'\colorbox[rgb]{%s}{\strut ##1}}' %
+                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{0pt}'
+                           r'\colorbox[rgb]{%s}{\strut ##1}}}' %
                            rgbcolor(ndef['bgcolor']))
             if cmndef == '':
                 continue


### PR DESCRIPTION
In case of texcomments=True or usage of escapeinside, arbitrary LaTeX
can be executed. The ``\PY@bc`` is executed at top level hence should not
set \fboxsep at this level but keep the change to a local scope.

There is another instance but it is part of PR #1708

Related:

- https://github.com/sphinx-doc/sphinx/issues/4249
- https://github.com/sphinx-doc/sphinx/issues/8874

P.-S. I think I may have a few years back either opened a ticket or even done a PR on bitbucket but I can't find trace. For this one and also #1708 