### PR TITLE
LaTeX: workaround minted incompatibility with Pygments 2.8.0

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -97,6 +97,10 @@ DOC_TEMPLATE = r'''
 
 STYLE_TEMPLATE = r'''
 \makeatletter
+%% workaround a minted <= v2.5 issue, which loads this file with - having
+%% catcode letter; also with _ having catcode 11 but this does not affect us
+\edef\%(cp)s@restore@catcode@of@minus@sign{\catcode`\noexpand\-=\the\catcode`\-\relax}
+\catcode`\-=12
 \def\%(cp)s@reset{\let\%(cp)s@it=\relax \let\%(cp)s@bf=\relax%%
     \let\%(cp)s@ul=\relax \let\%(cp)s@tc=\relax%%
     \let\%(cp)s@bc=\relax \let\%(cp)s@ff=\relax}
@@ -129,6 +133,7 @@ STYLE_TEMPLATE = r'''
 \def\%(cp)sZlb{[}
 \def\%(cp)sZrb{]}
 \makeatother
+\%(cp)s@restore@catcode@of@minus@sign
 '''
 
 


### PR DESCRIPTION
Fix: #1731
Fix: #1734

Upstream issue: https://github.com/gpoore/minted/issues/294