### PR TITLE
Fix most warnings in Sphinx build

### DIFF
--- a/doc/languages.rst
+++ b/doc/languages.rst
@@ -1,0 +1,5 @@
+:orphan:
+
+This file is overridden by _templates/languages.html and just exists to
+allow the language list to be reliably linked from the documentation
+(since its location varies between `make html` and `make dirhtml`).

--- a/pygments/lexers/macaulay2.py
+++ b/pygments/lexers/macaulay2.py
@@ -1655,6 +1655,8 @@ M2CONSTANTS = (
     )
 
 class Macaulay2Lexer(RegexLexer):
+    """Lexer for Macaulay2, a software system for research in algebraic geometry."""
+
     name = 'Macaulay2'
     url = 'https://faculty.math.illinois.edu/Macaulay2/'
     aliases = ['macaulay2']

--- a/pygments/lexers/meson.py
+++ b/pygments/lexers/meson.py
@@ -30,12 +30,12 @@ __all__ = ['MesonLexer']
 
 
 class MesonLexer(RegexLexer):
-    """
-    `meson language lexer.
+    """Meson language lexer.
+    
     The grammar definition use to transcribe the syntax was retrieved from
-    https://mesonbuild.com/Syntax.html#grammar for version 0.58
-    Some of those definitions are improperly transcribed so the Meson++
-    implementation was also checked: https://github.com/dcbaker/meson-plus-plus
+    https://mesonbuild.com/Syntax.html#grammar for version 0.58.
+    Some of those definitions are improperly transcribed, so the Meson++
+    implementation was also checked: https://github.com/dcbaker/meson-plus-plus.
 
     .. versionadded:: 2.10
     """

--- a/pygments/lexers/parsers.py
+++ b/pygments/lexers/parsers.py
@@ -230,7 +230,7 @@ class RagelRubyLexer(DelegatingLexer):
 
 class RagelCLexer(DelegatingLexer):
     """
-    A lexer forRagel in a C host file.
+    A lexer for Ragel in a C host file.
 
     .. versionadded:: 1.1
     """
@@ -266,7 +266,7 @@ class RagelDLexer(DelegatingLexer):
 
 class RagelCppLexer(DelegatingLexer):
     """
-    A lexer forRagel in a C++ host file.
+    A lexer for Ragel in a C++ host file.
 
     .. versionadded:: 1.1
     """

--- a/pygments/lexers/parsers.py
+++ b/pygments/lexers/parsers.py
@@ -33,12 +33,13 @@ __all__ = ['RagelLexer', 'RagelEmbeddedLexer', 'RagelCLexer', 'RagelDLexer',
 
 
 class RagelLexer(RegexLexer):
-    """
-    A pure Ragel lexer.  Use this for
-    fragments of Ragel.  For ``.rl`` files, use RagelEmbeddedLexer instead
-    (or one of the language-specific subclasses).
+    """A pure `Ragel <www.colm.net/open-source/ragel>`_ lexer.  Use this
+    for fragments of Ragel.  For ``.rl`` files, use
+    :class:`RagelEmbeddedLexer` instead (or one of the
+    language-specific subclasses).
 
     .. versionadded:: 1.1
+
     """
 
     name = 'Ragel'
@@ -128,7 +129,7 @@ class RagelLexer(RegexLexer):
 
 class RagelEmbeddedLexer(RegexLexer):
     """
-    A lexer for `Ragel`_ embedded in a host language file.
+    A lexer for Ragel embedded in a host language file.
 
     This will only highlight Ragel statements. If you want host language
     highlighting then call the language-specific Ragel lexer.
@@ -211,7 +212,7 @@ class RagelEmbeddedLexer(RegexLexer):
 
 class RagelRubyLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in a Ruby host file.
+    A lexer for Ragel in a Ruby host file.
 
     .. versionadded:: 1.1
     """
@@ -229,7 +230,7 @@ class RagelRubyLexer(DelegatingLexer):
 
 class RagelCLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in a C host file.
+    A lexer forRagel in a C host file.
 
     .. versionadded:: 1.1
     """
@@ -247,7 +248,7 @@ class RagelCLexer(DelegatingLexer):
 
 class RagelDLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in a D host file.
+    A lexer for Ragel in a D host file.
 
     .. versionadded:: 1.1
     """
@@ -265,7 +266,7 @@ class RagelDLexer(DelegatingLexer):
 
 class RagelCppLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in a CPP host file.
+    A lexer forRagel in a C++ host file.
 
     .. versionadded:: 1.1
     """
@@ -283,7 +284,7 @@ class RagelCppLexer(DelegatingLexer):
 
 class RagelObjectiveCLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in an Objective C host file.
+    A lexer for Ragel in an Objective C host file.
 
     .. versionadded:: 1.1
     """
@@ -301,7 +302,7 @@ class RagelObjectiveCLexer(DelegatingLexer):
 
 class RagelJavaLexer(DelegatingLexer):
     """
-    A lexer for `Ragel`_ in a Java host file.
+    A lexer for Ragel in a Java host file.
 
     .. versionadded:: 1.1
     """
@@ -514,7 +515,7 @@ class AntlrLexer(RegexLexer):
 
 class AntlrCppLexer(DelegatingLexer):
     """
-    `ANTLR`_ with CPP Target
+    ANTLR with C++ Target
 
     .. versionadded:: 1.1
     """
@@ -533,7 +534,7 @@ class AntlrCppLexer(DelegatingLexer):
 
 class AntlrObjectiveCLexer(DelegatingLexer):
     """
-    `ANTLR`_ with Objective-C Target
+    ANTLR with Objective-C Target
 
     .. versionadded:: 1.1
     """
@@ -552,7 +553,7 @@ class AntlrObjectiveCLexer(DelegatingLexer):
 
 class AntlrCSharpLexer(DelegatingLexer):
     """
-    `ANTLR`_ with C# Target
+    ANTLR with C# Target
 
     .. versionadded:: 1.1
     """
@@ -571,7 +572,7 @@ class AntlrCSharpLexer(DelegatingLexer):
 
 class AntlrPythonLexer(DelegatingLexer):
     """
-    `ANTLR`_ with Python Target
+    ANTLR with Python Target
 
     .. versionadded:: 1.1
     """
@@ -590,7 +591,7 @@ class AntlrPythonLexer(DelegatingLexer):
 
 class AntlrJavaLexer(DelegatingLexer):
     """
-    `ANTLR`_ with Java Target
+    ANTLR with Java Target
 
     .. versionadded:: 1.
     """
@@ -609,7 +610,7 @@ class AntlrJavaLexer(DelegatingLexer):
 
 class AntlrRubyLexer(DelegatingLexer):
     """
-    `ANTLR`_ with Ruby Target
+    ANTLR with Ruby Target
 
     .. versionadded:: 1.1
     """
@@ -628,7 +629,7 @@ class AntlrRubyLexer(DelegatingLexer):
 
 class AntlrPerlLexer(DelegatingLexer):
     """
-    `ANTLR`_ with Perl Target
+    ANTLR with Perl Target
 
     .. versionadded:: 1.1
     """
@@ -647,7 +648,7 @@ class AntlrPerlLexer(DelegatingLexer):
 
 class AntlrActionScriptLexer(DelegatingLexer):
     """
-    `ANTLR`_ with ActionScript Target
+    ANTLR with ActionScript Target
 
     .. versionadded:: 1.1
     """
@@ -668,7 +669,7 @@ class AntlrActionScriptLexer(DelegatingLexer):
 class TreetopBaseLexer(RegexLexer):
     """
     A base lexer for `Treetop <http://treetop.rubyforge.org/>`_ grammars.
-    Not for direct use; use TreetopLexer instead.
+    Not for direct use; use :class:`TreetopLexer` instead.
 
     .. versionadded:: 1.6
     """


### PR DESCRIPTION
Note that some invalid references are simply removed because the
lexers are all in the same section, so the link is already easy to
find and there is no need to repeat it over and over.