### PR TITLE
Bump pytest requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest-cov
 pytest-randomly
-pytest>=6.0
+pytest>=7.0
 pyflakes
 pylint
 tox


### PR DESCRIPTION
We require pytest 7 for the new from_parent() signature.