### PR TITLE
Only allow tables at line start to fix arrays in TOML lexer.

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -980,7 +980,7 @@ class TOMLLexer(RegexLexer):
             (r'(true|false)$', Keyword.Constant),
             (r'[a-zA-Z_][\w\-]*', Name),
 
-            (r'\[.*?\]$', Keyword),
+            (r'^\[.*?\]$', Keyword),
             # Datetime
             # TODO this needs to be expanded, as TOML is rather flexible:
             # https://github.com/toml-lang/toml#offset-date-time


### PR DESCRIPTION
Hi!

Arrays are matched as keywords on master. This PR aims to fix that.

On master:
![image](https://user-images.githubusercontent.com/176810/127370495-d1274867-5a81-4d31-ab2c-fa06aaa0c166.png)

With this PR:
![image](https://user-images.githubusercontent.com/176810/127370583-a5a4ace9-b50f-402e-a38e-9cce10253456.png)
