### PR TITLE
Add right margin to "inline" line numbers

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -588,14 +588,14 @@ class HtmlFormatter(Formatter):
 
     @property
     def _linenos_style(self):
-        return 'color: %s; background-color: %s; padding-left: 5px; padding-right: 5px;' % (
+        return 'color: %s; background-color: %s; padding-left: 5px; padding-right: 5px; margin-right: 3px;' % (
             self.style.line_number_color,
             self.style.line_number_background_color
         )
 
     @property
     def _linenos_special_style(self):
-        return 'color: %s; background-color: %s; padding-left: 5px; padding-right: 5px;' % (
+        return 'color: %s; background-color: %s; padding-left: 5px; padding-right: 5px; margin-right: 3px;' % (
             self.style.line_number_special_color,
             self.style.line_number_special_background_color
         )


### PR DESCRIPTION
Fixes #1774.

TBH, I have no clue what the "special" style is, I just added the margin there as well because it looked like a similar situation.

IMHO, the space between line numbers and the code lines is still quite a bit too small, but now at least it looks the same as when using the "table" style.