### PR TITLE
Remove unnecessary assignments in Paraiso style

### DIFF
--- a/pygments/styles/paraiso_dark.py
+++ b/pygments/styles/paraiso_dark.py
@@ -38,9 +38,6 @@ class ParaisoDarkStyle(Style):
     background_color = BACKGROUND
     highlight_color = SELECTION
 
-    background_color = BACKGROUND
-    highlight_color = SELECTION
-
     styles = {
         # No corresponding class for the following:
         Text:                      FOREGROUND,  # class:  ''

--- a/pygments/styles/paraiso_light.py
+++ b/pygments/styles/paraiso_light.py
@@ -38,9 +38,6 @@ class ParaisoLightStyle(Style):
     background_color = BACKGROUND
     highlight_color = SELECTION
 
-    background_color = BACKGROUND
-    highlight_color = SELECTION
-
     styles = {
         # No corresponding class for the following:
         Text:                      FOREGROUND,  # class:  ''


### PR DESCRIPTION
Remove the duplicated assignments to `background_color` and `highlight_color` in both paraiso_light and paraiso_dark styles.