### PR TITLE
Add FIXME to default code tags

### DIFF
--- a/pygments/filters/__init__.py
+++ b/pygments/filters/__init__.py
@@ -69,13 +69,16 @@ class CodeTagFilter(Filter):
 
     `codetags` : list of strings
        A list of strings that are flagged as code tags.  The default is to
-       highlight ``XXX``, ``TODO``, ``BUG`` and ``NOTE``.
+       highlight ``XXX``, ``TODO``, ``FIXME``, ``BUG`` and ``NOTE``.
+
+    .. versionchanged:: 2.13
+       Now recognizes ``FIXME`` by default.
     """
 
     def __init__(self, **options):
         Filter.__init__(self, **options)
         tags = get_list_opt(options, 'codetags',
-                            ['XXX', 'TODO', 'BUG', 'NOTE'])
+                            ['XXX', 'TODO', 'FIXME', 'BUG', 'NOTE'])
         self.tag_re = re.compile(r'\b(%s)\b' % '|'.join([
             re.escape(tag) for tag in tags if tag
         ]))


### PR DESCRIPTION
While passing in this file, add FIXME to the list of code tags recognized by the codetagify filter. It is quite common in my experience, along with 'TODO' and 'XXX'.

