### PR TITLE
CI: Only deploy for upstream

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,6 +28,7 @@ jobs:
         echo -e 'pygments.org\nwww.pygments.org' > _build/dirhtml/CNAME
         echo 'Automated deployment of docs for GitHub pages.' > _build/dirhtml/README
     - name: Deploy to repo
+      if: github.repository_owner == 'pygments'
       uses: peaceiris/actions-gh-pages@v2.5.0
       env:
         ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.10"
     - name: Checkout Pygments
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install Sphinx & WCAG contrast ratio
       run: pip install Sphinx wcag-contrast-ratio
     - name: Create Pyodide WASM package


### PR DESCRIPTION
Let's skip the deploy step for forks, it will fail because forks don't have `secrets.ACTIONS_DEPLOY_KEY`.

Also bump some versions.