### PR TITLE
Fix #1860 - Un in unexport keyword of Makefile correctly lexed

### DIFF
--- a/pygments/lexers/make.py
+++ b/pygments/lexers/make.py
@@ -84,9 +84,9 @@ class BaseMakefileLexer(RegexLexer):
             (r'\$[<@$+%?|*]', Keyword),
             (r'\s+', Text),
             (r'#.*?\n', Comment),
-            (r'(export)(\s+)(?=[\w${}\t -]+\n)',
+            (r'((?:un)?export)(\s+)(?=[\w${}\t -]+\n)',
              bygroups(Keyword, Text), 'export'),
-            (r'export\s+', Keyword),
+            (r'(?:un)?export\s+', Keyword),
             # assignment
             (r'([\w${}().-]+)(\s*)([!?:+]?=)([ \t]*)((?:.*\\\n)+|.*\n)',
              bygroups(Name.Variable, Text, Operator, Text, using(BashLexer))),


### PR DESCRIPTION
As pointed out by Issue #1860 the keyword unexport was not correctly
matched. Only the part `export' had been matched.

This commit adds an optional group to the regex of the `export`
keyword to match `unexport` as well.