### PR TITLE
LilyPond: fix 'maybe-subproperties' state for properties containing dashes

### DIFF
--- a/pygments/lexers/lilypond.py
+++ b/pygments/lexers/lilypond.py
@@ -10,7 +10,7 @@
 
 import re
 
-from pygments.lexer import default, inherit, words
+from pygments.lexer import bygroups, default, inherit, words
 from pygments.lexers.lisp import SchemeLexer
 from pygments.lexers._lilypond_builtins import (
     keywords, pitch_language_names, clefs, scales, repeat_types, units,
@@ -191,9 +191,9 @@ class LilyPondLexer(SchemeLexer):
         # everything that looks like a-known-property.foo.bar-baz as
         # one single property name.
         "maybe-subproperties": [
-            (r"\.", Token.Punctuation),
             (r"\s+", Token.Whitespace),
-            (r"([^\W\d])+" + NAME_END_RE, Token.Name.Builtin.GrobProperty),
+            (r"(\.)((?:[^\W\d]|-)+?)" + NAME_END_RE,
+             bygroups(Token.Punctuation, Token.Name.Builtin.GrobProperty)),
             default("#pop"),
         ]
     }

--- a/tests/examplefiles/lilypond/example.ly
+++ b/tests/examplefiles/lilypond/example.ly
@@ -68,6 +68,7 @@ piuPiano = \markup \italic "più piano"
 <<
   \new Staff = myStaff \with {
     \consists Duration_line_engraver
+    \override VerticalAxisGroup.staff-staff-spacing.basic-distance = 20
   }
   \relative c' {
     \clef alto

--- a/tests/examplefiles/lilypond/example.ly.output
+++ b/tests/examplefiles/lilypond/example.ly.output
@@ -332,6 +332,18 @@
 '\\consists'  Keyword
 ' '           Whitespace
 'Duration_line_engraver' Name.Builtin.Translator
+'\n    '      Whitespace
+'\\override'  Name.Builtin.MusicFunction
+' '           Whitespace
+'VerticalAxisGroup' Name.Builtin.Grob
+'.'           Punctuation
+'staff-staff-spacing' Name.Builtin.GrobProperty
+'.'           Punctuation
+'basic-distance' Name.Builtin.GrobProperty
+' '           Whitespace
+'='           Punctuation
+' '           Whitespace
+'20'          Literal.Number
 '\n  '        Whitespace
 '}'           Punctuation
 '\n  '        Whitespace


### PR DESCRIPTION
I saw this nasty case in our docs today.