### PR TITLE
Minted compatibility patch

### DIFF
--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -97,10 +97,6 @@ DOC_TEMPLATE = r'''
 
 STYLE_TEMPLATE = r'''
 \makeatletter
-%% workaround a minted <= v2.5 issue, which loads this file with - having
-%% catcode letter; also with _ having catcode 11 but this does not affect us
-\edef\%(cp)s@restore@catcode@of@minus@sign{\catcode`\noexpand\-=\the\catcode`\-\relax}
-\catcode`\-=12\relax
 \def\%(cp)s@reset{\let\%(cp)s@it=\relax \let\%(cp)s@bf=\relax%%
     \let\%(cp)s@ul=\relax \let\%(cp)s@tc=\relax%%
     \let\%(cp)s@bc=\relax \let\%(cp)s@ff=\relax}
@@ -132,7 +128,6 @@ STYLE_TEMPLATE = r'''
 \def\%(cp)sZat{@}
 \def\%(cp)sZlb{[}
 \def\%(cp)sZrb{]}
-\%(cp)s@restore@catcode@of@minus@sign
 \makeatother
 '''
 
@@ -304,7 +299,7 @@ class LatexFormatter(Formatter):
                 cmndef += (r'\def\$$@tc##1{\textcolor[rgb]{%s}{##1}}' %
                            rgbcolor(ndef['color']))
             if ndef['border']:
-                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{-\fboxrule}'
+                cmndef += (r'\def\$$@bc##1{{\setlength{\fboxsep}{\string -\fboxrule}'
                            r'\fcolorbox[rgb]{%s}{%s}{\strut ##1}}}' %
                            (rgbcolor(ndef['border']),
                             rgbcolor(ndef['bgcolor'])))

--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -100,7 +100,7 @@ STYLE_TEMPLATE = r'''
 %% workaround a minted <= v2.5 issue, which loads this file with - having
 %% catcode letter; also with _ having catcode 11 but this does not affect us
 \edef\%(cp)s@restore@catcode@of@minus@sign{\catcode`\noexpand\-=\the\catcode`\-\relax}
-\catcode`\-=12
+\catcode`\-=12\relax
 \def\%(cp)s@reset{\let\%(cp)s@it=\relax \let\%(cp)s@bf=\relax%%
     \let\%(cp)s@ul=\relax \let\%(cp)s@tc=\relax%%
     \let\%(cp)s@bc=\relax \let\%(cp)s@ff=\relax}
@@ -132,8 +132,8 @@ STYLE_TEMPLATE = r'''
 \def\%(cp)sZat{@}
 \def\%(cp)sZlb{[}
 \def\%(cp)sZrb{]}
-\makeatother
 \%(cp)s@restore@catcode@of@minus@sign
+\makeatother
 '''
 
 


### PR DESCRIPTION
LaTeX: workaround to ensure compatibility with minted
    
This reverts already merged #1735 (after a commit from #1736 to fix it)
and applies the first envisioned method discussed in #1734.

The reason is that the #1735-#1736 method only partially repairs the
minted compatibility.  Minted queries from Pygments the stylesheet
with a command prefix equal to the style name, which may contain
(at least, so far) characters such as - and _, which are not normally
allowed in LaTeX macros.  So it modifies the meaning of - and _ before
telling LaTeX to input the Pygments provided stylesheet.  Restoring
the normal meaning of - from inside the stylesheet must be carefully
localized: at top and bottom of stylesheets some macros will use in
their names the - and there the - must be the weird minted one, not
the normal one.

The #1735-#1736 method thus does fix compatibility with minted but *only*
for those style names not using a -, but it creates another issue if
used with e.g. style "paraiso-dark" which has a - character in its name.

"De guerre lasse", I feel it is simpler to use the somewhat strange
very localized hotfix of prefixing - by \string at the one spot where
we need it to be its normal self.  Hence this PR.


Fix #1734.

Relates: https://github.com/gpoore/minted/issues/294

I was not familiar with minted LaTeX code.  It has taken me some time to understand what is involved (and on this occasion I discovered that with LaTeX of spring 2021, loading  a file results in a log trace in about 10000 (!!) macro calls to the LaTeX3 syntax in the minted context so it is nowadays extremely laborious to examine a LaTeX problem via `\tracingmacros1`.). 

The good thing in minted approach is that it uses weird command prefix *only* to recover the stylesheet. Regarding actual mark-up for highlighting code it uses `\PYG` default prefix. So the catcode issues are, fortunately, localized to only actually loading the stylesheet for a given stylename.

Although minted will probably get an upgrade, many people will be for some time with its current version. So, despite this being entirely a design problem on minted side, it must be fixed on Pygments side. It is very ugly to add this `\string` like I do, but this works and solves the problem, as identified so far.

