### PR TITLE
Add links to lines with css-line numbers

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -765,7 +765,8 @@ class HtmlFormatter(Formatter):
         for t, line in inner:
             if t:
                 i += 1
-                yield 1, '<a id="%s-%d" name="%s-%d"></a>' % (s, i, s, i) + line
+                href = "" if self.linenos  else ' href="%s-%d"' % (s, i)
+                yield 1, '<a id="%s-%d" name="%s-%d"%s></a>' % (s, i, s, i, href) + line
             else:
                 yield 0, line
 


### PR DESCRIPTION
I wanted to link to the lines, and was disappointed that I could not click on the numbers.

Only later I realised, I could by hand create the links. This patch allows to have links, and thus makes the references easily discoverable.

Resolves https://github.com/Fortran-FOSS-Programmers/ford/issues/369