### PR TITLE
use `id` not `name` for line anchors;

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -303,7 +303,7 @@ class HtmlFormatter(Formatter):
 
     `lineanchors`
         If set to a nonempty string, e.g. ``foo``, the formatter will wrap each
-        output line in an anchor tag with a ``name`` of ``foo-linenumber``.
+        output line in an anchor tag with an ``id`` of ``foo-linenumber``.
         This allows easy linking to certain lines.
 
         .. versionadded:: 0.9
@@ -752,7 +752,7 @@ class HtmlFormatter(Formatter):
         for t, line in inner:
             if t:
                 i += 1
-                yield 1, '<a name="%s-%d"></a>' % (s, i) + line
+                yield 1, '<a id="%s-%d"></a>' % (s, i) + line
             else:
                 yield 0, line
 

--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -752,7 +752,7 @@ class HtmlFormatter(Formatter):
         for t, line in inner:
             if t:
                 i += 1
-                yield 1, '<a id="%s-%d"></a>' % (s, i) + line
+                yield 1, '<a id="%s-%d" name="%s-%d"></a>' % (s, i, s, i) + line
             else:
                 yield 0, line
 

--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -303,7 +303,7 @@ class HtmlFormatter(Formatter):
 
     `lineanchors`
         If set to a nonempty string, e.g. ``foo``, the formatter will wrap each
-        output line in an anchor tag with an ``id`` of ``foo-linenumber``.
+        output line in an anchor tag with an ``id`` (and `name`) of ``foo-linenumber``.
         This allows easy linking to certain lines.
 
         .. versionadded:: 0.9

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -99,7 +99,7 @@ def test_lineanchors():
     fmt = HtmlFormatter(**optdict)
     fmt.format(tokensource, outfile)
     html = outfile.getvalue()
-    assert re.search("<pre><span></span><a name=\"foo-1\">", html)
+    assert re.search("<pre><span></span><a id=\"foo-1\" name=\"foo-1\">", html)
 
 
 def test_lineanchors_with_startnum():
@@ -108,7 +108,7 @@ def test_lineanchors_with_startnum():
     fmt = HtmlFormatter(**optdict)
     fmt.format(tokensource, outfile)
     html = outfile.getvalue()
-    assert re.search("<pre><span></span><a name=\"foo-5\">", html)
+    assert re.search("<pre><span></span><a id=\"foo-5\" name=\"foo-5\">", html)
 
 
 def test_valid_output():


### PR DESCRIPTION
`name` attribute on `a` element is obsolete in html5;