### PR TITLE
CFamily: improve function detection

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -117,7 +117,7 @@ class CFamilyLexer(RegexLexer):
             # functions
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
-             r'(\s*\([^;]*?\))'            # signature
+             r'(\s*\([^;]*?\))'                          # signature
              r'([^;{]*)(\{)',
              bygroups(using(this), Name.Function, using(this), using(this),
                       Punctuation),
@@ -125,10 +125,11 @@ class CFamilyLexer(RegexLexer):
             # function declarations
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
-             r'(\s*\([^;]*?\))'            # signature
+             r'(\s*\([^;]*?\))'                          # signature
              r'([^;]*)(;)',
              bygroups(using(this), Name.Function, using(this), using(this),
                       Punctuation)),
+            include('types'),
             default('statement'),
         ],
         'statement': [

--- a/tests/examplefiles/cpp/functions.cpp
+++ b/tests/examplefiles/cpp/functions.cpp
@@ -62,6 +62,9 @@ explicit const string contains(const char* str) {}
 explicit const string contains(const char * str);
 explicit const string contains(const char * str) {}
 
+unsigned int contains() {}
+unsigned int contains();
+
 // Names with namespaces
 
 string Type::contains(char c) const noexcept;

--- a/tests/examplefiles/cpp/functions.cpp.output
+++ b/tests/examplefiles/cpp/functions.cpp.output
@@ -1091,6 +1091,30 @@
 
 '\n'          Text.Whitespace
 
+'unsigned'    Keyword.Type
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'contains'    Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'unsigned'    Keyword.Type
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'contains'    Name.Function
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
 '// Names with namespaces\n' Comment.Single
 
 '\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #1995. 

Detect functions with return types of more than a single word length (like `unsigned int` or `long long`).