### PR TITLE
Add numerical identifiers to LLVM label syntax

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -353,7 +353,7 @@ class LlvmLexer(RegexLexer):
     #: optional Comment or Whitespace
     string = r'"[^"]*?"'
     identifier = r'([-a-zA-Z$._][\w\-$.]*|' + string + ')'
-    block_label = identifier + r'|(\d+)'
+    block_label = r'(' + identifier + r'|(\d+))'
 
     tokens = {
         'root': [

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -353,13 +353,14 @@ class LlvmLexer(RegexLexer):
     #: optional Comment or Whitespace
     string = r'"[^"]*?"'
     identifier = r'([-a-zA-Z$._][\w\-$.]*|' + string + ')'
+    block_label = identifier + r'|(\d+)'
 
     tokens = {
         'root': [
             include('whitespace'),
 
             # Before keywords, because keywords are valid label names :(...
-            (identifier + r'\s*:', Name.Label),
+            (block_label + r'\s*:', Name.Label),
 
             include('keyword'),
 


### PR DESCRIPTION
Fixes #1874 

Implicitly-named labels of the form `\d+:` are valid as well as the
explicitly-identified ones already supported using the identifier
syntax.

This PR extends the LLVM lexer to include the numbered syntax.