### PR TITLE
Add golang alias for the Go language

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -182,7 +182,7 @@ LEXERS = {
     'GettextLexer': ('pygments.lexers.textfmts', 'Gettext Catalog', ('pot', 'po'), ('*.pot', '*.po'), ('application/x-gettext', 'text/x-gettext', 'text/gettext')),
     'GherkinLexer': ('pygments.lexers.testing', 'Gherkin', ('gherkin', 'cucumber'), ('*.feature',), ('text/x-gherkin',)),
     'GnuplotLexer': ('pygments.lexers.graphics', 'Gnuplot', ('gnuplot',), ('*.plot', '*.plt'), ('text/x-gnuplot',)),
-    'GoLexer': ('pygments.lexers.go', 'Go', ('go',), ('*.go',), ('text/x-gosrc',)),
+    'GoLexer': ('pygments.lexers.go', 'Go', ('go', 'golang'), ('*.go',), ('text/x-gosrc',)),
     'GoloLexer': ('pygments.lexers.jvm', 'Golo', ('golo',), ('*.golo',), ()),
     'GoodDataCLLexer': ('pygments.lexers.business', 'GoodData-CL', ('gooddata-cl',), ('*.gdc',), ('text/x-gooddata-cl',)),
     'GosuLexer': ('pygments.lexers.jvm', 'Gosu', ('gosu',), ('*.gs', '*.gsx', '*.gsp', '*.vark'), ('text/x-gosu',)),

--- a/pygments/lexers/go.py
+++ b/pygments/lexers/go.py
@@ -25,7 +25,7 @@ class GoLexer(RegexLexer):
     """
     name = 'Go'
     filenames = ['*.go']
-    aliases = ['go']
+    aliases = ['go', 'golang']
     mimetypes = ['text/x-gosrc']
 
     flags = re.MULTILINE | re.UNICODE


### PR DESCRIPTION
In our main project at @zestedesavoir we write our publications in (a slightly modified) Markdown and use hightlight.js to render it as HTML and Pygments to render it as PDF. We found that highlight.js supports the `golang` alias for the Go language but Pygments doesn't and I think that it would be nice to support it so here is the pull request!