### PR TITLE
LaTeX: \catcode assignment should be terminated

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -342,7 +342,8 @@ class LatexFormatter(Formatter):
                           (start and ',firstnumber=%d' % start or '') +
                           (step and ',stepnumber=%d' % step or ''))
         if self.mathescape or self.texcomments or self.escapeinside:
-            outfile.write(',codes={\\catcode`\\$=3\\catcode`\\^=7\\catcode`\\_=8}')
+            outfile.write(',codes={\\catcode`\\$=3\\catcode`\\^=7'
+                          '\\catcode`\\_=8\\relax}')
         if self.verboptions:
             outfile.write(',' + self.verboptions)
         outfile.write(']\n')


### PR DESCRIPTION
This is almost irrelevant. But ``\catcode`\_=8`` without termination might
let LaTeX expand prematurely its token stream. Of course here in the
context of fancyvrb.sty chances are 99.99% that what comes next does not
expand or expands safely. I did not look in code.

Only a matter of style, to be on the safe side.