### PR TITLE
Update Agda’s reserved words

### DIFF
--- a/pygments/lexers/haskell.py
+++ b/pygments/lexers/haskell.py
@@ -304,13 +304,13 @@ class AgdaLexer(RegexLexer):
     filenames = ['*.agda']
     mimetypes = ['text/x-agda']
 
-    reserved = ['abstract', 'codata', 'coinductive', 'constructor', 'data',
-                'field', 'forall', 'hiding', 'in', 'inductive', 'infix',
-                'infixl', 'infixr', 'instance', 'let', 'mutual', 'open',
-                'pattern', 'postulate', 'primitive', 'private',
-                'quote', 'quoteGoal', 'quoteTerm',
+    reserved = ['abstract', 'codata', 'coinductive', 'constructor', 'data', 'do',
+                'eta-equality', 'field', 'forall', 'hiding', 'in', 'inductive', 'infix',
+                'infixl', 'infixr', 'instance', 'interleaved', 'let', 'macro', 'mutual',
+                'no-eta-equality', 'open', 'overlap', 'pattern', 'postulate', 'primitive', 'private',
+                'quote', 'quoteTerm',
                 'record', 'renaming', 'rewrite', 'syntax', 'tactic',
-                'unquote', 'unquoteDecl', 'using', 'where', 'with']
+                'unquote', 'unquoteDecl', 'unquoteDef', 'using', 'variable', 'where', 'with']
 
     tokens = {
         'root': [


### PR DESCRIPTION
A number of keywords are added and a deprecated keyword `unquoteGoal` is removed. For the latest set of keywords in Agda, see https://github.com/agda/agda/blob/master/src/full/Agda/Syntax/Parser/Lexer.x#L153-L193.