### PR TITLE
Support comments in JSON

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -145,7 +145,7 @@ Other contributors, listed alphabetically, are:
 * Stephen McKamey -- Duel/JBST lexer
 * Brian McKenna -- F# lexer
 * Charles McLaughlin -- Puppet lexer
-* Kurt McKee -- Tera Term macro lexer, PostgreSQL updates, MySQL overhaul
+* Kurt McKee -- Tera Term macro lexer, PostgreSQL updates, MySQL overhaul, JSON lexer
 * Joe Eli McIlvain -- Savi lexer
 * Lukas Meuser -- BBCode formatter, Lua lexer
 * Cat Miller -- Pig lexer

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -604,6 +604,10 @@ class JsonLexer(Lexer):
                     in_comment_multiline = True
                     continue
 
+                # Exhaust the queue. Accept the existing token types.
+                yield from queue
+                queue.clear()
+
                 yield start, Error, text[start:stop]
                 # Fall through so the new character can be evaluated.
 

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -437,6 +437,12 @@ class JsonLexer(Lexer):
     """
     For JSON data structures.
 
+    Javascript-style comments are supported (like ``/* */`` and ``//``),
+    though comments are not part of the JSON specification.
+    This allows users to highlight JSON as it is used in the wild.
+
+    No validation is performed on the input JSON document.
+
     .. versionadded:: 1.5
     """
 

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -636,16 +636,14 @@ class JsonLexer(Lexer):
                     # Whitespace, Comment, or a quoted string.
                     #
                     # If it's a quoted string we emit Name.Tag.
-                    # Otherwise, we yield the whitespace or comment tokens.
-                    # In all other cases this is invalid JSON.
-                    # This allows for things like '"foo" "bar": "baz"'
-                    # but we're not a validating JSON lexer, so it's OK.
-                    if _token is Whitespace or _token.parent is Comment:
-                        yield _start, _token, _text
-                    elif _token is String.Double:
+                    # Otherwise, we yield the original token.
+                    #
+                    # In all other cases this would be invalid JSON,
+                    # but this is not a validating JSON lexer, so it's OK.
+                    if _token is String.Double:
                         yield _start, Name.Tag, _text
                     else:
-                        yield _start, Error, _text
+                        yield _start, _token, _text
                 queue.clear()
 
                 in_punctuation = True

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -152,7 +152,7 @@ def test_json_string_escapes_positive_match(lexer_json, text):
     assert tokens[0][2] == text
 
 
-@pytest.mark.parametrize('text', ('+\n', '0\n', '""0\n', 'a\nb\n',))
+@pytest.mark.parametrize('text', ('+\n', '0\n', '""0\n', 'a\nb\n', '""/-'))
 def test_json_round_trip_errors(lexer_json, text):
     """Validate that past round-trip errors never crop up again."""
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -68,12 +68,6 @@ def lexer_json_ld():
         ('false', (Keyword.Constant, )),
         ('null', (Keyword.Constant, )),
 
-        # Whitespace
-        ('\u0020', (Whitespace,)),  # space
-        ('\u000a', (Whitespace,)),  # newline
-        ('\u000d', (Whitespace,)),  # carriage return
-        ('\u0009', (Whitespace,)),  # tab
-
         # Arrays
         ('[]', (Punctuation,)),
         ('["a", "b"]', (Punctuation, String.Double, Punctuation,
@@ -85,14 +79,35 @@ def lexer_json_ld():
                         Whitespace, String.Double, Punctuation)),
     )
 )
-def test_json_literals_positive_match(lexer_json, text, expected_token_types):
+@pytest.mark.parametrize('end', ('', '\n'))
+def test_json_literals_positive_match(lexer_json, text, expected_token_types, end):
     """Validate that syntactically-correct JSON literals are parsed correctly."""
 
-    tokens = list(lexer_json.get_tokens_unprocessed(text))
-    assert len(tokens) == len(expected_token_types)
+    tokens = list(lexer_json.get_tokens_unprocessed(text + end))
+    assert len(tokens) == len(expected_token_types) + bool(end)
     assert all(token[1] is expected_token
                for token, expected_token in zip(tokens, expected_token_types))
-    assert ''.join(token[2] for token in tokens) == text
+    assert ''.join(token[2] for token in tokens) == text + end
+
+
+@pytest.mark.parametrize(
+    'text, expected',
+    (
+        ('\u0020', Whitespace),  # space
+        ('\u000a', Whitespace),  # newline
+        ('\u000d', Whitespace),  # carriage return
+        ('\u0009', Whitespace),  # tab
+    )
+)
+def test_json_whitespace_positive_match(lexer_json, text, expected):
+    """Validate that whitespace is parsed correctly."""
+
+    tokens = list(lexer_json.get_tokens_unprocessed(text))
+    assert tokens == [(0, expected, text)]
+
+    # Expand the whitespace and verify parsing again.
+    tokens = list(lexer_json.get_tokens_unprocessed(text * 2 + ' '))
+    assert tokens == [(0, expected, text * 2 + ' ')]
 
 
 @pytest.mark.parametrize(
@@ -109,6 +124,15 @@ def test_json_object_key_escapes_positive_match(lexer_json, text):
     assert len(tokens) == 6
     assert tokens[1][1] is Name.Tag
     assert tokens[1][2] == '"\\%s"' % text
+
+
+@pytest.mark.parametrize('text', ('uz', 'u1z', 'u12z', 'u123z'))
+def test_json_string_unicode_escapes_negative_match(lexer_json, text):
+    """Validate that if unicode escape sequences end abruptly there's no problem."""
+
+    tokens = list(lexer_json.get_tokens_unprocessed('"\\%s"' % text))
+    assert len(tokens) == 1
+    assert tokens[0] == (0, String.Double, '"\\%s"' % text)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds support for comments in JSON. Valid JSON documents are not affected, but if comments appear in the document they will be parsed as comments now.

This added support doesn't claim to support any JSON supersets like JSONC or JSON5. It's just comments. 😄

> Example, rendered in Monokai:
>
> ![image](https://user-images.githubusercontent.com/39996/150912812-c90ffd8b-2063-441d-8d83-c06be10d02ad.png)

Please let me know if there's anything that I need to cleanup or improve. Thanks!