### PR TITLE
Improve PromQL lexer with new test cases

### DIFF
--- a/pygments/lexers/promql.py
+++ b/pygments/lexers/promql.py
@@ -166,7 +166,7 @@ class PromQLLexer(RegexLexer):
             (r"\n", Whitespace),
             (r"\s+", Whitespace),
             (r",", Punctuation),
-            (r'([_a-zA-Z][a-zA-Z0-9_]*?)(\s*?)(=~|!=|=|~!)(\s*?)(")(.*?)(")',
+            (r'([_a-zA-Z][a-zA-Z0-9_]*?)(\s*?)(=~|!=|=|~!)(\s*?)("|\')(.*?)("|\')',
              bygroups(Name.Label, Whitespace, Operator, Whitespace,
                       Punctuation, String, Punctuation)),
         ],

--- a/pygments/lexers/promql.py
+++ b/pygments/lexers/promql.py
@@ -166,7 +166,7 @@ class PromQLLexer(RegexLexer):
             (r"\n", Whitespace),
             (r"\s+", Whitespace),
             (r",", Punctuation),
-            (r'([_a-zA-Z][a-zA-Z0-9_]*?)(\s*?)(=~|!=|=|~!)(\s*?)("|\')(.*?)("|\')',
+            (r'([_a-zA-Z][a-zA-Z0-9_]*?)(\s*?)(=~|!=|=|!~)(\s*?)("|\')(.*?)("|\')',
              bygroups(Name.Label, Whitespace, Operator, Whitespace,
                       Punctuation, String, Punctuation)),
         ],

--- a/tests/snippets/promql/test_complex_exp_single_quotes.txt
+++ b/tests/snippets/promql/test_complex_exp_single_quotes.txt
@@ -1,0 +1,35 @@
+---input---
+(sum(rate(metric_test_app{app='turtle',proc='web'}[2m])) by(node))
+
+---tokens---
+'('           Operator
+'sum'         Keyword
+'('           Operator
+'rate'        Keyword.Reserved
+'('           Operator
+'metric_test_app' Name.Variable
+'{'           Punctuation
+'app'         Name.Label
+'='           Operator
+"'"           Punctuation
+'turtle'      Literal.String
+"'"           Punctuation
+','           Punctuation
+'proc'        Name.Label
+'='           Operator
+"'"           Punctuation
+'web'         Literal.String
+"'"           Punctuation
+'}'           Punctuation
+'['           Punctuation
+'2m'          Literal.String
+']'           Punctuation
+')'           Operator
+')'           Operator
+' '           Text.Whitespace
+'by'          Keyword
+'('           Operator
+'node'        Name.Variable
+')'           Operator
+')'           Operator
+'\n'          Text.Whitespace

--- a/tests/snippets/promql/test_matching_operator_no_regex_match.txt
+++ b/tests/snippets/promql/test_matching_operator_no_regex_match.txt
@@ -1,0 +1,16 @@
+---input---
+metric_test_app{status!~'(4|5)..'}[2m]
+
+---tokens---
+'metric_test_app' Name.Variable
+'{'           Punctuation
+'status'      Name.Label
+'!~'          Operator
+"'"           Punctuation
+'(4|5)..'     Literal.String
+"'"           Punctuation
+'}'           Punctuation
+'['           Punctuation
+'2m'          Literal.String
+']'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This PR adds 2 minor improvements/fixes into the PromQL lexer:

* Values for labels can now be enclosed within single or double quotes (only double quotes were supported before). Eg: `metric{proc='web'}` and `metric{proc="web"}` will work as expected. Initial report [here](https://github.com/pabluk/pygments-promql/issues/4).
*  There was a typo into the regex used for labels. Correct label matching operator is `!~` instead of `~!`. See the [label matching operators documentation](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) for more details.


Please feel free to ask for any changes, or edit it as you want. Thanks everyone for all the work done on Pygments!