### PR TITLE
Support building docs when some plugins are installed

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,14 +233,15 @@ rst_prolog = '.. |language_count| replace:: {}'.format(len(list(pygments.lexers.
 def pg_context(app, pagename, templatename, ctx, event_arg):
     ctx['demo_active'] = bool(os.environ.get('WEBSITE_BUILD'))
 
+    if pagename in ('demo', 'languages'):
+        all_lexers = sorted(pygments.lexers.get_all_lexers(plugins=False), key=lambda x: x[0].lower())
     if pagename == 'demo':
-        ctx['lexers'] = sorted(pygments.lexers.get_all_lexers(), key=lambda x: x[0].lower())
+        ctx['lexers'] = all_lexers
 
     if pagename == 'languages':
         lexer_name_url = []
-
-        for entry in sorted(pygments.lexers.LEXERS.values(), key=lambda x: x[1].lower()):
-            lexer_cls = pygments.lexers.find_lexer_class(entry[1])
+        for entry in all_lexers:
+            lexer_cls = pygments.lexers.find_lexer_class(entry[0])
             lexer_name_url.append({'name': entry[1], 'url': lexer_cls.url})
         ctx['languages'] = lexer_name_url
 
@@ -251,7 +252,7 @@ def pg_context(app, pagename, templatename, ctx, event_arg):
         min_contrasts = test_contrasts.min_contrasts()
         ctx['styles_aa'] = []
         ctx['styles_sub_aa'] = []
-        for style in pygments.styles.get_all_styles():
+        for style in pygments.styles.STYLE_MAP:
             if not pygments.styles.get_style_by_name(style).web_style_gallery_exclude:
                 aa = min_contrasts[style] >= test_contrasts.WCAG_AA_CONTRAST
                 bg_r, bg_g, bg_b = test_contrasts.hex2rgb(pygments.styles.get_style_by_name(style).background_color)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -242,7 +242,7 @@ def pg_context(app, pagename, templatename, ctx, event_arg):
         lexer_name_url = []
         for entry in all_lexers:
             lexer_cls = pygments.lexers.find_lexer_class(entry[0])
-            lexer_name_url.append({'name': entry[1], 'url': lexer_cls.url})
+            lexer_name_url.append({'name': entry[0], 'url': lexer_cls.url})
         ctx['languages'] = lexer_name_url
 
     if pagename in ('styles', 'demo'):
@@ -252,6 +252,7 @@ def pg_context(app, pagename, templatename, ctx, event_arg):
         min_contrasts = test_contrasts.min_contrasts()
         ctx['styles_aa'] = []
         ctx['styles_sub_aa'] = []
+        # Use STYLE_MAP directly so we don't get plugins as with get_all_styles().
         for style in pygments.styles.STYLE_MAP:
             if not pygments.styles.get_style_by_name(style).web_style_gallery_exclude:
                 aa = min_contrasts[style] >= test_contrasts.WCAG_AA_CONTRAST


### PR DESCRIPTION
Pass plugins=False to get_all_lexers, otherwise we try to document
them, which fails. For styles, use STYLE_MAP directly; given that I'm
trying to introduce a new plugin interface, I'd rather not change
get_all_styles to support plugins=False right now.