### PR TITLE
Remove filename pattern caches

### DIFF
--- a/pygments/formatters/__init__.py
+++ b/pygments/formatters/__init__.py
@@ -11,7 +11,7 @@
 import re
 import sys
 import types
-import fnmatch
+from fnmatch import fnmatch
 from os.path import basename
 
 from pygments.formatters._mapping import FORMATTERS
@@ -22,16 +22,6 @@ __all__ = ['get_formatter_by_name', 'get_formatter_for_filename',
            'get_all_formatters', 'load_formatter_from_file'] + list(FORMATTERS)
 
 _formatter_cache = {}  # classes by name
-_pattern_cache = {}
-
-
-def _fn_matches(fn, glob):
-    """Return whether the supplied file name fn matches pattern filename."""
-    if glob not in _pattern_cache:
-        pattern = _pattern_cache[glob] = re.compile(fnmatch.translate(glob))
-        return pattern.match(fn)
-    return _pattern_cache[glob].match(fn)
-
 
 def _load_formatters(module_name):
     """Load a formatter (and all others in the module too)."""
@@ -122,13 +112,13 @@ def get_formatter_for_filename(fn, **options):
     fn = basename(fn)
     for modname, name, _, filenames, _ in FORMATTERS.values():
         for filename in filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 if name not in _formatter_cache:
                     _load_formatters(modname)
                 return _formatter_cache[name](**options)
     for cls in find_plugin_formatters():
         for filename in cls.filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 return cls(**options)
     raise ClassNotFound("no formatter found for file name %r" % fn)
 

--- a/pygments/lexers/__init__.py
+++ b/pygments/lexers/__init__.py
@@ -11,7 +11,7 @@
 import re
 import sys
 import types
-import fnmatch
+from fnmatch import fnmatch
 from os.path import basename
 
 from pygments.lexers._mapping import LEXERS
@@ -28,16 +28,6 @@ __all__ = ['get_lexer_by_name', 'get_lexer_for_filename', 'find_lexer_class',
            'guess_lexer', 'load_lexer_from_file'] + list(LEXERS) + list(COMPAT)
 
 _lexer_cache = {}
-_pattern_cache = {}
-
-
-def _fn_matches(fn, glob):
-    """Return whether the supplied file name fn matches pattern filename."""
-    if glob not in _pattern_cache:
-        pattern = _pattern_cache[glob] = re.compile(fnmatch.translate(glob))
-        return pattern.match(fn)
-    return _pattern_cache[glob].match(fn)
-
 
 def _load_lexers(module_name):
     """Load a lexer (and all others in the module too)."""
@@ -169,13 +159,13 @@ def find_lexer_class_for_filename(_fn, code=None):
     fn = basename(_fn)
     for modname, name, _, filenames, _ in LEXERS.values():
         for filename in filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 if name not in _lexer_cache:
                     _load_lexers(modname)
                 matches.append((_lexer_cache[name], filename))
     for cls in find_plugin_lexers():
         for filename in cls.filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 matches.append((cls, filename))
 
     if isinstance(code, bytes):
@@ -262,11 +252,11 @@ def guess_lexer_for_filename(_fn, _text, **options):
     matching_lexers = set()
     for lexer in _iter_lexerclasses():
         for filename in lexer.filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 matching_lexers.add(lexer)
                 primary[lexer] = True
         for filename in lexer.alias_filenames:
-            if _fn_matches(fn, filename):
+            if fnmatch(fn, filename):
                 matching_lexers.add(lexer)
                 primary[lexer] = False
     if not matching_lexers:


### PR DESCRIPTION
These are irrelevant because the fnmatch module implementation already
uses functools.lru_cache.

(More diff size reduction towards a new plugin system.)