### PR TITLE
Add support for .cljc clojure file extension

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -93,7 +93,7 @@ LEXERS = {
     'CirruLexer': ('pygments.lexers.webmisc', 'Cirru', ('cirru',), ('*.cirru',), ('text/x-cirru',)),
     'ClayLexer': ('pygments.lexers.c_like', 'Clay', ('clay',), ('*.clay',), ('text/x-clay',)),
     'CleanLexer': ('pygments.lexers.clean', 'Clean', ('clean',), ('*.icl', '*.dcl'), ()),
-    'ClojureLexer': ('pygments.lexers.jvm', 'Clojure', ('clojure', 'clj'), ('*.clj',), ('text/x-clojure', 'application/x-clojure')),
+    'ClojureLexer': ('pygments.lexers.jvm', 'Clojure', ('clojure', 'clj'), ('*.clj', '*.cljc'), ('text/x-clojure', 'application/x-clojure')),
     'ClojureScriptLexer': ('pygments.lexers.jvm', 'ClojureScript', ('clojurescript', 'cljs'), ('*.cljs',), ('text/x-clojurescript', 'application/x-clojurescript')),
     'CobolFreeformatLexer': ('pygments.lexers.business', 'COBOLFree', ('cobolfree',), ('*.cbl', '*.CBL'), ()),
     'CobolLexer': ('pygments.lexers.business', 'COBOL', ('cobol',), ('*.cob', '*.COB', '*.cpy', '*.CPY'), ('text/x-cobol',)),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -808,7 +808,7 @@ class ClojureLexer(RegexLexer):
     """
     name = 'Clojure'
     aliases = ['clojure', 'clj']
-    filenames = ['*.clj']
+    filenames = ['*.clj', '*.cljc']
     mimetypes = ['text/x-clojure', 'application/x-clojure']
 
     special_forms = (

--- a/tests/examplefiles/clojure/loggers.cljc
+++ b/tests/examplefiles/clojure/loggers.cljc
@@ -1,0 +1,51 @@
+(ns re-frame.loggers
+  (:require
+   [clojure.set :refer [difference]]
+   #?@(:clj [[clojure.string :as str]
+             [clojure.tools.logging :as log]])))
+
+#?(:clj (defn log [level & args]
+          (log/log level (if (= 1 (count args))
+                           (first args)
+                           (str/join " " args)))))
+
+
+;; XXX should loggers be put in the registrar ??
+(def ^:private loggers
+  "Holds the current set of logging functions.
+   By default, re-frame uses the functions provided by js/console.
+   Use `set-loggers!` to change these defaults
+  "
+  (atom #?(:cljs {:log       (js/console.log.bind   js/console)
+                  :warn      (js/console.warn.bind  js/console)
+                  :error     (js/console.error.bind js/console)
+                  :debug     (js/console.debug.bind js/console)
+                  :group     (if (.-group js/console)         ;; console.group does not exist  < IE 11
+                               (js/console.group.bind js/console)
+                               (js/console.log.bind   js/console))
+                  :groupEnd  (if (.-groupEnd js/console)        ;; console.groupEnd does not exist  < IE 11
+                               (js/console.groupEnd.bind js/console)
+                               #())})
+        ;; clojure versions
+        #?(:clj {:log      (partial log :info)
+                 :warn     (partial log :warn)
+                 :error    (partial log :error)
+                 :debug    (partial log :debug)
+                 :group    (partial log :info)
+                 :groupEnd  #()})))
+
+(defn console
+  [level & args]
+  (assert (contains? @loggers level) (str "re-frame: log called with unknown level: " level))
+  (apply (level @loggers) args))
+
+
+(defn set-loggers!
+  [new-loggers]
+  (assert  (empty? (difference (set (keys new-loggers)) (-> @loggers keys set))) "Unknown keys in new-loggers")
+  (swap! loggers merge new-loggers))
+
+(defn get-loggers
+  "Get the current logging functions used by re-frame."
+  []
+  @loggers)

--- a/tests/examplefiles/clojure/loggers.cljc.output
+++ b/tests/examplefiles/clojure/loggers.cljc.output
@@ -1,0 +1,370 @@
+'('           Punctuation
+'ns '         Keyword.Declaration
+'re-frame.loggers' Name.Variable
+'\n  '        Text
+'('           Punctuation
+':require'    Literal.String.Symbol
+'\n   '       Text
+'['           Punctuation
+'clojure.set' Name.Variable
+' '           Text
+':refer'      Literal.String.Symbol
+' '           Text
+'['           Punctuation
+'difference'  Name.Variable
+']'           Punctuation
+']'           Punctuation
+'\n   '       Text
+'#'           Operator
+'?'           Name.Variable
+'@'           Operator
+'('           Punctuation
+':clj'        Literal.String.Symbol
+' '           Text
+'['           Punctuation
+'['           Punctuation
+'clojure.string' Name.Variable
+' '           Text
+':as'         Literal.String.Symbol
+' '           Text
+'str'         Name.Variable
+']'           Punctuation
+'\n             ' Text
+'['           Punctuation
+'clojure.tools.logging' Name.Variable
+' '           Text
+':as'         Literal.String.Symbol
+' '           Text
+'log'         Name.Variable
+']'           Punctuation
+']'           Punctuation
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+'\n\n'        Text
+
+'#'           Operator
+'?'           Name.Variable
+'('           Punctuation
+':clj'        Literal.String.Symbol
+' '           Text
+'('           Punctuation
+'defn '       Keyword.Declaration
+'log'         Name.Variable
+' '           Text
+'['           Punctuation
+'level'       Name.Variable
+' '           Text
+'&'           Operator
+' '           Text
+'args'        Name.Variable
+']'           Punctuation
+'\n          ' Text
+'('           Punctuation
+'log/log'     Name.Function
+' '           Text
+'level'       Name.Variable
+' '           Text
+'('           Punctuation
+'if '         Keyword
+'('           Punctuation
+'= '          Name.Builtin
+'1'           Literal.Number.Integer
+' '           Text
+'('           Punctuation
+'count '      Name.Builtin
+'args'        Name.Variable
+')'           Punctuation
+')'           Punctuation
+'\n                           ' Text
+'('           Punctuation
+'first '      Name.Builtin
+'args'        Name.Variable
+')'           Punctuation
+'\n                           ' Text
+'('           Punctuation
+'str/join'    Name.Function
+' '           Text
+'" "'         Literal.String
+' '           Text
+'args'        Name.Variable
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+'\n\n\n'      Text
+
+';; XXX should loggers be put in the registrar ??' Comment.Single
+'\n'          Text
+
+'('           Punctuation
+'def '        Keyword
+'^'           Operator
+':private'    Literal.String.Symbol
+' '           Text
+'loggers'     Name.Variable
+'\n  '        Text
+'"Holds the current set of logging functions.\n   By default, re-frame uses the functions provided by js/console.\n   Use `set-loggers!` to change these defaults\n  "' Literal.String
+'\n  '        Text
+'('           Punctuation
+'atom'        Name.Function
+' '           Text
+'#'           Operator
+'?'           Name.Variable
+'('           Punctuation
+':cljs'       Literal.String.Symbol
+' '           Text
+'{'           Punctuation
+':log'        Literal.String.Symbol
+'       '     Text
+'('           Punctuation
+'js/console.log.bind' Name.Function
+'   '         Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                  ' Text
+':warn'       Literal.String.Symbol
+'      '      Text
+'('           Punctuation
+'js/console.warn.bind' Name.Function
+'  '          Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                  ' Text
+':error'      Literal.String.Symbol
+'     '       Text
+'('           Punctuation
+'js/console.error.bind' Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                  ' Text
+':debug'      Literal.String.Symbol
+'     '       Text
+'('           Punctuation
+'js/console.debug.bind' Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                  ' Text
+':group'      Literal.String.Symbol
+'     '       Text
+'('           Punctuation
+'if '         Keyword
+'('           Punctuation
+'.-group'     Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'         '   Text
+';; console.group does not exist  < IE 11' Comment.Single
+'\n                               ' Text
+'('           Punctuation
+'js/console.group.bind' Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                               ' Text
+'('           Punctuation
+'js/console.log.bind' Name.Function
+'   '         Text
+'js/console'  Name.Variable
+')'           Punctuation
+')'           Punctuation
+'\n                  ' Text
+':groupEnd'   Literal.String.Symbol
+'  '          Text
+'('           Punctuation
+'if '         Keyword
+'('           Punctuation
+'.-groupEnd'  Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'        '    Text
+';; console.groupEnd does not exist  < IE 11' Comment.Single
+'\n                               ' Text
+'('           Punctuation
+'js/console.groupEnd.bind' Name.Function
+' '           Text
+'js/console'  Name.Variable
+')'           Punctuation
+'\n                               ' Text
+'#'           Operator
+'('           Punctuation
+')'           Punctuation
+')'           Punctuation
+'}'           Punctuation
+')'           Punctuation
+'\n        '  Text
+';; clojure versions' Comment.Single
+'\n        '  Text
+'#'           Operator
+'?'           Name.Variable
+'('           Punctuation
+':clj'        Literal.String.Symbol
+' '           Text
+'{'           Punctuation
+':log'        Literal.String.Symbol
+'      '      Text
+'('           Punctuation
+'partial '    Name.Builtin
+'log'         Name.Variable
+' '           Text
+':info'       Literal.String.Symbol
+')'           Punctuation
+'\n                 ' Text
+':warn'       Literal.String.Symbol
+'     '       Text
+'('           Punctuation
+'partial '    Name.Builtin
+'log'         Name.Variable
+' '           Text
+':warn'       Literal.String.Symbol
+')'           Punctuation
+'\n                 ' Text
+':error'      Literal.String.Symbol
+'    '        Text
+'('           Punctuation
+'partial '    Name.Builtin
+'log'         Name.Variable
+' '           Text
+':error'      Literal.String.Symbol
+')'           Punctuation
+'\n                 ' Text
+':debug'      Literal.String.Symbol
+'    '        Text
+'('           Punctuation
+'partial '    Name.Builtin
+'log'         Name.Variable
+' '           Text
+':debug'      Literal.String.Symbol
+')'           Punctuation
+'\n                 ' Text
+':group'      Literal.String.Symbol
+'    '        Text
+'('           Punctuation
+'partial '    Name.Builtin
+'log'         Name.Variable
+' '           Text
+':info'       Literal.String.Symbol
+')'           Punctuation
+'\n                 ' Text
+':groupEnd'   Literal.String.Symbol
+'  '          Text
+'#'           Operator
+'('           Punctuation
+')'           Punctuation
+'}'           Punctuation
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+'\n\n'        Text
+
+'('           Punctuation
+'defn '       Keyword.Declaration
+'console'     Name.Variable
+'\n  '        Text
+'['           Punctuation
+'level'       Name.Variable
+' '           Text
+'&'           Operator
+' '           Text
+'args'        Name.Variable
+']'           Punctuation
+'\n  '        Text
+'('           Punctuation
+'assert '     Name.Builtin
+'('           Punctuation
+'contains? '  Name.Builtin
+'@'           Operator
+'loggers'     Name.Variable
+' '           Text
+'level'       Name.Variable
+')'           Punctuation
+' '           Text
+'('           Punctuation
+'str '        Name.Builtin
+'"re-frame: log called with unknown level: "' Literal.String
+' '           Text
+'level'       Name.Variable
+')'           Punctuation
+')'           Punctuation
+'\n  '        Text
+'('           Punctuation
+'apply '      Name.Builtin
+'('           Punctuation
+'level'       Name.Function
+' '           Text
+'@'           Operator
+'loggers'     Name.Variable
+')'           Punctuation
+' '           Text
+'args'        Name.Variable
+')'           Punctuation
+')'           Punctuation
+'\n\n\n'      Text
+
+'('           Punctuation
+'defn '       Keyword.Declaration
+'set-loggers!' Name.Variable
+'\n  '        Text
+'['           Punctuation
+'new-loggers' Name.Variable
+']'           Punctuation
+'\n  '        Text
+'('           Punctuation
+'assert '     Name.Builtin
+' '           Text
+'('           Punctuation
+'empty?'      Name.Function
+' '           Text
+'('           Punctuation
+'difference ' Name.Builtin
+'('           Punctuation
+'set '        Name.Builtin
+'('           Punctuation
+'keys '       Name.Builtin
+'new-loggers' Name.Variable
+')'           Punctuation
+')'           Punctuation
+' '           Text
+'('           Punctuation
+'-> '         Name.Builtin
+'@'           Operator
+'loggers'     Name.Variable
+' '           Text
+'keys '       Name.Builtin
+'set'         Name.Variable
+')'           Punctuation
+')'           Punctuation
+')'           Punctuation
+' '           Text
+'"Unknown keys in new-loggers"' Literal.String
+')'           Punctuation
+'\n  '        Text
+'('           Punctuation
+'swap!'       Name.Function
+' '           Text
+'loggers'     Name.Variable
+' '           Text
+'merge '      Name.Builtin
+'new-loggers' Name.Variable
+')'           Punctuation
+')'           Punctuation
+'\n\n'        Text
+
+'('           Punctuation
+'defn '       Keyword.Declaration
+'get-loggers' Name.Variable
+'\n  '        Text
+'"Get the current logging functions used by re-frame."' Literal.String
+'\n  '        Text
+'['           Punctuation
+']'           Punctuation
+'\n  '        Text
+'@'           Operator
+'loggers'     Name.Variable
+')'           Punctuation
+'\n'          Text


### PR DESCRIPTION
.cljc files are clojure source files that run on both clojure and clojurescript runtimes. This PR adds support for formatting .cljc files by adding the .cljc extension to the ClojureLexer.

An example test file was created using this source file from the [re-frame](https://github.com/day8/re-frame) project: 
https://github.com/day8/re-frame/blob/7199496997cfb226311444f4402d1bda5798af60/src/re_frame/loggers.cljc
I generated the loggers.cljc.output file using `pytest tests/examplefiles --update-goldens` and visually checked the output with `python -m pygments tests/examplefiles/clojure/loggers.cljc`