### PR TITLE
Tango style: stop underlining whitespace

### DIFF
--- a/pygments/styles/tango.py
+++ b/pygments/styles/tango.py
@@ -55,7 +55,7 @@ class TangoStyle(Style):
     styles = {
         # No corresponding class for the following:
         #Text:                     "", # class:  ''
-        Whitespace:                "underline #f8f8f8",      # class: 'w'
+        Whitespace:                "#f8f8f8",                # class: 'w'
         Error:                     "#a40000 border:#ef2929", # class: 'err'
         Other:                     "#000000",                # class 'x'
 


### PR DESCRIPTION
Fixes #2020.

To produce the output below I used:

```s
echo "int i = 1;" > test
pygmentize -l cpp -O full,style=tango -o test.html test
```

Before:

![firefox_8L9qpHcQQa](https://user-images.githubusercontent.com/49096391/148246659-e04249ff-700c-4c75-9828-6942fcde7ec9.png)

After:

![firefox_qyVVdgyvNK](https://user-images.githubusercontent.com/49096391/148246696-0b8f2e5c-f170-4bc5-93c7-9bc3e34756b1.png)

I selected/marked the text with my cursor, so the underline difference is visible, otherwise the underline is invisible as it is the same color as the background (I hope this makes sense).