### PR TITLE
Whoops... (another LilyPond fix)

### DIFF
--- a/pygments/styles/__init__.py
+++ b/pygments/styles/__init__.py
@@ -56,7 +56,7 @@ STYLE_MAP = {
     'gruvbox-light': 'gruvbox::GruvboxLightStyle',
     'dracula': 'dracula::DraculaStyle',
     'one-dark': 'onedark::OneDarkStyle',
-    'lilypond' : 'lilypond::LilypondStyle',
+    'lilypond' : 'lilypond::LilyPondStyle',
 }
 
 

--- a/pygments/styles/lilypond.py
+++ b/pygments/styles/lilypond.py
@@ -11,7 +11,7 @@
 from pygments.style import Style
 from pygments.token import Token
 
-class LilypondStyle(Style):
+class LilyPondStyle(Style):
     """
     Style for the LilyPond language.
         


### PR DESCRIPTION
Sorry, me again. This renames LilypondStyle to LilyPondStyle. It was silly from mine to call it LilypondStyle (lowercase 'p')
whereas the lexer is called LilyPondLexer (uppercase 'P').

CC @anteru