### PR TITLE
Fix #1237 cpp whitespace token usage expanded

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -82,7 +82,7 @@ class CFamilyLexer(RegexLexer):
             (r'[~!%^&*+=|?:<>/-]', Operator),
             (r'[()\[\],.]', Punctuation),
             (r'(true|false|NULL)\b', Name.Builtin),
-            (r'(' + _ident + r')(\s*)(:)(?!:)', bygroups(Name.Label, Text, Punctuation)),
+            (r'(' + _ident + r')(\s*)(:)(?!:)', bygroups(Name.Label, Whitespace, Punctuation)),
             (_ident, Name)
         ],
         'types': [
@@ -92,7 +92,7 @@ class CFamilyLexer(RegexLexer):
                     'unsigned', 'signed', 'void'), suffix=r'\b'), Keyword.Type)
         ],
         'keywords': [
-            (r'(struct|union)(\s+)', bygroups(Keyword, Text), 'classname'),
+            (r'(struct|union)(\s+)', bygroups(Keyword, Whitespace), 'classname'),
             (words(('asm', 'auto', 'break', 'case', 'const', 'continue',
                     'default', 'do', 'else', 'enum', 'extern', 'for', 'goto',
                     'if', 'register', 'restricted', 'return', 'sizeof', 'struct',
@@ -335,7 +335,7 @@ class CppLexer(CFamilyLexer):
             default('#pop')
         ],
         'keywords': [
-            (r'(class|concept|typename)(\s+)', bygroups(Keyword, Text), 'classname'),
+            (r'(class|concept|typename)(\s+)', bygroups(Keyword, Whitespace), 'classname'),
             (words((
                 'catch', 'const_cast', 'delete', 'dynamic_cast', 'explicit',
                 'export', 'friend', 'mutable', 'new', 'operator',
@@ -347,7 +347,7 @@ class CppLexer(CFamilyLexer):
                 'typename'),
                suffix=r'\b'), Keyword),
             (r'namespace\b', Keyword, 'namespace'),
-            (r'(enum)(\s+)', bygroups(Keyword, Text), 'enumname'),
+            (r'(enum)(\s+)', bygroups(Keyword, Whitespace), 'enumname'),
             inherit
         ],
         'types': [

--- a/tests/examplefiles/c/ceval.c.output
+++ b/tests/examplefiles/c/ceval.c.output
@@ -2210,7 +2210,7 @@
 'static'      Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -15727,7 +15727,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'Py_True'     Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'Py_False'    Name
@@ -16008,7 +16008,7 @@
 
 '\t\t\t\t\t\t  ' Text.Whitespace
 'Py_None'     Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'f'           Name
@@ -16073,7 +16073,7 @@
 
 '\t\t\t\t\t\t  ' Text.Whitespace
 'Py_None'     Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'f'           Name

--- a/tests/examplefiles/c/example.c.output
+++ b/tests/examplefiles/c/example.c.output
@@ -2779,7 +2779,7 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'RArray'      Name.Class
 ')'           Punctuation
 ';'           Punctuation
@@ -3836,7 +3836,7 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'RArray'      Name.Class
 ')'           Punctuation
 ';'           Punctuation
@@ -12824,7 +12824,7 @@
 '\n'          Text.Whitespace
 
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ary_sort_data' Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -12871,7 +12871,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ary_sort_data' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -12984,7 +12984,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ary_sort_data' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -13097,7 +13097,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ary_sort_data' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -13356,7 +13356,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ary_sort_data' Name.Class
 ' '           Text.Whitespace
 'data'        Name

--- a/tests/examplefiles/charmci/Charmci.ci.output
+++ b/tests/examplefiles/charmci/Charmci.ci.output
@@ -95,7 +95,7 @@
 ']'           Punctuation
 ' '           Text.Whitespace
 'ckcallback_group' Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'IrrGroup'    Name

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -796,7 +796,7 @@
 '\n'          Text.Whitespace
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'AnsiGenerator' Name.Class
 ' '           Text.Whitespace
 ':'           Operator
@@ -16253,7 +16253,7 @@
 
 '  '          Text.Whitespace
 'enum'        Keyword
-' '           Text
+' '           Text.Whitespace
 'BracketMode' Name.Class
 '   '         Text.Whitespace
 '{'           Punctuation
@@ -16275,7 +16275,7 @@
 
 '  '          Text.Whitespace
 'enum'        Keyword
-' '           Text
+' '           Text.Whitespace
 'BracketType' Name.Class
 '   '         Text.Whitespace
 '{'           Punctuation
@@ -16331,7 +16331,7 @@
 
 '  '          Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'ASBeautifier' Name.Class
 ' '           Text.Whitespace
 ':'           Operator

--- a/tests/examplefiles/cpp/functions.cpp.output
+++ b/tests/examplefiles/cpp/functions.cpp.output
@@ -1326,7 +1326,7 @@
 '\n'          Text.Whitespace
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'raz'         Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation

--- a/tests/examplefiles/cpp/namespace.cpp.output
+++ b/tests/examplefiles/cpp/namespace.cpp.output
@@ -97,7 +97,7 @@
 '\n'          Text.Whitespace
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'QualifiedName' Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation

--- a/tests/examplefiles/ec/test.ec.output
+++ b/tests/examplefiles/ec/test.ec.output
@@ -18,7 +18,7 @@
 'public'      Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'AnchorValue' Name.Class
 '\n'          Text.Whitespace
 
@@ -36,7 +36,7 @@
 
 '   '         Text.Whitespace
 'union'       Keyword
-'\n   '       Text
+'\n   '       Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -751,7 +751,7 @@
 'public'      Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'MiddleAnchorValue' Name.Class
 '\n'          Text.Whitespace
 
@@ -769,7 +769,7 @@
 
 '   '         Text.Whitespace
 'union'       Keyword
-'\n   '       Text
+'\n   '       Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1391,7 +1391,7 @@
 'public'      Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Anchor'      Name.Class
 '\n'          Text.Whitespace
 
@@ -1400,7 +1400,7 @@
 
 '   '         Text.Whitespace
 'union'       Keyword
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 ' '           Text.Whitespace
 'AnchorValue' Name
@@ -1419,7 +1419,7 @@
 
 '   '         Text.Whitespace
 'union'       Keyword
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 ' '           Text.Whitespace
 'AnchorValue' Name
@@ -2545,7 +2545,7 @@
 'class'       Keyword
 ' '           Text.Whitespace
 'AnchorButton' Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'Button'      Name
@@ -2898,7 +2898,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -2929,7 +2929,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -2960,7 +2960,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -2991,7 +2991,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -4124,7 +4124,7 @@
 'class'       Keyword
 ' '           Text.Whitespace
 'AnchorRelButton' Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'Button'      Name
@@ -4737,7 +4737,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'relative'    Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 '('           Punctuation
@@ -4750,7 +4750,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -4782,7 +4782,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'relative'    Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 '('           Punctuation
@@ -4795,7 +4795,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -4827,7 +4827,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'relative'    Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 '('           Punctuation
@@ -4840,7 +4840,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -4872,7 +4872,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'relative'    Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 '('           Punctuation
@@ -4885,7 +4885,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'offset'      Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'none'        Name
@@ -5912,7 +5912,7 @@
 'class'       Keyword
 ' '           Text.Whitespace
 'AnchorEditor' Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'Window'      Name
@@ -6020,7 +6020,7 @@
 'class'       Keyword
 ' '           Text.Whitespace
 'AnchorDropBox' Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'DropBox'     Name

--- a/tests/examplefiles/ec/test.eh.output
+++ b/tests/examplefiles/ec/test.eh.output
@@ -1441,7 +1441,7 @@
 'typedef'     Keyword
 ' '           Text.Whitespace
 'union'       Keyword
-' '           Text
+' '           Text.Whitespace
 'YYSTYPE'     Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1750,7 +1750,7 @@
 'typedef'     Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'YYLTYPE'     Name.Class
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/mql/example.mqh.output
+++ b/tests/examplefiles/mql/example.mqh.output
@@ -25,7 +25,7 @@
 '//+------------------------------------------------------------------+\n' Comment.Single
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'CArray'      Name.Class
 ' '           Text.Whitespace
 ':'           Operator

--- a/tests/examplefiles/nesc/IPDispatchC.nc.output
+++ b/tests/examplefiles/nesc/IPDispatchC.nc.output
@@ -365,7 +365,7 @@
 'PoolC'       Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
@@ -386,7 +386,7 @@
 'QueueC'      Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -405,7 +405,7 @@
 'PoolC'       Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 ','           Punctuation
 ' '           Text.Whitespace

--- a/tests/examplefiles/nesc/IPDispatchP.nc.output
+++ b/tests/examplefiles/nesc/IPDispatchP.nc.output
@@ -249,7 +249,7 @@
 'Pool'        Name
 '<'           Operator
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 '>'           Operator
 ' '           Text.Whitespace
@@ -265,7 +265,7 @@
 'Pool'        Name
 '<'           Operator
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 '>'           Operator
 ' '           Text.Whitespace
@@ -281,7 +281,7 @@
 'Queue'       Name
 '<'           Operator
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -355,7 +355,7 @@
 'lowpan_extern_read_context' Name.Function
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'in6_addr'    Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -397,7 +397,7 @@
 'lowpan_extern_match_context' Name.Function
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'in6_addr'    Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -582,7 +582,7 @@
 
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 'recon_data'  Name
@@ -626,7 +626,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -636,7 +636,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -663,7 +663,7 @@
 'sizeof'      Keyword
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ip6_metadata' Name.Class
 ')'           Punctuation
 ')'           Punctuation
@@ -702,7 +702,7 @@
 
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -715,7 +715,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -843,7 +843,7 @@
 'SENDINFO_DECR' Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -1254,7 +1254,7 @@
 'sizeof'      Keyword
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ')'           Punctuation
 ','           Punctuation
@@ -1306,7 +1306,7 @@
 'deliver'     Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -1318,7 +1318,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ip6_hdr'     Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -1328,7 +1328,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ip6_hdr'     Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -1374,7 +1374,7 @@
 'sizeof'      Keyword
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ip6_hdr'     Name.Class
 ')'           Punctuation
 ')'           Punctuation
@@ -1481,7 +1481,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -1491,7 +1491,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2040,7 +2040,7 @@
 
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2061,7 +2061,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2115,7 +2115,7 @@
 
 '      '      Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2125,7 +2125,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2357,7 +2357,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'packed_lowmsg' Name.Class
 ' '           Text.Whitespace
 'lowmsg'      Name
@@ -2366,7 +2366,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ieee154_frame_addr' Name.Class
 ' '           Text.Whitespace
 'frame_address' Name
@@ -2551,7 +2551,7 @@
 
 '      '      Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -2946,7 +2946,7 @@
 
 '      '      Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_reconstruct' Name.Class
 ' '           Text.Whitespace
 'recon'       Name
@@ -3206,7 +3206,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -3583,7 +3583,7 @@
 'send'        Name
 '('           Punctuation
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ieee154_frame_addr' Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -3593,7 +3593,7 @@
 
 '                               ' Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ip6_packet'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -3613,7 +3613,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lowpan_ctx'  Name.Class
 ' '           Text.Whitespace
 'ctx'         Name
@@ -3622,7 +3622,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_info'   Name.Class
 '  '          Text.Whitespace
 '*'           Operator
@@ -3632,7 +3632,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator
@@ -4483,7 +4483,7 @@
 
 '    '        Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'send_entry'  Name.Class
 ' '           Text.Whitespace
 '*'           Operator

--- a/tests/examplefiles/swig/swig_java.swg.output
+++ b/tests/examplefiles/swig/swig_java.swg.output
@@ -12528,7 +12528,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'null'        Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'new'         Keyword
@@ -12590,7 +12590,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'null'        Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'new'         Keyword
@@ -12718,7 +12718,7 @@
 '?'           Operator
 ' '           Text.Whitespace
 'null'        Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 ' '           Text.Whitespace
 'new'         Keyword

--- a/tests/examplefiles/swig/swig_std_vector.i.output
+++ b/tests/examplefiles/swig/swig_std_vector.i.output
@@ -209,12 +209,12 @@
 'template'    Keyword
 '<'           Operator
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Tp'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Alloc'      Name.Class
 ' '           Text.Whitespace
 '='           Operator
@@ -231,7 +231,7 @@
 
 '  '          Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'vector'      Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -403,7 +403,7 @@
 '>'           Operator
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'traits'      Name.Class
 '<'           Operator
 'std'         Name
@@ -573,12 +573,12 @@
 'template'    Keyword
 '<'           Operator
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Tp'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Alloc'      Name.Class
 ' '           Text.Whitespace
 '>'           Operator
@@ -586,7 +586,7 @@
 
 '  '          Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'vector'      Name.Class
 '<'           Operator
 '_Tp'         Name
@@ -757,7 +757,7 @@
 '>'           Operator
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'traits'      Name.Class
 '<'           Operator
 'std'         Name
@@ -926,12 +926,12 @@
 'template'    Keyword
 '<'           Operator
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Tp'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Alloc'      Name.Class
 ' '           Text.Whitespace
 '>'           Operator
@@ -939,7 +939,7 @@
 
 '  '          Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'vector'      Name.Class
 '<'           Operator
 '_Tp'         Name
@@ -1118,7 +1118,7 @@
 '>'           Operator
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'traits'      Name.Class
 '<'           Operator
 'std'         Name
@@ -1295,7 +1295,7 @@
 'template'    Keyword
 '<'           Operator
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 '_Alloc'      Name.Class
 ' '           Text.Whitespace
 '>'           Operator
@@ -1304,7 +1304,7 @@
 
 '  '          Text.Whitespace
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'vector'      Name.Class
 '<'           Operator
 'bool'        Keyword.Type
@@ -1471,7 +1471,7 @@
 '>'           Operator
 '  '          Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'traits'      Name.Class
 '<'           Operator
 'std'         Name

--- a/tests/snippets/c/test_label_space_before_colon.txt
+++ b/tests/snippets/c/test_label_space_before_colon.txt
@@ -17,7 +17,7 @@ foo :
 '\n'          Text.Whitespace
 
 'foo'         Name.Label
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
 '\n'          Text.Whitespace
 


### PR DESCRIPTION
It seems likely, that the original issuer had a highlighting theme where the token `Text` has been highlighted.

Whereever applicable, the `Text` token is replaced with the more specific `Whitespace` token - not just the `class` keyword, but also similar occurrences, such as enums and structs.

This should fix #1237, and should generally be more precise lexing as well.