### PR TITLE
Fixes for C and C++ functions and namespaces

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -42,7 +42,9 @@ class CFamilyLexer(RegexLexer):
     _intsuffix = r'(([uU][lL]{0,2})|[lL]{1,2}[uU]?)?'
 
     # Identifier regex with C and C++ Universal Character Name (UCN) support.
-    _ident = r'(?:[a-zA-Z_$]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})(?:[\w$]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})*'
+    chars = (r'[a-zA-Z_$]|\\u[0-9a-fA-F]{4}', r'\\U[0-9a-fA-F]{8})(?:[\w$]', r'\\u[0-9a-fA-F]{4}', r'\\U[0-9a-fA-F]{8}')
+    _ident = fr'(?:{"|".join(chars)})*'
+    _namespaced_ident = fr'(?:{"|".join(chars + (r"::",))})*'
 
     tokens = {
         'whitespace': [
@@ -116,16 +118,16 @@ class CFamilyLexer(RegexLexer):
             include('whitespace'),
             include('keywords'),
             # functions
-            (r'((?:' + _ident + r'(?:[&*\s])+))'  # return arguments
-             r'(' + _ident + r')'             # method name
+            (r'((?:' + _namespaced_ident + r'(?:[&*\s])+))'  # return arguments
+             r'(' + _namespaced_ident + r')'             # method name
              r'(\s*\([^;]*?\))'            # signature
              r'([^;{]*)(\{)',
              bygroups(using(this), Name.Function, using(this), using(this),
                       Punctuation),
              'function'),
             # function declarations
-            (r'((?:' + _ident + r'(?:[&*\s])+))'  # return arguments
-             r'(' + _ident + r')'             # method name
+            (r'((?:' + _namespaced_ident + r'(?:[&*\s])+))'  # return arguments
+             r'(' + _namespaced_ident + r')'             # method name
              r'(\s*\([^;]*?\))'            # signature
              r'([^;]*)(;)',
              bygroups(using(this), Name.Function, using(this), using(this),

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -118,7 +118,7 @@ class CFamilyLexer(RegexLexer):
             include('whitespace'),
             include('keywords'),
             # functions
-            (r'((?:' + _namespaced_ident + r'(?:[&*\s])+))'  # return arguments
+            (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
              r'(\s*\([^;]*?\))'            # signature
              r'([^;{]*)(\{)',
@@ -126,7 +126,7 @@ class CFamilyLexer(RegexLexer):
                       Punctuation),
              'function'),
             # function declarations
-            (r'((?:' + _namespaced_ident + r'(?:[&*\s])+))'  # return arguments
+            (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
              r'(\s*\([^;]*?\))'            # signature
              r'([^;]*)(;)',

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -43,8 +43,8 @@ class CFamilyLexer(RegexLexer):
 
     # Identifier regex with C and C++ Universal Character Name (UCN) support.
     chars = (r'[a-zA-Z_$]|\\u[0-9a-fA-F]{4}', r'\\U[0-9a-fA-F]{8})(?:[\w$]', r'\\u[0-9a-fA-F]{4}', r'\\U[0-9a-fA-F]{8}')
-    _ident = fr'(?:{"|".join(chars)})*'
-    _namespaced_ident = fr'(?:{"|".join(chars + (r"::",))})*'
+    _ident = r'(?:' + "|".join(chars) + r')*'
+    _namespaced_ident = r'(?:' + "|".join(chars + (r"::",)) + r')*'
 
     tokens = {
         'whitespace': [

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -339,7 +339,7 @@ class CppLexer(CFamilyLexer):
             (r'(class|concept|typename)(\s+)', bygroups(Keyword, Text), 'classname'),
             (words((
                 'catch', 'const_cast', 'delete', 'dynamic_cast', 'explicit',
-                'export', 'friend', 'mutable', 'namespace', 'new', 'operator',
+                'export', 'friend', 'mutable', 'new', 'operator',
                 'private', 'protected', 'public', 'reinterpret_cast', 'class',
                 'restrict', 'static_cast', 'template', 'this', 'throw', 'throws',
                 'try', 'typeid', 'using', 'virtual', 'constexpr', 'nullptr', 'concept',
@@ -347,12 +347,19 @@ class CppLexer(CFamilyLexer):
                 'co_await', 'co_return', 'co_yield', 'requires', 'import', 'module',
                 'typename'),
                suffix=r'\b'), Keyword),
+            (r'namespace\b', Keyword, 'namespace'),
             (r'(enum)(\s+)', bygroups(Keyword, Text), 'enumname'),
             inherit
         ],
         'types': [
             (r'char(16_t|32_t|8_t)\b', Keyword.Type),
             inherit
+        ],
+        'namespace': [
+            (r'[;{]', Punctuation, ('#pop', 'root')),
+            (r'inline', Keyword),
+            (CFamilyLexer._ident, Name.Namespace),
+            include('statement')
         ]
     }
 

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -334,6 +334,11 @@ class SwigLexer(CppLexer):
     priority = 0.04  # Lower than C/C++ and Objective C/C++
 
     tokens = {
+        'root': [
+            # Match it here so it won't be matched as a function in the rest of root
+            (r'\$\**\&?\w+', Name),
+            inherit
+        ],
         'statements': [
             # SWIG directives
             (r'(%[a-z_][a-z0-9_]*)', Name.Function),
@@ -549,7 +554,7 @@ class CharmciLexer(CppLexer):
     mimetypes = []
 
     tokens = {
-        'statements': [
+        'keywords': [
             (r'(module)(\s+)', bygroups(Keyword, Text), 'classname'),
             (words(('mainmodule', 'mainchare', 'chare', 'array', 'group',
                     'nodegroup', 'message', 'conditional')), Keyword),

--- a/tests/examplefiles/c/ceval.c.output
+++ b/tests/examplefiles/c/ceval.c.output
@@ -115,7 +115,7 @@
 'void'        Keyword.Type
 '\n'          Text
 
-'ppc_getcounter' Name
+'ppc_getcounter' Name.Function
 '('           Punctuation
 'uint64'      Name
 ' '           Text
@@ -178,7 +178,7 @@
 '\t'          Text
 'asm'         Keyword
 ' '           Text
-'volatile'    Name.Function
+'volatile'    Keyword
 ' '           Text
 '('           Punctuation
 '"'           Literal.String
@@ -202,7 +202,7 @@
 '\t'          Text
 'asm'         Keyword
 ' '           Text
-'volatile'    Name.Function
+'volatile'    Keyword
 ' '           Text
 '('           Punctuation
 '"'           Literal.String
@@ -321,7 +321,7 @@
 
 'void'        Keyword.Type
 ' '           Text
-'dump_tsc'    Name
+'dump_tsc'    Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ' '           Text
@@ -575,7 +575,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'call_function' Name
+'call_function' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -607,7 +607,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'call_function' Name
+'call_function' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -631,7 +631,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'fast_function' Name
+'fast_function' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -662,7 +662,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'do_call'     Name
+'do_call'     Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -690,7 +690,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'ext_do_call' Name
+'ext_do_call' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -721,7 +721,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'update_keyword_args' Name
+'update_keyword_args' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -750,7 +750,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'update_star_args' Name
+'update_star_args' Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ','           Punctuation
@@ -778,7 +778,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'load_args'   Name
+'load_args'   Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -818,7 +818,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'prtrace'     Name
+'prtrace'     Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -840,7 +840,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'call_trace'  Name
+'call_trace'  Name.Function
 '('           Punctuation
 'Py_tracefunc' Name
 ','           Punctuation
@@ -871,7 +871,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'call_trace_protected' Name
+'call_trace_protected' Name.Function
 '('           Punctuation
 'Py_tracefunc' Name
 ','           Punctuation
@@ -902,7 +902,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'call_exc_trace' Name
+'call_exc_trace' Name.Function
 '('           Punctuation
 'Py_tracefunc' Name
 ','           Punctuation
@@ -923,7 +923,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'maybe_call_line_trace' Name
+'maybe_call_line_trace' Name.Function
 '('           Punctuation
 'Py_tracefunc' Name
 ','           Punctuation
@@ -965,7 +965,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'apply_slice' Name
+'apply_slice' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -988,7 +988,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'assign_slice' Name
+'assign_slice' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -1020,7 +1020,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'cmp_outcome' Name
+'cmp_outcome' Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ','           Punctuation
@@ -1043,7 +1043,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'import_from' Name
+'import_from' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -1061,7 +1061,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'import_all_from' Name
+'import_all_from' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -1081,7 +1081,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'build_class' Name
+'build_class' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -1104,7 +1104,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'exec_statement' Name
+'exec_statement' Name.Function
 '('           Punctuation
 'PyFrameObject' Name
 ' '           Text
@@ -1134,7 +1134,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'set_exc_info' Name
+'set_exc_info' Name.Function
 '('           Punctuation
 'PyThreadState' Name
 ' '           Text
@@ -1162,7 +1162,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'reset_exc_info' Name
+'reset_exc_info' Name.Function
 '('           Punctuation
 'PyThreadState' Name
 ' '           Text
@@ -1175,7 +1175,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'format_exc_check_arg' Name
+'format_exc_check_arg' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -1200,7 +1200,7 @@
 ' '           Text
 '*'           Operator
 ' '           Text
-'string_concatenate' Name
+'string_concatenate' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -3176,7 +3176,7 @@
 ' '           Text
 'why_code'    Name
 ' '           Text
-'do_raise'    Name
+'do_raise'    Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text
@@ -3199,7 +3199,7 @@
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
-'unpack_iterable' Name
+'unpack_iterable' Name.Function
 '('           Punctuation
 'PyObject'    Name
 ' '           Text

--- a/tests/examplefiles/c/example.c.output
+++ b/tests/examplefiles/c/example.c.output
@@ -40,7 +40,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'yyerror'     Name
+'yyerror'     Name.Function
 '('           Punctuation
 'char'        Keyword.Type
 '*'           Operator
@@ -216,7 +216,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'increaseStackby' Name
+'increaseStackby' Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ' '           Text
@@ -1809,7 +1809,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'increaseStackby' Name
+'increaseStackby' Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ' '           Text
@@ -1908,7 +1908,7 @@
 
 'char'        Keyword.Type
 ' '           Text
-'convertType' Name
+'convertType' Name.Function
 '('           Punctuation
 'int'         Keyword.Type
 ' '           Text
@@ -2026,7 +2026,7 @@
 
 'int'         Keyword.Type
 ' '           Text
-'main'        Name
+'main'        Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -2643,7 +2643,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_obj_freeze' Name.Function
+'rb_obj_freeze' Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -2744,7 +2744,7 @@
 'VALUE'       Name
 '\n'          Text
 
-'ary_alloc'   Name
+'ary_alloc'   Name.Function
 '('           Punctuation
 'klass'       Name
 ')'           Punctuation
@@ -3067,7 +3067,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'ary_new'     Name.Function
+'ary_new'     Name
 '('           Punctuation
 'rb_cArray'   Name
 ','           Punctuation
@@ -3098,7 +3098,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_ary_new2' Name.Function
+'rb_ary_new2' Name
 '('           Punctuation
 'ARY_DEFAULT_SIZE' Name
 ')'           Punctuation
@@ -3963,7 +3963,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'RARRAY'      Name.Function
+'RARRAY'      Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -4147,7 +4147,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'ary_shared_array' Name.Function
+'ary_shared_array' Name
 '('           Punctuation
 'rb_cValues'  Name
 ','           Punctuation
@@ -4184,7 +4184,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'ary_shared_array' Name.Function
+'ary_shared_array' Name
 '('           Punctuation
 'rb_cArray'   Name
 ','           Punctuation
@@ -4227,7 +4227,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_values_new' Name.Function
+'rb_values_new' Name
 '('           Punctuation
 '2'           Literal.Number.Integer
 ','           Punctuation
@@ -4269,7 +4269,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_convert_type' Name.Function
+'rb_convert_type' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -4318,7 +4318,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_convert_type' Name.Function
+'rb_convert_type' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -4365,7 +4365,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_check_convert_type' Name.Function
+'rb_check_convert_type' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -4420,7 +4420,7 @@
 'VALUE'       Name
 '\n'          Text
 
-'rb_ary_initialize' Name
+'rb_ary_initialize' Name.Function
 '('           Punctuation
 'argc'        Name
 ','           Punctuation
@@ -6332,7 +6332,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_ary_pop'  Name.Function
+'rb_ary_pop'  Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -6616,7 +6616,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_ary_shift' Name.Function
+'rb_ary_shift' Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -7929,7 +7929,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_ary_entry' Name.Function
+'rb_ary_entry' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -8090,7 +8090,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_ary_entry' Name.Function
+'rb_ary_entry' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -8197,7 +8197,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'RARRAY'      Name.Function
+'RARRAY'      Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -8223,7 +8223,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'ary_shared_first' Name.Function
+'ary_shared_first' Name
 '('           Punctuation
 'argc'        Name
 ','           Punctuation
@@ -8334,7 +8334,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'RARRAY'      Name.Function
+'RARRAY'      Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -8367,7 +8367,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'ary_shared_last' Name.Function
+'ary_shared_last' Name
 '('           Punctuation
 'argc'        Name
 ','           Punctuation
@@ -8841,7 +8841,7 @@
 '\t\t'        Text
 'return'      Keyword
 ' '           Text
-'LONG2NUM'    Name.Function
+'LONG2NUM'    Name
 '('           Punctuation
 'i'           Name
 ')'           Punctuation
@@ -9324,7 +9324,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'to_ary'      Name.Function
+'to_ary'      Name
 '('           Punctuation
 'obj'         Name
 ')'           Punctuation
@@ -11053,7 +11053,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'LONG2NUM'    Name.Function
+'LONG2NUM'    Name
 '('           Punctuation
 'RARRAY'      Name
 '('           Punctuation
@@ -11270,7 +11270,7 @@
 'VALUE'       Name
 '\n'          Text
 
-'recursive_join' Name
+'recursive_join' Name.Function
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -11320,7 +11320,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_str_new2' Name.Function
+'rb_str_new2' Name
 '('           Punctuation
 '"'           Literal.String
 '[...]'       Literal.String
@@ -11986,7 +11986,7 @@
 '    \n    '  Text
 'return'      Keyword
 ' '           Text
-'rb_ary_join' Name.Function
+'rb_ary_join' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -12058,7 +12058,7 @@
 '    \n    '  Text
 'return'      Keyword
 ' '           Text
-'rb_ary_join' Name.Function
+'rb_ary_join' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation
@@ -12381,7 +12381,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_exec_recursive' Name.Function
+'rb_exec_recursive' Name
 '('           Punctuation
 'inspect_ary' Name
 ','           Punctuation
@@ -12743,7 +12743,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_ary_reverse' Name.Function
+'rb_ary_reverse' Name
 '('           Punctuation
 'ary'         Name
 ')'           Punctuation
@@ -12784,7 +12784,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_ary_reverse' Name.Function
+'rb_ary_reverse' Name
 '('           Punctuation
 'rb_ary_dup'  Name
 '('           Punctuation
@@ -12839,7 +12839,7 @@
 'void'        Keyword.Type
 '\n'          Text
 
-'ary_sort_check' Name
+'ary_sort_check' Name.Function
 '('           Punctuation
 'data'        Name
 ')'           Punctuation
@@ -13232,7 +13232,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_str_cmp'  Name.Function
+'rb_str_cmp'  Name
 '('           Punctuation
 'a'           Name
 ','           Punctuation
@@ -13696,7 +13696,7 @@
 '\t'          Text
 'return'      Keyword
 ' '           Text
-'rb_ary_new4' Name.Function
+'rb_ary_new4' Name
 '('           Punctuation
 'RARRAY'      Name
 '('           Punctuation
@@ -14319,7 +14319,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'rb_get_values_at' Name.Function
+'rb_get_values_at' Name
 '('           Punctuation
 'ary'         Name
 ','           Punctuation

--- a/tests/examplefiles/charmci/Charmci.ci.output
+++ b/tests/examplefiles/charmci/Charmci.ci.output
@@ -69,7 +69,7 @@
 '\t\t'        Text
 'entry'       Keyword
 ' '           Text
-'ckcallback_main' Name.Function
+'ckcallback_main' Name
 '('           Punctuation
 'CkArgMsg'    Name
 ' '           Text
@@ -103,7 +103,7 @@
 '\t\t'        Text
 'entry'       Keyword
 ' '           Text
-'ckcallback_group' Name.Function
+'ckcallback_group' Name
 '('           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -114,7 +114,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'registerCcsCallback' Name
+'registerCcsCallback' Name.Function
 '('           Punctuation
 'char'        Keyword.Type
 ' '           Text
@@ -143,7 +143,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'call'        Name
+'call'        Name.Function
 '('           Punctuation
 'CkCallback'  Name
 ' '           Text
@@ -161,7 +161,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'call'        Name
+'call'        Name.Function
 '('           Punctuation
 'CkCallback'  Name
 ' '           Text

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -519,7 +519,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'string'      Name.Function
+'string'      Name
 '('           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -569,7 +569,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'string'      Name.Function
+'string'      Name
 '('           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -4875,7 +4875,7 @@
 '    '        Text
 'return'      Keyword
 ' '           Text
-'beautify'    Name.Function
+'beautify'    Name
 '('           Punctuation
 'sourceIterator' Name
 '-'           Operator
@@ -7038,7 +7038,7 @@
 '    '        Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 '!'           Operator
@@ -8678,7 +8678,7 @@
 '\n'          Text
 
 '                  ' Text
-'registerInStatementIndent' Name.Function
+'registerInStatementIndent' Name
 '('           Punctuation
 'line'        Name
 ','           Punctuation
@@ -13779,7 +13779,7 @@
 '    '        Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 '!'           Operator
@@ -13838,7 +13838,7 @@
 '    '        Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 '!'           Operator
@@ -15080,7 +15080,7 @@
 '        '    Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 'ch'          Name
@@ -16363,7 +16363,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'init'        Name
+'init'        Name.Function
 '('           Punctuation
 'ASSourceIterator' Name
 '*'           Operator
@@ -16379,7 +16379,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'init'        Name
+'init'        Name.Function
 '('           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -16390,7 +16390,7 @@
 ' '           Text
 'bool'        Keyword.Type
 ' '           Text
-'hasMoreLines' Name
+'hasMoreLines' Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -16403,7 +16403,7 @@
 ' '           Text
 'string'      Name
 ' '           Text
-'nextLine'    Name
+'nextLine'    Name.Function
 '('           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -16414,7 +16414,7 @@
 ' '           Text
 'string'      Name
 ' '           Text
-'beautify'    Name
+'beautify'    Name.Function
 '('           Punctuation
 'const'       Keyword
 ' '           Text
@@ -16680,7 +16680,7 @@
 'string'      Name
 ' '           Text
 '*'           Operator
-'findHeader'  Name
+'findHeader'  Name.Function
 '('           Punctuation
 'const'       Keyword
 ' '           Text

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -20,7 +20,7 @@
 ' '           Text
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
@@ -28,7 +28,7 @@
 
 'namespace'   Keyword
 ' '           Text
-'highlight'   Name
+'highlight'   Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -783,7 +783,7 @@
 
 'namespace'   Keyword
 ' '           Text
-'highlight'   Name
+'highlight'   Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -1093,7 +1093,7 @@
 ' '           Text
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
@@ -1115,7 +1115,7 @@
 
 'namespace'   Keyword
 ' '           Text
-'astyle'      Name
+'astyle'      Name.Namespace
 '\n'          Text
 
 '  '          Text
@@ -16219,7 +16219,7 @@
 ' '           Text
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
@@ -16227,7 +16227,7 @@
 
 'namespace'   Keyword
 ' '           Text
-'astyle'      Name
+'astyle'      Name.Namespace
 '\n'          Text
 
 '  '          Text
@@ -17560,6 +17560,6 @@
 ' '           Text
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ';'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -39,10 +39,7 @@
 
 'string'      Name
 '  '          Text
-'AnsiGenerator' Name
-':'           Operator
-':'           Operator
-'getOpenTag'  Name
+'AnsiGenerator::getOpenTag' Name.Function
 '('           Punctuation
 'const'       Keyword
 ' '           Text
@@ -1236,10 +1233,7 @@
 '  '          Text
 'void'        Keyword.Type
 ' '           Text
-'ASBeautifier' Name
-':'           Operator
-':'           Operator
-'initStatic'  Name
+'ASBeautifier::initStatic' Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/cpp/functions.cpp
+++ b/tests/examplefiles/cpp/functions.cpp
@@ -1,0 +1,62 @@
+string contains(const char str);
+string contains(const char str) {}
+string* contains(const char str);
+string* contains(const char str) {}
+string * contains(const char str);
+string * contains(const char str) {}
+string    *    contains(const char str);
+string    *    contains(const char str) {}
+string   *contains(const char str);
+string   *contains(const char str) {}
+string   **contains(const char str);
+string   **contains(const char str) {}
+string** contains(const char str);
+string** contains(const char str) {}
+string  ** contains(const char str);
+string  ** contains(const char str) {}
+string  &  contains(const char str);
+string  &  contains(const char str) {}
+string&   contains(const char str);
+string&   contains(const char str) {}
+string   &contains(const char str);
+string   &contains(const char str) {}
+string   &&contains(const char str);
+string   &&contains(const char str) {}
+string   &&   contains(const char str);
+string   &&   contains(const char str) {}
+string&&   contains(const char str);
+string&&   contains(const char str) {}
+const string contains(const char str);
+const string contains(const char str) {}
+explicit const string contains(const char str);
+explicit const string contains(const char str) {}
+explicit const string contains(const char str) noexcept;
+explicit const string contains(const char str) noexcept {}
+explicit const string contains(const char str) noexcept const;
+explicit const string contains(const char str) noexcept const {}
+
+
+explicit const string contains(const char&str);
+explicit const string contains(const char&str) {}
+explicit const string contains(const char&   str);
+explicit const string contains(const char&   str) {}
+explicit const string contains(const char   str);
+explicit const string contains(const char   str) {}
+explicit const string contains(const char&&   str);
+explicit const string contains(const char&&   str) {}
+explicit const string contains(const char&&   str);
+explicit const string contains(const char&&   str) {}
+explicit const string contains(const char &&str);
+explicit const string contains(const char &&str) {}
+explicit const string contains(const char *****  str);
+explicit const string contains(const char *****  str) {}
+explicit const string contains(const char *****str);
+explicit const string contains(const char *****str) {}
+explicit const string contains(const char***** str);
+explicit const string contains(const char***** str) {}
+explicit const string contains(const char *str);
+explicit const string contains(const char *str) {}
+explicit const string contains(const char* str);
+explicit const string contains(const char* str) {}
+explicit const string contains(const char * str);
+explicit const string contains(const char * str) {}

--- a/tests/examplefiles/cpp/functions.cpp
+++ b/tests/examplefiles/cpp/functions.cpp
@@ -1,3 +1,4 @@
+using std::numerical;
 string contains(const char str);
 string contains(const char str) {}
 string* contains(const char str);
@@ -60,3 +61,27 @@ explicit const string contains(const char* str);
 explicit const string contains(const char* str) {}
 explicit const string contains(const char * str);
 explicit const string contains(const char * str) {}
+
+// Names with namespaces
+
+string Type::contains(char c) const noexcept;
+string Type::contains(char c) const noexcept {}
+std::string contains(char c) const noexcept;
+std::string contains(char c) const noexcept {}
+std::string contains(std::vector<char> chars) const noexcept;
+std::string contains(std::vector<char> chars) const noexcept {}
+std::string std::vector::contains(std::vector<char> chars) const;
+std::string std::vector::contains(std::vector<char> chars) const  {}
+const inline explicit std::string std::vector::contains(std::vector<char> chars) const  {}
+const inline explicit std::string std::vector::contains(std::vector<char> chars) const;
+
+// inside classes
+
+class raz {
+    const virtual std::string contains(const std::string str);
+}
+
+// Make sure these are not functions:
+else if(flag && func_call()) {}
+new T();
+const operator int() const {} // so int is lexed as type and not function.name

--- a/tests/examplefiles/cpp/functions.cpp.output
+++ b/tests/examplefiles/cpp/functions.cpp.output
@@ -1,3 +1,12 @@
+'using'       Keyword
+' '           Text
+'std'         Name
+':'           Operator
+':'           Operator
+'numerical'   Name
+';'           Punctuation
+'\n'          Text
+
 'string'      Name
 ' '           Text
 'contains'    Name.Function
@@ -1079,3 +1088,318 @@
 '{'           Punctuation
 '}'           Punctuation
 '\n'          Text
+
+'\n'          Text
+
+'// Names with namespaces\n' Comment.Single
+
+'\n'          Text
+
+'string'      Name
+' '           Text
+'Type::contains' Name.Function
+'('           Punctuation
+'char'        Keyword.Type
+' '           Text
+'c'           Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+' '           Text
+'Type::contains' Name.Function
+'('           Punctuation
+'char'        Keyword.Type
+' '           Text
+'c'           Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'char'        Keyword.Type
+' '           Text
+'c'           Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+';'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'char'        Keyword.Type
+' '           Text
+'c'           Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+';'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'std::vector::contains' Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+';'           Punctuation
+'\n'          Text
+
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'std::vector::contains' Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+'  '          Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'const'       Keyword
+' '           Text
+'inline'      Keyword.Reserved
+' '           Text
+'explicit'    Keyword
+' '           Text
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'std::vector::contains' Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+'  '          Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'const'       Keyword
+' '           Text
+'inline'      Keyword.Reserved
+' '           Text
+'explicit'    Keyword
+' '           Text
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'std::vector::contains' Name.Function
+'('           Punctuation
+'std'         Name
+':'           Operator
+':'           Operator
+'vector'      Name
+'<'           Operator
+'char'        Keyword.Type
+'>'           Operator
+' '           Text
+'chars'       Name
+')'           Punctuation
+' '           Text
+'const'       Keyword
+';'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// inside classes\n' Comment.Single
+
+'\n'          Text
+
+'class'       Keyword
+' '           Text
+'raz'         Name.Class
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'const'       Keyword
+' '           Text
+'virtual'     Keyword
+' '           Text
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'std'         Name
+':'           Operator
+':'           Operator
+'string'      Name
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Make sure these are not functions:\n' Comment.Single
+
+'else'        Keyword
+' '           Text
+'if'          Keyword
+'('           Punctuation
+'flag'        Name
+' '           Text
+'&'           Operator
+'&'           Operator
+' '           Text
+'func_call'   Name
+'('           Punctuation
+')'           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'new'         Keyword
+' '           Text
+'T'           Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'const'       Keyword
+' '           Text
+'operator'    Keyword
+' '           Text
+'int'         Keyword.Type
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+' '           Text
+'// so int is lexed as type and not function.name\n' Comment.Single

--- a/tests/examplefiles/cpp/functions.cpp.output
+++ b/tests/examplefiles/cpp/functions.cpp.output
@@ -1,0 +1,1081 @@
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+' '           Text
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+' '           Text
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'    '        Text
+'*'           Operator
+'    '        Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'    '        Text
+'*'           Operator
+'    '        Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'*'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'*'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'*'           Operator
+'*'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'*'           Operator
+'*'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'*'           Operator
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'*'           Operator
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'  '          Text
+'*'           Operator
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'  '          Text
+'*'           Operator
+'*'           Operator
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'  '          Text
+'&'           Operator
+'  '          Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'  '          Text
+'&'           Operator
+'  '          Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'&'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'&'           Operator
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'   '         Text
+'&'           Operator
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'string'      Name
+'&'           Operator
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'string'      Name
+'&'           Operator
+'&'           Operator
+'   '         Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'noexcept'    Keyword
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'const'       Keyword
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'noexcept'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'   '         Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'   '         Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'&'           Operator
+'&'           Operator
+'   '         Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'&'           Operator
+'&'           Operator
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'&'           Operator
+'&'           Operator
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'  '          Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'  '          Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text
+
+'explicit'    Keyword
+' '           Text
+'const'       Keyword
+' '           Text
+'string'      Name
+' '           Text
+'contains'    Name.Function
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'char'        Keyword.Type
+' '           Text
+'*'           Operator
+' '           Text
+'str'         Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text

--- a/tests/examplefiles/cpp/namespace.cpp
+++ b/tests/examplefiles/cpp/namespace.cpp
@@ -1,0 +1,35 @@
+namespace std {}
+namespace std::exprimental::inner {}
+namespace {}
+namespace std::exprimental::inline innner {}
+namespace std::inline exprimental::innner {}
+namespace other = std;
+namespace other = std::exprimental;
+
+namespace std::exprimental::inner {
+class QualifiedName {
+public:
+    QualifiedName(const FlyString& local_name)
+    {
+    }
+    const FlyString& local_name() const { return m_local_name; }
+
+private:
+    FlyString m_local_name;
+};  
+}
+
+namespace ns::inner::inline pygments {
+    using namespace outer;
+    int has_value() {
+        namespace other = std;
+    }
+    namespace {
+        namespace user {
+            int has_value() {
+                using namespace inner;
+                return 4;
+            }
+        }
+    }
+}

--- a/tests/examplefiles/cpp/namespace.cpp.output
+++ b/tests/examplefiles/cpp/namespace.cpp.output
@@ -1,0 +1,276 @@
+'namespace'   Keyword
+' '           Text
+'std'         Name.Namespace
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'std'         Name.Namespace
+':'           Operator
+':'           Operator
+'exprimental' Name.Namespace
+':'           Operator
+':'           Operator
+'inner'       Name.Namespace
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'std'         Name.Namespace
+':'           Operator
+':'           Operator
+'exprimental' Name.Namespace
+':'           Operator
+':'           Operator
+'inline'      Keyword
+' '           Text
+'innner'      Name.Namespace
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'std'         Name.Namespace
+':'           Operator
+':'           Operator
+'inline'      Keyword
+' '           Text
+'exprimental' Name.Namespace
+':'           Operator
+':'           Operator
+'innner'      Name.Namespace
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'other'       Name.Namespace
+' '           Text
+'='           Operator
+' '           Text
+'std'         Name.Namespace
+';'           Punctuation
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'other'       Name.Namespace
+' '           Text
+'='           Operator
+' '           Text
+'std'         Name.Namespace
+':'           Operator
+':'           Operator
+'exprimental' Name.Namespace
+';'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'std'         Name.Namespace
+':'           Operator
+':'           Operator
+'exprimental' Name.Namespace
+':'           Operator
+':'           Operator
+'inner'       Name.Namespace
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'class'       Keyword
+' '           Text
+'QualifiedName' Name.Class
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'public'      Keyword
+':'           Operator
+'\n'          Text
+
+'    '        Text
+'QualifiedName' Name
+'('           Punctuation
+'const'       Keyword
+' '           Text
+'FlyString'   Name
+'&'           Operator
+' '           Text
+'local_name'  Name
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'const'       Keyword
+' '           Text
+'FlyString'   Name
+'&'           Operator
+' '           Text
+'local_name'  Name
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'const'       Keyword
+' '           Text
+'{'           Punctuation
+' '           Text
+'return'      Keyword
+' '           Text
+'m_local_name' Name
+';'           Punctuation
+' '           Text
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'private'     Keyword
+':'           Operator
+'\n'          Text
+
+'    '        Text
+'FlyString'   Name
+' '           Text
+'m_local_name' Name
+';'           Punctuation
+'\n'          Text
+
+'}'           Punctuation
+';'           Punctuation
+'  \n'        Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'namespace'   Keyword
+' '           Text
+'ns'          Name.Namespace
+':'           Operator
+':'           Operator
+'inner'       Name.Namespace
+':'           Operator
+':'           Operator
+'inline'      Keyword
+' '           Text
+'pygments'    Name.Namespace
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'using'       Keyword
+' '           Text
+'namespace'   Keyword
+' '           Text
+'outer'       Name.Namespace
+';'           Punctuation
+'\n'          Text
+
+'    '        Text
+'int'         Keyword.Type
+' '           Text
+'has_value'   Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'        '    Text
+'namespace'   Keyword
+' '           Text
+'other'       Name.Namespace
+' '           Text
+'='           Operator
+' '           Text
+'std'         Name.Namespace
+';'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'namespace'   Keyword
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'        '    Text
+'namespace'   Keyword
+' '           Text
+'user'        Name.Namespace
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'            ' Text
+'int'         Keyword.Type
+' '           Text
+'has_value'   Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'                ' Text
+'using'       Keyword
+' '           Text
+'namespace'   Keyword
+' '           Text
+'inner'       Name.Namespace
+';'           Punctuation
+'\n'          Text
+
+'                ' Text
+'return'      Keyword
+' '           Text
+'4'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text
+
+'            ' Text
+'}'           Punctuation
+'\n'          Text
+
+'        '    Text
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text

--- a/tests/examplefiles/ec/test.ec.output
+++ b/tests/examplefiles/ec/test.ec.output
@@ -2730,10 +2730,7 @@
 '   '         Text
 'bool'        Keyword.Type
 ' '           Text
-'AnchorEditor' Name
-':'           Operator
-':'           Operator
-'NotifyClicked' Name
+'AnchorEditor::NotifyClicked' Name.Function
 '('           Punctuation
 'Button'      Name
 ' '           Text
@@ -4301,10 +4298,7 @@
 '   '         Text
 'bool'        Keyword.Type
 ' '           Text
-'AnchorEditor' Name
-':'           Operator
-':'           Operator
-'NotifyClicked' Name
+'AnchorEditor::NotifyClicked' Name.Function
 '('           Punctuation
 'Button'      Name
 ' '           Text
@@ -6904,10 +6898,7 @@
 '   '         Text
 'bool'        Keyword.Type
 ' '           Text
-'DataBox'     Name
-':'           Operator
-':'           Operator
-'NotifyTextEntry' Name
+'DataBox::NotifyTextEntry' Name.Function
 '('           Punctuation
 'AnchorDropBox' Name
 ' '           Text

--- a/tests/examplefiles/ec/test.ec.output
+++ b/tests/examplefiles/ec/test.ec.output
@@ -3440,7 +3440,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -3503,7 +3503,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -3579,7 +3579,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -3668,7 +3668,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -5227,7 +5227,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -5290,7 +5290,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -5366,7 +5366,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation
@@ -5455,7 +5455,7 @@
 '         '   Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 '('           Punctuation
 'anchor'      Name
 '.'           Punctuation

--- a/tests/examplefiles/mql/example.mqh.output
+++ b/tests/examplefiles/mql/example.mqh.output
@@ -281,7 +281,7 @@
 ' '           Text
 'bool'        Keyword.Type
 '      '      Text
-'Save'        Name
+'Save'        Name.Function
 '('           Punctuation
 'const'       Keyword
 ' '           Text
@@ -297,7 +297,7 @@
 ' '           Text
 'bool'        Keyword.Type
 '      '      Text
-'Load'        Name
+'Load'        Name.Function
 '('           Punctuation
 'const'       Keyword
 ' '           Text

--- a/tests/examplefiles/pike/FakeFile.pike.output
+++ b/tests/examplefiles/pike/FakeFile.pike.output
@@ -46,7 +46,7 @@
 
 'protected'   Keyword
 ' '           Text
-'int'         Name.Function
+'int'         Keyword.Type
 '('           Punctuation
 '0.'          Literal.Number.Float
 '.1'          Literal.Number.Float
@@ -58,7 +58,7 @@
 
 'protected'   Keyword
 ' '           Text
-'int'         Name.Function
+'int'         Keyword.Type
 '('           Punctuation
 '0.'          Literal.Number.Float
 '.1'          Literal.Number.Float
@@ -435,7 +435,7 @@
 ' '           Text
 'string'      Keyword.Type
 ' '           Text
-'make_type_str' Name
+'make_type_str' Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -506,7 +506,7 @@
 
 'this_program' Name
 ' '           Text
-'dup'         Name
+'dup'         Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -516,7 +516,7 @@
 '  '          Text
 'return'      Keyword
 ' '           Text
-'this_program' Name.Function
+'this_program' Name
 '('           Punctuation
 'data'        Name
 ','           Punctuation
@@ -544,7 +544,7 @@
 
 'int'         Keyword.Type
 ' '           Text
-'errno'       Name
+'errno'       Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -800,7 +800,7 @@
 '  '          Text
 'return'      Keyword
 ' '           Text
-'lambda'      Name.Function
+'lambda'      Keyword.Type
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -1649,7 +1649,7 @@
 '  '          Text
 'return'      Keyword
 ' '           Text
-'sizeof'      Name.Function
+'sizeof'      Keyword
 '('           Punctuation
 'data'        Name
 ')'           Punctuation
@@ -2492,7 +2492,7 @@
 '  '          Text
 'return'      Keyword
 ' '           Text
-'sizeof'      Name.Function
+'sizeof'      Keyword
 '('           Punctuation
 'data'        Name
 ')'           Punctuation

--- a/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
+++ b/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
@@ -33,7 +33,7 @@
 ' '           Text
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ';'           Punctuation
 '\n'          Text
 

--- a/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
+++ b/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
@@ -486,7 +486,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'write'       Name
+'write'       Name.Function
 '('           Punctuation
 ' '           Text
 'const'       Keyword
@@ -521,7 +521,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'write'       Name
+'write'       Name.Function
 '('           Punctuation
 ' '           Text
 'char'        Keyword.Type
@@ -553,7 +553,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'write'       Name
+'write'       Name.Function
 '('           Punctuation
 ' '           Text
 'const'       Keyword

--- a/tests/examplefiles/swig/swig_java.swg.output
+++ b/tests/examplefiles/swig/swig_java.swg.output
@@ -447,7 +447,7 @@
 '    '        Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 '('           Punctuation
@@ -507,7 +507,7 @@
 '    '        Text
 'else'        Keyword
 ' \n      '   Text
-'return'      Name.Function
+'return'      Keyword
 ' '           Text
 '('           Punctuation
 'char'        Keyword.Type
@@ -585,7 +585,7 @@
 '    '        Text
 'else'        Keyword
 ' '           Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Punctuation
 '('           Punctuation
@@ -639,7 +639,7 @@
 '    '        Text
 'else'        Keyword
 ' \n      '   Text
-'return'      Name.Function
+'return'      Keyword
 ' '           Text
 '('           Punctuation
 'char'        Keyword.Type
@@ -13310,7 +13310,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'finalize'    Name
+'finalize'    Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -13642,7 +13642,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'$methodname' Name
+'$methodname' Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -13696,7 +13696,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'$methodname' Name
+'$methodname' Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -13750,7 +13750,7 @@
 ' '           Text
 'void'        Keyword.Type
 ' '           Text
-'$methodname' Name
+'$methodname' Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text

--- a/tests/examplefiles/swig/swig_std_vector.i.output
+++ b/tests/examplefiles/swig/swig_std_vector.i.output
@@ -189,7 +189,7 @@
 
 'namespace'   Keyword
 ' '           Text
-'std'         Name
+'std'         Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -382,7 +382,7 @@
 '      '      Text
 'namespace'   Keyword
 ' '           Text
-'swig'        Name
+'swig'        Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -730,7 +730,7 @@
 '      '      Text
 'namespace'   Keyword
 ' '           Text
-'swig'        Name
+'swig'        Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -1088,7 +1088,7 @@
 '      '      Text
 'namespace'   Keyword
 ' '           Text
-'swig'        Name
+'swig'        Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text
@@ -1435,7 +1435,7 @@
 '      '      Text
 'namespace'   Keyword
 ' '           Text
-'swig'        Name
+'swig'        Name.Namespace
 ' '           Text
 '{'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/swig/swig_std_vector.i.output
+++ b/tests/examplefiles/swig/swig_std_vector.i.output
@@ -431,7 +431,7 @@
 'char'        Keyword.Type
 '*'           Operator
 ' '           Text
-'type_name'   Name
+'type_name'   Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -780,7 +780,7 @@
 'char'        Keyword.Type
 '*'           Operator
 ' '           Text
-'type_name'   Name
+'type_name'   Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -1140,7 +1140,7 @@
 'char'        Keyword.Type
 '*'           Operator
 ' '           Text
-'type_name'   Name
+'type_name'   Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -1484,7 +1484,7 @@
 'char'        Keyword.Type
 '*'           Operator
 ' '           Text
-'type_name'   Name
+'type_name'   Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text


### PR DESCRIPTION
This fixes #1561 and also fixes #1719. 

Fix lexing of function names (#1561) by adding a keywords state for matching keywords, inside and outside functions.
Before this, when a keyword would appear the lexer would go to the statements state, in which functions were not matched, so functions prefixed with keywords were not matched.

- Apart from the c and cpp lexers, I only updated the swig lexer and made sure it's keywords are in the new keywords state, as it was the only lexer that was breaking from this change.

- The new keywords state is (almost) entirely optional on purpose for deriving lexers. They don't benefit from using it themselves. Because of that I think it's a waste of time to incorporate this state in deriving lexers so I decided against it. 

Fix matching functions with a name or return argument that includes a '::' (also #1561) by introducing a second identifiers regex that matches all the previous identifiers, and also '::', and use it to match for function names and return arguments.

- I took the decision to create a second identifiers regex with '::' inside, simply because using the old identifiers regex would hurt
performance massively on every solution I tried to craft. I think this solution is still pretty elegant though, and the issue it fixes is big.

Fix lexing of namespaces (#1719) wherever possible, by adding a namespace state that is entered each time the namespace keyword is matched, and lexes all names matched as namespaces.

Cases this approach doesn't cover:
- Namespaces in using declarations.
- Namespaces that prefix names in random code.

Unfortunately, in both of these cases the names before and after '::' are not always namespaces so these cases can't be covered.