### PR TITLE
Fix Bibtex comment/commentary keyword difference

### DIFF
--- a/pygments/lexers/bibtex.py
+++ b/pygments/lexers/bibtex.py
@@ -55,7 +55,7 @@ class BibTeXLexer(ExtendedRegexLexer):
     tokens = {
         'root': [
             include('whitespace'),
-            ('@comment', Comment),
+            (r'@comment(?!ary)', Comment),
             ('@preamble', Name.Class, ('closing-brace', 'value', 'opening-brace')),
             ('@string', Name.Class, ('closing-brace', 'field', 'opening-brace')),
             ('@' + IDENTIFIER, Name.Class,


### PR DESCRIPTION
This PR is a fix for #1806

A negative lookahead will jump over a `@commentary` keyword avoiding mislexing the `@comment` keyword.