### PR TITLE
PHP: 8.x keywords

### DIFF
--- a/pygments/lexers/php.py
+++ b/pygments/lexers/php.py
@@ -71,7 +71,7 @@ class ZephirLexer(RegexLexer):
             (r'(abstract|boolean|bool|char|class|const|double|enum|export|extends|final|'
              r'native|goto|implements|import|int|string|interface|long|ulong|char|uchar|'
              r'float|unsigned|private|protected|public|short|static|self|throws|reverse|'
-             r'transient|volatile)\b', Keyword.Reserved),
+             r'transient|volatile|readonly)\b', Keyword.Reserved),
             (r'(true|false|null|undefined)\b', Keyword.Constant),
             (r'(Array|Boolean|Date|_REQUEST|_COOKIE|_SESSION|'
              r'_GET|_POST|_SERVER|this|stdClass|range|count|iterator|'
@@ -221,7 +221,7 @@ class PhpLexer(RegexLexer):
              r'array|E_ALL|NULL|final|php_user_filter|interface|'
              r'implements|public|private|protected|abstract|clone|try|'
              r'catch|throw|this|use|namespace|trait|yield|'
-             r'finally)\b', Keyword),
+             r'finally|match)\b', Keyword),
             (r'(true|false|null)\b', Keyword.Constant),
             include('magicconstants'),
             (r'\$\{\$+' + _ident_inner + r'\}', Name.Variable),


### PR DESCRIPTION
This is part of the work required to get PHP 8.x support in Pygments. There is something else that needs to be added onto this patch that I couldn't figure out.

The file `pygments/lexers/_php_builtins.py` needs to be regenerated as there are several new functions in the standard library, such as `str_starts_with` (8.0) and `array_is_list` (8.1). I tried to run it locally after installing `requirements.txt` with Pip, but I keep getting `ModuleNotFoundError`. I'm not a Python developer, what do I need to do to get this to rebuild?