### PR TITLE
Native: adjust colours to meet WCAG AAA contrast guidelines

### DIFF
--- a/pygments/styles/native.py
+++ b/pygments/styles/native.py
@@ -26,27 +26,27 @@ class NativeStyle(Style):
         Token:              '#d0d0d0',
         Whitespace:         '#666666',
 
-        Comment:            'italic #999999',
+        Comment:            'italic #ababab',
         Comment.Preproc:    'noitalic bold #cd2828',
         Comment.Special:    'noitalic bold #e50808 bg:#520000',
 
-        Keyword:            'bold #6ab825',
+        Keyword:            'bold #6ebf26',
         Keyword.Pseudo:     'nobold',
-        Operator.Word:      'bold #6ab825',
+        Operator.Word:      'bold #6ebf26',
 
         String:             '#ed9d13',
         String.Other:       '#ffa500',
 
-        Number:             '#3677a9',
+        Number:             '#51b2fd',
 
-        Name.Builtin:       '#24909d',
+        Name.Builtin:       '#2fbccd',
         Name.Variable:      '#40ffff',
         Name.Constant:      '#40ffff',
-        Name.Class:         'underline #447fcf',
-        Name.Function:      '#447fcf',
-        Name.Namespace:     'underline #447fcf',
+        Name.Class:         'underline #71adff',
+        Name.Function:      '#71adff',
+        Name.Namespace:     'underline #71adff',
         Name.Exception:     '#bbbbbb',
-        Name.Tag:           'bold #6ab825',
+        Name.Tag:           'bold #6ebf26',
         Name.Attribute:     '#bbbbbb',
         Name.Decorator:     '#ffa500',
 


### PR DESCRIPTION
I used both WAVE (Web Accessibility Evaluation Tool) and the [CSS Overview panel in Chrome DevTools](https://developer.chrome.com/docs/devtools/css-overview/#open) to identify these by checking https://python.github.io/peps/pep-0008/.

https://wave.webaim.org/report#/https://python.github.io/peps/pep-0008/

https://developer.chrome.com/blog/new-in-devtools-87/#css-overview

Some of the colours already met AA (all but one of these are for Native):

![image](https://user-images.githubusercontent.com/1324225/149805552-ded2a7a4-8d33-49e7-b74b-7fb3f02c8066.png)
 
But I've bumped them all to AAA using Chrome's suggestions. They provide two suggestions, one to meet AA (4.5:1) and another for AAA (7:1).

For example, inspect element:

![image](https://user-images.githubusercontent.com/1324225/149805827-e1be9821-ad3b-4186-b27a-60dfef70aeac.png)

Click the colour box:

![image](https://user-images.githubusercontent.com/1324225/149805919-625f4560-9d25-446c-b603-3d82ac07d5aa.png)

And click the icon to the right of the 🚫  to select AAA:

![image](https://user-images.githubusercontent.com/1324225/149806025-c2e9be1f-0836-4df0-b542-507e4de45725.png)


# Demo

Before: https://python.github.io/peps/pep-0008/#other-recommendations
After: https://hugovk.github.io/peps/pep-0008/#other-recommendations

Before, 137 contrast errors: https://wave.webaim.org/report#/https://python.github.io/peps/pep-0008/
After, no contrast errors: https://wave.webaim.org/report#/https://hugovk.github.io/peps/pep-0008/
