### PR TITLE
Fix #1573

### DIFF
--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -87,7 +87,7 @@ class CSharpLexer(RegexLexer):
                 (r'[~!%^&*()+=|\[\]:;,.<>/?-]', Punctuation),
                 (r'[{}]', Punctuation),
                 (r'@"(""|[^"])*"', String),
-                (r'"(\\\\|\\[^\\]|[^"\\\n])*["\n]', String),
+                (r'\$?"(\\\\|\\[^\\]|[^"\\\n])*["\n]', String),
                 (r"'\\.'|'[^\\]'", String.Char),
                 (r"[0-9](\.[0-9]*)?([eE][+-][0-9]+)?"
                  r"[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?", Number),


### PR DESCRIPTION
Allow $ sign in C# language for interpolated strings.