### PR TITLE
Add `pwsh` alias for “PowerShell” lexers

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -655,7 +655,7 @@ class PowerShellLexer(RegexLexer):
     .. versionadded:: 1.5
     """
     name = 'PowerShell'
-    aliases = ['powershell', 'posh', 'ps1', 'psm1']
+    aliases = ['powershell', 'pwsh', 'posh', 'ps1', 'psm1']
     filenames = ['*.ps1', '*.psm1']
     mimetypes = ['text/x-powershell']
 
@@ -771,7 +771,7 @@ class PowerShellSessionLexer(ShellSessionBaseLexer):
     """
 
     name = 'PowerShell Session'
-    aliases = ['ps1con']
+    aliases = ['pwsh-session', 'ps1con']
     filenames = []
     mimetypes = []
 


### PR DESCRIPTION
This matches the official executable name [of **PowerShell 6** and newer](https://github.com/PowerShell/PowerShell):
- <https://github.com/PowerShell/PowerShell/issues/4214>

---

Also, the `posh` alias should be deprecated as it clashes with the “[Policy‑compliant Ordinary SHell](https://www.commandlinux.com/man-page/man1/posh.1.html)”.