### PR TITLE
Leading underscore in APL variable names (GNU, Dyalog)

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -15,7 +15,7 @@
 LEXERS = {
     'ABAPLexer': ('pygments.lexers.business', 'ABAP', ('abap',), ('*.abap', '*.ABAP'), ('text/x-abap',)),
     'AMDGPULexer': ('pygments.lexers.amdgpu', 'AMDGPU', ('amdgpu',), ('*.isa',), ()),
-    'APLLexer': ('pygments.lexers.apl', 'APL', ('apl',), ('*.apl',), ()),
+    'APLLexer': ('pygments.lexers.apl', 'APL', ('apl',), ('*.apl', '*.aplf', '*.aplo', '*.apln', '*.aplc', '*.apli', '*.dyalog'), ()),
     'AbnfLexer': ('pygments.lexers.grammar_notation', 'ABNF', ('abnf',), ('*.abnf',), ('text/x-abnf',)),
     'ActionScript3Lexer': ('pygments.lexers.actionscript', 'ActionScript 3', ('as3', 'actionscript3'), ('*.as',), ('application/x-actionscript3', 'text/x-actionscript3', 'text/actionscript3')),
     'ActionScriptLexer': ('pygments.lexers.actionscript', 'ActionScript', ('as', 'actionscript'), ('*.as',), ('application/x-actionscript', 'text/x-actionscript', 'text/actionscript')),

--- a/pygments/lexers/apl.py
+++ b/pygments/lexers/apl.py
@@ -23,7 +23,10 @@ class APLLexer(RegexLexer):
     """
     name = 'APL'
     aliases = ['apl']
-    filenames = ['*.apl']
+    filenames = [
+        '*.apl', '*.aplf', '*.aplo', '*.apln',  
+        '*.aplc', '*.apli', '*.dyalog',
+    ]
 
     tokens = {
         'root': [
@@ -65,8 +68,8 @@ class APLLexer(RegexLexer):
             #
             # Variables
             # =========
-            # following IBM APL2 standard
-            (r'[A-Za-zΔ∆⍙][A-Za-zΔ∆⍙_¯0-9]*', Name.Variable),
+            # following IBM APL2 standard (with a leading _ ok for GNU APL and Dyalog)
+            (r'[A-Za-zΔ∆⍙_][A-Za-zΔ∆⍙_¯0-9]*', Name.Variable),     
             #
             # Numbers
             # =======

--- a/tests/snippets/apl/test_leading_underscore.txt
+++ b/tests/snippets/apl/test_leading_underscore.txt
@@ -1,0 +1,26 @@
+---input---
+_op_←{_←⍺ ⍵⋄(⍺⍺ ⍺)+⍵⍵ ⍵}
+
+---tokens---
+'_op_'        Name.Variable
+'←'           Keyword.Declaration
+'{'           Keyword.Type
+'_'           Name.Variable
+'←'           Keyword.Declaration
+'⍺'           Name.Builtin.Pseudo
+' '           Text
+'⍵'           Name.Builtin.Pseudo
+'⋄'           Punctuation
+'('           Punctuation
+'⍺'           Name.Builtin.Pseudo
+'⍺'           Name.Builtin.Pseudo
+' '           Text
+'⍺'           Name.Builtin.Pseudo
+')'           Punctuation
+'+'           Operator
+'⍵'           Name.Builtin.Pseudo
+'⍵'           Name.Builtin.Pseudo
+' '           Text
+'⍵'           Name.Builtin.Pseudo
+'}'           Keyword.Type
+'\n'          Text


### PR DESCRIPTION
Two small tweaks to the APL lexer

1. Add all APL file suffixes
2. Allow leading _ in variable names (GNU APL, Dyalog)