### PR TITLE
Add missing keywords (Vernacular commands and tactics) for the Coq lexer

### DIFF
--- a/pygments/lexers/theorem.py
+++ b/pygments/lexers/theorem.py
@@ -34,16 +34,16 @@ class CoqLexer(RegexLexer):
     keywords1 = (
         # Vernacular commands
         'Section', 'Module', 'End', 'Require', 'Import', 'Export', 'Variable',
-        'Variables', 'Parameter', 'Parameters', 'Axiom', 'Hypothesis',
+        'Variables', 'Parameter', 'Parameters', 'Axiom', 'Axioms', 'Hypothesis',
         'Hypotheses', 'Notation', 'Local', 'Tactic', 'Reserved', 'Scope',
-        'Open', 'Close', 'Bind', 'Delimit', 'Definition', 'Let', 'Ltac',
-        'Fixpoint', 'CoFixpoint', 'Morphism', 'Relation', 'Implicit',
-        'Arguments', 'Set', 'Unset', 'Contextual', 'Strict', 'Prenex',
+        'Open', 'Close', 'Bind', 'Delimit', 'Definition', 'Example', 'Let',
+        'Ltac', 'Fixpoint', 'CoFixpoint', 'Morphism', 'Relation', 'Implicit',
+        'Arguments', 'Types', 'Set', 'Unset', 'Contextual', 'Strict', 'Prenex',
         'Implicits', 'Inductive', 'CoInductive', 'Record', 'Structure',
-        'Canonical', 'Coercion', 'Theorem', 'Lemma', 'Corollary',
-        'Proposition', 'Fact', 'Remark', 'Example', 'Proof', 'Goal', 'Save',
-        'Qed', 'Defined', 'Hint', 'Resolve', 'Rewrite', 'View', 'Search',
-        'Abort', 'Admitted',
+        'Variant', 'Canonical', 'Coercion', 'Theorem', 'Lemma', 'Fact',
+        'Remark', 'Corollary', 'Proposition', 'Property', 'Goal',
+        'Proof', 'Restart', 'Save', 'Qed', 'Defined', 'Abort', 'Admitted',
+        'Hint', 'Resolve', 'Rewrite', 'View', 'Search',
         'Show', 'Print', 'Printing', 'All', 'Graph', 'Projections', 'inside',
         'outside', 'Check', 'Global', 'Instance', 'Class', 'Existing',
         'Universe', 'Polymorphic', 'Monomorphic', 'Context'
@@ -74,7 +74,8 @@ class CoqLexer(RegexLexer):
     )
     keywords5 = (
         # Terminators
-        'by', 'done', 'exact', 'reflexivity', 'tauto', 'romega', 'omega',
+        'by', 'now', 'done', 'exact', 'reflexivity',
+        'tauto', 'romega', 'omega', 'lia', 'nia', 'lra', 'nra', 'psatz',
         'assumption', 'solve', 'contradiction', 'discriminate',
         'congruence',
     )


### PR DESCRIPTION
Here are the relevant parts of the reference manual:
- [`Axioms`](https://coq.github.io/doc/v8.14/refman/language/core/assumptions.html#coq:cmd.Axioms)
- [`Implicit Types`](https://coq.github.io/doc/v8.14/refman/language/extensions/implicit-arguments.html#coq:cmd.Implicit-Types)
- [`Variant`](https://coq.github.io/doc/v8.14/refman/language/core/variants.html#coq:cmd.Variant)
- [`Property`](https://coq.github.io/doc/v8.14/refman/language/core/definitions.html#coq:cmd.Property)
- [`Restart`](https://coq.github.io/doc/v8.14/refman/proofs/writing-proofs/proof-mode.html#coq:cmd.Restart)
- [`now`](https://coq.github.io/doc/v8.14/refman/proofs/automatic-tactics/auto.html#coq:tacn.now)
- [`lia`, `nia`, `lra`, `nra`, and `psatz`](https://coq.github.io/doc/v8.14/refman/addendum/micromega.html#short-description-of-the-tactics)

I also reordered `keywords1` to get a better grouping of keywords.