### PR TITLE
LaTeX: use \@namedef (refactoring)

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -321,8 +321,7 @@ class LatexFormatter(Formatter):
         cp = self.commandprefix
         styles = []
         for name, definition in self.cmd2def.items():
-            styles.append(r'\expandafter\def\csname %s@tok@%s\endcsname{%s}' %
-                          (cp, name, definition))
+            styles.append(r'\@namedef{%s@tok@%s}{%s}' % (cp, name, definition))
         return STYLE_TEMPLATE % {'cp': self.commandprefix,
                                  'styles': '\n'.join(styles)}
 


### PR DESCRIPTION
```
$ latexdef @namedef

\@namedef:
macro:#1->\expandafter \def \csname #1\endcsname
```

And the `@` character is usable here in macro names (the variable with
name definition is authorized to contain for example `\PY@it`)

This makes the output shorter. It makes for a neater
sphinxhighlight.sty...

Related:

- was reported at https://github.com/sphinx-doc/sphinx/issues/8874