### PR TITLE
native: darker line numbers

### DIFF
--- a/pygments/styles/native.py
+++ b/pygments/styles/native.py
@@ -20,6 +20,7 @@ class NativeStyle(Style):
 
     background_color = '#202020'
     highlight_color = '#404040'
+    line_number_color = '#aaaaaa'
 
     styles = {
         Token:              '#d0d0d0',


### PR DESCRIPTION
Similar to #1778, this makes the line numbers stand out a bit less.

I chose the same color as is used for prompts, which seems consistent to me.

According to Firefox, this is still OK contrast for accessibility (see also #1718).