### PR TITLE
Highlight python 3.10's EncodingWarning

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -258,7 +258,8 @@ class PythonLexer(RegexLexer):
                 'InterruptedError', 'IsADirectoryError', 'NotADirectoryError',
                 'PermissionError', 'ProcessLookupError', 'TimeoutError',
                 # others new in Python 3
-                'StopAsyncIteration', 'ModuleNotFoundError', 'RecursionError'),
+                'StopAsyncIteration', 'ModuleNotFoundError', 'RecursionError',
+                'EncodingWarning'),
                 prefix=r'(?<!\.)', suffix=r'\b'),
              Name.Exception),
         ],


### PR DESCRIPTION
EncodingWarning was added in 3.10: https://docs.python.org/3/library/exceptions.html#EncodingWarning