### PR TITLE
Allow C-style line comments in F* to start anywhere in a line

### DIFF
--- a/pygments/lexers/ml.py
+++ b/pygments/lexers/ml.py
@@ -908,7 +908,7 @@ class FStarLexer(RegexLexer):
             (r'\b([A-Z][\w\']*)(?=\s*\.)', Name.Namespace, 'dotted'),
             (r'\b([A-Z][\w\']*)', Name.Class),
             (r'\(\*(?![)])', Comment, 'comment'),
-            (r'^\/\/.+$', Comment),
+            (r'\/\/.+$', Comment),
             (r'\b(%s)\b' % '|'.join(keywords), Keyword),
             (r'\b(%s)\b' % '|'.join(assume_keywords), Name.Exception),
             (r'\b(%s)\b' % '|'.join(decl_keywords), Keyword.Declaration),


### PR DESCRIPTION
F* actually allows for C-style `//` line comments to start anywhere in a line, not just at the beginning.

@denismerigoux @protz Since you came up with the original lexer code (thanks!), I tagged you here so you can take a look as well - maybe I overlooked an obvious problem with starting comments in the middle of a line.