### PR TITLE
autopygmentize: use file before pygmentize; add JSON support

### DIFF
--- a/external/autopygmentize
+++ b/external/autopygmentize
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Best effort auto-pygmentization with transparent decompression
-# by Reuben Thomas 2008-2019
+# by Reuben Thomas 2008-2021
 # This program is in the public domain.
 
 # Strategy: first see if pygmentize can find a lexer; if not, ask file; if that finds nothing, fail
@@ -13,58 +13,58 @@ options=${@:1:$(($#-1))}  # handle others args as options to pass to pygmentize
 
 file_common_opts="--brief --dereference"
 
-lexer=$(pygmentize -N "$file")
-if [[ "$lexer" == text ]]; then
-    # Try to do better than just "text"
-    case $(file --mime-type --uncompress $file_common_opts "$file") in
-        application/xml|image/svg+xml) lexer=xml;;
-        application/javascript) lexer=javascript;;
-        text/html) lexer=html;;
-        text/troff) lexer=nroff;;
-        text/x-asm) lexer=nasm;;
-        text/x-awk) lexer=awk;;
-        text/x-c) lexer=c;;
-        text/x-c++) lexer=cpp;;
-        text/x-crystal) lexer=crystal;;
-        text/x-diff) lexer=diff;;
-        text/x-fortran) lexer=fortran;;
-        text/x-gawk) lexer=gawk;;
-        text/x-java) lexer=java;;
-        text/x-lisp) lexer=common-lisp;;
-        text/x-lua) lexer=lua;;
-        text/x-makefile) lexer=make;;
-        text/x-msdos-batch) lexer=bat;;
-        text/x-nawk) lexer=nawk;;
-        text/x-pascal) lexer=pascal;;
-        text/x-perl) lexer=perl;;
-        text/x-php) lexer=php;;
-        text/x-po) lexer=po;;
-        text/x-python) lexer=python;;
-        text/x-ruby) lexer=ruby;;
-        text/x-shellscript) lexer=sh;;
-        text/x-tcl) lexer=tcl;;
-        text/x-tex|text/x-texinfo) lexer=latex;; # FIXME: texinfo really needs its own lexer
-        
-        # Types that file outputs which pygmentize didn't support as of file 5.20, pygments 2.0
-        # text/calendar
-        # text/inf
-        # text/PGP
-        # text/rtf
-        # text/texmacs
-        # text/vnd.graphviz
-        # text/x-bcpl
-        # text/x-info
-        # text/x-m4
-        # text/x-vcard
-        # text/x-xmcd
-        
-        text/plain)  # special filenames. TODO: insert more
-            case $(basename "$file") in
-                .zshrc) lexer=sh;;
-            esac
-            ;;
-    esac
-fi
+case $(file --mime-type --uncompress $file_common_opts "$file") in
+    application/xml|image/svg+xml) lexer=xml;;
+    application/javascript) lexer=javascript;;
+    application/json) lexer=json;;
+    text/html) lexer=html;;
+    text/troff) lexer=nroff;;
+    text/x-asm) lexer=nasm;;
+    text/x-awk) lexer=awk;;
+    text/x-c) lexer=c;;
+    text/x-c++) lexer=cpp;;
+    text/x-crystal) lexer=crystal;;
+    text/x-diff) lexer=diff;;
+    text/x-fortran) lexer=fortran;;
+    text/x-gawk) lexer=gawk;;
+    text/x-java) lexer=java;;
+    text/x-lisp) lexer=common-lisp;;
+    text/x-lua) lexer=lua;;
+    text/x-makefile) lexer=make;;
+    text/x-msdos-batch) lexer=bat;;
+    text/x-nawk) lexer=nawk;;
+    text/x-pascal) lexer=pascal;;
+    text/x-perl) lexer=perl;;
+    text/x-php) lexer=php;;
+    text/x-po) lexer=po;;
+    text/x-python) lexer=python;;
+    text/x-ruby) lexer=ruby;;
+    text/x-shellscript) lexer=sh;;
+    text/x-tcl) lexer=tcl;;
+    text/x-tex|text/x-texinfo) lexer=latex;; # FIXME: texinfo really needs its own lexer
+
+    # Types that file outputs which pygmentize didn't support as of file 5.20, pygments 2.0
+    # text/calendar
+    # text/inf
+    # text/PGP
+    # text/rtf
+    # text/texmacs
+    # text/vnd.graphviz
+    # text/x-bcpl
+    # text/x-info
+    # text/x-m4
+    # text/x-vcard
+    # text/x-xmcd
+
+    text/plain)  # special filenames. TODO: insert more
+        case $(basename "$file") in
+            .zshrc) lexer=sh;;
+        esac
+        # pygmentize -N is much cheaper than file, but makes some bad guesses (e.g.
+        # it guesses ".pl" is Prolog, not Perl)
+        lexer=$(pygmentize -N "$file")
+        ;;
+esac
 
 # Find a concatenator for compressed files
 concat=cat


### PR DESCRIPTION
Although pygmentize -N is much cheaper than file, it makes some bad guesses,
so use file first.

Add support for MIME type application/json.