### PR TITLE
Detect true-color terminal support for pygmentize

### DIFF
--- a/doc/docs/cmdline.rst
+++ b/doc/docs/cmdline.rst
@@ -13,6 +13,18 @@ You can use Pygments from the shell, provided you installed the
 will print the file test.py to standard output, using the Python lexer
 (inferred from the file name extension) and the terminal formatter (because
 you didn't give an explicit formatter name).
+:program:`pygmentize` attempts to
+detect the maximum number of colors that the terminal supports. The difference
+between color formatters for 16 and 256 colors is immense, but there is a less
+noticeable difference between color formatters for 256 and 16 million colors.
+
+Here's the process of how it detects the maxiumum number of colors
+supported by your terminal. If the ``COLORTERM`` environment variable is set to
+either ``truecolor`` or ``24bit``, it will use a 16 million color representation
+(like ``terminal16m``). Next, it will try to find ``256`` is anywhere in the
+environment variable ``TERM``, which it will use a 256-color representaion
+(such as ``terminal256``).  When neither of those are found, it falls back to a
+the 16 color representation (like ``terminal``).
 
 If you want HTML output::
 

--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -25,7 +25,7 @@ from pygments.formatters.latex import LatexEmbeddedLexer, LatexFormatter
 from pygments.formatters import get_all_formatters, get_formatter_by_name, \
     load_formatter_from_file, get_formatter_for_filename, find_formatter_class
 from pygments.formatters.terminal import TerminalFormatter
-from pygments.formatters.terminal256 import Terminal256Formatter
+from pygments.formatters.terminal256 import Terminal256Formatter, TerminalTrueColorFormatter
 from pygments.filters import get_all_filters, find_filter_class
 from pygments.styles import get_all_styles, get_style_by_name
 
@@ -445,7 +445,9 @@ def main_inner(parser, argns):
             return 1
     else:
         if not fmter:
-            if '256' in os.environ.get('TERM', ''):
+            if os.environ.get('COLORTERM','') in ('truecolor', '24bit'):
+                fmter = TerminalTrueColorFormatter(**parsed_opts)
+            elif '256' in os.environ.get('TERM', ''):
                 fmter = Terminal256Formatter(**parsed_opts)
             else:
                 fmter = TerminalFormatter(**parsed_opts)


### PR DESCRIPTION
For the `pygmentize` command line, this pull request adds detection of true-color support on the terminal and makes that the default formatter.  It looks up the `COLORTERM` environment variable having a value of `truecolor` or `24bit`. If that is the case, it sets the default formatter to use the `TerminalTrueColorFormatter`.

The `COLORTERM` environment variable is a convention that has been adopted by some terminals for specifying true-color is supported.