### PR TITLE
Better `Lexer.analyse_text`

### DIFF
--- a/pygments/lexer.py
+++ b/pygments/lexer.py
@@ -42,6 +42,8 @@ class LexerMeta(type):
     def __new__(mcs, name, bases, d):
         if 'analyse_text' in d:
             d['analyse_text'] = make_analysator(d['analyse_text'])
+        if 'recognize_text' in d:
+            d['recognize_text'] = staticmethod(d['recognize_text'])
         return type.__new__(mcs, name, bases, d)
 
 

--- a/pygments/lexers/algebra.py
+++ b/pygments/lexers/algebra.py
@@ -67,24 +67,18 @@ class GAPLexer(RegexLexer):
         ],
     }
 
-    def analyse_text(text):
-        score = 0.0
-
+    def recognize_text(text):
         # Declaration part
-        if re.search(
+        yield re.search(
             r"(InstallTrueMethod|Declare(Attribute|Category|Filter|Operation" +
             r"|GlobalFunction|Synonym|SynonymAttr|Property))", text
-        ):
-            score += 0.7
+        ), 0.5
 
         # Implementation part
-        if re.search(
+        yield re.search(
             r"(DeclareRepresentation|Install(GlobalFunction|Method|" +
             r"ImmediateMethod|OtherMethod)|New(Family|Type)|Objectify)", text
-        ):
-            score += 0.7
-
-        return min(score, 1.0)
+        ), 0.5
 
 
 class MathematicaLexer(RegexLexer):

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -270,11 +270,9 @@ class CLexer(CFamilyLexer):
         ]
     }
 
-    def analyse_text(text):
-        if re.search(r'^\s*#include [<"]', text, re.MULTILINE):
-            return 0.1
-        if re.search(r'^\s*#ifn?def ', text, re.MULTILINE):
-            return 0.1
+    def recognize_text(text):
+        yield re.search(r'^\s*#include [<"]', text, re.MULTILINE), 0.1
+        yield re.search(r'^\s*#ifn?def ', text, re.MULTILINE), 0.1
 
 
 class CppLexer(CFamilyLexer):

--- a/pygments/lexers/html.py
+++ b/pygments/lexers/html.py
@@ -228,9 +228,8 @@ class XmlLexer(RegexLexer):
         ],
     }
 
-    def analyse_text(text):
-        if looks_like_xml(text):
-            return 0.45  # less than HTML
+    def recognize_text(text):
+        yield looks_like_xml(text), 0.45 # less than HTML
 
 
 class XsltLexer(XmlLexer):

--- a/pygments/util.py
+++ b/pygments/util.py
@@ -188,16 +188,17 @@ _looks_like_xml_cache = {}
 
 def looks_like_xml(text):
     """Check if a doctype exists or if we have some tags."""
-    if xml_decl_re.match(text):
-        return True
+    m = xml_decl_re.match(text)
+    if m:
+        return m
     key = hash(text)
     try:
         return _looks_like_xml_cache[key]
     except KeyError:
         m = doctype_lookup_re.search(text)
         if m is not None:
-            return True
-        rv = tag_re.search(text[:1000]) is not None
+            return m
+        rv = tag_re.search(text[:1000])
         _looks_like_xml_cache[key] = rv
         return rv
 

--- a/tests/test_guess.py
+++ b/tests/test_guess.py
@@ -21,6 +21,13 @@ def get_input(lexer, filename):
     return Path(TESTDIR, 'examplefiles', lexer, filename).read_text(encoding='utf-8')
 
 
+def test_guess():
+    lx = guess_lexer('<test>\n#include <stdio.h>;\n</test>')
+    assert lx.__class__.__name__ == 'XmlLexer'
+    lx = guess_lexer('#include <stdio.h>; char *str = "<test></test>";')
+    assert lx.__class__.__name__ == 'CLexer'
+
+
 @pytest.mark.skip(reason="This is identified as T-SQL")
 def test_guess_lexer_fsharp():
     lx = guess_lexer(get_input('fsharp', 'Deflate.fs'))


### PR DESCRIPTION
While playing with the [new demo](https://pygments.org/demo/) I introduced in #1999 I noticed that the lexer guessing solely based on text very much leaves things to be desired. It works fine for clear cut cases like shebangs and DOCTYPES but when there isn't such a dead giveaway and you actually have to guess it's very often wrong.

`pygments.lexers.guess_lexer(text)` is currently powered by `Lexer.analyse_text(text)` which returns a float from 0 to 1 indicating how much the lexer thinks it recognizes its language (1 meaning it's certainly the right lexer and 0 meaning it's certainly not the right lexer).

IMO the clear problem with this is that most patterns can occur anywhere in the text and the position they occur in currently isn't used for lexer ranking. To illustrate this with an example:

* `#include <stdio.h>` is correctly recognized as C
* `<test></test>` is correctly recognized as XML
* The following is also correctly recognized as XML:
  ```xml
  <test>
  #include <stdio.h>
  </test>
  ```
* The following however is wrongly recognized as XML:
  ```c
  #include <stdio.h>
  
  void main(){
          printf("<test></test>");
  }
  ```
That is because the code currently looks like:

```python
class CLexer(CFamilyLexer):
    def analyse_text(text):
        if re.search(r'^\s*#include [<"]', text, re.MULTILINE):
            return 0.1

class XmlLexer(RegexLexer):
    def analyse_text(text):
        if looks_like_xml(text):
            return 0.45  # less than HTML
```

Since the `analyse_text` API doesn't propagate the positions of the matches only one of the last two examples will ever be guessed correctly.

Please note that C and XML were only examples. You can have the same problem with pretty much any pair of Pygment's >500 languages. Another example would be:

* ```python
  import sqlite3
  # ...
  cur.execute("INSERT INTO items (text) VALUES (?)", (text,))
  ```
  which should be recognized as Python, versus
* ```sql
  INSERT INTO items (text) VALUES ("import sqlite")
  ```
  which should be recognized as SQL.

So my idea is to improve the language guessing in Pygments by deprecating `Lexer.analse_text` in favor of a new method `Lexer.recognize_text` that yields the indexes of matches so that they can be factored into the scoring.

To give you two examples of how `analyse_text` would be converted to `recognize_text`:

```python
# before:
def analyse_text(text):
    if re.search(r'^\s*#include [<"]', text, re.MULTILINE):
        return 0.1
# after:
def recognize_text(text):
    yield re.search(r'^\s*#include [<"]', text, re.MULTILINE), 0.1
```

```python
# before:
def analyse_text(text):
    rv = 0
    if 'import ' in text:
        rv += 0.5
    if 'print ' in text:
        rv += 0.3
    return rv
# after:
def recognize_text(text):
    yield text.find('import '), 0.5
    yield text.find('print '), 0.3
```

Since there currently are about 150 `analyse_text` implementations, converting them all at once isn't feasible. This PR Draft demonstrates how we could introduce `recognize_text` in a backwards compatible manner, allowing us to convert the `analyse_text` methods one by one, improving lexer guessing incrementally.

What do you think?