### PR TITLE
Fix for MATLAB lexer iterpreting command syntax wrong. Fixes #1706.

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -139,7 +139,7 @@ class MatlabLexer(RegexLexer):
             # `cd ./ foo`.).  Here, the regex checks that the first word in the
             # line is not followed by <spaces> and then
             # (equal | open-parenthesis | <operator><space> | <space>).
-            (r'(?:^|(?<=;))(\s*)(\w+)(\s+)(?!=|\(|%s\s|\s)' % _operators,
+            (r'(?:^|(?<=;))(\s*)(\w+)([ \t]+)(?!=|\(|%s\s|\s)' % _operators,
              bygroups(Whitespace, Name, Whitespace), 'commandargs'),
 
             include('expressions')

--- a/tests/snippets/matlab/test_command_mode.txt
+++ b/tests/snippets/matlab/test_command_mode.txt
@@ -1,12 +1,28 @@
 # MATLAB allows char function arguments to not be enclosed by parentheses
 # or contain quote characters, as long as they are space separated. Test
 # that one common such function is formatted appropriately.
+# Also test that a single word on a line doesn't turn the next line into
+# the argument to a command.
 
 ---input---
 help sin
+
+a
+b = a;
 
 ---tokens---
 'help'        Name
 ' '           Text.Whitespace
 'sin'         Literal.String
+'\n\n'        Text.Whitespace
+
+'a'           Name
+'\n'          Text.Whitespace
+
+'b'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'a'           Name
+';'           Punctuation
 '\n'          Text.Whitespace

--- a/tests/snippets/matlab/test_elseif.txt
+++ b/tests/snippets/matlab/test_elseif.txt
@@ -1,0 +1,84 @@
+Issue #1490 shows this case to produce a wrong output.
+
+---input---
+if (i == r)
+    j = j + 1;
+elseif (j == 1)
+    i = i + 1;
+else
+    i = i + 1;
+    j = j - 1;
+end
+
+---tokens---
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'i'           Name.Builtin
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'r'           Name
+')'           Punctuation
+'\n    '      Text.Whitespace
+'j'           Name.Builtin
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'j'           Name.Builtin
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'elseif'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'j'           Name.Builtin
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+')'           Punctuation
+'\n    '      Text.Whitespace
+'i'           Name.Builtin
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'i'           Name.Builtin
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'else'        Keyword
+'\n    '      Text.Whitespace
+'i'           Name.Builtin
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'i'           Name.Builtin
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n    '      Text.Whitespace
+'j'           Name.Builtin
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'j'           Name.Builtin
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'end'         Keyword
+'\n'          Text.Whitespace


### PR DESCRIPTION
As I mentioned in #1706, this simple tweak of changing `\s` into `[ \t]` avoids the command syntax spanning lines.

I have added a test for this particular case, and also one that addresses #1490. That one seemed fixed already though, the output was correct already.

However, looking through the other regexes in the MATLAB lexer, it seems that `\s` is used a lot where newlines should really not be accepted. For example, this is currently accepted as correct syntax (it is not!), with `foo` tagged as a function name:
```matlab
function [x]
= foo(y)
```
I'm not sure it is important to fix these cases, as the lever is not intended to identify syntax errors.