### PR TITLE
lexer SQL to use whitespace token - regarding #1905

### DIFF
--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -161,7 +161,7 @@ class PostgresLexer(PostgresBase, RegexLexer):
     flags = re.IGNORECASE
     tokens = {
         'root': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'--.*\n?', Comment.Single),
             (r'/\*', Comment.Multiline, 'multiline-comments'),
             (r'(' + '|'.join(s.replace(" ", r"\s+")
@@ -254,7 +254,7 @@ class PsqlRegexLexer(PostgresBase, RegexLexer):
         (r'\\[^\s]+', Keyword.Pseudo, 'psql-command'))
     tokens['psql-command'] = [
         (r'\n', Text, 'root'),
-        (r'\s+', Text),
+        (r'\s+', Whitespace),
         (r'\\[^\s]+', Keyword.Pseudo),
         (r""":(['"]?)[a-z]\w*\b\1""", Name.Variable),
         (r"'(''|[^'])*'", String.Single),
@@ -381,7 +381,7 @@ class SqlLexer(RegexLexer):
     flags = re.IGNORECASE
     tokens = {
         'root': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'--.*\n?', Comment.Single),
             (r'/\*', Comment.Multiline, 'multiline-comments'),
             (words((
@@ -599,7 +599,7 @@ class MySqlLexer(RegexLexer):
     flags = re.IGNORECASE
     tokens = {
         'root': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
 
             # Comments
             (r'(?:#|--\s+).*', Comment.Single),
@@ -655,14 +655,14 @@ class MySqlLexer(RegexLexer):
 
             # Exceptions; these words tokenize differently in different contexts.
             (r'\b(set)(?!\s*\()', Keyword),
-            (r'\b(character)(\s+)(set)\b', bygroups(Keyword, Text, Keyword)),
+            (r'\b(character)(\s+)(set)\b', bygroups(Keyword, Whitespace, Keyword)),
             # In all other known cases, "SET" is tokenized by MYSQL_DATATYPES.
 
             (words(MYSQL_CONSTANTS, prefix=r'\b', suffix=r'\b'), Name.Constant),
             (words(MYSQL_DATATYPES, prefix=r'\b', suffix=r'\b'), Keyword.Type),
             (words(MYSQL_KEYWORDS, prefix=r'\b', suffix=r'\b'), Keyword),
             (words(MYSQL_FUNCTIONS, prefix=r'\b', suffix=r'\b(\s*)(\()'),
-             bygroups(Name.Function, Text, Punctuation)),
+             bygroups(Name.Function, Whitespace, Punctuation)),
 
             # Schema object names
             #
@@ -820,7 +820,7 @@ class RqlLexer(RegexLexer):
     flags = re.IGNORECASE
     tokens = {
         'root': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'(DELETE|SET|INSERT|UNION|DISTINCT|WITH|WHERE|BEING|OR'
              r'|AND|NOT|GROUPBY|HAVING|ORDERBY|ASC|DESC|LIMIT|OFFSET'
              r'|TODAY|NOW|TRUE|FALSE|NULL|EXISTS)\b', Keyword),

--- a/tests/examplefiles/postgresql/postgresql_test.txt.output
+++ b/tests/examplefiles/postgresql/postgresql_test.txt.output
@@ -1,75 +1,75 @@
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'OR'          Keyword
-' '           Text
+' '           Text.Whitespace
 'REPLACE'     Keyword
-' '           Text
+' '           Text.Whitespace
 'FUNCTION'    Keyword
-' '           Text
+' '           Text.Whitespace
 'something'   Name
 '('           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'RETURNS'     Keyword
-' '           Text
+' '           Text.Whitespace
 'int4'        Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 'x'           Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'BEGIN'       Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'RETURN'      Keyword
-' '           Text
+' '           Text.Whitespace
 '42'          Literal.Number.Float
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'END'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 'x'           Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'LANGUAGE'    Keyword
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 'plpgsql'     Literal.String.Single
 "'"           Literal.String.Single
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'FUNCTION'    Keyword
-' '           Text
+' '           Text.Whitespace
 'pymax'       Name
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'a'           Name
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'b'           Name
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
 ')'           Punctuation
-'\n  '        Text
+'\n  '        Text.Whitespace
 'RETURNS'     Keyword
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
-'\n'          Text
+'\n'          Text.Whitespace
 
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
@@ -101,45 +101,45 @@
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
-' '           Text
+' '           Text.Whitespace
 'language'    Keyword
-' '           Text
+' '           Text.Whitespace
 'plpythonu'   Name
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'FUNCTION'    Keyword
-' '           Text
+' '           Text.Whitespace
 'nested_lexers' Name
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'a'           Name
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'b'           Name
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 'function'    Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'BEGIN'       Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 '$1'          Name.Variable
-' '           Text
+' '           Text.Whitespace
 '~'           Operator
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 'q'           Literal.String.Delimiter
 '$'           Literal.String
@@ -149,162 +149,162 @@
 '$'           Literal.String
 ')'           Punctuation
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'END'         Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 'function'    Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'LANGUAGE'    Keyword
-' '           Text
+' '           Text.Whitespace
 'sql'         Keyword
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'OR'          Keyword
-' '           Text
+' '           Text.Whitespace
 'REPLACE'     Keyword
-' '           Text
+' '           Text.Whitespace
 'FUNCTION'    Keyword
-' '           Text
+' '           Text.Whitespace
 'measurement_insert_trigger' Name
 '('           Punctuation
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'RETURNS'     Keyword
-' '           Text
+' '           Text.Whitespace
 'TRIGGER'     Keyword
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'BEGIN'       Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 '<<test>>'    Name.Label
-'\n    '      Text
+'\n    '      Text.Whitespace
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'INTO'        Keyword
-' '           Text
+' '           Text.Whitespace
 'measurement_y2008m01' Name
-' '           Text
+' '           Text.Whitespace
 'VALUES'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'NEW'         Keyword
 '.'           Literal.Number.Float
 '*'           Operator
 ')'           Punctuation
 ';'           Punctuation
-'\n    '      Text
+'\n    '      Text.Whitespace
 'RETURN'      Keyword
-' '           Text
+' '           Text.Whitespace
 'NULL'        Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'END'         Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'LANGUAGE'    Keyword
-' '           Text
+' '           Text.Whitespace
 'plpgsql'     Name
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-- As returned by pg_dump\n' Comment.Single
 
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'FUNCTION'    Keyword
-' '           Text
+' '           Text.Whitespace
 'test_function' Name
 '('           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'RETURNS'     Keyword
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
-'\n    '      Text
+'\n    '      Text.Whitespace
 'LANGUAGE'    Keyword
-' '           Text
+' '           Text.Whitespace
 'plpgsql'     Name
-' '           Text
+' '           Text.Whitespace
 'STABLE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'STRICT'      Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 'begin'       Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'return'      Keyword
-' '           Text
+' '           Text.Whitespace
 '42'          Literal.Number.Float
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-- Unicode names and strings\n' Comment.Single
 
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'U&'          Literal.String.Affix
 "'"           Literal.String.Single
 '\\0441\\043B\\043E\\043D' Literal.String.Single
 "'"           Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'FROM'        Keyword
-' '           Text
+' '           Text.Whitespace
 'U&'          Literal.String.Affix
 '"'           Literal.String.Name
 '\\0441\\043B\\043E\\043D' Literal.String.Name
 '"'           Literal.String.Name
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-- Escapes\n' Comment.Single
 
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Literal.String.Affix
 "'"           Literal.String.Single
 '1\\n2\\n3'   Literal.String.Single
 "'"           Literal.String.Single
 ';'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-- DO example from postgresql documentation\n' Comment.Single
 
@@ -351,110 +351,110 @@
 '*'           Comment.Multiline
 ' SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.\n ' Comment.Multiline
 '*/'          Comment.Multiline
-'\n'          Text
+'\n'          Text.Whitespace
 
 'DO'          Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
 'DECLARE'     Keyword
-' '           Text
+' '           Text.Whitespace
 'r'           Name
-' '           Text
+' '           Text.Whitespace
 'record'      Name.Builtin
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'BEGIN'       Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'FOR'         Keyword
-' '           Text
+' '           Text.Whitespace
 'r'           Name
-' '           Text
+' '           Text.Whitespace
 'IN'          Keyword
-' '           Text
+' '           Text.Whitespace
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'table_schema' Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'table_name'  Name
-' '           Text
+' '           Text.Whitespace
 'FROM'        Keyword
-' '           Text
+' '           Text.Whitespace
 'information_schema' Name
 '.'           Literal.Number.Float
 'tables'      Keyword
-'\n             ' Text
+'\n             ' Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'table_type'  Name
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 'VIEW'        Literal.String.Single
 "'"           Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 'AND'         Keyword
-' '           Text
+' '           Text.Whitespace
 'table_schema' Name
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 'public'      Literal.String.Single
 "'"           Literal.String.Single
-'\n    '      Text
+'\n    '      Text.Whitespace
 'LOOP'        Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'EXECUTE'     Keyword
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 'GRANT ALL ON ' Literal.String.Single
 "'"           Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 '||'          Operator
-' '           Text
+' '           Text.Whitespace
 'quote_ident' Name
 '('           Punctuation
 'r'           Name
 '.'           Literal.Number.Float
 'table_schema' Name
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '||'          Operator
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '.'           Literal.String.Single
 "'"           Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 '||'          Operator
-' '           Text
+' '           Text.Whitespace
 'quote_ident' Name
 '('           Punctuation
 'r'           Name
 '.'           Literal.Number.Float
 'table_name'  Name
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '||'          Operator
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 ' TO webuser' Literal.String.Single
 "'"           Literal.String.Single
 ';'           Punctuation
-'\n    '      Text
+'\n    '      Text.Whitespace
 'END'         Keyword
-' '           Text
+' '           Text.Whitespace
 'LOOP'        Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'END'         Keyword
 '$'           Literal.String
 ''            Literal.String.Delimiter
 '$'           Literal.String
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/examplefiles/psql/psql_session.txt.output
+++ b/tests/examplefiles/psql/psql_session.txt.output
@@ -1,10 +1,10 @@
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 'foo'         Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'ERROR:'      Generic.Strong
 '  column "foo" does not exist\n' Generic.Error
@@ -18,18 +18,18 @@
 '               ^\n' Generic.Error
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '\\q'         Keyword.Pseudo
 '\n'          Text
 
 '\n'          Generic.Output
 
 'peter@localhost testdb=>' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '\\a'         Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 '\\t'         Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 '\\x'         Keyword.Pseudo
 '\n'          Text
 
@@ -42,14 +42,14 @@
 '\n'          Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '\\x'         Literal.String.Single
 "'"           Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'WARNING:'    Generic.Strong
 '  nonstandard use of escape in a string literal\n' Generic.Output
@@ -73,46 +73,46 @@
 '\n'          Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Literal.String.Affix
 "'"           Literal.String.Single
 '\\x'         Literal.String.Single
 "'"           Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Generic.Output
 
 'piro=>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '\\set'       Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'foo'         Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 '30;'         Literal.String.Symbol
 '\n'          Text
 
 'piro=>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '*'           Operator
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'foo'         Name
-' '           Text
+' '           Text.Whitespace
 '<='          Operator
-' '           Text
+' '           Text.Whitespace
 ':foo'        Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' foo | bar \n' Generic.Output
 
@@ -127,68 +127,68 @@
 '\n'          Generic.Output
 
 'testdb=>'    Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '\\set'       Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'foo'         Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 "'my_table'"  Literal.String.Single
 '\n'          Text
 
 'testdb=>'    Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 '*'           Operator
-' '           Text
+' '           Text.Whitespace
 'FROM'        Keyword
-' '           Text
+' '           Text.Whitespace
 ':"foo"'      Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Generic.Output
 
 'testdb=>'    Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '\\set'       Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'content'     Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 '`cat my_file.txt`' Literal.String.Backtick
 '\n'          Text
 
 'testdb=>'    Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'INTO'        Keyword
-' '           Text
+' '           Text.Whitespace
 'my_table'    Name
-' '           Text
+' '           Text.Whitespace
 'VALUES'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 ":'content'"  Name.Variable
 ')'           Punctuation
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'regression(#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Float
 ')'           Punctuation
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' ?column? \n' Generic.Output
 
@@ -201,23 +201,23 @@
 '\n'          Generic.Output
 
 'piro=>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'piro(>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '\n'          Literal.String.Single
 
 "piro'>"      Generic.Prompt
 ' '           Literal.String.Single
 "'"           Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 '||'          Operator
-' '           Text
+' '           Text.Whitespace
 '$'           Literal.String
 '$'           Literal.String
 '\n'          Literal.String
@@ -227,12 +227,12 @@
 '$'           Literal.String
 '$'           Literal.String
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'piro->'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Name
 '\n'          Literal.String.Name
 
@@ -240,7 +240,7 @@
 ' foo'        Literal.String.Name
 '"'           Literal.String.Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'ERROR:'      Generic.Strong
 '  relation "\n' Generic.Error
@@ -255,37 +255,37 @@
 '\n'          Generic.Error
 
 'testdb=>'    Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'CREATE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'TABLE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'my_table'    Name
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'first'       Keyword
-' '           Text
+' '           Text.Whitespace
 'integer'     Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'null'        Keyword
-' '           Text
+' '           Text.Whitespace
 'default'     Keyword
-' '           Text
+' '           Text.Whitespace
 '0'           Literal.Number.Float
 ','           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'second'      Keyword
-' '           Text
+' '           Text.Whitespace
 'text'        Name.Builtin
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 ';'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '-- end of command\n' Comment.Single
 
 'CREATE TABLE\n' Generic.Output
@@ -295,60 +295,60 @@
 '-- Table output\n' Generic.Output
 
 '=#'          Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '0x10'        Literal.String.Single
 "'"           Literal.String.Single
 '::'          Operator
 'mpz'         Name
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Name
 'hex'         Literal.String.Name
 '"'           Literal.String.Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '10'          Literal.String.Single
 "'"           Literal.String.Single
 '::'          Operator
 'mpz'         Name
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Name
 'dec'         Literal.String.Name
 '"'           Literal.String.Name
 ','           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-#'          Generic.Prompt
-'        '    Text
+'        '    Text.Whitespace
 "'"           Literal.String.Single
 '010'         Literal.String.Single
 "'"           Literal.String.Single
 '::'          Operator
 'mpz'         Name
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 'oct'         Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '0b10'        Literal.String.Single
 "'"           Literal.String.Single
 '::'          Operator
 'mpz'         Name
-' '           Text
+' '           Text.Whitespace
 'AS'          Keyword
-' '           Text
+' '           Text.Whitespace
 'bin'         Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' hex | dec | oct | bin\n' Generic.Output
 
@@ -363,20 +363,20 @@
 '-- One field output\n' Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 'schemaname'  Name
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
-'  '          Text
+'  '          Text.Whitespace
 'pg_tables'   Name
-' '           Text
+' '           Text.Whitespace
 'limit'       Keyword
-' '           Text
+' '           Text.Whitespace
 '3'           Literal.Number.Float
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' schemaname \n' Generic.Output
 
@@ -395,11 +395,11 @@
 '-- TODO: prompt in multiline comments still not handled correctly\n' Generic.Output
 
 'test=>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Float
-' '           Text
+' '           Text.Whitespace
 '/*'          Comment.Multiline
 ' multiline\ntest' Comment.Multiline
 '*'           Comment.Multiline
@@ -412,10 +412,10 @@
 '> end comment ' Comment.Multiline
 '*/'          Comment.Multiline
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '2'           Literal.Number.Float
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' ?column? | ?column? \n' Generic.Output
 
@@ -426,18 +426,18 @@
 '\n'          Generic.Output
 
 '=#'          Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '10.0'        Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1e-6'        Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1E+6'        Literal.Number.Float
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' ?column? | ?column? | ?column? \n' Generic.Output
 
@@ -450,32 +450,32 @@
 '\n'          Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'begin'       Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'BEGIN\n'     Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'create'      Keyword
-' '           Text
+' '           Text.Whitespace
 'table'       Keyword
-' '           Text
+' '           Text.Whitespace
 'asdf'        Name
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'foo'         Name
-' '           Text
+' '           Text.Whitespace
 'serial'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'primary'     Keyword
-' '           Text
+' '           Text.Whitespace
 'key'         Keyword
 ')'           Punctuation
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'NOTICE:'     Generic.Strong
 '  CREATE TABLE will create implicit sequence "asdf_foo_seq" for serial column "asdf.foo"\n' Generic.Output
@@ -486,24 +486,24 @@
 'CREATE TABLE\n' Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
-' '           Text
+' '           Text.Whitespace
 'into'        Keyword
-' '           Text
+' '           Text.Whitespace
 'asdf'        Name
-' '           Text
+' '           Text.Whitespace
 'values'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 '10'          Literal.Number.Float
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'returning'   Keyword
-' '           Text
+' '           Text.Whitespace
 'foo'         Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 ' foo \n'     Generic.Output
 
@@ -518,40 +518,40 @@
 'INSERT 0 1\n' Generic.Output
 
 'regression=#' Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'ROLLBACK'    Keyword
-' '           Text
+' '           Text.Whitespace
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'ROLLBACK\n'  Generic.Output
 
 '\n'          Generic.Output
 
 '=>'          Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'EXPLAIN'     Keyword
-' '           Text
+' '           Text.Whitespace
 'SELECT'      Keyword
-' '           Text
+' '           Text.Whitespace
 '*'           Operator
-' '           Text
+' '           Text.Whitespace
 'FROM'        Keyword
-' '           Text
+' '           Text.Whitespace
 'tenk1'       Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 '->'          Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'unique1'     Name
-' '           Text
+' '           Text.Whitespace
 '<'           Operator
-' '           Text
+' '           Text.Whitespace
 '100'         Literal.Number.Float
 ';'           Punctuation
-'   '         Text
+'   '         Text.Whitespace
 "-- Don't take -> in the plan as a prompt\n" Comment.Single
 
 '\n'          Generic.Output
@@ -575,14 +575,14 @@
 "-- don't swallow the end of a malformed line\n" Generic.Output
 
 'test=>'      Generic.Prompt
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Float
 ','           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'"           Literal.String.Single
 'this line must be emitted' Literal.String.Single
 "'"           Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/examplefiles/rql/rql-queries.rql.output
+++ b/tests/examplefiles/rql/rql-queries.rql.output
@@ -1,314 +1,314 @@
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N2'          Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Note'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N2'          Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Note'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'a_faire_par' Name
-' '           Text
+' '           Text.Whitespace
 'P1'          Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P1'          Name
-' '           Text
+' '           Text.Whitespace
 'nom'         Name
-' '           Text
+' '           Text.Whitespace
 "'john'"      Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N2'          Name
-' '           Text
+' '           Text.Whitespace
 'a_faire_par' Name
-' '           Text
+' '           Text.Whitespace
 'P2'          Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P2'          Name
-' '           Text
+' '           Text.Whitespace
 'nom'         Name
-' '           Text
+' '           Text.Whitespace
 "'jane'"      Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'DISTINCT'    Keyword
-' '           Text
+' '           Text.Whitespace
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'DESC'        Keyword
-' '           Text
+' '           Text.Whitespace
 'LIMIT'       Keyword
-' '           Text
+' '           Text.Whitespace
 '40'          Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Note'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'diem'        Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Workcase'    Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'concerned_by' Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'cost'        Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'text'        Name
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'author'      Name
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'diem'        Name
-' '           Text
+' '           Text.Whitespace
 '<'           Operator
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'today'       Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Bookmark'    Name
-' '           Text
+' '           Text.Whitespace
 'B'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'B'           Name
-' '           Text
+' '           Text.Whitespace
 'owned_by'    Name
-' '           Text
+' '           Text.Whitespace
 'G'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'G'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '5'           Literal.Number.Integer
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '22762'       Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'NOT'         Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Name
-' '           Text
+' '           Text.Whitespace
 'is_in'       Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'modification_date' Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'DESC'        Keyword
-' '           Text
+' '           Text.Whitespace
 'LIMIT'       Keyword
-' '           Text
+' '           Text.Whitespace
 '41'          Literal.Number.Integer
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'R'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'SUB'         Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'R'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"Workcase"'  Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'S'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Division'    Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'S'           Name
-' '           Text
+' '           Text.Whitespace
 'concerned_by' Name
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'subject'     Name
-' '           Text
+' '           Text.Whitespace
 'SUB'         Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'S'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '85'          Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'ref'         Name
-' '           Text
+' '           Text.Whitespace
 'R'           Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'L'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Document'    Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'concerned_by' Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '14533'       Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'title'       Name
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'location'    Name
-' '           Text
+' '           Text.Whitespace
 'L'           Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
 'A'           Name
@@ -318,882 +318,882 @@
 'C'           Name
 ','           Punctuation
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'DESC'        Keyword
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Note'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'concerned_by' Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '14533'       Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'diem'        Name
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'author'      Name
-' '           Text
+' '           Text.Whitespace
 'B'           Name
 ','           Punctuation
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'text'        Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'cost'        Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'DESC'        Keyword
-' '           Text
+' '           Text.Whitespace
 'LIMIT'       Keyword
-' '           Text
+' '           Text.Whitespace
 '41'          Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '18134'       Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'NOT'         Keyword
-' '           Text
+' '           Text.Whitespace
 'E'           Name
-' '           Text
+' '           Text.Whitespace
 'concerned_by' Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'modification_date' Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'DISTINCT'    Keyword
-' '           Text
+' '           Text.Whitespace
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'ORDERBY'     Keyword
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'ASC'         Keyword
-' '           Text
+' '           Text.Whitespace
 'LIMIT'       Keyword
-' '           Text
+' '           Text.Whitespace
 '40'          Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Note'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'diem'        Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'to_be_contacted_by' Name
-' '           Text
+' '           Text.Whitespace
 'G'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'cost'        Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'text'        Name
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'author'      Name
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'G'           Name
-' '           Text
+' '           Text.Whitespace
 'login'       Name
-' '           Text
+' '           Text.Whitespace
 '"john"'      Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'surname'     Name
-' '           Text
+' '           Text.Whitespace
 '"Doe"'       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'firstname'   Name
-' '           Text
+' '           Text.Whitespace
 '"John"'      Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Workcase'    Name
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'ref'         Name
-' '           Text
+' '           Text.Whitespace
 '"ABCD12"'    Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Workcase'    Name
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'W'           Name
-' '           Text
+' '           Text.Whitespace
 'ref'         Name
-' '           Text
+' '           Text.Whitespace
 'LIKE'        Name
-' '           Text
+' '           Text.Whitespace
 '"AB%"'       Literal.String.Single
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '53'          Literal.Number.Integer
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'Document'    Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'occurence_of' Name
-' '           Text
+' '           Text.Whitespace
 'F'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'F'           Name
-' '           Text
+' '           Text.Whitespace
 'class'       Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'C'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'Comics'"    Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'owned_by'    Name
-' '           Text
+' '           Text.Whitespace
 'U'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'U'           Name
-' '           Text
+' '           Text.Whitespace
 'login'       Name
-' '           Text
+' '           Text.Whitespace
 "'syt'"       Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'available'   Name
-' '           Text
+' '           Text.Whitespace
 'true'        Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'work_for'    Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'S'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'Acme'"      Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'interested_by' Name
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'T'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'training'"  Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Note'        Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'written_on'  Name
-' '           Text
+' '           Text.Whitespace
 'D'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'D'           Name
-' '           Text
+' '           Text.Whitespace
 'day'         Name
 '>'           Operator
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'today'       Keyword
-' '           Text
+' '           Text.Whitespace
 '-'           Operator
 '10'          Literal.Number.Integer
 ')'           Punctuation
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'N'           Name
-' '           Text
+' '           Text.Whitespace
 'written_by'  Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'joe'"       Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'jack'"      Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'interested_by' Name
-' '           Text
+' '           Text.Whitespace
 'T'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'T'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'training'"  Literal.String.Single
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'city'        Name
-' '           Text
+' '           Text.Whitespace
 "'Paris'"     Literal.String.Single
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'first_name'  Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'String'      Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 'N'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'first_name'  Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'widget'"    Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'foo'"       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'nice'"      Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'friend'      Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'INSERT'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'foo'"       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'friend'      Name
-'  '          Text
+'  '          Text.Whitespace
 'Y'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'nice'"      Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'SET'         Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'bar'"       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'first_name'  Name
-' '           Text
+' '           Text.Whitespace
 "'original'"  Literal.String.Single
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'foo'"       Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'SET'         Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'know'        Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
-'  '          Text
+'  '          Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'friend'      Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'DELETE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'foo'"       Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'DELETE'      Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'friend'      Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Person'      Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'foo'"       Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 'LIKE'        Name
-' '           Text
+' '           Text.Whitespace
 "'%lt'"       Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 'IN'          Name
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'joe'"       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'jack'"      Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'william'"   Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 "'averell'"   Literal.String.Single
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'V'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'concerns'    Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'eid'         Name
-' '           Text
+' '           Text.Whitespace
 '42'          Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'corrected_in' Name
-' '           Text
+' '           Text.Whitespace
 'V?'          Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'C'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Card'        Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P?'          Name
-' '           Text
+' '           Text.Whitespace
 'documented_by' Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Point'       Name
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'abs'         Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'ord'         Name
-' '           Text
+' '           Text.Whitespace
 'Y'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'P'           Name
-' '           Text
+' '           Text.Whitespace
 'value'       Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
 '+'           Operator
 'Y'           Name
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Document'    Name
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'where'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'class'       Name
-' '           Text
+' '           Text.Whitespace
 'C'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'C'           Name
-' '           Text
+' '           Text.Whitespace
 'name'        Name
-' '           Text
+' '           Text.Whitespace
 "'Cartoon'"   Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'owned_by'    Name
-' '           Text
+' '           Text.Whitespace
 'U'           Name
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'U'           Name
-' '           Text
+' '           Text.Whitespace
 'login'       Name
-' '           Text
+' '           Text.Whitespace
 "'joe'"       Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'available'   Name
-' '           Text
+' '           Text.Whitespace
 'true'        Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '('           Punctuation
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Document'    Name
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'UNION'       Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'File'        Name
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'A'           Name
 ','           Punctuation
 'B'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'creation_date' Name
-' '           Text
+' '           Text.Whitespace
 'B'           Name
-' '           Text
+' '           Text.Whitespace
 'WITH'        Keyword
-' '           Text
+' '           Text.Whitespace
 'A'           Name
-' '           Text
+' '           Text.Whitespace
 'BEING'       Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Document'    Name
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'UNION'       Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'Any'         Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'WHERE'       Keyword
-' '           Text
+' '           Text.Whitespace
 'X'           Name
-' '           Text
+' '           Text.Whitespace
 'is'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'File'        Name
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/examplefiles/sqlite3/sqlite3.sqlite3-console.output
+++ b/tests/examplefiles/sqlite3/sqlite3.sqlite3-console.output
@@ -5,7 +5,7 @@
 'sqlite> '    Generic.Prompt
 '.'           Punctuation
 'schema'      Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'CREATE TABLE paste (paste_id integer, code text, parsed_code text, pub_date\n' Generic.Output
 
@@ -15,61 +15,61 @@
 
 'sqlite> '    Generic.Prompt
 'a'           Name
-' '           Text
+' '           Text.Whitespace
 "'\n"         Literal.String.Single
 
 '   ...> '    Generic.Prompt
 "'"           Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '   ...> '    Generic.Prompt
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'SQL error: near "a": syntax error\n' Generic.Traceback
 
 'sqlite> '    Generic.Prompt
 '%'           Operator
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'SQL error: near "%": syntax error\n' Generic.Traceback
 
 'sqlite> '    Generic.Prompt
 'select'      Keyword
-' '           Text
+' '           Text.Whitespace
 'count'       Keyword
 '('           Punctuation
 'language'    Keyword
 ')'           Punctuation
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'language'    Keyword
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
-' '           Text
+' '           Text.Whitespace
 'paste'       Name
-' '           Text
+' '           Text.Whitespace
 'group'       Keyword
-' '           Text
+' '           Text.Whitespace
 'by'          Keyword
-' '           Text
+' '           Text.Whitespace
 'language'    Keyword
-' '           Text
+' '           Text.Whitespace
 'order'       Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '   ...> '    Generic.Prompt
 'by'          Keyword
-' '           Text
+' '           Text.Whitespace
 'count'       Keyword
 '('           Punctuation
 'language'    Keyword
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'desc'        Keyword
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '144|python\n' Generic.Output
 
@@ -96,4 +96,4 @@
 '1|scheme\n'  Generic.Output
 
 'sqlite> '    Generic.Prompt
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -11,7 +11,7 @@ import pytest
 from pygments.lexers.sql import MySqlLexer
 
 from pygments.token import Comment, Keyword, Literal, Name, Number, Operator, \
-    Punctuation, String, Text
+    Punctuation, String, Whitespace
 
 
 @pytest.fixture(scope='module')
@@ -161,9 +161,9 @@ def test_optimizer_hints(lexer, text):
         ('SET', (Keyword,)),
         ('SET abc = 1;', (Keyword,)),
         ('SET @abc = 1;', (Keyword,)),
-        ('CHARACTER SET latin1', (Keyword, Text, Keyword)),
+        ('CHARACTER SET latin1', (Keyword, Whitespace, Keyword,)),
         ('SET("r", "g", "b")', (Keyword.Type, Punctuation)),
-        ('SET ("r", "g", "b")', (Keyword.Type, Text, Punctuation)),
+        ('SET ("r", "g", "b")', (Keyword.Type, Whitespace, Punctuation)),
     ),
 )
 def test_exceptions(lexer, text, expected_types):


### PR DESCRIPTION
This PR specifes whitespace-only matches with the respective Text.Whitespace token.
It is submitted in the context of #1905. The changes are minimal, and related test files have been adapted.

----

Anyhow, I noticed a possible inconsitency and would like a second opinion on how to deal with it.

While the following regex does not include the trailing white space, the sqlite prompt does.
https://github.com/pygments/pygments/blob/339ad2b31f5359dc0e554399a35a464ec839c62b/pygments/lexers/sql.py#L266
https://github.com/pygments/pygments/blob/339ad2b31f5359dc0e554399a35a464ec839c62b/pygments/lexers/sql.py#L786-L801

In this state there are Prompt Token lexed such as tests/examplefiles/psql/psql_session.txt.output line 27 (matched by the re_prompt regex) which are trailed by a Whitespace token. However, the `sqlite> ` prompt does include the trailing space in the token group (matched via the startswith expressions). The latter has an example in tests/examplefiles/sqlite3/sqlite3.sqlite3-console.output line 98 (at the end of the diff)