### PR TITLE
groovy lexer: detect quoted function names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -27,6 +27,7 @@ Version 2.9.0
   * Chapel (#1743)
   * Coq (#1721)
   * Cython (#853)
+  * Groovy (#1765)
   * Julia (#1715)
   * Octave: Allow multiline and block-percent comments (#1726)
   * PowerShell: Improve lexing of ``:`` (#1682, #1758)

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -559,7 +559,11 @@ class GroovyLexer(RegexLexer):
              Keyword),
             # method names
             (r'^(\s*(?:[a-zA-Z_][\w.\[\]]*\s+)+?)'  # return arguments
-             r'([a-zA-Z_]\w*)'                      # method name
+             r'('
+             r'[a-zA-Z_]\w*'                        # method name
+             r'|"(?:\\\\|\\[^\\]|[^"\\])*"'         # or double-quoted method name
+             r"|'(?:\\\\|\\[^\\]|[^'\\])*'"         # or single-quoted method name
+             r')'
              r'(\s*)(\()',                          # signature start
              bygroups(using(this), Name.Function, Text, Operator)),
             (r'@[a-zA-Z_][\w.]*', Name.Decorator),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -549,18 +549,20 @@ class GroovyLexer(RegexLexer):
             default('base'),
         ],
         'base': [
+            (r'[^\S\n]+', Text),
+            (r'//.*?\n', Comment.Single),
+            (r'/\*.*?\*/', Comment.Multiline),
+            # keywords: go before method names to avoid lexing "throw new XYZ"
+            # as a method signature
+            (r'(assert|break|case|catch|continue|default|do|else|finally|for|'
+             r'if|goto|instanceof|new|return|switch|this|throw|try|while|in|as)\b',
+             Keyword),
             # method names
             (r'^(\s*(?:[a-zA-Z_][\w.\[\]]*\s+)+?)'  # return arguments
              r'([a-zA-Z_]\w*)'                      # method name
              r'(\s*)(\()',                          # signature start
              bygroups(using(this), Name.Function, Text, Operator)),
-            (r'[^\S\n]+', Text),
-            (r'//.*?\n', Comment.Single),
-            (r'/\*.*?\*/', Comment.Multiline),
             (r'@[a-zA-Z_][\w.]*', Name.Decorator),
-            (r'(assert|break|case|catch|continue|default|do|else|finally|for|'
-             r'if|goto|instanceof|new|return|switch|this|throw|try|while|in|as)\b',
-             Keyword),
             (r'(abstract|const|enum|extends|final|implements|native|private|'
              r'protected|public|static|strictfp|super|synchronized|throws|'
              r'transient|volatile)\b', Keyword.Declaration),

--- a/tests/examplefiles/groovy/quoted.groovy
+++ b/tests/examplefiles/groovy/quoted.groovy
@@ -1,0 +1,2 @@
+def "long function name"(i) { return i }
+assert 'long function name'(1) == 1

--- a/tests/examplefiles/groovy/quoted.groovy.output
+++ b/tests/examplefiles/groovy/quoted.groovy.output
@@ -1,0 +1,28 @@
+'def'         Keyword.Type
+' '           Text
+'"long function name"' Name.Function
+'('           Operator
+'i'           Name
+')'           Operator
+' '           Text
+'{'           Operator
+' '           Text
+'return'      Keyword
+' '           Text
+'i'           Name
+' '           Text
+'}'           Operator
+'\n'          Text
+
+'assert'      Keyword
+' '           Text
+"'long function name'" Literal.String.Single
+'('           Operator
+'1'           Literal.Number.Integer
+')'           Operator
+' '           Text
+'='           Operator
+'='           Operator
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text

--- a/tests/examplefiles/groovy/test.gradle.output
+++ b/tests/examplefiles/groovy/test.gradle.output
@@ -88,7 +88,7 @@
 ' '           Text
 'String'      Name
 ' '           Text
-'getWorldString' Name.Function
+'getWorldString' Name
 '('           Operator
 ')'           Operator
 ' '           Text

--- a/tests/examplefiles/groovy/test.groovy.output
+++ b/tests/examplefiles/groovy/test.groovy.output
@@ -167,7 +167,7 @@
 '\n'          Text
 
 '        '    Text
-'if'          Name.Function
+'if'          Keyword
 ' '           Text
 '('           Operator
 '!'           Operator
@@ -183,7 +183,7 @@
 ' '           Text
 'new'         Keyword
 ' '           Text
-'RuntimeException' Name.Function
+'RuntimeException' Name
 '('           Operator
 '"$activity activity doesn\'t exist"' Literal.String.Double
 ')'           Operator
@@ -273,7 +273,7 @@
 '\n'          Text
 
 '        '    Text
-'switch'      Name.Function
+'switch'      Keyword
 ' '           Text
 '('           Operator
 'activityValue' Name


### PR DESCRIPTION
Should fix #1753. I don't have a VM with Python set up in a way where I can easily test this, so I am depending on the tests in CI.

In Groovy it is valid to have a function name which is a quoted string. Single quote (`'`), double quote (`"`) and the triple-single/triple-double formats are all allowed, but I suspect most people only use standard single or double. In most syntax highlighters the quoted function name is displayed as if it were a string (e.g. https://groovyconsole.appspot.com/), which perhaps we could also do by switching the priority to parse strings before function declarations. But since we already detect a function name here, I just try to expand the pattern a little bit to match the quoted string as a function name too.

While we are here, also fix a bug where sometimes keywords would be interpreted as function names (already fixed in Java lexer).