### PR TITLE
PowerShell: lex ':' 

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -730,7 +730,7 @@ class PowerShellLexer(RegexLexer):
             (r'\[[a-z_\[][\w. `,\[\]]*\]', Name.Constant),  # .net [type]s
             (r'-[a-z_]\w*', Name),
             (r'\w+', Name),
-            (r'[.,;@{}\[\]$()=+*/\\&%!~?^`|<>-]|::', Punctuation),
+            (r'[.,;:@{}\[\]$()=+*/\\&%!~?^`|<>-]', Punctuation),
         ],
         'child': [
             (r'\)', Punctuation, '#pop'),

--- a/tests/snippets/powershell/test_colon_punctuation.txt
+++ b/tests/snippets/powershell/test_colon_punctuation.txt
@@ -1,0 +1,35 @@
+---input---
+$message = (Test-Path C:\) ? "Path exists" : "Path not found"
+[math]::pi
+
+---tokens---
+'$message'    Name.Variable
+' '           Text
+'='           Punctuation
+' '           Text
+'('           Punctuation
+'Test-Path'   Name.Builtin
+' '           Text
+'C'           Name
+':'           Punctuation
+'\\'          Punctuation
+')'           Punctuation
+' '           Text
+'?'           Punctuation
+' '           Text
+'"'           Literal.String.Double
+'Path exists' Literal.String.Double
+'"'           Literal.String.Double
+' '           Text
+':'           Punctuation
+' '           Text
+'"'           Literal.String.Double
+'Path not found' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text
+
+'[math]'      Name.Constant
+':'           Punctuation
+':'           Punctuation
+'pi'          Name
+'\n'          Text

--- a/tests/snippets/powershell/test_remoting_session.txt
+++ b/tests/snippets/powershell/test_remoting_session.txt
@@ -7,11 +7,11 @@
 '-NetBIOS'    Name
 '-Hostname'   Name
 ']'           Punctuation
-':'           Error
+':'           Punctuation
 ' '           Text
 'PS '         Name.Builtin
 'C'           Name
-':'           Error
+':'           Punctuation
 '\\'          Punctuation
 '>'           Punctuation
 ' '           Text

--- a/tests/snippets/powershell/test_session.txt
+++ b/tests/snippets/powershell/test_session.txt
@@ -8,7 +8,7 @@ PS > Get-ChildItem
 ---tokens---
 'PS '         Name.Builtin
 'C'           Name
-':'           Error
+':'           Punctuation
 '\\'          Punctuation
 '>'           Punctuation
 ' '           Text


### PR DESCRIPTION
This fixes #1682.

This won't match ```:``` as ```Text``` if it's inside a path, but other shell lexers don't do that as well, so I think it's a reasonable fix.