### PR TITLE
Make Formatter generic for the benefit of typeshed

### DIFF
--- a/pygments/formatter.py
+++ b/pygments/formatter.py
@@ -9,6 +9,7 @@
 """
 
 import codecs
+from typing import Generic, TypeVar
 
 from pygments.util import get_bool_opt
 from pygments.styles import get_style_by_name
@@ -21,8 +22,11 @@ def _lookup_style(style):
         return get_style_by_name(style)
     return style
 
+_T = TypeVar('_T', str, bytes)
+# Formatter is only generic for the benefit of the Pygments type stubs
+# living in the typeshed (https://github.com/python/typeshed).
 
-class Formatter:
+class Formatter(Generic[_T]):
     """
     Converts a token stream to text.
 

--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -228,7 +228,7 @@ class FontManager:
             return self.fonts['NORMAL']
 
 
-class ImageFormatter(Formatter):
+class ImageFormatter(Formatter[bytes]):
     """
     Create a PNG image from source code. This uses the Python Imaging Library to
     generate a pixmap from the source code.


### PR DESCRIPTION
The type stubs for Pygments in the typeshed have made `pygments.formatter.Formatter` generic in https://github.com/python/typeshed/pull/6819 so that an `outfile` passed to `pygments.highlight()` must be opened in binary mode when the formatter was created with a given `encoding`, for example:

```python
import pygments
import pygments.lexers
import pygments.formatters

lexer = pygments.lexers.get_lexer_by_name('python')
formatter = pygments.formatters.html.HtmlFormatter(encoding='utf-8')

with open('out.html', 'wb') as f: # mypy reports a type error if opened with 'w'
    pygments.highlight('test', lexer, formatter, outfile=f)
```

This does however come with the disadvantage that subclassing `Formatter` no longer type checks with `mypy --strict`:

```python
class Foo(pygments.formatter.Formatter):
     pass
```

because mypy complains with `Missing type parameters for generic type "Formatter"`. The problem with that is that fixing this by specifying the type parameter would result in a runtime error because the real `pygments.formatter.Formatter` is not generic and thus not subscriptable.

Making the actual `Formatter` generic improves the situation for pygments users using static type checkers and should not change anything for the pygments users that don't.