### PR TITLE
AMDGPU: Updated modifier tokenization.

### DIFF
--- a/pygments/lexers/amdgpu.py
+++ b/pygments/lexers/amdgpu.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pygments.lexer import RegexLexer
+from pygments.lexer import RegexLexer, words
 from pygments.token import Name, Text, Keyword, Whitespace, Number, Comment
 
 import re
@@ -28,25 +28,6 @@ class AMDGPULexer(RegexLexer):
 
     flags = re.IGNORECASE
 
-    modifiers = [
-        'op',
-        'vaddr',
-        'vdata',
-        'soffset',
-        'srsrc',
-        'format',
-        'offset',
-        'offen',
-        'idxen',
-        'glc',
-        'dlc',
-        'slc',
-        'tfe',
-        'lds',
-        'lit',
-        'unorm'        
-    ]
-
     tokens = {
         'root': [
             (r'\s+', Whitespace),
@@ -57,7 +38,10 @@ class AMDGPULexer(RegexLexer):
             (r'((s_)?(ds|buffer|flat|image)_[a-z0-9_]+)', Keyword.Reserved),
             (r'(_lo|_hi)', Name.Variable),
             (r'(vmcnt|lgkmcnt|expcnt)', Name.Attribute),
-            (r'(' + '|'.join(modifiers) + ')', Name.Attribute),
+            (words((
+                'op', 'vaddr', 'vdata', 'soffset', 'srsrc', 'format',
+                'offset', 'offen', 'idxen', 'glc', 'dlc', 'slc', 'tfe', 'lds',
+                'lit', 'unorm'), suffix=r'\b'), Name.Attribute),
             (r'(label_[a-z0-9]+)', Keyword),
             (r'(_L[0-9]*)', Name.Variable),
             (r'(s|v)_[a-z0-9_]+', Keyword),

--- a/pygments/lexers/amdgpu.py
+++ b/pygments/lexers/amdgpu.py
@@ -28,6 +28,25 @@ class AMDGPULexer(RegexLexer):
 
     flags = re.IGNORECASE
 
+    modifiers = [
+        'op',
+        'vaddr',
+        'vdata',
+        'soffset',
+        'srsrc',
+        'format',
+        'offset',
+        'offen',
+        'idxen',
+        'glc',
+        'dlc',
+        'slc',
+        'tfe',
+        'lds',
+        'lit',
+        'unorm'        
+    ]
+
     tokens = {
         'root': [
             (r'\s+', Whitespace),
@@ -37,7 +56,8 @@ class AMDGPULexer(RegexLexer):
             (r'([;#]|//).*?\n', Comment.Single),
             (r'((s_)?(ds|buffer|flat|image)_[a-z0-9_]+)', Keyword.Reserved),
             (r'(_lo|_hi)', Name.Variable),
-            (r'(vmcnt|lgkmcnt|expcnt|vmcnt|lit|unorm|glc)', Name.Attribute),
+            (r'(vmcnt|lgkmcnt|expcnt)', Name.Attribute),
+            (r'(' + '|'.join(modifiers) + ')', Name.Attribute),
             (r'(label_[a-z0-9]+)', Keyword),
             (r'(_L[0-9]*)', Name.Variable),
             (r'(s|v)_[a-z0-9_]+', Keyword),

--- a/tests/examplefiles/amdgpu/amdgpu.isa
+++ b/tests/examplefiles/amdgpu/amdgpu.isa
@@ -8,3 +8,4 @@ v_addc_u32    v2, vcc, v2, 0, vcc
 v_add_u32     v3, vcc, s0, v0
 v_mov_b32     v4, s1
 v_addc_u32    v4, vcc, v4, 0, vcc
+buffer_load_dword v4, v2, s[8:11], 0 offen

--- a/tests/examplefiles/amdgpu/amdgpu.isa.output
+++ b/tests/examplefiles/amdgpu/amdgpu.isa.output
@@ -128,3 +128,22 @@
 ' '           Text.Whitespace
 'vcc'         Name.Variable
 '\n'          Text.Whitespace
+
+'buffer_load_dword' Keyword.Reserved
+' '           Text.Whitespace
+'v4'          Name.Variable
+','           Text
+' '           Text.Whitespace
+'v2'          Name.Variable
+','           Text
+' '           Text.Whitespace
+'s'           Name.Variable
+'['           Text
+'8:11'        Name.Attribute
+']'           Text
+','           Text
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'offen'       Name.Attribute
+'\n'          Text.Whitespace


### PR DESCRIPTION
This should fix #1717 by adding all possible modifiers , also removes a duplicate part of the previous modifier regex.