### PR TITLE
Add formatter for Pango Markup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -239,5 +239,6 @@ Other contributors, listed alphabetically, are:
 * 15b3 -- Image Formatter improvements
 * Fabian Neumann -- CDDL lexer
 * Thomas Duboucher -- CDDL lexer
+* Philipp Imhof -- Pango Markup formatter
 
 Many thanks for all contributions!

--- a/pygments/formatters/_mapping.py
+++ b/pygments/formatters/_mapping.py
@@ -22,6 +22,7 @@ FORMATTERS = {
     'JpgImageFormatter': ('pygments.formatters.img', 'img_jpg', ('jpg', 'jpeg'), ('*.jpg',), 'Create a JPEG image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
     'LatexFormatter': ('pygments.formatters.latex', 'LaTeX', ('latex', 'tex'), ('*.tex',), 'Format tokens as LaTeX code. This needs the `fancyvrb` and `color` standard packages.'),
     'NullFormatter': ('pygments.formatters.other', 'Text only', ('text', 'null'), ('*.txt',), 'Output the text unchanged without any formatting.'),
+    'PangoMarkupFormatter': ('pygments.formatters.pangomarkup', 'Pango Markup', ('pango', 'pangomarkup'), (), 'Format tokens as Pango Markup code. It can then be rendered to an SVG.'),
     'RawTokenFormatter': ('pygments.formatters.other', 'Raw tokens', ('raw', 'tokens'), ('*.raw',), 'Format tokens as a raw representation for storing token streams.'),
     'RtfFormatter': ('pygments.formatters.rtf', 'RTF', ('rtf',), ('*.rtf',), 'Format tokens as RTF markup. This formatter automatically outputs full RTF documents with color information and other useful stuff. Perfect for Copy and Paste into Microsoft(R) Word(R) documents.'),
     'SvgFormatter': ('pygments.formatters.svg', 'SVG', ('svg',), ('*.svg',), 'Format tokens as an SVG graphics file.  This formatter is still experimental. Each line of code is a ``<text>`` element with explicit ``x`` and ``y`` coordinates containing ``<tspan>`` elements with the individual token styles.'),

--- a/pygments/formatters/pangomarkup.py
+++ b/pygments/formatters/pangomarkup.py
@@ -15,9 +15,10 @@ __all__ = ['PangoMarkupFormatter']
 
 
 class PangoMarkupFormatter(Formatter):
-    r"""
+    """
     Format tokens as Pango Markup code. It can then be rendered to an SVG.
     """
+
     name = 'Pango Markup'
     aliases = ['pango', 'pangomarkup']
     filenames = []
@@ -31,7 +32,7 @@ class PangoMarkupFormatter(Formatter):
             start = ''
             end = ''
             if style['color']:
-                start += f'<span fgcolor="#{style["color"]}">'
+                start += '<span fgcolor="#%s">' % style['color']
                 end = '</span>' + end
             if style['bold']:
                 start += '<b>'

--- a/pygments/formatters/pangomarkup.py
+++ b/pygments/formatters/pangomarkup.py
@@ -14,6 +14,17 @@ from pygments.formatter import Formatter
 __all__ = ['PangoMarkupFormatter']
 
 
+_escape_table = {
+    ord('&'): '&amp;',
+    ord('<'): '&lt;',
+}
+
+
+def escape_special_chars(text, table=_escape_table):
+    """Escape & and < for Pango Markup."""
+    return text.translate(table)
+
+
 class PangoMarkupFormatter(Formatter):
     """
     Format tokens as Pango Markup code. It can then be rendered to an SVG.
@@ -45,7 +56,7 @@ class PangoMarkupFormatter(Formatter):
                 end = '</u>' + end
             self.styles[token] = (start, end)
 
-    def format(self, tokensource, outfile):
+    def format_unencoded(self, tokensource, outfile):
         lastval = ''
         lasttype = None
 
@@ -55,16 +66,16 @@ class PangoMarkupFormatter(Formatter):
             while ttype not in self.styles:
                 ttype = ttype.parent
             if ttype == lasttype:
-                lastval += value
+                lastval += escape_special_chars(value)
             else:
                 if lastval:
                     stylebegin, styleend = self.styles[lasttype]
                     outfile.write(stylebegin + lastval + styleend)
-                lastval = value
+                lastval = escape_special_chars(value)
                 lasttype = ttype
 
         if lastval:
             stylebegin, styleend = self.styles[lasttype]
             outfile.write(stylebegin + lastval + styleend)
 
-        outfile.write('</tt>\n')
+        outfile.write('</tt>')

--- a/pygments/formatters/pangomarkup.py
+++ b/pygments/formatters/pangomarkup.py
@@ -1,0 +1,69 @@
+"""
+    pygments.formatters.pango
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Formatter for Pango markup output.
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.formatter import Formatter
+
+
+__all__ = ['PangoMarkupFormatter']
+
+
+class PangoMarkupFormatter(Formatter):
+    r"""
+    Format tokens as Pango Markup code. It can then be rendered to an SVG.
+    """
+    name = 'Pango Markup'
+    aliases = ['pango', 'pangomarkup']
+    filenames = []
+
+    def __init__(self, **options):
+        Formatter.__init__(self, **options)
+
+        self.styles = {}
+
+        for token, style in self.style:
+            start = ''
+            end = ''
+            if style['color']:
+                start += f'<span fgcolor="#{style["color"]}">'
+                end = '</span>' + end
+            if style['bold']:
+                start += '<b>'
+                end = '</b>' + end
+            if style['italic']:
+                start += '<i>'
+                end = '</i>' + end
+            if style['underline']:
+                start += '<u>'
+                end = '</u>' + end
+            self.styles[token] = (start, end)
+
+    def format(self, tokensource, outfile):
+        lastval = ''
+        lasttype = None
+
+        outfile.write('<tt>')
+
+        for ttype, value in tokensource:
+            while ttype not in self.styles:
+                ttype = ttype.parent
+            if ttype == lasttype:
+                lastval += value
+            else:
+                if lastval:
+                    stylebegin, styleend = self.styles[lasttype]
+                    outfile.write(stylebegin + lastval + styleend)
+                lastval = value
+                lasttype = ttype
+
+        if lastval:
+            stylebegin, styleend = self.styles[lasttype]
+            outfile.write(stylebegin + lastval + styleend)
+
+        outfile.write('</tt>\n')

--- a/tests/test_pangomarkup_formatter.py
+++ b/tests/test_pangomarkup_formatter.py
@@ -7,9 +7,10 @@
 """
 
 import pytest
+import re
 
 from pygments import highlight
-from pygments.formatters import PangoMarkupFormatter, NullFormatter
+from pygments.formatters import PangoMarkupFormatter
 from pygments.lexers import JavascriptLexer
 
 INPUT = r"""
@@ -26,18 +27,19 @@ function foobar(a, b) {
 }
 """
 
-OUTPUT = r"""<tt><span fgcolor="#008000"><b>function</b></span> foobar(a, b) {
-   <span fgcolor="#008000"><b>if</b></span> (a <span fgcolor="#666666">></span> b) {
-      <span fgcolor="#008000"><b>return</b></span> a <span fgcolor="#666666">&amp;</span> b;
+OUTPUT = r"""<tt><span fgcolor="#"><b>function</b></span> foobar(a, b) {
+   <span fgcolor="#"><b>if</b></span> (a <span fgcolor="#">></span> b) {
+      <span fgcolor="#"><b>return</b></span> a <span fgcolor="#">&amp;</span> b;
    }
-   <span fgcolor="#008000"><b>if</b></span> (a <span fgcolor="#666666">&lt;</span> b) {
-      <span fgcolor="#008000"><b>return</b></span> <span fgcolor="#008000"><b>true</b></span>;
+   <span fgcolor="#"><b>if</b></span> (a <span fgcolor="#">&lt;</span> b) {
+      <span fgcolor="#"><b>return</b></span> <span fgcolor="#"><b>true</b></span>;
    }
-   console.log(<span fgcolor="#BA2121">"single quote ' and double quote \""</span>)
-   console.log(<span fgcolor="#BA2121">'single quote \' and double quote "'</span>)
-   <span fgcolor="#408080"><i>// comment with äöü ç
+   console.log(<span fgcolor="#">"single quote ' and double quote \""</span>)
+   console.log(<span fgcolor="#">'single quote \' and double quote "'</span>)
+   <span fgcolor="#"><i>// comment with äöü ç
 </i></span>}
 </tt>"""
 
 def test_correct_output():
-    assert OUTPUT == highlight(INPUT, JavascriptLexer(), PangoMarkupFormatter())
+    markup = highlight(INPUT, JavascriptLexer(), PangoMarkupFormatter())
+    assert OUTPUT == re.sub('<span fgcolor="#[^"]{6}">', '<span fgcolor="#">', markup)

--- a/tests/test_pangomarkup_formatter.py
+++ b/tests/test_pangomarkup_formatter.py
@@ -1,0 +1,45 @@
+"""
+    Pygments Pango Markup formatter tests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import os
+import re
+import tempfile
+from io import StringIO
+from os import path
+
+import pytest
+
+from pygments.formatters import PangoMarkupFormatter, NullFormatter
+from pygments.lexers import PythonLexer
+
+TESTDIR = path.dirname(path.abspath(__file__))
+TESTFILE = path.join(TESTDIR, 'test_pangomarkup_formatter.py')
+
+with open(TESTFILE, encoding='utf-8') as fp:
+    tokensource = list(PythonLexer().get_tokens(fp.read()))
+
+
+def test_correct_output():
+    pfmt = PangoMarkupFormatter(nowrap=True)
+    poutfile = StringIO()
+    pfmt.format(tokensource, poutfile)
+
+    nfmt = NullFormatter()
+    noutfile = StringIO()
+    nfmt.format(tokensource, noutfile)
+
+    stripped_markup = re.sub('</?(b|u|i)>', '', poutfile.getvalue())
+    stripped_markup = re.sub('<span[^>]+>', '', stripped_markup)
+    stripped_markup = re.sub('</span>', '', stripped_markup)
+
+    text = noutfile.getvalue()
+    text = text.replace('&', '&amp;')
+    text = text.replace('<', '&lt;')
+    text = '<tt>' + text + '</tt>'
+
+    assert stripped_markup == text

--- a/tests/test_pangomarkup_formatter.py
+++ b/tests/test_pangomarkup_formatter.py
@@ -6,40 +6,38 @@
     :license: BSD, see LICENSE for details.
 """
 
-import os
-import re
-import tempfile
-from io import StringIO
-from os import path
-
 import pytest
 
+from pygments import highlight
 from pygments.formatters import PangoMarkupFormatter, NullFormatter
-from pygments.lexers import PythonLexer
+from pygments.lexers import JavascriptLexer
 
-TESTDIR = path.dirname(path.abspath(__file__))
-TESTFILE = path.join(TESTDIR, 'test_pangomarkup_formatter.py')
+INPUT = r"""
+function foobar(a, b) {
+   if (a > b) {
+      return a & b;
+   }
+   if (a < b) {
+      return true;
+   }
+   console.log("single quote ' and double quote \"")
+   console.log('single quote \' and double quote "')
+   // comment with äöü ç
+}
+"""
 
-with open(TESTFILE, encoding='utf-8') as fp:
-    tokensource = list(PythonLexer().get_tokens(fp.read()))
-
+OUTPUT = r"""<tt><span fgcolor="#008000"><b>function</b></span> foobar(a, b) {
+   <span fgcolor="#008000"><b>if</b></span> (a <span fgcolor="#666666">></span> b) {
+      <span fgcolor="#008000"><b>return</b></span> a <span fgcolor="#666666">&amp;</span> b;
+   }
+   <span fgcolor="#008000"><b>if</b></span> (a <span fgcolor="#666666">&lt;</span> b) {
+      <span fgcolor="#008000"><b>return</b></span> <span fgcolor="#008000"><b>true</b></span>;
+   }
+   console.log(<span fgcolor="#BA2121">"single quote ' and double quote \""</span>)
+   console.log(<span fgcolor="#BA2121">'single quote \' and double quote "'</span>)
+   <span fgcolor="#408080"><i>// comment with äöü ç
+</i></span>}
+</tt>"""
 
 def test_correct_output():
-    pfmt = PangoMarkupFormatter(nowrap=True)
-    poutfile = StringIO()
-    pfmt.format(tokensource, poutfile)
-
-    nfmt = NullFormatter()
-    noutfile = StringIO()
-    nfmt.format(tokensource, noutfile)
-
-    stripped_markup = re.sub('</?(b|u|i)>', '', poutfile.getvalue())
-    stripped_markup = re.sub('<span[^>]+>', '', stripped_markup)
-    stripped_markup = re.sub('</span>', '', stripped_markup)
-
-    text = noutfile.getvalue()
-    text = text.replace('&', '&amp;')
-    text = text.replace('<', '&lt;')
-    text = '<tt>' + text + '</tt>'
-
-    assert stripped_markup == text
+    assert OUTPUT == highlight(INPUT, JavascriptLexer(), PangoMarkupFormatter())


### PR DESCRIPTION
New formatter for Pango Markup as described in https://developer.gnome.org/pango/stable/pango-Markup.html

Using Pango, the output of this formatter can then be converted to an SVG file. 

<details>
  <summary>Together with https://github.com/ManimCommunity/manim, the output can also be used to create fancy animations.</summary>


```python
from pygments import highlight
from pygments.lexers import JavascriptLexer
from pygments.formatters import PangoMarkupFormatter

code = """
function bla(n, m) {
   console.log(n*m);
}
"""
print(highlight(code, JavascriptLexer(), PangoMarkupFormatter()))
```
yields
```
<tt><span fgcolor="#008000"><b>function</b></span> bla(n, m) {
   console.log(n<span fgcolor="#666666">*</span>m);
}
</tt>
```
and with this one can do
```python
from manim import *
from manimpango import *

class TestCode(Scene):
    def construct(self):
        text = MarkupText(
            """<tt><span fgcolor="#008000"><b>function</b></span> bla(n, m) {
   console.log(n<span fgcolor="#666666">*</span>m);
}
</tt>""")
        self.play(Write(text))
        self.wait()
```
to get:

https://user-images.githubusercontent.com/52650214/109392867-cff74280-791e-11eb-9238-49eeaf094870.mp4

</details>