### PR TITLE
Add gruvbox styles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,10 @@ Version 2.9.0
   * For more details and discussion see the issue
     https://github.com/pygments/pygments/issues/1757
 
+- Added styles:
+
+  * Gruvbox light+dark (#1763)
+
 Version 2.8.0
 -------------
 (released February 14, 2021)

--- a/pygments/styles/__init__.py
+++ b/pygments/styles/__init__.py
@@ -52,6 +52,8 @@ STYLE_MAP = {
     'stata-dark':  'stata_dark::StataDarkStyle',
     'inkpot':      'inkpot::InkPotStyle',
     'zenburn': 'zenburn::ZenburnStyle',
+    'gruvbox-dark': 'gruvbox::GruvboxDarkStyle',
+    'gruvbox-light': 'gruvbox::GruvboxLightStyle',
 }
 
 

--- a/pygments/styles/gruvbox.py
+++ b/pygments/styles/gruvbox.py
@@ -1,0 +1,107 @@
+"""
+    pygments.styles.gruvbox
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    pygments version of the "gruvbox" vim theme.
+    https://github.com/morhetz/gruvbox
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.style import Style
+from pygments.token import Keyword, Name, Comment, String, Error, \
+     Number, Operator, Generic
+
+
+class GruvboxDarkStyle(Style):
+    """
+    Pygments version of the "gruvbox" dark vim theme.
+    """
+
+    background_color = '#282828'
+    highlight_color = '#ebdbb2'
+
+    styles = {
+        Comment:            'italic #928374',
+        Comment.PreProc:    '#8ec07c',
+        Comment.Special:    'bold italic #ebdbb2',
+
+        Keyword:            '#fb4934',
+        Operator.Word:      '#fb4934',
+
+        String:             '#b8bb26',
+        String.Escape:      '#fe8019',
+
+        Number:             '#d3869b',
+
+        Name.Builtin:       '#fe8019',
+        Name.Variable:      '#83a598',
+        Name.Constant:      '#d3869b',
+        Name.Class:         '#8ec07c',
+        Name.Function:      '#8ec07c',
+        Name.Namespace:     '#8ec07c',
+        Name.Exception:     '#fb4934',
+        Name.Tag:           '#8ec07c',
+        Name.Attribute:     '#fabd2f',
+        Name.Decorator:     '#fb4934',
+
+        Generic.Heading:    'bold #ebdbb2',
+        Generic.Subheading: 'underline #ebdbb2',
+        Generic.Deleted:    'bg:#fb4934 #282828',
+        Generic.Inserted:   'bg:#b8bb26 #282828',
+        Generic.Error:      '#fb4934',
+        Generic.Emph:       'italic',
+        Generic.Strong:     'bold',
+        Generic.Prompt:     '#a89984',
+        Generic.Output:     '#f2e5bc',
+        Generic.Traceback:  '#fb4934',
+
+        Error:              'bg:#fb4934 #282828'
+    }
+
+class GruvboxLightStyle(Style):
+    """
+    Pygments version of the "gruvbox" Light vim theme.
+    """
+
+    background_color = '#fbf1c7'
+    highlight_color = '#3c3836'
+
+    styles = {
+        Comment:            'italic #928374',
+        Comment.PreProc:    '#427b58',
+        Comment.Special:    'bold italic #3c3836',
+
+        Keyword:            '#9d0006',
+        Operator.Word:      '#9d0006',
+
+        String:             '#79740e',
+        String.Escape:      '#af3a03',
+
+        Number:             '#8f3f71',
+
+        Name.Builtin:       '#af3a03',
+        Name.Variable:      '#076678',
+        Name.Constant:      '#8f3f71',
+        Name.Class:         '#427b58',
+        Name.Function:      '#427b58',
+        Name.Namespace:     '#427b58',
+        Name.Exception:     '#9d0006',
+        Name.Tag:           '#427b58',
+        Name.Attribute:     '#b57614',
+        Name.Decorator:     '#9d0006',
+
+        Generic.Heading:    'bold #3c3836',
+        Generic.Subheading: 'underline #3c3836',
+        Generic.Deleted:    'bg:#9d0006 #fbf1c7',
+        Generic.Inserted:   'bg:#79740e #fbf1c7',
+        Generic.Error:      '#9d0006',
+        Generic.Emph:       'italic',
+        Generic.Strong:     'bold',
+        Generic.Prompt:     '#7c6f64',
+        Generic.Output:     '#32302f',
+        Generic.Traceback:  '#9d0006',
+
+        Error:              'bg:#9d0006 #fbf1c7'
+    }


### PR DESCRIPTION
Added styles gruvbox-dark and gruvbox-light based on the famous [vim theme](https://github.com/morhetz/gruvbox) from morhetz.

Gruvbox is not my property but it is MIT licensed so there shouldn't be any licensing problem using it under BSD.