### PR TITLE
Use `linespans` for `anchorlinenos`

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -667,7 +667,7 @@ class HtmlFormatter(Formatter):
         mw = len(str(lncount + fl - 1))
         sp = self.linenospecial
         st = self.linenostep
-        la = self.lineanchors
+        anchor_name = self.lineanchors or self.linespans
         aln = self.anchorlinenos
         nocls = self.noclasses
 
@@ -680,7 +680,7 @@ class HtmlFormatter(Formatter):
             if print_line:
                 line = '%*d' % (mw, i)
                 if aln:
-                    line = '<a href="#%s-%d">%s</a>' % (la, i, line)
+                    line = '<a href="#%s-%d">%s</a>' % (anchor_name, i, line)
             else:
                 line = ' ' * mw
 
@@ -729,7 +729,7 @@ class HtmlFormatter(Formatter):
         st = self.linenostep
         num = self.linenostart
         mw = len(str(len(inner_lines) + num - 1))
-        la = self.lineanchors
+        anchor_name = self.lineanchors or self.linespans
         aln = self.anchorlinenos
         nocls = self.noclasses
 
@@ -759,7 +759,7 @@ class HtmlFormatter(Formatter):
                 linenos = line
 
             if aln:
-                yield 1, ('<a href="#%s-%d">%s</a>' % (la, num, linenos) +
+                yield 1, ('<a href="#%s-%d">%s</a>' % (anchor_name, num, linenos) +
                           inner_line)
             else:
                 yield 1, linenos + inner_line

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -93,6 +93,14 @@ def test_all_options():
                     check(optdict)
 
 
+def test_linespans():
+    outfile = StringIO()
+    fmt = HtmlFormatter(linespans='L', anchorlinenos=True, linenos="inline")
+    fmt.format(tokensource, outfile)
+    html = outfile.getvalue()
+    assert re.search(r"""<span id="L-1">\s*<a href="#L-1"><span\s*class="linenos">\s*1</span></a>""", html)
+
+
 def test_lineanchors():
     optdict = dict(lineanchors="foo")
     outfile = StringIO()


### PR DESCRIPTION
When using the HTML formatter with `linespans=foo`, `linenos=inline`, and `anchorlinenos=True`,
the generated anchor links should be `#foo-42` and not `#-42`.

Thanks for maintaining pygments, we are very happy users with [pdoc](https://pdoc.dev/)! 😃 🍰 