### PR TITLE
Support error locations in Python tracebacks

### DIFF
--- a/doc/docs/tokens.rst
+++ b/doc/docs/tokens.rst
@@ -306,6 +306,12 @@ Punctuation
 `Punctuation`
     For any punctuation which is not an operator (e.g. ``[``, ``(``...)
 
+`Punctuation.Marker`
+    For markers that point to a location (e.g., carets in Python
+    tracebacks for syntax errors).
+
+    .. versionadded:: 2.10
+
 
 Comments
 ========

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -727,13 +727,22 @@ class PythonTracebackLexer(RegexLexer):
             (r'^(  File )("[^"]+")(, line )(\d+)(\n)',
              bygroups(Text, Name.Builtin, Text, Number, Text)),
             (r'^(    )(.+)(\n)',
-             bygroups(Text, using(PythonLexer), Text)),
+             bygroups(Text, using(PythonLexer), Text), 'markers'),
             (r'^([ \t]*)(\.\.\.)(\n)',
              bygroups(Text, Comment, Text)),  # for doctests...
             (r'^([^:]+)(: )(.+)(\n)',
              bygroups(Generic.Error, Text, Name, Text), '#pop'),
             (r'^([a-zA-Z_][\w.]*)(:?\n)',
              bygroups(Generic.Error, Text), '#pop')
+        ],
+        'markers': [
+            # Either `PEP 657 <https://www.python.org/dev/peps/pep-0657/>`
+            # error locations in Python 3.11+, or single-caret markers
+            # for syntax errors before that.
+            (r'^( {4,})(\^+)(\n)',
+             bygroups(Text, Punctuation.Marker, Text),
+             '#pop'),
+            default('#pop'),
         ],
     }
 
@@ -773,13 +782,18 @@ class Python2TracebackLexer(RegexLexer):
             (r'^(  File )("[^"]+")(, line )(\d+)(\n)',
              bygroups(Text, Name.Builtin, Text, Number, Text)),
             (r'^(    )(.+)(\n)',
-             bygroups(Text, using(Python2Lexer), Text)),
+             bygroups(Text, using(Python2Lexer), Text), 'marker'),
             (r'^([ \t]*)(\.\.\.)(\n)',
              bygroups(Text, Comment, Text)),  # for doctests...
             (r'^([^:]+)(: )(.+)(\n)',
              bygroups(Generic.Error, Text, Name, Text), '#pop'),
             (r'^([a-zA-Z_]\w*)(:?\n)',
              bygroups(Generic.Error, Text), '#pop')
+        ],
+        'marker': [
+            # For syntax errors.
+            (r'( {4,})(\^)', bygroups(Text, Punctuation.Marker), '#pop'),
+            default('#pop'),
         ],
     }
 

--- a/tests/examplefiles/pycon/pycon_ctrlc_traceback.output
+++ b/tests/examplefiles/pycon/pycon_ctrlc_traceback.output
@@ -271,9 +271,8 @@
 '='           Operator
 '\n'          Text
 
-'    '        Text
-'   '         Text
-'^'           Operator
+'       '     Text
+'^'           Punctuation.Marker
 '\n'          Text
 
 'SyntaxError' Generic.Error

--- a/tests/examplefiles/pycon/pycon_test.pycon.output
+++ b/tests/examplefiles/pycon/pycon_test.pycon.output
@@ -14,7 +14,7 @@
 '\n'          Text
 
 '    '        Text
-'^'           Operator
+'^'           Punctuation.Marker
 '\n'          Text
 
 'SyntaxError' Generic.Error

--- a/tests/examplefiles/pytb/error_locations.pytb
+++ b/tests/examplefiles/pytb/error_locations.pytb
@@ -1,0 +1,17 @@
+Traceback (most recent call last):
+  File "/home/tb.py", line 13, in <module>
+    in_Python_3_11()
+    ^^^^^^^^^^^^^^^^
+  File "/home/tb.py", line 2, in in_Python_3_11
+    return error_locations()
+           ^^^^^^^^^^^^^^^^^
+  File "/home/tb.py", line 5, in error_locations
+    return are_provided() is True
+           ^^^^^^^^^^^^^^
+  File "/home/tb.py", line 8, in are_provided
+    return in_tracebacks()
+           ^^^^^^^^^^^^^^^
+  File "/home/tb.py", line 11, in in_tracebacks
+    return 1/0
+           ^^^
+ZeroDivisionError: division by zero

--- a/tests/examplefiles/pytb/error_locations.pytb.output
+++ b/tests/examplefiles/pytb/error_locations.pytb.output
@@ -1,0 +1,108 @@
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"/home/tb.py"' Name.Builtin
+', line '     Text
+'13'          Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text
+
+'    '        Text
+'in_Python_3_11' Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'^^^^^^^^^^^^^^^^' Punctuation.Marker
+'\n'          Text
+
+'  File '     Text
+'"/home/tb.py"' Name.Builtin
+', line '     Text
+'2'           Literal.Number
+', in '       Text
+'in_Python_3_11' Name
+'\n'          Text
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'error_locations' Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text
+
+'           ' Text
+'^^^^^^^^^^^^^^^^^' Punctuation.Marker
+'\n'          Text
+
+'  File '     Text
+'"/home/tb.py"' Name.Builtin
+', line '     Text
+'5'           Literal.Number
+', in '       Text
+'error_locations' Name
+'\n'          Text
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'are_provided' Name
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'is'          Operator.Word
+' '           Text
+'True'        Keyword.Constant
+'\n'          Text
+
+'           ' Text
+'^^^^^^^^^^^^^^' Punctuation.Marker
+'\n'          Text
+
+'  File '     Text
+'"/home/tb.py"' Name.Builtin
+', line '     Text
+'8'           Literal.Number
+', in '       Text
+'are_provided' Name
+'\n'          Text
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'in_tracebacks' Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text
+
+'           ' Text
+'^^^^^^^^^^^^^^^' Punctuation.Marker
+'\n'          Text
+
+'  File '     Text
+'"/home/tb.py"' Name.Builtin
+', line '     Text
+'11'          Literal.Number
+', in '       Text
+'in_tracebacks' Name
+'\n'          Text
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'1'           Literal.Number.Integer
+'/'           Operator
+'0'           Literal.Number.Integer
+'\n'          Text
+
+'           ' Text
+'^^^'         Punctuation.Marker
+'\n'          Text
+
+'ZeroDivisionError' Generic.Error
+': '          Text
+'division by zero' Name
+'\n'          Text

--- a/tests/examplefiles/pytb/syntax_error.py2tb
+++ b/tests/examplefiles/pytb/syntax_error.py2tb
@@ -1,0 +1,4 @@
+  File "<stdin>", line 1
+    mismatch(]
+           ^
+SyntaxError: closing parenthesis ']' does not match opening parenthesis '('

--- a/tests/examplefiles/pytb/syntax_error.py2tb.output
+++ b/tests/examplefiles/pytb/syntax_error.py2tb.output
@@ -6,15 +6,16 @@
 '\n'          Text
 
 '    '        Text
-'1'           Literal.Number.Integer
-'+'           Operator
+'mismatch'    Name
+'('           Punctuation
+']'           Punctuation
 '\n'          Text
 
-'     '       Text
+'           ' Text
 '^'           Punctuation.Marker
 '\n'          Text
 
 'SyntaxError' Generic.Error
 ': '          Text
-'invalid syntax' Name
+"closing parenthesis ']' does not match opening parenthesis '('" Name
 '\n'          Text

--- a/tests/examplefiles/pytb/syntax_error.pytb
+++ b/tests/examplefiles/pytb/syntax_error.pytb
@@ -1,0 +1,4 @@
+  File "<stdin>", line 1
+    mismatch(]
+           ^
+SyntaxError: closing parenthesis ']' does not match opening parenthesis '('

--- a/tests/examplefiles/pytb/syntax_error.pytb.output
+++ b/tests/examplefiles/pytb/syntax_error.pytb.output
@@ -6,15 +6,16 @@
 '\n'          Text
 
 '    '        Text
-'1'           Literal.Number.Integer
-'+'           Operator
+'mismatch'    Name
+'('           Punctuation
+']'           Punctuation
 '\n'          Text
 
-'     '       Text
+'           ' Text
 '^'           Punctuation.Marker
 '\n'          Text
 
 'SyntaxError' Generic.Error
 ': '          Text
-'invalid syntax' Name
+"closing parenthesis ']' does not match opening parenthesis '('" Name
 '\n'          Text

--- a/tests/examplefiles/pytb/syntax_error_caret_code.py2tb
+++ b/tests/examplefiles/pytb/syntax_error_caret_code.py2tb
@@ -1,0 +1,3 @@
+  File "<stdin>", line 1
+    ^
+    ^

--- a/tests/examplefiles/pytb/syntax_error_caret_code.py2tb.output
+++ b/tests/examplefiles/pytb/syntax_error_caret_code.py2tb.output
@@ -6,15 +6,9 @@
 '\n'          Text
 
 '    '        Text
-'1'           Literal.Number.Integer
-'+'           Operator
+'^'           Operator
 '\n'          Text
 
-'     '       Text
+'    '        Text
 '^'           Punctuation.Marker
-'\n'          Text
-
-'SyntaxError' Generic.Error
-': '          Text
-'invalid syntax' Name
 '\n'          Text

--- a/tests/examplefiles/pytb/syntax_error_caret_code.pytb
+++ b/tests/examplefiles/pytb/syntax_error_caret_code.pytb
@@ -1,0 +1,3 @@
+  File "<stdin>", line 1
+    ^
+    ^

--- a/tests/examplefiles/pytb/syntax_error_caret_code.pytb.output
+++ b/tests/examplefiles/pytb/syntax_error_caret_code.pytb.output
@@ -6,15 +6,9 @@
 '\n'          Text
 
 '    '        Text
-'1'           Literal.Number.Integer
-'+'           Operator
+'^'           Operator
 '\n'          Text
 
-'     '       Text
+'    '        Text
 '^'           Punctuation.Marker
-'\n'          Text
-
-'SyntaxError' Generic.Error
-': '          Text
-'invalid syntax' Name
 '\n'          Text


### PR DESCRIPTION
Support both single carets for syntax errors (Python 2 and 3)
and fine-grained error locations with several carets (Python 3.11+).
Previously, the carets were highlighted as operators.  This uses
a new token, Token.Punctuation.Marker.  For now, no style supports
it specifically.  In the future, styles might start differentiating
it from Token.Punctuation.

[Closes #1850.]