### PR TITLE
Add lexers.specials.OutputLexer.

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -334,7 +334,7 @@ LEXERS = {
     'OocLexer': ('pygments.lexers.ooc', 'Ooc', ('ooc',), ('*.ooc',), ('text/x-ooc',)),
     'OpaLexer': ('pygments.lexers.ml', 'Opa', ('opa',), ('*.opa',), ('text/x-opa',)),
     'OpenEdgeLexer': ('pygments.lexers.business', 'OpenEdge ABL', ('openedge', 'abl', 'progress'), ('*.p', '*.cls'), ('text/x-openedge', 'application/x-openedge')),
-    'OutputLexer': ('pygments.lexers.special', 'Text output', ('output',), ('*.txt',), ('text/plain',)),
+    'OutputLexer': ('pygments.lexers.special', 'Text output', ('output',), (), ()),
     'PacmanConfLexer': ('pygments.lexers.configs', 'PacmanConf', ('pacmanconf',), ('pacman.conf',), ()),
     'PanLexer': ('pygments.lexers.dsls', 'Pan', ('pan',), ('*.pan',), ()),
     'ParaSailLexer': ('pygments.lexers.parasail', 'ParaSail', ('parasail',), ('*.psi', '*.psl'), ('text/x-parasail',)),

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -334,6 +334,7 @@ LEXERS = {
     'OocLexer': ('pygments.lexers.ooc', 'Ooc', ('ooc',), ('*.ooc',), ('text/x-ooc',)),
     'OpaLexer': ('pygments.lexers.ml', 'Opa', ('opa',), ('*.opa',), ('text/x-opa',)),
     'OpenEdgeLexer': ('pygments.lexers.business', 'OpenEdge ABL', ('openedge', 'abl', 'progress'), ('*.p', '*.cls'), ('text/x-openedge', 'application/x-openedge')),
+    'OutputLexer': ('pygments.lexers.special', 'Text output', ('output',), ('*.txt',), ('text/plain',)),
     'PacmanConfLexer': ('pygments.lexers.configs', 'PacmanConf', ('pacmanconf',), ('pacman.conf',), ()),
     'PanLexer': ('pygments.lexers.dsls', 'Pan', ('pan',), ('*.pan',), ()),
     'ParaSailLexer': ('pygments.lexers.parasail', 'ParaSail', ('parasail',), ('*.psi', '*.psl'), ('text/x-parasail',)),

--- a/pygments/lexers/special.py
+++ b/pygments/lexers/special.py
@@ -12,11 +12,11 @@ import ast
 import re
 
 from pygments.lexer import Lexer
-from pygments.token import Token, Error, Text
+from pygments.token import Token, Error, Text, Generic
 from pygments.util import get_choice_opt
 
 
-__all__ = ['TextLexer', 'RawTokenLexer']
+__all__ = ['TextLexer', 'OutputLexer', 'RawTokenLexer']
 
 
 class TextLexer(Lexer):
@@ -34,6 +34,21 @@ class TextLexer(Lexer):
 
     def analyse_text(text):
         return TextLexer.priority
+
+
+class OutputLexer(Lexer):
+    """
+    Simple lexer that highlights everything as ``Token.Generic.Output``.
+
+    .. versionadded:: 2.10
+    """
+    name = 'Text output'
+    aliases = ['output']
+    filenames = ['*.txt']
+    mimetypes = ['text/plain']
+
+    def get_tokens_unprocessed(self, text):
+        yield 0, Generic.Output, text
 
 
 _ttype_cache = {}

--- a/pygments/lexers/special.py
+++ b/pygments/lexers/special.py
@@ -44,8 +44,6 @@ class OutputLexer(Lexer):
     """
     name = 'Text output'
     aliases = ['output']
-    filenames = ['*.txt']
-    mimetypes = ['text/plain']
 
     def get_tokens_unprocessed(self, text):
         yield 0, Generic.Output, text


### PR DESCRIPTION
This pull request adds `lexers.specials.OutputLexer`, a lexer that highlights everything as `Token.Generic.Output` as discussed in issue #1835.