### PR TITLE
HTMLFormatter: Allow inline line numbers with nowrap (#2127)

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -967,7 +967,7 @@ class HtmlFormatter(Formatter):
 
         # As a special case, we wrap line numbers before line highlighting
         # so the line numbers get wrapped in the highlighting tag.
-        if not self.nowrap and self.linenos == 2:
+        if self.linenos == 2:
             source = self._wrap_inlinelinenos(source)
 
         if self.hl_lines:

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -118,6 +118,13 @@ def test_lineanchors_with_startnum():
     html = outfile.getvalue()
     assert re.search("<pre>\\s*<span>\\s*</span>\\s*<a id=\"foo-5\" name=\"foo-5\" href=\"#foo-5\">", html)
 
+def test_linenos_inline_with_nowrap():
+    optdict = dict(linenos="inline", nowrap=True)
+    outfile = StringIO()
+    fmt = HtmlFormatter(**optdict)
+    fmt.format(tokensource, outfile)
+    html = outfile.getvalue()
+    assert re.search("^<span class=\"linenos\">  1", html)
 
 def test_valid_output():
     # test all available wrappers


### PR DESCRIPTION
This patch allows the nowrap option to be used with linenos=inline.
Previously, when nowrap was set linenos=inline was ignored.

Fixes #2127 