### PR TITLE
Improve objdump-nasm lexer

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -775,7 +775,8 @@ class NasmLexer(RegexLexer):
         'whitespace': [
             (r'\n', Whitespace),
             (r'[ \t]+', Whitespace),
-            (r';.*', Comment.Single)
+            (r';.*', Comment.Single),
+            (r'#.*', Comment.Single)
         ],
         'punctuation': [
             (r'[,():\[\]]+', Punctuation),

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -132,6 +132,10 @@ def _objdump_lexer_tokens(asm_lexer):
             ('( *)('+hex_re+r'+:)(\t)((?:'+hex_re+hex_re+' )+)( *\t)([a-zA-Z].*?)$',
                 bygroups(Whitespace, Name.Label, Whitespace, Number.Hex, Whitespace,
                          using(asm_lexer))),
+            # Code line without raw instructions (objdump --no-show-raw-insn)
+            ('( *)('+hex_re+r'+:)( *\t)([a-zA-Z].*?)$',
+                bygroups(Whitespace, Name.Label, Whitespace,
+                         using(asm_lexer))),
             # Code line with ascii
             ('( *)('+hex_re+r'+:)(\t)((?:'+hex_re+hex_re+' )+)( *)(.*?)$',
                 bygroups(Whitespace, Name.Label, Whitespace, Number.Hex, Whitespace, String)),


### PR DESCRIPTION
This improves the objdump-nasm lexer in the following two ways : 

- output from objdump --no-show-raw-insn is now pretty-printed
- comments starting with # are now also correctly interpreted

Take for example the following output from objdump : 
```sh
$ cat foo.dump 

foo.o:     file format elf64-x86-64


Disassembly of section .text:

0000000000000000 <foo>:
   0:	endbr64 
   4:	push   rbp
   5:	mov    rbp,rsp
   8:	sub    rsp,0x10
   c:	mov    DWORD PTR [rbp-0x4],edi
   f:	lea    rdi,[rip+0x0]        # 16 <foo+0x16>
  16:	call   1b <foo+0x1b>
  1b:	mov    eax,0x0
  20:	leave  
  21:	ret    
```
Running

```
pygmentize -l objdump-nasm -f html -O full -o /tmp/test.html /tmp/foo.dump 
```
with the original version of pygments results in the following unsatisfactory listing : 
![scr1](https://user-images.githubusercontent.com/2515989/144942018-f318b910-11d8-4082-883c-83e8b8673b26.png)

With these changes applied, the result is instead : 

![scr2](https://user-images.githubusercontent.com/2515989/144942197-86d97f5b-b3cf-41aa-9fd4-50f696175294.png)

