### PR TITLE
Python: lex soft keywords

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -9,9 +9,10 @@
 """
 
 import re
+import keyword
 
 from pygments.lexer import Lexer, RegexLexer, include, bygroups, using, \
-    default, words, combined, do_insertions
+    default, words, combined, do_insertions, this
 from pygments.util import get_bool_opt, shebang_matches
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Number, Punctuation, Generic, Other, Error
@@ -110,6 +111,7 @@ class PythonLexer(RegexLexer):
             (r'\\\n', Text),
             (r'\\', Text),
             include('keywords'),
+            include('soft-keywords'),
             (r'(def)((?:\s|\\\s)+)', bygroups(Keyword, Text), 'funcname'),
             (r'(class)((?:\s|\\\s)+)', bygroups(Keyword, Text), 'classname'),
             (r'(from)((?:\s|\\\s)+)', bygroups(Keyword.Namespace, Text),
@@ -206,6 +208,20 @@ class PythonLexer(RegexLexer):
                 'yield from', 'as', 'with'), suffix=r'\b'),
              Keyword),
             (words(('True', 'False', 'None'), suffix=r'\b'), Keyword.Constant),
+        ],
+        'soft-keywords': [
+            # `match`, `case` and `_` soft keywords
+            (r'(^[ \t]*)'              # at beginning of line + possible indentation
+             r'(match|case)\b'         # a possible keyword
+             r'(?![ \t]*(?:'           # not followed by...
+             r'[:,;=^&|@~)\]}]|(?:' +  # characters and keywords that mean this isn't 
+             r'|'.join(keyword.kwlist) + r')\b))',                 # pattern matching
+             bygroups(Text, Keyword), 'soft-keywords-inner'),
+        ],
+        'soft-keywords-inner': [
+            # optional `_` keyword
+            (r'(\s+)([^\n_]*)(_\b)', bygroups(Text, using(this), Keyword)),
+            default('#pop')
         ],
         'builtins': [
             (words((

--- a/tests/examplefiles/python/switch_case.txt
+++ b/tests/examplefiles/python/switch_case.txt
@@ -1,0 +1,23 @@
+match command.split():
+    case ['to', direction] if direction in destination.route:
+        return 1
+    case 'foo' | 'bar':
+        return 2
+    case 'raz' as name:
+        return 3
+    case ['to', _]:
+        return 4
+    case else_bar:
+        return 5
+    case _:
+        return 6
+
+match command.split():
+    case _Direction():
+        return 1
+    case _ as default:
+        return 2
+
+case = 1
+match = 1
+match if True else bar

--- a/tests/examplefiles/python/switch_case.txt.output
+++ b/tests/examplefiles/python/switch_case.txt.output
@@ -1,0 +1,196 @@
+'match'       Keyword
+' '           Text
+'command'     Name
+'.'           Operator
+'split'       Name
+'('           Punctuation
+')'           Punctuation
+':'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'['           Punctuation
+"'"           Literal.String.Single
+'to'          Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+'direction'   Name
+']'           Punctuation
+' '           Text
+'if'          Keyword
+' '           Text
+'direction'   Name
+' '           Text
+'in'          Operator.Word
+' '           Text
+'destination' Name
+'.'           Operator
+'route'       Name
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+"'"           Literal.String.Single
+'foo'         Literal.String.Single
+"'"           Literal.String.Single
+' '           Text
+'|'           Operator
+' '           Text
+"'"           Literal.String.Single
+'bar'         Literal.String.Single
+"'"           Literal.String.Single
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'2'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+"'"           Literal.String.Single
+'raz'         Literal.String.Single
+"'"           Literal.String.Single
+' '           Text
+'as'          Keyword
+' '           Text
+'name'        Name
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'3'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'['           Punctuation
+"'"           Literal.String.Single
+'to'          Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+'_'           Keyword
+']'           Punctuation
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'4'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'else_bar'    Name
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'5'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'_'           Keyword
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'6'           Literal.Number.Integer
+'\n'          Text
+
+'\n'          Text
+
+'match'       Keyword
+' '           Text
+'command'     Name
+'.'           Operator
+'split'       Name
+'('           Punctuation
+')'           Punctuation
+':'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'_Direction'  Name
+'('           Punctuation
+')'           Punctuation
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'_'           Keyword
+' '           Text
+'as'          Keyword
+' '           Text
+'default'     Name
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'return'      Keyword
+' '           Text
+'2'           Literal.Number.Integer
+'\n'          Text
+
+'\n'          Text
+
+'case'        Name
+' '           Text
+'='           Operator
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text
+
+'match'       Name
+' '           Text
+'='           Operator
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text
+
+'match'       Name
+' '           Text
+'if'          Keyword
+' '           Text
+'True'        Keyword.Constant
+' '           Text
+'else'        Keyword
+' '           Text
+'bar'         Name
+'\n'          Text


### PR DESCRIPTION
Some notes:

- This approach is very similar to what @taleinat did in python/cpython#25851 (thank you! this was a huge help).
  It is not perfect, but it's rather simple and I can't think of an edge case.

- I did not use the `words` function to create the regex matching the
  keywords list, because it returns a capturing group (`()`) and it
  needs to be non-capturing here (because of `bygroups` usage).

- I chose to go to the 'soft-keywords-inner' state after both
  `match` and `case`, even though it's unnecessary for `match`
  (the inner state catches the `_` wildcard keyword which appears
  only after a `case`).

  This is mostly harmless and saves us from writing the 'soft-keywords'
  regex twice each for `match` and `case` with the extra inner state
  just for `case`.

  The only piece of code this will lex incorrectly is `match _:`
  (`_` will be lexed as keyword). I doubt though that pattern matching
  will be used like this.

Fixes #1797.