### PR TITLE
Refine the One Dark theme a bit for consistency with other popular projects (Atom, Vim, Alacritty, etc) using the same theme

### DIFF
--- a/pygments/styles/onedark.py
+++ b/pygments/styles/onedark.py
@@ -12,14 +12,14 @@
 """
 
 from pygments.style import Style
-from pygments.token import Token, Punctuation, Keyword, Name, Comment, String, \
-     Number, Operator, Generic, Whitespace
+from pygments.token import (Comment, Generic, Keyword, Name, Number, Operator,
+                            Punctuation, String, Token, Whitespace)
 
 
 class OneDarkStyle(Style):
     """
     Theme inspired by One Dark Pro for Atom
-    
+
     .. versionadded:: 2.11
     """
 
@@ -31,29 +31,29 @@ class OneDarkStyle(Style):
         Punctuation:            '#ABB2BF',
         Punctuation.Marker:     '#ABB2BF',
 
-        Keyword:                '#D55FDE',
+        Keyword:                '#C678DD',
         Keyword.Constant:       '#E5C07B',
-        Keyword.Declaration:    '#D55FDE',
-        Keyword.Namespace:      '#D55FDE',
-        Keyword.Reserved:       '#D55FDE',
+        Keyword.Declaration:    '#C678DD',
+        Keyword.Namespace:      '#C678DD',
+        Keyword.Reserved:       '#C678DD',
         Keyword.Type:           '#E5C07B',
 
-        Name:                   '#EF596F',
-        Name.Attribute:         '#EF596F',
+        Name:                   '#E06C75',
+        Name.Attribute:         '#E06C75',
         Name.Builtin:           '#E5C07B',
         Name.Class:             '#E5C07B',
         Name.Function:          'bold #61AFEF',
-        Name.Function.Magic:    'bold #2BBAC5',
-        Name.Other:             '#EF596F',
-        Name.Tag:               '#EF596F',
+        Name.Function.Magic:    'bold #56B6C2',
+        Name.Other:             '#E06C75',
+        Name.Tag:               '#E06C75',
         Name.Decorator:         '#61AFEF',
         Name.Variable.Class:    '',
-        
-        String:                 '#89CA78',
+
+        String:                 '#98C379',
 
         Number:                 '#D19A66',
 
-        Operator:               '#2BBAC5',
+        Operator:               'bold #56B6C2',
 
         Comment:                '#7F848E'
     }

--- a/pygments/styles/onedark.py
+++ b/pygments/styles/onedark.py
@@ -53,7 +53,7 @@ class OneDarkStyle(Style):
 
         Number:                 '#D19A66',
 
-        Operator:               'bold #56B6C2',
+        Operator:               '#56B6C2',
 
         Comment:                '#7F848E'
     }


### PR DESCRIPTION
@Anteru As per my comment in https://github.com/pygments/pygments/pull/1924#issuecomment-985987042. Just want to emphasize that the exact values are more reliable metric than the "contrast" thing since the latter is kinda subjective. Other users that don't like the contrast of One Dark could just use the other themes. But for fans of One Dark, I think they will value consistency.

Actually, it's not much different. Here's the current Pygment's version (just ignore the IPython prompt's/left side color which are custom, non-One Dark color):

<img width="446" alt="Color - One Dark - With Custom Prompt Color and Characters__" src="https://user-images.githubusercontent.com/4292088/144704292-8a5b888a-91a9-48d9-9a7f-1b5622507a06.png">

and here's the expected version:

<img width="449" alt="Color - One Dark - With Custom Prompt Color and Characters" src="https://user-images.githubusercontent.com/4292088/144704314-c1f8b39f-5748-4f79-a1fe-8b1c3ff70d56.png">

Non-fans will not notice the subtle difference. And I noticed only since I'm using Alacritty with One Dark theme also (i.e. there are 2 flavors of "orange" color in the first photo above). Thanks :)

