### PR TITLE
Fix link to graphviz project

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -51,7 +51,7 @@ Programming languages
 * `Dart <https://dart.dev/>`_
 * DCPU-16
 * `Delphi <https://www.embarcadero.com/products/delphi>`_
-* `DOT / Graphviz <https://graphviz.org>` _
+* `DOT / Graphviz <https://graphviz.org>`_
 * `Devicetree <https://www.devicetree.org/>`_
 * `Dylan <https://opendylan.org/>`_ (incl. console)
 * `Eiffel <https://www.eiffel.org/>`_


### PR DESCRIPTION
Visual diff:
<img width="714" alt="Screenshot 2021-02-15 at 05 57 20" src="https://user-images.githubusercontent.com/12058428/107906964-b9caa900-6f52-11eb-864c-67ad8a3d1eaa.png">
