### PR TITLE
Terraform: Fix class name lexing

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -715,19 +715,14 @@ class TerraformLexer(ExtendedRegexLexer):
 
             # e.g. resource "aws_security_group" "allow_tls" {
             # e.g. backend "consul" {
-            (classes_re + r'(\s+)', bygroups(Keyword.Reserved, Whitespace), 'blockname'),
+            (classes_re + r'(\s+)("[0-9a-zA-Z-_]+")?(\s*)("[0-9a-zA-Z-_]+")(\s+)(\{)',
+             bygroups(Keyword.Reserved, Whitespace, Name.Class, Whitespace, Name.Variable, Whitespace, Punctuation)),
 
             # here-doc style delimited strings
             (
                 r'(<<-?)\s*([a-zA-Z_]\w*)(.*?\n)',
                 heredoc_callback,
             )
-        ],
-        'blockname': [
-            # e.g. resource "aws_security_group" "allow_tls" {
-            # e.g. backend "consul" {
-            (r'(\s*)("[0-9a-zA-Z-_]+")?(\s*)("[0-9a-zA-Z-_]+")(\s+)(\{)',
-             bygroups(Whitespace, Name.Class, Whitespace, Name.Variable, Whitespace, Punctuation)),
         ],
         'identifier': [
             (r'\b(var\.[0-9a-zA-Z-_\.\[\]]+)\b', bygroups(Name.Variable)),

--- a/tests/snippets/terraform/test_backend.txt
+++ b/tests/snippets/terraform/test_backend.txt
@@ -18,7 +18,7 @@ terraform {
 '"consul"'    Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    '        Text.Whitespace
 'address'     Name.Attribute

--- a/tests/snippets/terraform/test_comment.txt
+++ b/tests/snippets/terraform/test_comment.txt
@@ -6,6 +6,9 @@
   comment
 
 */
+provider "azurerm" { # (1)
+  features {}
+} 
 
 ---tokens---
 '# Single line comment\n' Comment.Single
@@ -42,3 +45,20 @@
 
 '*/'          Comment.Multiline
 '\n'          Text.Whitespace
+
+'provider'    Keyword.Reserved
+' '           Text.Whitespace
+'"azurerm"'   Name.Variable
+' '           Text.Whitespace
+'{'           Punctuation
+' # (1)\n'    Comment.Single
+
+'  '          Text.Whitespace
+'features'    Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' \n'         Text.Whitespace

--- a/tests/snippets/terraform/test_functions.txt
+++ b/tests/snippets/terraform/test_functions.txt
@@ -13,7 +13,7 @@ provider "aws" {
 '"aws"'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'value'       Name.Attribute
@@ -36,7 +36,7 @@ provider "aws" {
 '"aws"'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'value'       Name.Attribute

--- a/tests/snippets/terraform/test_heredoc.txt
+++ b/tests/snippets/terraform/test_heredoc.txt
@@ -13,7 +13,7 @@ resource "local_file" "heredoc" {
 '"heredoc"'   Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'content'     Name.Attribute

--- a/tests/snippets/terraform/test_module.txt
+++ b/tests/snippets/terraform/test_module.txt
@@ -10,7 +10,7 @@ module "consul" {
 '"consul"'    Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'source'      Name.Attribute

--- a/tests/snippets/terraform/test_resource.txt
+++ b/tests/snippets/terraform/test_resource.txt
@@ -39,7 +39,7 @@ resource "aws_security_group" "allow_tls" {
 '"base_igw"'  Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'vpc_id'      Name.Attribute
@@ -81,7 +81,7 @@ resource "aws_security_group" "allow_tls" {
 '"allow_tls"' Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'name'        Name.Attribute

--- a/tests/snippets/terraform/test_types.txt
+++ b/tests/snippets/terraform/test_types.txt
@@ -17,7 +17,7 @@ variable "set-str" {
 '"consul"'    Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'data'        Keyword.Reserved
 ' '           Text.Whitespace
@@ -26,35 +26,35 @@ variable "set-str" {
 '"example"'   Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'module'      Keyword.Reserved
 ' '           Text.Whitespace
 '"consul"'    Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'output'      Keyword.Reserved
 ' '           Text.Whitespace
 '"instance_ip_addr"' Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'provider'    Keyword.Reserved
 ' '           Text.Whitespace
 '"aws"'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'provisioner' Keyword.Reserved
 ' '           Text.Whitespace
 '"local-exec"' Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'resource'    Keyword.Reserved
 ' '           Text.Whitespace
@@ -63,21 +63,21 @@ variable "set-str" {
 '"base_igw"'  Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'variable'    Keyword.Reserved
 ' '           Text.Whitespace
 '"aws_region"' Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'variable'    Keyword.Reserved
 ' '           Text.Whitespace
 '"set-str"'   Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'type'        Name.Attribute

--- a/tests/snippets/terraform/test_variable_declaration.txt
+++ b/tests/snippets/terraform/test_variable_declaration.txt
@@ -11,7 +11,7 @@ variable "aws_region" {
 '"aws_region"' Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'description' Name.Attribute

--- a/tests/snippets/terraform/test_variable_read.txt
+++ b/tests/snippets/terraform/test_variable_read.txt
@@ -9,7 +9,7 @@ provider "aws" {
 '"aws"'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '  '          Text.Whitespace
 'region'      Name.Attribute


### PR DESCRIPTION
Fixes #2094.

The `blockname` state did not have a `#pop` after it's only rule, which caused outputting errors in https://github.com/pygments/pygments/issues/2094.

Instead of adding a `#pop`, I merged the `blockname` state with the rule that uses it, to achieve the exact same lexing logic, but without another state in the lexer.