### PR TITLE
use ini lexer for systemd service files

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -215,7 +215,7 @@ LEXERS = {
     'Inform6Lexer': ('pygments.lexers.int_fiction', 'Inform 6', ('inform6', 'i6'), ('*.inf',), ()),
     'Inform6TemplateLexer': ('pygments.lexers.int_fiction', 'Inform 6 template', ('i6t',), ('*.i6t',), ()),
     'Inform7Lexer': ('pygments.lexers.int_fiction', 'Inform 7', ('inform7', 'i7'), ('*.ni', '*.i7x'), ()),
-    'IniLexer': ('pygments.lexers.configs', 'INI', ('ini', 'cfg', 'dosini'), ('*.ini', '*.cfg', '*.inf'), ('text/x-ini', 'text/inf')),
+    'IniLexer': ('pygments.lexers.configs', 'INI', ('ini', 'cfg', 'dosini'), ('*.ini', '*.cfg', '*.inf', '*.service', '*.socket', '*.device', '*.mount', '*.automount', '*.swap', '*.target', '*.path', '*.timer', '*.slice', '*.scope'), ('text/x-ini', 'text/inf')),
     'IoLexer': ('pygments.lexers.iolang', 'Io', ('io',), ('*.io',), ('text/x-iosrc',)),
     'IokeLexer': ('pygments.lexers.jvm', 'Ioke', ('ioke', 'ik'), ('*.ik',), ('text/x-iokesrc',)),
     'IrcLogsLexer': ('pygments.lexers.textfmts', 'IRC logs', ('irc',), ('*.weechatlog',), ('text/x-irclog',)),

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -31,7 +31,13 @@ class IniLexer(RegexLexer):
 
     name = 'INI'
     aliases = ['ini', 'cfg', 'dosini']
-    filenames = ['*.ini', '*.cfg', '*.inf', '*.service']
+    filenames = [
+        '*.ini', '*.cfg', '*.inf',
+        # systemd unit files
+        # https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+        '*.service', '*.socket', '*.device', '*.mount', '*.automount',
+        '*.swap', '*.target', '*.path', '*.timer', '*.slice', '*.scope',
+    ]
     mimetypes = ['text/x-ini', 'text/inf']
 
     tokens = {

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -31,7 +31,7 @@ class IniLexer(RegexLexer):
 
     name = 'INI'
     aliases = ['ini', 'cfg', 'dosini']
-    filenames = ['*.ini', '*.cfg', '*.inf']
+    filenames = ['*.ini', '*.cfg', '*.inf', '*.service']
     mimetypes = ['text/x-ini', 'text/inf']
 
     tokens = {


### PR DESCRIPTION
A `foo.service` specific lexer could highlight valid and invalid keys differently, but this is much better than no syntax highlighting.