### PR TITLE
Graphics: add "." as operator to POV-Ray lexer

### DIFF
--- a/pygments/lexers/graphics.py
+++ b/pygments/lexers/graphics.py
@@ -766,14 +766,12 @@ class PovrayLexer(RegexLexer):
                 'quadric', 'quartic', 'smooth_triangle', 'sor', 'sphere', 'superellipsoid',
                 'text', 'torus', 'triangle', 'union'), suffix=r'\b'),
              Name.Builtin),
-            # TODO: <=, etc
-            (r'[\[\](){}<>;,]', Punctuation),
-            (r'[-+*/=.]', Operator),
             (r'\b(x|y|z|u|v)\b', Name.Builtin.Pseudo),
             (r'[a-zA-Z_]\w*', Name),
-            (r'[0-9]+\.[0-9]*', Number.Float),
-            (r'\.[0-9]+', Number.Float),
+            (r'[0-9]*\.[0-9]+', Number.Float),
             (r'[0-9]+', Number.Integer),
+            (r'[\[\](){}<>;,]', Punctuation),
+            (r'[-+*/=.|&]|<=|>=|!=', Operator),
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
             (r'\s+', Whitespace),
         ]

--- a/pygments/lexers/graphics.py
+++ b/pygments/lexers/graphics.py
@@ -768,7 +768,7 @@ class PovrayLexer(RegexLexer):
              Name.Builtin),
             # TODO: <=, etc
             (r'[\[\](){}<>;,]', Punctuation),
-            (r'[-+*/=]', Operator),
+            (r'[-+*/=.]', Operator),
             (r'\b(x|y|z|u|v)\b', Name.Builtin.Pseudo),
             (r'[a-zA-Z_]\w*', Name),
             (r'[0-9]+\.[0-9]*', Number.Float),

--- a/tests/examplefiles/pov/sphere.pov
+++ b/tests/examplefiles/pov/sphere.pov
@@ -1,18 +1,69 @@
+#version 3.7;
 #include "colors.inc"    
 
-background { color Cyan }
-
 camera {
-  location <0, 2, -3>
-  look_at <0, 1, 2>
+  sky <0,0,1>
+  direction <-1,0,0>
+  right <-4/3,0,0>
+  location <-300,-800,600>
+  look_at <0,0,0>     //Where camera is pointing
+  angle 30
+  rotate <0,0,-360*(clock+0.10)>
 }
 
-sphere {
-  <0, 1, 2>, 2
-  texture {
-    pigment { color Yellow }
+global_settings { ambient_light White }
+background { color White }
+
+light_source {
+  <0,0,500>
+  color White*2
+  spotlight
+  radius 100
+  area_light <100, 0, 0>, <0, 0, 100>, 3, 3
+  adaptive 1
+  jitter
+}
+
+union {
+  sphere {
+    <0, 1, 2>, 2
+    texture {
+      pigment { color Yellow }
+      finish {
+        ambient 0.1
+        brilliance 1.5
+        diffuse .5
+      }
+      normal {
+        scale 0.3
+        wrinkles 0.4
+      }
+    }
   }
+  cylinder{-x,x,.57,1 scale <1,2,3>}
 }
 
-light_source { <2, 4, -3> color White}
+#macro Tangent(position, row1, row2, row3)
+  #if (vlength(row1)!=0 | row2.x <= 7)
+    object {
+      cylinder { 
+        <0, 0, 0>, <0, 0, 1>, 0.7*50
+        texture {
+          pigment {
+            rgb <0.7,0.0,0.3> transmit 0.7
+          }
+        }
+      }
+      matrix <row1.x, row2.x, row3.x,
+              row1.y, row2.y, row3.y,
+              row1.z, row2.z, row3.z,
+              0, 0, 0>
+      translate position
+    }
+  #end
+#end
+
+Tangent(<-200.0, 42, .75>)
+
+#include concat("data-", str(frame_number, 1, 0), ".inc")
 

--- a/tests/examplefiles/pov/sphere.pov.output
+++ b/tests/examplefiles/pov/sphere.pov.output
@@ -1,34 +1,62 @@
+'#version'    Comment.Preproc
+' '           Text.Whitespace
+'3.7'         Literal.Number.Float
+';'           Punctuation
+'\n'          Text.Whitespace
+
 '#include'    Comment.Preproc
 ' '           Text.Whitespace
 '"colors.inc"' Literal.String.Double
 '    \n\n'    Text.Whitespace
 
-'background'  Keyword
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'color'       Keyword
-' '           Text.Whitespace
-'Cyan'        Name
-' '           Text.Whitespace
-'}'           Punctuation
-'\n\n'        Text.Whitespace
-
 'camera'      Name.Builtin
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text.Whitespace
-'location'    Keyword
+'sky'         Keyword
 ' '           Text.Whitespace
 '<'           Punctuation
 '0'           Literal.Number.Integer
 ','           Punctuation
-' '           Text.Whitespace
-'2'           Literal.Number.Integer
+'0'           Literal.Number.Integer
 ','           Punctuation
+'1'           Literal.Number.Integer
+'>'           Punctuation
+'\n  '        Text.Whitespace
+'direction'   Keyword
 ' '           Text.Whitespace
+'<'           Punctuation
 '-'           Operator
+'1'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+'>'           Punctuation
+'\n  '        Text.Whitespace
+'right'       Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'-'           Operator
+'4'           Literal.Number.Integer
+'/'           Operator
 '3'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+'>'           Punctuation
+'\n  '        Text.Whitespace
+'location'    Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'-'           Operator
+'300'         Literal.Number.Integer
+','           Punctuation
+'-'           Operator
+'800'         Literal.Number.Integer
+','           Punctuation
+'600'         Literal.Number.Integer
 '>'           Punctuation
 '\n  '        Text.Whitespace
 'look_at'     Keyword
@@ -36,21 +64,131 @@
 '<'           Punctuation
 '0'           Literal.Number.Integer
 ','           Punctuation
-' '           Text.Whitespace
-'1'           Literal.Number.Integer
+'0'           Literal.Number.Integer
 ','           Punctuation
+'0'           Literal.Number.Integer
+'>'           Punctuation
+'     '       Text.Whitespace
+'//Where camera is pointing' Comment.Single
+'\n  '        Text.Whitespace
+'angle'       Keyword
 ' '           Text.Whitespace
-'2'           Literal.Number.Integer
+'30'          Literal.Number.Integer
+'\n  '        Text.Whitespace
+'rotate'      Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'-'           Operator
+'360'         Literal.Number.Integer
+'*'           Operator
+'('           Punctuation
+'clock'       Keyword
+'+'           Operator
+'0.10'        Literal.Number.Float
+')'           Punctuation
 '>'           Punctuation
 '\n'          Text.Whitespace
 
 '}'           Punctuation
 '\n\n'        Text.Whitespace
 
-'sphere'      Name.Builtin
+'global_settings' Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'ambient_light' Keyword
+' '           Text.Whitespace
+'White'       Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'background'  Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'color'       Keyword
+' '           Text.Whitespace
+'White'       Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'light_source' Name.Builtin
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text.Whitespace
+'<'           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+'500'         Literal.Number.Integer
+'>'           Punctuation
+'\n  '        Text.Whitespace
+'color'       Keyword
+' '           Text.Whitespace
+'White'       Name
+'*'           Operator
+'2'           Literal.Number.Integer
+'\n  '        Text.Whitespace
+'spotlight'   Keyword
+'\n  '        Text.Whitespace
+'radius'      Keyword
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+'\n  '        Text.Whitespace
+'area_light'  Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'100'         Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'>'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'<'           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+'>'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+'\n  '        Text.Whitespace
+'adaptive'    Keyword
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n  '        Text.Whitespace
+'jitter'      Keyword
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'union'       Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'sphere'      Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
 '<'           Punctuation
 '0'           Literal.Number.Integer
 ','           Punctuation
@@ -63,11 +201,11 @@
 ','           Punctuation
 ' '           Text.Whitespace
 '2'           Literal.Number.Integer
-'\n  '        Text.Whitespace
+'\n    '      Text.Whitespace
 'texture'     Keyword
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n    '      Text.Whitespace
+'\n      '    Text.Whitespace
 'pigment'     Keyword
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -77,30 +215,272 @@
 'Yellow'      Name
 ' '           Text.Whitespace
 '}'           Punctuation
+'\n      '    Text.Whitespace
+'finish'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'ambient'     Keyword
+' '           Text.Whitespace
+'0.1'         Literal.Number.Float
+'\n        '  Text.Whitespace
+'brilliance'  Keyword
+' '           Text.Whitespace
+'1.5'         Literal.Number.Float
+'\n        '  Text.Whitespace
+'diffuse'     Keyword
+' '           Text.Whitespace
+'.5'          Literal.Number.Float
+'\n      '    Text.Whitespace
+'}'           Punctuation
+'\n      '    Text.Whitespace
+'normal'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'scale'       Keyword
+' '           Text.Whitespace
+'0.3'         Literal.Number.Float
+'\n        '  Text.Whitespace
+'wrinkles'    Keyword
+' '           Text.Whitespace
+'0.4'         Literal.Number.Float
+'\n      '    Text.Whitespace
+'}'           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
 '\n  '        Text.Whitespace
+'}'           Punctuation
+'\n  '        Text.Whitespace
+'cylinder'    Name.Builtin
+'{'           Punctuation
+'-'           Operator
+'x'           Name.Builtin.Pseudo
+','           Punctuation
+'x'           Name.Builtin.Pseudo
+','           Punctuation
+'.57'         Literal.Number.Float
+','           Punctuation
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+'scale'       Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'1'           Literal.Number.Integer
+','           Punctuation
+'2'           Literal.Number.Integer
+','           Punctuation
+'3'           Literal.Number.Integer
+'>'           Punctuation
 '}'           Punctuation
 '\n'          Text.Whitespace
 
 '}'           Punctuation
 '\n\n'        Text.Whitespace
 
-'light_source' Name.Builtin
+'#macro'      Comment.Preproc
 ' '           Text.Whitespace
-'{'           Punctuation
+'Tangent'     Name
+'('           Punctuation
+'position'    Name
+','           Punctuation
+' '           Text.Whitespace
+'row1'        Name
+','           Punctuation
+' '           Text.Whitespace
+'row2'        Name
+','           Punctuation
+' '           Text.Whitespace
+'row3'        Name
+')'           Punctuation
+'\n  '        Text.Whitespace
+'#if'         Comment.Preproc
+' '           Text.Whitespace
+'('           Punctuation
+'vlength'     Keyword
+'('           Punctuation
+'row1'        Name
+')'           Punctuation
+'!='          Operator
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'row2'        Name
+'.'           Operator
+'x'           Name.Builtin.Pseudo
 ' '           Text.Whitespace
 '<'           Punctuation
-'2'           Literal.Number.Integer
+'='           Operator
+' '           Text.Whitespace
+'7'           Literal.Number.Integer
+')'           Punctuation
+'\n    '      Text.Whitespace
+'object'      Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+'\n      '    Text.Whitespace
+'cylinder'    Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+' \n        ' Text.Whitespace
+'<'           Punctuation
+'0'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
-'4'           Literal.Number.Integer
+'0'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
-'-'           Operator
-'3'           Literal.Number.Integer
+'0'           Literal.Number.Integer
+'>'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'<'           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'>'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'0.7'         Literal.Number.Float
+'*'           Operator
+'50'          Literal.Number.Integer
+'\n        '  Text.Whitespace
+'texture'     Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n          ' Text.Whitespace
+'pigment'     Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'rgb'         Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'0.7'         Literal.Number.Float
+','           Punctuation
+'0.0'         Literal.Number.Float
+','           Punctuation
+'0.3'         Literal.Number.Float
 '>'           Punctuation
 ' '           Text.Whitespace
-'color'       Keyword
+'transmit'    Keyword
 ' '           Text.Whitespace
-'White'       Name
+'0.7'         Literal.Number.Float
+'\n          ' Text.Whitespace
 '}'           Punctuation
+'\n        '  Text.Whitespace
+'}'           Punctuation
+'\n      '    Text.Whitespace
+'}'           Punctuation
+'\n      '    Text.Whitespace
+'matrix'      Keyword
+' '           Text.Whitespace
+'<'           Punctuation
+'row1'        Name
+'.'           Operator
+'x'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row2'        Name
+'.'           Operator
+'x'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row3'        Name
+'.'           Operator
+'x'           Name.Builtin.Pseudo
+','           Punctuation
+'\n              ' Text.Whitespace
+'row1'        Name
+'.'           Operator
+'y'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row2'        Name
+'.'           Operator
+'y'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row3'        Name
+'.'           Operator
+'y'           Name.Builtin.Pseudo
+','           Punctuation
+'\n              ' Text.Whitespace
+'row1'        Name
+'.'           Operator
+'z'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row2'        Name
+'.'           Operator
+'z'           Name.Builtin.Pseudo
+','           Punctuation
+' '           Text.Whitespace
+'row3'        Name
+'.'           Operator
+'z'           Name.Builtin.Pseudo
+','           Punctuation
+'\n              ' Text.Whitespace
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'>'           Punctuation
+'\n      '    Text.Whitespace
+'translate'   Keyword
+' '           Text.Whitespace
+'position'    Name
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n  '        Text.Whitespace
+'#end'        Comment.Preproc
+'\n'          Text.Whitespace
+
+'#end'        Comment.Preproc
+'\n\n'        Text.Whitespace
+
+'Tangent'     Name
+'('           Punctuation
+'<'           Punctuation
+'-'           Operator
+'200.0'       Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'42'          Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'.75'         Literal.Number.Float
+'>'           Punctuation
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'#include'    Comment.Preproc
+' '           Text.Whitespace
+'concat'      Keyword
+'('           Punctuation
+'"data-"'     Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'str'         Keyword
+'('           Punctuation
+'frame_number' Name
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'".inc"'      Literal.String.Double
+')'           Punctuation
 '\n'          Text.Whitespace


### PR DESCRIPTION
Dot is used in POV-Ray to access vector coordinates.
```povray
#declare vec = <1,2,3>;
vec.x
vec.y
vec.z
```
The "." is currently rendered as error. I have seen that in other languages, dot is classified as Operator so I added it.