### PR TITLE
Add Python 3.11 in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-alpha - 3.11"]
       max-parallel: 4
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
       max-parallel: 4
 
     steps:


### PR DESCRIPTION
Python 3.11 is in the beta phase (3.11b3 released yesterday, although this is conceptually b2 because they expedited b3 due to an incompatibility with pytest -- https://mail.python.org/archives/list/python-dev@python.org/thread/VZ222BFFAWW73DYFCR7NZR2C5M3TXD65/). I propose to hit the ground running by adding it to the CI already now.