### PR TITLE
Let Groff formatter inherit token styles correctly

### DIFF
--- a/pygments/formatters/groff.py
+++ b/pygments/formatters/groff.py
@@ -144,6 +144,8 @@ class GroffFormatter(Formatter):
             self._write_lineno(outfile)
 
         for ttype, value in tokensource:
+            while ttype not in self.styles:
+                ttype = ttype.parent
             start, end = self.styles[ttype]
 
             for line in value.splitlines(True):

--- a/tests/test_groff_formatter.py
+++ b/tests/test_groff_formatter.py
@@ -1,0 +1,40 @@
+"""
+    Pygments Groff formatter tests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments import highlight
+from pygments.lexer import RegexLexer
+from pygments.style import Style
+from pygments.token import Token
+from pygments.formatters import GroffFormatter
+
+
+# FIXME: this tests a bug fix, but the basic functionality
+# is not tested thoroughly yet.
+
+class ToyLexer(RegexLexer):
+    tokens = {
+        "root": [
+            ("a", Token.Name),
+            ("b", Token.Name.Custom),
+        ],
+    }
+
+class ToyStyle(Style):
+    styles = {
+        Token.Name: "bold",
+    }
+
+
+expected = r""".nf
+\f[CR]
+\f[CB]a\f[CR]\f[CB]b\f[CR]
+
+.fi"""
+
+def test_inheritance_custom_tokens():
+    assert highlight("ab", ToyLexer(), GroffFormatter(style=ToyStyle)) == expected


### PR DESCRIPTION
Previously, Token.Name.Custom would raise KeyError on custom token
types not given rules in the style.

Fixes the rest of #1986.