### PR TITLE
made changes in the regex to solve tokenizing of semicolon

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -119,16 +119,16 @@ class CFamilyLexer(RegexLexer):
             # functions
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
-             r'(\s*\([^;]*?\))'                          # signature
-             r'([^;{]*)(\{)',
+             r'(\s*\(;*\))'                            # signature
+             r'([^;{]*)({ | })',
              bygroups(using(this), Name.Function, using(this), using(this),
                       Punctuation),
              'function'),
             # function declarations
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
              r'(' + _namespaced_ident + r')'             # method name
-             r'(\s*\([^;]*?\))'                          # signature
-             r'([^;]*)(;)',
+             r'(\s*\(;*\))'                         # signature
+             r'([;])',
              bygroups(using(this), Name.Function, using(this), using(this),
                       Punctuation)),
             include('types'),


### PR DESCRIPTION
I saw issue #1891 decoded the regex and made a few changes to accept any operator between the scope of a function and the function declaration.