### PR TITLE
demo: Sort options in lexer select

### DIFF
--- a/doc/_static/demo.js
+++ b/doc/_static/demo.js
@@ -6,6 +6,7 @@ languagePluginLoader.then(() => {
         let qvars = getQueryVariables();
 
         var lexerlist = pyodide.runPython('list(pygments.lexers.get_all_lexers())');
+        lexerlist.sort((a,b) => a[1][0] < b[1][0] ? -1 : 1);
         var sel = document.getElementById("lang");
         for (lex of lexerlist) {
             if (lex[1][0] === undefined) {


### PR DESCRIPTION
Previously CSS+Django/Jinja, CSS+Ruby, and CSS+Genshi Text were all
before CSS because pygments.lexers.LEXERS contains the lexers ordered
alphabetically by their class name and CssDjangoLexer, CssErbLexer and
CssGenshiLexer come before CssLexer.

If users are however typing "CSS" while focusing the language select in
the demo, chances are that they actually want the base CSS lexer. The
same applies to HTML, JavaScript, XML, etc.