### PR TITLE
Don't mix foreground & background in _deprecated_ansicolors lookup

### DIFF
--- a/pygments/style.py
+++ b/pygments/style.py
@@ -134,7 +134,7 @@ class StyleMeta(type):
             color = _ansimap[color]
         bgcolor = t[4]
         if bgcolor in _deprecated_ansicolors:
-            bgcolor = _deprecated_ansicolors[color]
+            bgcolor = _deprecated_ansicolors[bgcolor]
         if bgcolor in ansicolors:
             bgansicolor = bgcolor
             bgcolor = _ansimap[bgcolor]


### PR DESCRIPTION
Hello!
A static analyzer alerted us that the wrong variable is used in the `_deprecated_ansicolors` lookup for `bgcolor`.
I'm aware that this is deprecated functionality, but since the code is in the project, you might want to keep it correct.

I looked into writing a test, but I'm new to the codebase and don't know where to start. If you think fixing this issue is worth it, I'd appreciate a pointer.