### PR TITLE
Add URLs to project metadata for pypi.org

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ license = BSD License
 author = Georg Brandl
 author_email = georg@python.org
 description = Pygments is a syntax highlighting package written in Python.
-long_description = file:description.rst    
+long_description = file:description.rst
 platforms = any
 keywords = syntax highlighting
 classifiers =
@@ -27,6 +27,11 @@ classifiers =
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing :: Filters
     Topic :: Utilities
+project_urls =
+    Documentation = https://pygments.org/docs/
+    Source = https://github.com/pygments/pygments
+    Bug Tracker = https://github.com/pygments/pygments/issues
+    Changelog = https://github.com/pygments/pygments/blob/master/CHANGES
 
 [options]
 packages = find:


### PR DESCRIPTION
Right now there is no link to the GitHub repository on [the PyPI page](https://pypi.org/project/Pygments/). This PR adds links on the left like so:

![screenshot of PyPI](https://user-images.githubusercontent.com/426784/135723594-f8840e00-0fb2-42fd-b38d-8bc3fab74c15.png)
