### PR TITLE
lexers: devicetree: allow node label without root node

### DIFF
--- a/pygments/lexers/devicetree.py
+++ b/pygments/lexers/devicetree.py
@@ -58,7 +58,7 @@ class DevicetreeLexer(RegexLexer):
             (r'(L?)(")', bygroups(String.Affix, String), 'string'),
             (r'0x[0-9a-fA-F]+', Number.Hex),
             (r'\d+', Number.Integer),
-            (r'([^\s{}/*]*)(\s*)(:)', bygroups(Name.Label, Text, Punctuation)),
+            (r'([^\s{}/*]*)(\s*)(:)', bygroups(Name.Label, Text, Punctuation), '#pop'),
             (words(('compatible', 'model', 'phandle', 'status', '#address-cells',
                     '#size-cells', 'reg', 'virtual-reg', 'ranges', 'dma-ranges',
                     'device_type', 'name'), suffix=r'\b'), Keyword.Reserved),

--- a/tests/test_devicetree_lexer.py
+++ b/tests/test_devicetree_lexer.py
@@ -1,0 +1,32 @@
+"""
+    Devicetree Lexer Tests
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments.lexers.devicetree import DevicetreeLexer
+from pygments.token import Token
+
+
+@pytest.fixture(scope="module")
+def lexer():
+    yield DevicetreeLexer()
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    (
+        'nodelabel: node@0 { foo = "bar"; };',
+        'nodelabel: node { foo = "bar"; };',
+        'nodelabel0: nodelabel1: node@0 { foo = "bar"; };',
+    ),
+)
+def test_fragment_out_of_root_node(lexer, fragment):
+    """Validate that a devicetree fragment out of a root node is parsed correctly."""
+
+    tokens = list(lexer.get_tokens(fragment))
+    assert all(x[0] != Token.Error for x in tokens)


### PR DESCRIPTION
It is sometimes useful to render DeviceTree snippets such as:

```
foo: bar@1234 {
    foo = "bar";
};
```

However, the snippet shown above does not render properly unless it is
enclosed on a root node, i.e.

```
/{
    foo: bar@1234 {
        foo = "bar";
    };
};
```

Fixes #1754 