### PR TITLE
LilyPond: fix wrong lexing of name containing builtin name

### DIFF
--- a/pygments/lexers/lilypond.py
+++ b/pygments/lexers/lilypond.py
@@ -169,7 +169,9 @@ class LilyPondLexer(SchemeLexer):
             (r"([^\W\d]|-)+(?=([^\W\d]|[\-.])*\s*=)", Token.Name.Lvalue),
 
             # Virtually everything can appear in markup mode, so we highlight
-            # as text.
+            # as text.  Try to get a complete word, or we might wrongly the second
+            # half of a word that happens to be a builtin (e.g., "myStaff").
+            (r"([^\W\d]|-)+?" + NAME_END_RE, Token.Text),
             (r".", Token.Text),
         ],
         "string": [

--- a/pygments/lexers/lilypond.py
+++ b/pygments/lexers/lilypond.py
@@ -169,8 +169,8 @@ class LilyPondLexer(SchemeLexer):
             (r"([^\W\d]|-)+(?=([^\W\d]|[\-.])*\s*=)", Token.Name.Lvalue),
 
             # Virtually everything can appear in markup mode, so we highlight
-            # as text.  Try to get a complete word, or we might wrongly the second
-            # half of a word that happens to be a builtin (e.g., "myStaff").
+            # as text.  Try to get a complete word, or we might wrongly lex
+            # a suffix that happens to be a builtin as a builtin (e.g., "myStaff").
             (r"([^\W\d]|-)+?" + NAME_END_RE, Token.Text),
             (r".", Token.Text),
         ],

--- a/tests/examplefiles/lilypond/example.ly
+++ b/tests/examplefiles/lilypond/example.ly
@@ -66,7 +66,7 @@ piuPiano = \markup \italic "più piano"
 #(symbol->string 'some-symbol)
 
 <<
-  \new Staff \with {
+  \new Staff = myStaff \with {
     \consists Duration_line_engraver
   }
   \relative c' {

--- a/tests/examplefiles/lilypond/example.ly.output
+++ b/tests/examplefiles/lilypond/example.ly.output
@@ -321,6 +321,10 @@
 ' '           Whitespace
 'Staff'       Name.Builtin.Context
 ' '           Whitespace
+'='           Punctuation
+' '           Whitespace
+'myStaff'     Text
+' '           Whitespace
 '\\with'      Keyword
 ' '           Whitespace
 '{'           Punctuation
@@ -481,18 +485,11 @@
 ' '           Whitespace
 '{'           Punctuation
 '\n               ' Whitespace
-'S'           Text
-'o'           Text
-'m'           Text
-'e'           Pitch
+'Some'        Text
 '\n               ' Whitespace
-'T'           Text
-'e'           Text
-'x'           Text
-'t'           Text
+'Text'        Text
 '\n               ' Whitespace
-'I'           Text
-'n'           Text
+'In'          Text
 '\n               ' Whitespace
 'A'           Text
 '\n               ' Whitespace
@@ -500,21 +497,12 @@
 ' '           Whitespace
 '\\italic'    Name.Builtin.MarkupCommand
 ' '           Whitespace
-'C'           Text
-'o'           Text
-'l'           Text
-'u'           Text
-'m'           Text
-'n'           Text
+'Column'      Text
 '!'           Text
 '\n               ' Whitespace
 '\\small-italic' Name.BackslashReference
 ' '           Whitespace
-'s'           Text
-'u'           Text
-'p'           Text
-'e'           Text
-'r'           Pitch
+'super'       Text
 '\n             ' Whitespace
 '}'           Punctuation
 '\n    '      Whitespace
@@ -545,11 +533,7 @@
 '_\\piuPiano' Name.BackslashReference
 '^\\markup'   Name.Builtin.MarkupCommand
 ' '           Whitespace
-'d'           Text
-'o'           Text
-'l'           Text
-'c'           Text
-'e'           Pitch
+'dolce'       Text
 '\n  '        Whitespace
 '}'           Punctuation
 '\n  '        Whitespace
@@ -570,20 +554,13 @@
 '('           Punctuation
 ')'           Punctuation
 '\n    '      Whitespace
-'M'           Text
-'y'           Text
+'My'          Text
 ' '           Whitespace
-'L'           Text
-'i'           Text
-'l'           Text
-'y'           Text
+'Lily'        Text
 ' '           Whitespace
 '--'          Punctuation
 ' '           Whitespace
-'S'           Text
-'o'           Text
-'n'           Text
-'g'           Pitch
+'Song'        Text
 '\n  '        Whitespace
 '}'           Punctuation
 '\n  '        Whitespace


### PR DESCRIPTION
Non-builtin names were scanned character by character, possibly
causing recognition of a suffix as builtin.