### PR TITLE
Java: fix lexing of 'record' soft keyword

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -37,7 +37,7 @@ class JavaLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'(^\s*)((?:public|private|protected|static|strictfp)(?:\s+))*(record)\b',
+            (r'(^\s*)((?:(?:public|private|protected|static|strictfp)(?:\s+))*)(record)\b',
              bygroups(Text, using(this), Keyword.Declaration), 'class'),
             (r'[^\S\n]+', Text),
             (r'//.*?\n', Comment.Single),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -37,6 +37,8 @@ class JavaLexer(RegexLexer):
 
     tokens = {
         'root': [
+            (r'(^\s*)((?:public|private|protected|static|strictfp)(?:\s+))*(record)\b',
+             bygroups(Text, using(this), Keyword.Declaration), 'class'),
             (r'[^\S\n]+', Text),
             (r'//.*?\n', Comment.Single),
             (r'/\*.*?\*/', Comment.Multiline),
@@ -58,8 +60,7 @@ class JavaLexer(RegexLexer):
              Keyword.Type),
             (r'(package)(\s+)', bygroups(Keyword.Namespace, Text), 'import'),
             (r'(true|false|null)\b', Keyword.Constant),
-            (r'(class|interface|record)(\s+)', bygroups(Keyword.Declaration, Text),
-             'class'),
+            (r'(class|interface)\b', Keyword.Declaration, 'class'),
             (r'(var)(\s+)', bygroups(Keyword.Declaration, Text),
              'var'),
             (r'(import(?:\s+static)?)(\s+)', bygroups(Keyword.Namespace, Text),
@@ -89,6 +90,7 @@ class JavaLexer(RegexLexer):
             (r'\n', Text)
         ],
         'class': [
+            (r'\s+', Text),
             (r'([^\W\d]|\$)[\w$]*', Name.Class, '#pop')
         ],
         'var': [

--- a/tests/snippets/java/test_record.txt
+++ b/tests/snippets/java/test_record.txt
@@ -1,15 +1,65 @@
 ---input---
 public record RecordTest() {}
+public static record RecordTest() {}
+record Person(String firstName, String lastName) {}
+String[] record = csvReader.getValues();
+
 
 ---tokens---
 'public'      Keyword.Declaration
 ' '           Text
 'record'      Keyword.Declaration
 ' '           Text
-'RecordTest'  Name.Function
+'RecordTest'  Name.Class
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
 '{'           Punctuation
 '}'           Punctuation
+'\n'          Text
+
+'static'      Keyword.Declaration
+' '           Text
+'record'      Keyword.Declaration
+' '           Text
+'RecordTest'  Name.Class
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'record'      Keyword.Declaration
+' '           Text
+'Person'      Name.Class
+'('           Punctuation
+'String'      Name
+' '           Text
+'firstName'   Name
+','           Punctuation
+' '           Text
+'String'      Name
+' '           Text
+'lastName'    Name
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'String'      Name
+'['           Operator
+']'           Operator
+' '           Text
+'record'      Name
+' '           Text
+'='           Operator
+' '           Text
+'csvReader'   Name
+'.'           Punctuation
+'getValues'   Name.Attribute
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
 '\n'          Text

--- a/tests/snippets/java/test_record.txt
+++ b/tests/snippets/java/test_record.txt
@@ -18,6 +18,8 @@ String[] record = csvReader.getValues();
 '}'           Punctuation
 '\n'          Text
 
+'public'      Keyword.Declaration
+' '           Text
 'static'      Keyword.Declaration
 ' '           Text
 'record'      Keyword.Declaration


### PR DESCRIPTION
Refactor the Java lexer to treat `record` as a soft keyword. Fixes #2016.

Previously, the lexer assumed record is a reserved word, even though
it is a soft keyword which can be used as a variable name. This meant
that if pygments tried to highlight Java code like `int record = 1`
(assignment to a variable named record) an error token would be produced.

This refactor lexes record as a keyword only if it appears at the
beginning of the line, with some potential other keywords like public
and private preceding it.
I am not a Java expert at all, but after reading the JEP for records, I think this
covers all cases.