### PR TITLE
Fix nested type name highlighting in Savi lexer.

### DIFF
--- a/pygments/lexers/savi.py
+++ b/pygments/lexers/savi.py
@@ -58,8 +58,11 @@ class SaviLexer(RegexLexer):
       # Single-Char String
       (r"'", String.Char, "string.char"),
 
-      # Class (or other type)
+      # Type Name
       (r'(_?[A-Z]\w*)', Name.Class),
+
+      # Nested Type Name
+      (r'(\.)(\s*)(_?[A-Z]\w*)', bygroups(Punctuation, Whitespace, Name.Class)),
 
       # Declare
       (r'^([ \t]*)(:\w+)',

--- a/tests/examplefiles/savi/example.savi.output
+++ b/tests/examplefiles/savi/example.savi.output
@@ -14,7 +14,7 @@
 '    '        Text.Whitespace
 'Spec'        Name.Class
 '.'           Punctuation
-'Process'     Name.Function
+'Process'     Name.Class
 '.'           Punctuation
 'run'         Name.Function
 '('           Punctuation
@@ -27,7 +27,7 @@
 '      '      Text.Whitespace
 'Spec'        Name.Class
 '.'           Punctuation
-'Run'         Name.Function
+'Run'         Name.Class
 '('           Punctuation
 'AdditionSpec' Name.Class
 ')'           Punctuation


### PR DESCRIPTION
Nested type names were being highlighted as if they were function names.

Now a phrase like `Spec.Process.run` is highlighted properly as:
- `Name.Class`
- `Punctuation`
- `Name.Class`
- `Punctuation`
- `Name.Function`

Instead of wrongly highlighted as it was before this commit:
- `Name.Class`
- `Punctuation`
- `Name.Function`
- `Punctuation`
- `Name.Function`