### PR TITLE
Futhark: add missing tokens

### DIFF
--- a/pygments/lexers/futhark.py
+++ b/pygments/lexers/futhark.py
@@ -37,7 +37,8 @@ class FutharkLexer(RegexLexer):
 
     other_types = ('bool', )
 
-    reserved = ('if', 'then', 'else', 'let', 'loop', 'in', 'with', 'type',
+    reserved = ('if', 'then', 'else', 'def', 'let', 'loop', 'in', 'with',
+                'type', 'type~', 'type^',
                 'val', 'entry', 'for', 'while', 'do', 'case', 'match',
                 'include', 'import', 'module', 'open', 'local', 'assert', '_')
 
@@ -62,11 +63,11 @@ class FutharkLexer(RegexLexer):
 
             # Identifiers
             (r'#\[([a-zA-Z_\(\) ]*)\]', Comment.Preproc),
-            (r'!?(%s\.)*%s' % (identifier_re, identifier_re), Name),
+            (r'[#!]?(%s\.)*%s' % (identifier_re, identifier_re), Name),
 
             (r'\\', Operator),
             (r'[-+/%=!><|&*^][-+/%=!><|&*^.]*', Operator),
-            (r'[][(),:;`{}]', Punctuation),
+            (r'[][(),:;`{}?.\'~^]', Punctuation),
 
             #  Numbers
             (r'0[xX]_*[\da-fA-F](_*[\da-fA-F])*_*[pP][+-]?\d(_*\d)*' + num_postfix,

--- a/tests/examplefiles/futhark/example.fut
+++ b/tests/examplefiles/futhark/example.fut
@@ -1,16 +1,17 @@
+local let dotprod [n] 't
+                  (mul: t -> t -> t) (add: t -> t -> t) (zero: t)
+                  (a: [n]t) (b: [n]t): t =
+  map2 mul a b |> reduce add zero
+
 module matmul (F: numeric) = {
   type t = F.t
   open F
 
-  local let dotprod [n] (a: [n]t) (b: [n]t): t =
-  map2 (*) a b |> reduce (+) (i32 0)
-
-
-  let matmul [n1][n2][m] (xss: [n1][m]t) (yss: [m][n2]t): [n1][n2]t =
-    map (\xs -> map (\ys -> dotprod xs ys) <| transpose yss) xss
+  let matmul [n1][n2][m] (xss: [n1][m]t) (yss: [m][n2]t): *[n1][n2]t =
+    map (\xs -> map (\ys -> dotprod (*) (+) (i32 0) xs ys) <| transpose yss) xss
 }
 
 module matmul32 = matmul f32
 
-let main [n][m] (xss: [n][m]f32) (yss: [m][n]f32): *[n][n]f32 =
+let main [n][m] (xss: [n][m]f32) (yss: [m][n]f32): ?[a][b].[a][b]f32 =
   matmul32.matmul xss yss

--- a/tests/examplefiles/futhark/example.fut.output
+++ b/tests/examplefiles/futhark/example.fut.output
@@ -1,30 +1,3 @@
-'module'      Keyword.Reserved
-' '           Text.Whitespace
-'matmul'      Name
-' '           Text.Whitespace
-'('           Punctuation
-'F'           Name
-':'           Punctuation
-' '           Text.Whitespace
-'numeric'     Name
-')'           Punctuation
-' '           Text.Whitespace
-'='           Operator
-' '           Text.Whitespace
-'{'           Punctuation
-'\n  '        Text.Whitespace
-'type'        Keyword.Reserved
-' '           Text.Whitespace
-'t'           Name
-' '           Text.Whitespace
-'='           Operator
-' '           Text.Whitespace
-'F.t'         Name
-'\n  '        Text.Whitespace
-'open'        Keyword.Reserved
-' '           Text.Whitespace
-'F'           Name
-'\n\n  '      Text.Whitespace
 'local'       Keyword.Reserved
 ' '           Text.Whitespace
 'let'         Keyword.Reserved
@@ -35,6 +8,46 @@
 'n'           Name
 ']'           Punctuation
 ' '           Text.Whitespace
+"'"           Punctuation
+'t'           Name
+'\n                  ' Text.Whitespace
+'('           Punctuation
+'mul'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'t'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'add'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'t'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'zero'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'t'           Name
+')'           Punctuation
+'\n                  ' Text.Whitespace
 '('           Punctuation
 'a'           Name
 ':'           Punctuation
@@ -62,9 +75,7 @@
 '\n  '        Text.Whitespace
 'map2'        Name
 ' '           Text.Whitespace
-'('           Punctuation
-'*'           Operator
-')'           Punctuation
+'mul'         Name
 ' '           Text.Whitespace
 'a'           Name
 ' '           Text.Whitespace
@@ -74,16 +85,38 @@
 ' '           Text.Whitespace
 'reduce'      Name
 ' '           Text.Whitespace
-'('           Punctuation
-'+'           Operator
-')'           Punctuation
+'add'         Name
+' '           Text.Whitespace
+'zero'        Name
+'\n\n'        Text.Whitespace
+
+'module'      Keyword.Reserved
+' '           Text.Whitespace
+'matmul'      Name
 ' '           Text.Whitespace
 '('           Punctuation
-'i32'         Keyword.Type
+'F'           Name
+':'           Punctuation
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
+'numeric'     Name
 ')'           Punctuation
-'\n\n\n  '    Text.Whitespace
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'type'        Keyword.Reserved
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'F.t'         Name
+'\n  '        Text.Whitespace
+'open'        Keyword.Reserved
+' '           Text.Whitespace
+'F'           Name
+'\n\n  '      Text.Whitespace
 'let'         Keyword.Reserved
 ' '           Text.Whitespace
 'matmul'      Name
@@ -125,6 +158,7 @@
 ')'           Punctuation
 ':'           Punctuation
 ' '           Text.Whitespace
+'*'           Operator
 '['           Punctuation
 'n1'          Name
 ']'           Punctuation
@@ -152,6 +186,20 @@
 '->'          Operator
 ' '           Text.Whitespace
 'dotprod'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'*'           Operator
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'+'           Operator
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'i32'         Keyword.Type
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+')'           Punctuation
 ' '           Text.Whitespace
 'xs'          Name
 ' '           Text.Whitespace
@@ -220,12 +268,19 @@
 ')'           Punctuation
 ':'           Punctuation
 ' '           Text.Whitespace
-'*'           Operator
+'?'           Punctuation
 '['           Punctuation
-'n'           Name
+'a'           Name
 ']'           Punctuation
 '['           Punctuation
-'n'           Name
+'b'           Name
+']'           Punctuation
+'.'           Punctuation
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+'['           Punctuation
+'b'           Name
 ']'           Punctuation
 'f32'         Keyword.Type
 ' '           Text.Whitespace


### PR DESCRIPTION
Adds recognition of 'def'/'type^'/'type~' keywords and adds some
missing characters to the regexes for identifiers and punctuation.