### PR TITLE
WIP - Test for Whitespace token - Don't merge yet

### DIFF
--- a/tests/test_trivial_whitespace.py
+++ b/tests/test_trivial_whitespace.py
@@ -1,0 +1,33 @@
+"""
+    Pygments whitespace test
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    This test checks whether a single whitespace is lexed with the
+    Whitespace token.
+
+    :copyright: Copyright 2006-2021 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+
+from pygments import lexers
+from pygments.token import Whitespace
+
+@pytest.mark.parametrize('cls', lexers._iter_lexerclasses(plugins=True))
+def test_trivial_whitespace_token(cls):
+    inst = cls()
+
+    try:
+        token = list(inst.get_tokens(' '))
+    except KeyboardInterrupt:
+        raise KeyboardInterrupt(
+            'interupted %s.get_tokens(): test_content=%r' %
+            (cls.__name__, test_content))
+
+    # idially, only one Token of type Whitespace occurs
+    # but for now allow the Newline to be a separate token, but of type Whitespace
+    for token_type, token_value in token:
+        assert token_type == Whitespace, "%s lexer trivial whitespace test failed: %s of value %r is not of type %s" %  \
+            (cls.name, token_type, token_value, Whitespace)
+


### PR DESCRIPTION
This included test might be a way to "enforce" the usage of the `Whitespace` token. The trivial case of a single whitespace is lexed by every lexer in `pygments.lexers.LEXER`. The way it is implemented now, allows either two tokens of type `Whitespace` for `' '` and `'\n'` or a single Token for `' \n'`of type `Whitespace`.  Having this test fully pass can be seen as the goal of #1905.

```bash
$ pytest tests/test_trivial_whitespace.py
[...]
============= 426 failed, 82 passed in 8.55s ========
```

There are so many fails right now. For this reason, I think it would be good to **not merge** this PR any time soon. 


Any opinion on this?

