### PR TITLE
LaTeX: Fix rare `missing number treated as zero`

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -299,7 +299,7 @@ class LatexFormatter(Formatter):
                 cmndef += (r'\def\$$@tc##1{\textcolor[rgb]{%s}{##1}}' %
                            rgbcolor(ndef['color']))
             if ndef['border']:
-                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{-\fboxrule}'
+                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{0pt minus \fboxrule}'
                            r'\fcolorbox[rgb]{%s}{%s}{\strut ##1}}}' %
                            (rgbcolor(ndef['border']),
                             rgbcolor(ndef['bgcolor'])))


### PR DESCRIPTION
I have a `.tex` document that uses a lot of packages. One of them (or a combination thereof) must mess with the `-` symbol used in `\setlength` (as defined in the calc package), resulting in:
`! Missing number, treated as zero`
on `\PYG{err}{XXX}` with the default highlighting.
Replacing `\setlength{\fboxsep}{-\fboxrule}` with the seemingly more robust `\setlength{\fboxsep}{0pt minus \fboxrule}` fixes the issue.

I do not have a MWE exhibiting the bug.