### PR TITLE
Generate valid links if lineanchors but no linenos set (#2013)

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -772,7 +772,7 @@ class HtmlFormatter(Formatter):
         for t, line in inner:
             if t:
                 i += 1
-                href = "" if self.linenos  else ' href="%s-%d"' % (s, i)
+                href = "" if self.linenos else ' href="#%s-%d"' % (s, i)
                 yield 1, '<a id="%s-%d" name="%s-%d"%s></a>' % (s, i, s, i, href) + line
             else:
                 yield 0, line


### PR DESCRIPTION
This fixes part of #2013 by making the generated links valid (but as mentioned in #2013, I am not sure if those links are useful and are worth generating).