### PR TITLE
Update for new Python traceback locations

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -739,7 +739,7 @@ class PythonTracebackLexer(RegexLexer):
             # Either `PEP 657 <https://www.python.org/dev/peps/pep-0657/>`
             # error locations in Python 3.11+, or single-caret markers
             # for syntax errors before that.
-            (r'^( {4,})(\^+)(\n)',
+            (r'^( {4,})([~^]+)(\n)',
              bygroups(Text, Punctuation.Marker, Text),
              '#pop'),
             default('#pop'),

--- a/tests/examplefiles/pytb/error_locations.pytb
+++ b/tests/examplefiles/pytb/error_locations.pytb
@@ -13,5 +13,5 @@ Traceback (most recent call last):
            ^^^^^^^^^^^^^^^
   File "/home/tb.py", line 11, in in_tracebacks
     return 1/0
-           ^^^
+           ~^~
 ZeroDivisionError: division by zero

--- a/tests/examplefiles/pytb/error_locations.pytb.output
+++ b/tests/examplefiles/pytb/error_locations.pytb.output
@@ -99,7 +99,7 @@
 '\n'          Text
 
 '           ' Text
-'^^^'         Punctuation.Marker
+'~^~'         Punctuation.Marker
 '\n'          Text
 
 'ZeroDivisionError' Generic.Error


### PR DESCRIPTION
Since https://github.com/python/cpython/pull/27037, they can include
tildes in addition to the carets.