### PR TITLE
Fix "do concurrent" and "go to" keywords in the Fortran lexer.

### DIFF
--- a/pygments/lexers/fortran.py
+++ b/pygments/lexers/fortran.py
@@ -12,7 +12,7 @@ import re
 
 from pygments.lexer import RegexLexer, bygroups, include, words, using, default
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
-    Number, Punctuation, Generic
+    Number, Punctuation, Generic, Whitespace
 
 __all__ = ['FortranLexer', 'FortranFixedLexer']
 
@@ -48,11 +48,15 @@ class FortranLexer(RegexLexer):
         ],
         'core': [
             # Statements
+
+            (r'(DO)(\s+)(CONCURRENT)', bygroups(Keyword, Whitespace, Keyword)),
+            (r'(GO)(\s*)(TO)', bygroups(Keyword, Whitespace, Keyword)),
+
             (words((
                 'ABSTRACT', 'ACCEPT', 'ALL', 'ALLSTOP', 'ALLOCATABLE', 'ALLOCATE',
                 'ARRAY', 'ASSIGN', 'ASSOCIATE', 'ASYNCHRONOUS', 'BACKSPACE', 'BIND',
                 'BLOCK', 'BLOCKDATA', 'BYTE', 'CALL', 'CASE', 'CLASS', 'CLOSE',
-                'CODIMENSION', 'COMMON', 'CONCURRRENT', 'CONTIGUOUS', 'CONTAINS',
+                'CODIMENSION', 'COMMON', 'CONTIGUOUS', 'CONTAINS',
                 'CONTINUE', 'CRITICAL', 'CYCLE', 'DATA', 'DEALLOCATE', 'DECODE',
                 'DEFERRED', 'DIMENSION', 'DO', 'ELEMENTAL', 'ELSE', 'ENCODE', 'END',
                 'ENDASSOCIATE', 'ENDBLOCK', 'ENDDO', 'ENDENUM', 'ENDFORALL',
@@ -60,7 +64,7 @@ class FortranLexer(RegexLexer):
                 'ENDSELECT', 'ENDSUBMODULE', 'ENDSUBROUTINE', 'ENDTYPE', 'ENDWHERE',
                 'ENTRY', 'ENUM', 'ENUMERATOR', 'EQUIVALENCE', 'ERROR STOP', 'EXIT',
                 'EXTENDS', 'EXTERNAL', 'EXTRINSIC', 'FILE', 'FINAL', 'FORALL', 'FORMAT',
-                'FUNCTION', 'GENERIC', 'GOTO', 'IF', 'IMAGES', 'IMPLICIT',
+                'FUNCTION', 'GENERIC', 'IF', 'IMAGES', 'IMPLICIT',
                 'IMPORT', 'IMPURE', 'INCLUDE', 'INQUIRE', 'INTENT', 'INTERFACE',
                 'INTRINSIC', 'IS', 'LOCK', 'MEMORY', 'MODULE', 'NAMELIST', 'NULLIFY',
                 'NONE', 'NON_INTRINSIC', 'NON_OVERRIDABLE', 'NOPASS', 'ONLY', 'OPEN', 

--- a/pygments/lexers/fortran.py
+++ b/pygments/lexers/fortran.py
@@ -12,7 +12,7 @@ import re
 
 from pygments.lexer import RegexLexer, bygroups, include, words, using, default
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
-    Number, Punctuation, Generic, Whitespace
+    Number, Punctuation, Generic
 
 __all__ = ['FortranLexer', 'FortranFixedLexer']
 
@@ -49,8 +49,8 @@ class FortranLexer(RegexLexer):
         'core': [
             # Statements
 
-            (r'\b(DO)(\s+)(CONCURRENT)\b', bygroups(Keyword, Whitespace, Keyword)),
-            (r'\b(GO)(\s*)(TO)\b', bygroups(Keyword, Whitespace, Keyword)),
+            (r'\b(DO)(\s+)(CONCURRENT)\b', bygroups(Keyword, Text.Whitespace, Keyword)),
+            (r'\b(GO)(\s*)(TO)\b', bygroups(Keyword, Text.Whitespace, Keyword)),
 
             (words((
                 'ABSTRACT', 'ACCEPT', 'ALL', 'ALLSTOP', 'ALLOCATABLE', 'ALLOCATE',

--- a/pygments/lexers/fortran.py
+++ b/pygments/lexers/fortran.py
@@ -49,8 +49,8 @@ class FortranLexer(RegexLexer):
         'core': [
             # Statements
 
-            (r'(DO)(\s+)(CONCURRENT)', bygroups(Keyword, Whitespace, Keyword)),
-            (r'(GO)(\s*)(TO)', bygroups(Keyword, Whitespace, Keyword)),
+            (r'\b(DO)(\s+)(CONCURRENT)\b', bygroups(Keyword, Whitespace, Keyword)),
+            (r'\b(GO)(\s*)(TO)\b', bygroups(Keyword, Whitespace, Keyword)),
 
             (words((
                 'ABSTRACT', 'ACCEPT', 'ALL', 'ALLSTOP', 'ALLOCATABLE', 'ALLOCATE',

--- a/tests/examplefiles/fortran/zmlrpc.f90.output
+++ b/tests/examplefiles/fortran/zmlrpc.f90.output
@@ -908,7 +908,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n    '      Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n  '        Text
 'end '        Keyword
@@ -947,7 +949,9 @@
 "'no_ml_ in mlprc_aply?'" Literal.String.Single
 ')'           Punctuation
 '\n    '      Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n  '    Text
 'case'        Keyword
@@ -1034,7 +1038,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n    '      Text
 'allocate'    Keyword
@@ -1251,7 +1257,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n        '  Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n      '    Text
 'end '        Keyword
@@ -1442,7 +1450,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'else\n          ' Keyword
@@ -1522,7 +1532,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'else'        Keyword
@@ -1889,7 +1901,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'else\n\n        ' Keyword
@@ -1991,7 +2005,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n  '    Text
 'case'        Keyword
@@ -2409,7 +2425,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n          ' Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'end '        Keyword
@@ -2537,7 +2555,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n          ' Text
 'else\n            ' Keyword
@@ -2618,7 +2638,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else'        Keyword
@@ -2827,7 +2849,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'enddo\n\n\n      ' Keyword
@@ -2886,7 +2910,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n      ' Text
 'do '         Keyword
@@ -3028,7 +3054,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else\n          ' Keyword
@@ -3179,7 +3207,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'call '       Keyword
@@ -3237,7 +3267,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'enddo\n\n      ' Keyword
@@ -3276,7 +3308,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n    '  Text
 'case'        Keyword
@@ -3429,7 +3463,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n        '  Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n      '    Text
 'end '        Keyword
@@ -3523,7 +3559,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'mlprec_wrk'  Name
@@ -3598,7 +3636,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'do '         Keyword
@@ -3759,7 +3799,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n          ' Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'end '        Keyword
@@ -3887,7 +3929,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n          ' Text
 'else\n            ' Keyword
@@ -3967,7 +4011,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else'        Keyword
@@ -4197,7 +4243,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'if'          Keyword
@@ -4282,7 +4330,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'endif\n\n      ' Keyword
@@ -4426,7 +4476,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else\n\n          ' Keyword
@@ -4549,7 +4601,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n\n    ' Text
 'case'        Keyword
@@ -4772,7 +4826,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n        '  Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n      '    Text
 'end '        Keyword
@@ -4898,7 +4954,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'mlprec_wrk'  Name
@@ -4973,7 +5031,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'do '         Keyword
@@ -5188,7 +5248,9 @@
 "'Allocate'"  Literal.String.Single
 ')'           Punctuation
 '\n          ' Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'end '        Keyword
@@ -5274,7 +5336,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n          ' Text
 'else\n            ' Keyword
@@ -5354,7 +5418,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else'        Keyword
@@ -5574,7 +5640,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'call '       Keyword
@@ -5631,7 +5699,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'if'          Keyword
@@ -5716,7 +5786,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n        '  Text
 'endif\n\n      ' Keyword
@@ -5858,7 +5930,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'else\n          ' Keyword
@@ -5995,7 +6069,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n        ' Text
 'call '       Keyword
@@ -6053,7 +6129,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n      '  Text
 'enddo\n\n      ' Keyword
@@ -6096,7 +6174,9 @@
 '0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n\n    '  Text
 'case '       Keyword
@@ -6142,7 +6222,9 @@
 ')'           Punctuation
 ')'           Punctuation
 '\n      '    Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n    '    Text
 'end '        Keyword
@@ -6190,7 +6272,9 @@
 ')'           Punctuation
 ')'           Punctuation
 '\n    '      Text
-'goto '       Keyword
+'go'          Keyword
+'to'          Keyword
+' '           Text
 '9999'        Literal.Number.Integer
 '\n\n  '      Text
 'end '        Keyword

--- a/tests/examplefiles/fortranfixed/ahcon.f.output
+++ b/tests/examplefiles/fortranfixed/ahcon.f.output
@@ -681,9 +681,9 @@
 '1.D0'        Literal.Number.Float
 ')'           Punctuation
 ' '           Text
-'GO'          Name
-' '           Text
-'TO'          Name
+'GO'          Keyword
+' '           Text.Whitespace
+'TO'          Keyword
 ' '           Text
 '100'         Literal.Number.Integer
 '\n'          Text


### PR DESCRIPTION
* "Go to" statement was only highlighted if there was no space between "go" and "to".
* "Concurrent" keyword in the "Do Concurrent" statement was never highlighted because of a typo. It has been fixed. In addition, it now highlights them only if "Concurrent" is right after the "Do" keyword.
* I had to put the "do concurrent" changes before the already available list of keywords. Otherwise it won't highlight "Concurrent" because it finds first the "Do" keyword in the other list and stops searching for more keywords.
* This PR fixes issue #1865 

I used the following program to test the changes:

```
program myProgram
  implicit none
  integer :: x
  character :: concurrent
  integer :: go, to
  concurrent = '1'
  do concurrent (x = 1: 2)
     write(*,*) x, concurrent
     go = 100
     to = 200
  end do
  Do ConCuRRENT (x = 1: 2)
     write(*,*) x, concurrent
     go = 100
     to = 200
  end do
  goto 100
  go to 100
  GO   to 100
  do  x = 1, 2
     write(*,*) x
  end do
100   write(*,*) go, to
end program myProgram
```