### PR TITLE
friendly: lighter line numbers

### DIFF
--- a/pygments/styles/friendly.py
+++ b/pygments/styles/friendly.py
@@ -20,6 +20,7 @@ class FriendlyStyle(Style):
 
     background_color = "#f0f0f0"
     default_style = ""
+    line_number_color = "#666666"
 
     styles = {
         Whitespace:                "#bbbbbb",


### PR DESCRIPTION
The default color for line numbers looks too intense in comparison with the rest of the colors.