### PR TITLE
Added groff formatter

### DIFF
--- a/pygments/formatters/_mapping.py
+++ b/pygments/formatters/_mapping.py
@@ -16,6 +16,7 @@ FORMATTERS = {
     'BBCodeFormatter': ('pygments.formatters.bbcode', 'BBCode', ('bbcode', 'bb'), (), 'Format tokens with BBcodes. These formatting codes are used by many bulletin boards, so you can highlight your sourcecode with pygments before posting it there.'),
     'BmpImageFormatter': ('pygments.formatters.img', 'img_bmp', ('bmp', 'bitmap'), ('*.bmp',), 'Create a bitmap image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
     'GifImageFormatter': ('pygments.formatters.img', 'img_gif', ('gif',), ('*.gif',), 'Create a GIF image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),
+    'GroffFormatter': ('pygments.formatters.groff', 'groff', ('groff', 'troff', 'roff'), (), 'Format tokens with groff escapes to change their color and font style.'),
     'HtmlFormatter': ('pygments.formatters.html', 'HTML', ('html',), ('*.html', '*.htm'), "Format tokens as HTML 4 ``<span>`` tags within a ``<pre>`` tag, wrapped in a ``<div>`` tag. The ``<div>``'s CSS class can be set by the `cssclass` option."),
     'IRCFormatter': ('pygments.formatters.irc', 'IRC', ('irc', 'IRC'), (), 'Format tokens with IRC color sequences'),
     'ImageFormatter': ('pygments.formatters.img', 'img', ('img', 'IMG', 'png'), ('*.png',), 'Create a PNG image from source code. This uses the Python Imaging Library to generate a pixmap from the source code.'),

--- a/pygments/formatters/groff.py
+++ b/pygments/formatters/groff.py
@@ -1,0 +1,166 @@
+"""
+    pygments.formatters.groff
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Formatter for groff output.
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import math
+from pygments.formatter import Formatter
+from pygments.util import get_bool_opt, get_int_opt
+
+__all__ = ['GroffFormatter']
+
+
+class GroffFormatter(Formatter):
+    """
+    Format tokens with groff escapes to change their color and font style.
+
+    Additional options accepted:
+
+    `style`
+        The style to use, can be a string or a Style subclass (default:
+        ``'default'``).
+
+    `monospaced`
+        If set to true, monospace font will be used (default: ``true``).
+
+    `linenos`
+        If set to true, print the line numbers (default: ``false``).
+
+    `wrap`
+        Wrap lines to the specified number of characters. Disabled if set to 0
+        (default: ``0``).
+    """
+
+    name = 'groff'
+    aliases = ['groff','troff','roff']
+    filenames = []
+
+    def __init__(self, **options):
+        Formatter.__init__(self, **options)
+
+        self.monospaced = get_bool_opt(options, 'monospaced', True)
+        self.linenos = get_bool_opt(options, 'linenos', False)
+        self._lineno = 0
+        self.wrap = get_int_opt(options, 'wrap', 0)
+        self._linelen = 0
+
+        self.styles = {}
+        self._make_styles()
+
+
+    def _make_styles(self):
+        regular = '\\f[CR]' if self.monospaced else '\\f[R]'
+        bold = '\\f[CB]' if self.monospaced else '\\f[B]'
+        italic = '\\f[CI]' if self.monospaced else '\\f[I]'
+
+        for ttype, ndef in self.style:
+            start = end = ''
+            if ndef['color']:
+                start += '\\m[%s]' % ndef['color']
+                end = '\\m[]' + end
+            if ndef['bold']:
+                start += bold
+                end = regular + end
+            if ndef['italic']:
+                start += italic
+                end = regular + end
+            if ndef['bgcolor']:
+                start += '\\M[%s]' % ndef['bgcolor']
+                end = '\\M[]' + end
+
+            self.styles[ttype] = start, end
+
+
+    def _define_colors(self, outfile):
+        colors = set()
+        for _, ndef in self.style:
+            if ndef['color'] is not None:
+                colors.add(ndef['color'])
+
+        for color in colors:
+            outfile.write('.defcolor ' + color + ' rgb #' + color + '\n')
+
+
+    def _write_lineno(self, outfile):
+        self._lineno += 1
+        outfile.write("%s% 4d " % (self._lineno != 1 and '\n' or '', self._lineno))
+
+
+    def _wrap_line(self, line):
+        length = len(line.rstrip('\n'))
+        space = '     ' if self.linenos else ''
+        newline = ''
+
+        if length > self.wrap:
+            for i in range(0, math.floor(length / self.wrap)):
+                chunk = line[i*self.wrap:i*self.wrap+self.wrap]
+                newline += (chunk + '\n' + space)
+            remainder = length % self.wrap
+            if remainder > 0:
+                newline += line[-remainder-1:]
+                self._linelen = remainder
+        elif self._linelen + length > self.wrap:
+            newline = ('\n' + space) + line
+            self._linelen = length
+        else:
+            newline = line
+            self._linelen += length
+
+        return newline
+
+
+    def _escape_chars(self, text):
+        text = text.replace('\\', '\\[u005C]'). \
+                    replace('.', '\\[char46]'). \
+                    replace('\'', '\\[u0027]'). \
+                    replace('`', '\\[u0060]'). \
+                    replace('~', '\\[u007E]')
+        copy = text
+
+        for char in copy:
+            if len(char) != len(char.encode()):
+                uni = char.encode('unicode_escape') \
+                    .decode()[1:] \
+                    .replace('x', 'u00') \
+                    .upper()
+                text = text.replace(char, '\\[u' + uni[1:] + ']')
+
+        return text
+
+
+    def format_unencoded(self, tokensource, outfile):
+        self._define_colors(outfile)
+
+        outfile.write('.nf\n\\f[CR]\n')
+
+        if self.linenos:
+            self._write_lineno(outfile)
+
+        for ttype, value in tokensource:
+            start, end = self.styles[ttype]
+
+            for line in value.splitlines(True):
+                if self.wrap > 0:
+                    line = self._wrap_line(line)
+
+                if start and end:
+                    text = self._escape_chars(line.rstrip('\n'))
+                    if text != '':
+                        outfile.write(''.join((start, text, end)))
+                else:
+                    outfile.write(self._escape_chars(line.rstrip('\n')))
+
+                if line.endswith('\n'):
+                    if self.linenos:
+                        self._write_lineno(outfile)
+                        self._linelen = 0
+                    else:
+                        outfile.write('\n')
+                        self._linelen = 0
+
+        outfile.write('\n.fi')


### PR DESCRIPTION
This is a formatter that can output the source code in a form that can be used with [GNU Troff (groff)](https://www.gnu.org/software/groff/).

Groff is a typesetting system that has its roots in some of the oldest text formatting software out there. It can be used to create formatted documents, papers, books, etc. It is similar to LaTeX in that sense but much more minimal and older. Nowadays, it's mostly used for creation of `man` manual pages.

This formatter is using groff escapes to change the color and font style (regular, bold, italic) of the text. It also has a few options that allow the user to print the source code with line numbers and wrap it to a specified width. By default, the output is using a monospace font but it can be disabled too. Some special characters that are used by groff are replaced by escapes for printing Unicode characters. The same applies for non-ASCII characters, which groff can't print. The formatter isn't using any macro specific commands, so it should work with all of them (ms, mom, man, etc.).

I tested the formatter thoroughly using various source code files of my own and the ones available in the tests/examplefiles directory. I also used different combinations of options to make sure they don't conflict with each other. I didn't notice any issues. The only time when the output might look different than expected is when input contains characters that groff doesn't support (possibly to the lack of them in the default font). It will then give a warning that it cannot find the character and won't print it.

To test it yourself, you can use the following command:
```
pygmentize -f groff <input> | groff -Tpdf > output.pdf
```

It is my first contribution to the project and I'm not programming in Python that often, so I'm open to comments and feedback.