### PR TITLE
Highlight Clojure ratios as Numbers

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -895,6 +895,7 @@ class ClojureLexer(RegexLexer):
             (r'-?\d+\.\d+', Number.Float),
             (r'-?\d+', Number.Integer),
             (r'0x-?[abcdef\d]+', Number.Hex),
+            (r'-?\d+/\d+', Number),
 
             # strings, symbols and characters
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -893,9 +893,9 @@ class ClojureLexer(RegexLexer):
 
             # numbers
             (r'-?\d+\.\d+', Number.Float),
+            (r'-?\d+/\d+', Number),
             (r'-?\d+', Number.Integer),
             (r'0x-?[abcdef\d]+', Number.Hex),
-            (r'-?\d+/\d+', Number),
 
             # strings, symbols and characters
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),


### PR DESCRIPTION
Currently, the numerator is highlighted differently from the slash and denominator, which looks slightly odd.