### PR TITLE
Swift lexer: add 'associatedtype' keyword

### DIFF
--- a/pygments/lexers/objective.py
+++ b/pygments/lexers/objective.py
@@ -440,8 +440,8 @@ class SwiftLexer(RegexLexer):
             (r'(var|let)(\s+)([a-zA-Z_]\w*)', bygroups(Keyword.Declaration,
              Text, Name.Variable)),
             (words((
-                'class', 'deinit', 'enum', 'extension', 'func', 'import', 'init',
-                'internal', 'let', 'operator', 'private', 'protocol', 'public',
+                'associatedtype', 'class', 'deinit', 'enum', 'extension', 'func', 'import',
+                'init', 'internal', 'let', 'operator', 'private', 'protocol', 'public',
                 'static', 'struct', 'subscript', 'typealias', 'var'), suffix=r'\b'),
              Keyword.Declaration)
         ],


### PR DESCRIPTION
Adds the `associatedtype` keyword to the Swift lexer.

I also moved the `init` keyword to the next line to keep them at a roughly even length.