### PR TITLE
Fix python lexer parsing floats incorrectly

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -160,6 +160,7 @@ class PythonLexer(RegexLexer):
             ("([uUbB]?)(')", bygroups(String.Affix, String.Single),
              combined('stringescape', 'sqs')),
             (r'[^\S\n]+', Text),
+            include('numbers'),
             (r'!=|==|<<|>>|:=|[-~+/*%=<>&^|.]', Operator),
             (r'[]{}:(),;[]', Punctuation),
             (r'(in|is|and|or|not)\b', Operator.Word),
@@ -168,7 +169,6 @@ class PythonLexer(RegexLexer):
             include('magicfuncs'),
             include('magicvars'),
             include('name'),
-            include('numbers'),
         ],
         'expr-inside-fstring': [
             (r'[{([]', Punctuation, 'expr-inside-fstring-inner'),

--- a/tests/snippets/python/test_floats.txt
+++ b/tests/snippets/python/test_floats.txt
@@ -1,0 +1,75 @@
+---input---
+123 -11 0 -0 0.5 .5 1. -0.5 +0.5 -.5 -1. 2e1 -2e1 2e -2e +2e e.3 -e.3 11.2e-3 -11.2e-3 5_6 5__6 _5 6_ 5.6_7 5.67_
+
+---tokens---
+'123'       Token.Literal.Number.Integer
+' '         Token.Text
+'-'         Token.Operator
+'11'        Token.Literal.Number.Integer
+' '         Token.Text
+'0'         Token.Literal.Number.Integer
+' '         Token.Text
+'-'         Token.Operator
+'0'         Token.Literal.Number.Integer
+' '         Token.Text
+'0.5'       Token.Literal.Number.Float
+' '         Token.Text
+'.5'        Token.Literal.Number.Float
+' '         Token.Text
+'1.'        Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'0.5'       Token.Literal.Number.Float
+' '         Token.Text
+'+'         Token.Operator
+'0.5'       Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'.5'        Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'1.'        Token.Literal.Number.Float
+' '         Token.Text
+'2e1'       Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'2e1'       Token.Literal.Number.Float
+' '         Token.Text
+'2'         Token.Literal.Number.Integer
+'e'         Token.Name
+' '         Token.Text
+'-'         Token.Operator
+'2'         Token.Literal.Number.Integer
+'e'         Token.Name
+' '         Token.Text
+'+'         Token.Operator
+'2'         Token.Literal.Number.Integer
+'e'         Token.Name
+' '         Token.Text
+'e'         Token.Name
+'.3'        Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'e'         Token.Name
+'.3'        Token.Literal.Number.Float
+' '         Token.Text
+'11.2e-3'   Token.Literal.Number.Float
+' '         Token.Text
+'-'         Token.Operator
+'11.2e-3'   Token.Literal.Number.Float
+' '         Token.Text
+'5_6'       Token.Literal.Number.Integer
+' '         Token.Text
+'5'         Token.Literal.Number.Integer
+'__6'       Token.Name
+' '         Token.Text
+'_5'        Token.Name
+' '         Token.Text
+'6'         Token.Literal.Number.Integer
+'_'         Token.Name
+' '         Token.Text
+'5.6_7'     Token.Literal.Number.Float
+' '         Token.Text
+'5.67'      Token.Literal.Number.Float
+'_'         Token.Name
+'\n'        Token.Text

--- a/tests/snippets/python/test_floats.txt
+++ b/tests/snippets/python/test_floats.txt
@@ -2,74 +2,74 @@
 123 -11 0 -0 0.5 .5 1. -0.5 +0.5 -.5 -1. 2e1 -2e1 2e -2e +2e e.3 -e.3 11.2e-3 -11.2e-3 5_6 5__6 _5 6_ 5.6_7 5.67_
 
 ---tokens---
-'123'       Token.Literal.Number.Integer
-' '         Token.Text
-'-'         Token.Operator
-'11'        Token.Literal.Number.Integer
-' '         Token.Text
-'0'         Token.Literal.Number.Integer
-' '         Token.Text
-'-'         Token.Operator
-'0'         Token.Literal.Number.Integer
-' '         Token.Text
-'0.5'       Token.Literal.Number.Float
-' '         Token.Text
-'.5'        Token.Literal.Number.Float
-' '         Token.Text
-'1.'        Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'0.5'       Token.Literal.Number.Float
-' '         Token.Text
-'+'         Token.Operator
-'0.5'       Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'.5'        Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'1.'        Token.Literal.Number.Float
-' '         Token.Text
-'2e1'       Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'2e1'       Token.Literal.Number.Float
-' '         Token.Text
-'2'         Token.Literal.Number.Integer
-'e'         Token.Name
-' '         Token.Text
-'-'         Token.Operator
-'2'         Token.Literal.Number.Integer
-'e'         Token.Name
-' '         Token.Text
-'+'         Token.Operator
-'2'         Token.Literal.Number.Integer
-'e'         Token.Name
-' '         Token.Text
-'e'         Token.Name
-'.3'        Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'e'         Token.Name
-'.3'        Token.Literal.Number.Float
-' '         Token.Text
-'11.2e-3'   Token.Literal.Number.Float
-' '         Token.Text
-'-'         Token.Operator
-'11.2e-3'   Token.Literal.Number.Float
-' '         Token.Text
-'5_6'       Token.Literal.Number.Integer
-' '         Token.Text
-'5'         Token.Literal.Number.Integer
-'__6'       Token.Name
-' '         Token.Text
-'_5'        Token.Name
-' '         Token.Text
-'6'         Token.Literal.Number.Integer
-'_'         Token.Name
-' '         Token.Text
-'5.6_7'     Token.Literal.Number.Float
-' '         Token.Text
-'5.67'      Token.Literal.Number.Float
-'_'         Token.Name
-'\n'        Token.Text
+'123'         Literal.Number.Integer
+' '           Text
+'-'           Operator
+'11'          Literal.Number.Integer
+' '           Text
+'0'           Literal.Number.Integer
+' '           Text
+'-'           Operator
+'0'           Literal.Number.Integer
+' '           Text
+'0.5'         Literal.Number.Float
+' '           Text
+'.5'          Literal.Number.Float
+' '           Text
+'1.'          Literal.Number.Float
+' '           Text
+'-'           Operator
+'0.5'         Literal.Number.Float
+' '           Text
+'+'           Operator
+'0.5'         Literal.Number.Float
+' '           Text
+'-'           Operator
+'.5'          Literal.Number.Float
+' '           Text
+'-'           Operator
+'1.'          Literal.Number.Float
+' '           Text
+'2e1'         Literal.Number.Float
+' '           Text
+'-'           Operator
+'2e1'         Literal.Number.Float
+' '           Text
+'2'           Literal.Number.Integer
+'e'           Name
+' '           Text
+'-'           Operator
+'2'           Literal.Number.Integer
+'e'           Name
+' '           Text
+'+'           Operator
+'2'           Literal.Number.Integer
+'e'           Name
+' '           Text
+'e'           Name
+'.3'          Literal.Number.Float
+' '           Text
+'-'           Operator
+'e'           Name
+'.3'          Literal.Number.Float
+' '           Text
+'11.2e-3'     Literal.Number.Float
+' '           Text
+'-'           Operator
+'11.2e-3'     Literal.Number.Float
+' '           Text
+'5_6'         Literal.Number.Integer
+' '           Text
+'5'           Literal.Number.Integer
+'__6'         Name
+' '           Text
+'_5'          Name
+' '           Text
+'6'           Literal.Number.Integer
+'_'           Name
+' '           Text
+'5.6_7'       Literal.Number.Float
+' '           Text
+'5.67'        Literal.Number.Float
+'_'           Name
+'\n'          Text


### PR DESCRIPTION
This PR fixes the issue discussed in issue #1740. We've also added some test cases to specifically test the python lexer against floats and integers. Let us know if there's any changes that need to be made.

The issue was that numbers were parsed after operators. This just required rearranging the order in which the tokens are processed.