### PR TITLE
Updates to Markdown lexer

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -555,7 +555,7 @@ class MarkdownLexer(RegexLexer):
             (r'^(\s*)([0-9]+\.)( .+\n)',
             bygroups(Text, Keyword, using(this, state='inline'))),
             # quote
-            (r'^(\s*>\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
+            (r'^(\s*[> ]+\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
             # code block fenced by 3 backticks
             (r'^(\s*```\n[\w\W]*?^\s*```$\n)', String.Backtick),
             # code block with language

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -573,11 +573,13 @@ class MarkdownLexer(RegexLexer):
             # bold fenced by '**'
             (r'([^\*]?)(\*\*[^* \n][^*\n]*\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'
-            (r'([^_]?)(__[^_ \n][^_\n]*__)', bygroups(Text, Generic.Strong)),
+            (r'(?<!_)(__[^_ \n]([^_\n]+\n?)*(?<![ \n])__)(?!_)',
+             bygroups(Generic.Strong)),
             # italics fenced by '*'
             (r'([^\*]?)(\*[^* \n][^*\n]*\*)', bygroups(Text, Generic.Emph)),
             # italics fenced by '_'
-            (r'([^_]?)(_[^_ \n][^_\n]*_)', bygroups(Text, Generic.Emph)),
+            (r'(?<!_)(_[^_ \n]([^_\n]+\n?)*(?<![ \n])_)(?!_)',
+             bygroups(Generic.Emph)),
             # strikethrough
             (r'([^~]?)(~~[^~ \n][^~\n]*~~)', bygroups(Text, Generic.Deleted)),
             # mentions and topics (twitter and github stuff)

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -571,12 +571,14 @@ class MarkdownLexer(RegexLexer):
             # warning: the following rules eat outer tags.
             # eg. **foo _bar_ baz** => foo and baz are not recognized as bold
             # bold fenced by '**'
-            (r'([^\*]?)(\*\*[^* \n][^*\n]*\*\*)', bygroups(Text, Generic.Strong)),
+            (r'(?<!\*)(\*\*[^* \n]([^*\n]+\n?)*(?<![ \n])\*\*)(?!\*)',
+             bygroups(Generic.Strong)),
             # bold fenced by '__'
             (r'(?<!_)(__[^_ \n]([^_\n]+\n?)*(?<![ \n])__)(?!_)',
              bygroups(Generic.Strong)),
             # italics fenced by '*'
-            (r'([^\*]?)(\*[^* \n][^*\n]*\*)', bygroups(Text, Generic.Emph)),
+            (r'(?<!\*)(\*[^* \n]([^*\n]+\n?)*(?<![ \n])\*)(?!\*)',
+             bygroups(Generic.Emph)),
             # italics fenced by '_'
             (r'(?<!_)(_[^_ \n]([^_\n]+\n?)*(?<![ \n])_)(?!_)',
              bygroups(Generic.Emph)),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -555,7 +555,7 @@ class MarkdownLexer(RegexLexer):
             (r'^(\s*)([0-9]+\.)( .+\n)',
             bygroups(Text, Keyword, using(this, state='inline'))),
             # quote
-            (r'^(\s*[> ]+\s)(.+\n)', bygroups(Keyword, Generic.Emph)),
+            (r'^(\s*[> ]+\s)(.+\n)', bygroups(Keyword, using(this, state='inline'))),
             # code block fenced by 3 backticks
             (r'^(\s*```\n[\w\W]*?^\s*```$\n)', String.Backtick),
             # code block with language

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -179,6 +179,8 @@ def test_invalid_code_block(lexer):
 
 
 BOLD_ITA_MARKUP_TEST_CASES = (
+    ('_ita_', [(Generic.Emph, '_ita_'), (Token.Text, '\n')]),
+    ('*ita*', [(Generic.Emph, '*ita*'), (Token.Text, '\n')]),
     ('__bold__', [(Generic.Strong, '__bold__'), (Token.Text, '\n')]),
     ('**bold**', [(Generic.Strong, '**bold**'), (Token.Text, '\n')]),
 
@@ -193,6 +195,17 @@ BOLD_ITA_MARKUP_TEST_CASES = (
                  (Token.Text, 'text_'),
                  (Token.Text, '\n')]),
 
+    ('*italic\nit be*', [(Generic.Emph, '*italic\nit be*'),
+                         (Token.Text, '\n')]),
+    ('*text *', [(Token.Text, '*text'),
+                 (Token.Text, ' '),
+                 (Token.Text, '*'),
+                 (Token.Text, '\n')]),
+    ('* text*', [(Token.Keyword, '*'),
+                 (Token.Text, ' '),
+                 (Token.Text, 'text*'),
+                 (Token.Text, '\n')]),
+
     ('__bold\nit be__', [(Generic.Strong, '__bold\nit be__'),
                          (Token.Text, '\n')]),
     ('__text __', [(Token.Text, '__text'),
@@ -202,6 +215,17 @@ BOLD_ITA_MARKUP_TEST_CASES = (
     ('__ text__', [(Token.Text, '__'),
                    (Token.Text, ' '),
                    (Token.Text, 'text__'),
+                   (Token.Text, '\n')]),
+
+    ('**bold\nit be**', [(Generic.Strong, '**bold\nit be**'),
+                         (Token.Text, '\n')]),
+    ('**text **', [(Token.Text, '**text'),
+                   (Token.Text, ' '),
+                   (Token.Text, '**'),
+                   (Token.Text, '\n')]),
+    ('** text**', [(Token.Text, '**'),
+                   (Token.Text, ' '),
+                   (Token.Text, 'text**'),
                    (Token.Text, '\n')]),
 
     # something for the future: expressions can contain underscores

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -240,3 +240,18 @@ BOLD_ITA_MARKUP_TEST_CASES = (
 @pytest.mark.parametrize("fragment,tokens", BOLD_ITA_MARKUP_TEST_CASES)
 def test_bold_ita_markup(lexer, fragment, tokens):
     assert list(lexer.get_tokens(fragment)) == tokens
+
+
+QUOTE_MARKUP_TEST_CASES = (
+    ('> sometext', [(Token.Keyword, "> "),
+                    (Generic.Emph, "sometext\n")]),
+    ('>> sometext', [(Token.Keyword, ">> "),
+                     (Generic.Emph, "sometext\n")]),
+    ('> > sometext', [(Token.Keyword, "> > "),
+                      (Generic.Emph, "sometext\n")]),
+)
+
+
+@pytest.mark.parametrize("fragment,tokens", QUOTE_MARKUP_TEST_CASES)
+def test_quote(lexer, fragment, tokens):
+    assert list(lexer.get_tokens(fragment)) == tokens

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -244,11 +244,14 @@ def test_bold_ita_markup(lexer, fragment, tokens):
 
 QUOTE_MARKUP_TEST_CASES = (
     ('> sometext', [(Token.Keyword, "> "),
-                    (Generic.Emph, "sometext\n")]),
+                    (Token.Text, "sometext"),
+                    (Token.Text, "\n")]),
     ('>> sometext', [(Token.Keyword, ">> "),
-                     (Generic.Emph, "sometext\n")]),
+                     (Token.Text, "sometext"),
+                     (Token.Text, "\n")]),
     ('> > sometext', [(Token.Keyword, "> > "),
-                      (Generic.Emph, "sometext\n")]),
+                      (Token.Text, "sometext"),
+                      (Token.Text, "\n")]),
 )
 
 

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -176,3 +176,43 @@ def test_invalid_code_block(lexer):
     for fragment in fragments:
         for token, _ in lexer.get_tokens(fragment):
             assert token != String.Backtick
+
+
+BOLD_ITA_MARKUP_TEST_CASES = (
+    ('__bold__', [(Generic.Strong, '__bold__'), (Token.Text, '\n')]),
+    ('**bold**', [(Generic.Strong, '**bold**'), (Token.Text, '\n')]),
+
+    ('_italic\nit be_', [(Generic.Emph, '_italic\nit be_'),
+                         (Token.Text, '\n')]),
+    ('_text _', [(Token.Text, '_text'),
+                 (Token.Text, ' '),
+                 (Token.Text, '_'),
+                 (Token.Text, '\n')]),
+    ('_ text_', [(Token.Text, '_'),
+                 (Token.Text, ' '),
+                 (Token.Text, 'text_'),
+                 (Token.Text, '\n')]),
+
+    ('__bold\nit be__', [(Generic.Strong, '__bold\nit be__'),
+                         (Token.Text, '\n')]),
+    ('__text __', [(Token.Text, '__text'),
+                   (Token.Text, ' '),
+                   (Token.Text, '__'),
+                   (Token.Text, '\n')]),
+    ('__ text__', [(Token.Text, '__'),
+                   (Token.Text, ' '),
+                   (Token.Text, 'text__'),
+                   (Token.Text, '\n')]),
+
+    # something for the future: expressions can contain underscores
+    # ('_text_text_', [(Generic.Emph, '_text_text_'),
+    #                    (Token.Text, '\n')]),
+    #
+    # ('_text__text__', [(Generic.Emph, '_text__text__'),
+    #                    (Token.Text, '\n')]),
+)
+
+
+@pytest.mark.parametrize("fragment,tokens", BOLD_ITA_MARKUP_TEST_CASES)
+def test_bold_ita_markup(lexer, fragment, tokens):
+    assert list(lexer.get_tokens(fragment)) == tokens


### PR DESCRIPTION
Some improvements to how bold/italic markdown formatting is tokenized e.g. in multiline situations.
Not that these things became 100% accurate, but a few useful improvements for my current purposes.

Opening a pull request before these get forgotten forever :)
May or may not be "ready" - no harm is done if the PR gets rejected, I appreciate comments if that would be the case.
Might be good to clear things up early, more commits may be on the way soon.

I see there are months old PRs so I'm not expecting any immediate reaction, but anyway, thanks in advance!