### PR TITLE
Improve CddlLexer performance

### DIFF
--- a/pygments/lexers/cddl.py
+++ b/pygments/lexers/cddl.py
@@ -104,7 +104,8 @@ class CddlLexer(RegexLexer):
 
     _re_id = (
         r"[$@A-Z_a-z]"
-        r"(?:[\-\.]*[$@0-9A-Z_a-z]|[$@0-9A-Z_a-z])*"
+        r"(?:[\-\.]+(?=[$@0-9A-Z_a-z])|[$@0-9A-Z_a-z])*"
+
     )
 
     # While the spec reads more like "an int must not start with 0" we use a
@@ -186,6 +187,6 @@ class CddlLexer(RegexLexer):
         "bstr": [
             (r"'", String.Single, "#pop"),
             (r"\\.", String.Escape),
-            (r"[^']", String.Single),
+            (r"[^'\\]+", String.Single),
         ],
     }

--- a/tests/examplefiles/cddl/example.cddl.output
+++ b/tests/examplefiles/cddl/example.cddl.output
@@ -2037,17 +2037,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Single
-'h'           Literal.String.Single
-'e'           Literal.String.Single
-'l'           Literal.String.Single
-'l'           Literal.String.Single
-'o'           Literal.String.Single
-' '           Literal.String.Single
-'w'           Literal.String.Single
-'o'           Literal.String.Single
-'r'           Literal.String.Single
-'l'           Literal.String.Single
-'d'           Literal.String.Single
+'hello world' Literal.String.Single
 "'"           Literal.String.Single
 ' '           Text.Whitespace
 '/'           Operator
@@ -2073,53 +2063,11 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Single
-'<'           Literal.String.Single
-'?'           Literal.String.Single
-'p'           Literal.String.Single
-'h'           Literal.String.Single
-'p'           Literal.String.Single
-' '           Literal.String.Single
-'p'           Literal.String.Single
-'r'           Literal.String.Single
-'i'           Literal.String.Single
-'n'           Literal.String.Single
-'t'           Literal.String.Single
-'('           Literal.String.Single
+'<?php print(' Literal.String.Single
 "\\'"         Literal.String.Escape
-'h'           Literal.String.Single
-'e'           Literal.String.Single
-'l'           Literal.String.Single
-'l'           Literal.String.Single
-'o'           Literal.String.Single
-' '           Literal.String.Single
-'w'           Literal.String.Single
-'o'           Literal.String.Single
-'r'           Literal.String.Single
-'l'           Literal.String.Single
-'d'           Literal.String.Single
+'hello world' Literal.String.Single
 "\\'"         Literal.String.Escape
-')'           Literal.String.Single
-';'           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-'/'           Literal.String.Single
-'/'           Literal.String.Single
-' '           Literal.String.Single
-'n'           Literal.String.Single
-'o'           Literal.String.Single
-' '           Literal.String.Single
-'c'           Literal.String.Single
-'o'           Literal.String.Single
-'m'           Literal.String.Single
-'m'           Literal.String.Single
-'e'           Literal.String.Single
-'n'           Literal.String.Single
-'t'           Literal.String.Single
-' '           Literal.String.Single
-'…'           Literal.String.Single
-' '           Literal.String.Single
-'?'           Literal.String.Single
-'>'           Literal.String.Single
+');  // no comment … ?>' Literal.String.Single
 "'"           Literal.String.Single
 '\n'          Text.Whitespace
 
@@ -2128,68 +2076,11 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Single
-'\n'          Literal.String.Single
-
-' '           Literal.String.Single
-' '           Literal.String.Single
-'<'           Literal.String.Single
-'?'           Literal.String.Single
-'p'           Literal.String.Single
-'h'           Literal.String.Single
-'p'           Literal.String.Single
-'\n'          Literal.String.Single
-
-' '           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-'p'           Literal.String.Single
-'r'           Literal.String.Single
-'i'           Literal.String.Single
-'n'           Literal.String.Single
-'t'           Literal.String.Single
-'('           Literal.String.Single
+'\n  <?php\n    print(' Literal.String.Single
 "\\'"         Literal.String.Escape
-'h'           Literal.String.Single
-'e'           Literal.String.Single
-'l'           Literal.String.Single
-'l'           Literal.String.Single
-'o'           Literal.String.Single
-' '           Literal.String.Single
-'w'           Literal.String.Single
-'o'           Literal.String.Single
-'r'           Literal.String.Single
-'l'           Literal.String.Single
-'d'           Literal.String.Single
+'hello world' Literal.String.Single
 "\\'"         Literal.String.Escape
-')'           Literal.String.Single
-';'           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-'/'           Literal.String.Single
-'/'           Literal.String.Single
-' '           Literal.String.Single
-'n'           Literal.String.Single
-'o'           Literal.String.Single
-' '           Literal.String.Single
-'c'           Literal.String.Single
-'o'           Literal.String.Single
-'m'           Literal.String.Single
-'m'           Literal.String.Single
-'e'           Literal.String.Single
-'n'           Literal.String.Single
-'t'           Literal.String.Single
-'\n'          Literal.String.Single
-
-' '           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-' '           Literal.String.Single
-'…'           Literal.String.Single
-' '           Literal.String.Single
-'?'           Literal.String.Single
-'>'           Literal.String.Single
-'\n'          Literal.String.Single
+');  // no comment\n    … ?>\n' Literal.String.Single
 
 "'"           Literal.String.Single
 '\n'          Text.Whitespace


### PR DESCRIPTION
The `CddlLexer` always seemed incredibly slow for the tiny provided example file. Profiling showed that the re engine took most of the time. After some testing the `_re_id` expression proved to be the culprit.

An other minor change improved grouping of the `String.Single` Token. That's the only reason the examplefile output needs an update.

---- 

If you want, I can remove the modification for the `String.Single` token to only keep the important change to the `_re_id` expression