### PR TITLE
Detect multiline patterns in velocity lexer text analysis

### DIFF
--- a/pygments/lexers/templates.py
+++ b/pygments/lexers/templates.py
@@ -267,11 +267,11 @@ class VelocityLexer(RegexLexer):
 
     def analyse_text(text):
         rv = 0.0
-        if re.search(r'#\{?macro\}?\(.*?\).*?#\{?end\}?', text):
+        if re.search(r'#\{?macro\}?\(.*?\).*?#\{?end\}?', text, re.DOTALL):
             rv += 0.25
-        if re.search(r'#\{?if\}?\(.+?\).*?#\{?end\}?', text):
+        if re.search(r'#\{?if\}?\(.+?\).*?#\{?end\}?', text, re.DOTALL):
             rv += 0.15
-        if re.search(r'#\{?foreach\}?\(.+?\).*?#\{?end\}?', text):
+        if re.search(r'#\{?foreach\}?\(.+?\).*?#\{?end\}?', text, re.DOTALL):
             rv += 0.15
         if re.search(r'\$!?\{?[a-zA-Z_]\w*(\([^)]*\))?'
                      r'(\.\w+(\([^)]*\))?)*\}?', text):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pygments.lexers.templates import JavascriptDjangoLexer, MasonLexer
+from pygments.lexers.templates import JavascriptDjangoLexer, MasonLexer, VelocityLexer
 from pygments.token import Comment, Token
 
 
@@ -11,6 +11,10 @@ def lexer():
 @pytest.fixture(scope='module')
 def lexerMason():
     yield MasonLexer()
+
+@pytest.fixture(scope='module')
+def lexerVelocity():
+    yield VelocityLexer()
 
 def test_do_not_mistake_JSDoc_for_django_comment(lexer):
     """
@@ -41,3 +45,39 @@ def test_mason_unnamed_block(lexerMason):
             """
     res = lexerMason.analyse_text(text)
     assert res == 1.0
+
+def test_velocity_macro(lexerVelocity):
+    text = """
+            #macro(getBookListLink, $readingTrackerResult)
+              $readingTrackerResult.getBookListLink()
+            #end
+            """
+    res = lexerVelocity.analyse_text(text)
+    assert res == 0.26
+
+def test_velocity_foreach(lexerVelocity):
+    text = """
+            <ul>
+            #foreach( $product in $allProducts )
+              <li>$product</li>
+            #end
+            </ul>
+            """
+    res = lexerVelocity.analyse_text(text)
+    assert res == 0.16
+
+def test_velocity_if(lexerVelocity):
+    text = """
+            #if( $display )
+              <strong>Velocity!</strong>
+            #end
+            """
+    res = lexerVelocity.analyse_text(text)
+    assert res == 0.16
+
+def test_velocity_reference(lexerVelocity):
+    text = """
+            Hello $name!  Welcome to Velocity!
+            """
+    res = lexerVelocity.analyse_text(text)
+    assert res == 0.01


### PR DESCRIPTION
The existing implementation of `VelocityLexer` text analysis did not take into account, that template directives `macro`, `foreach` and `if` usually stretch over multiple lines. 

This PR adds `re.DOTALL` flag to the `re.search` call in text analysis of `VelocityLexer` to detect multi-line directives. Unit tests are included.