### PR TITLE
Fix parsing of Isabelle symbols.

### DIFF
--- a/pygments/lexers/theorem.py
+++ b/pygments/lexers/theorem.py
@@ -336,7 +336,7 @@ class IsabelleLexer(RegexLexer):
 
             (words(keyword_proof_script, prefix=r'\b', suffix=r'\b'), Keyword.Pseudo),
 
-            (r'\\<\w*>', Text.Symbol),
+            (r'\\<[\^\w]*>', Text.Symbol),
 
             (r"[^\W\d][.\w']*", Name),
             (r"\?[^\W\d][.\w']*", Name),

--- a/pygments/lexers/theorem.py
+++ b/pygments/lexers/theorem.py
@@ -364,14 +364,14 @@ class IsabelleLexer(RegexLexer):
         ],
         'string': [
             (r'[^"\\]+', String),
-            (r'\\<\w*>', String.Symbol),
+            (r'\\<[\^\w]*>', String.Symbol),
             (r'\\"', String),
             (r'\\', String),
             (r'"', String, '#pop'),
         ],
         'fact': [
             (r'[^`\\]+', String.Other),
-            (r'\\<\w*>', String.Symbol),
+            (r'\\<[\^\w]*>', String.Symbol),
             (r'\\`', String.Other),
             (r'\\', String.Other),
             (r'`', String.Other, '#pop'),


### PR DESCRIPTION
This PR resolves parsing of Isabelle operators having a ^ in their name, like \\<^sub>. Previously they were not understood as a single token, which prevented the symbols filter from replacing these operators with Unicode.