### PR TITLE
encode `str` into `bytes` for `_lookup_ctag` argument;

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -877,7 +877,7 @@ class HtmlFormatter(Formatter):
 
     def _lookup_ctag(self, token):
         entry = ctags.TagEntry()
-        if self._ctags.find(entry, token, 0):
+        if self._ctags.find(entry, token.encode(), 0):
             return entry['file'], entry['lineNumber']
         else:
             return None, None


### PR DESCRIPTION
check source code of `python-ctags` and `python-ctags3` to see what
argument type is expected (answer: `char *`);

guess this is python 2 legacy; but now it should work in python 3;