### PR TITLE
Fix capnproto URL

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -219,7 +219,7 @@ Other markup
 * Apache Pig
 * BBCode
 * CapDL
-* `Cap'n Proto <https://capnproto.com>`_
+* `Cap'n Proto <https://capnproto.org>`_
 * `CDDL <https://datatracker.ietf.org/doc/rfc8610/>`_
 * CMake
 * `Csound <https://csound.com>`_ scores


### PR DESCRIPTION
`https://capnproto.com` does not work, so this PR changes to working `https://capnproto.org` URL.