### PR TITLE
Teraterm updates

### DIFF
--- a/pygments/lexers/teraterm.py
+++ b/pygments/lexers/teraterm.py
@@ -52,7 +52,7 @@ class TeraTermLexer(RegexLexer):
             (r'[*/]', Comment.Multiline)
         ],
         'labels': [
-            (r'(?i)^(\s*)(:[a-z0-9_]+)', bygroups(Text, Name.Label)),
+            (r'(?i)^(\s*)(:[a-z0-9_]+)', bygroups(Text.Whitespace, Name.Label)),
         ],
         'commands': [
             (
@@ -260,7 +260,7 @@ class TeraTermLexer(RegexLexer):
                 Keyword,
             ),
             (r'(?i)(call|goto)([ \t]+)([a-z0-9_]+)',
-             bygroups(Keyword, Text, Name.Label)),
+             bygroups(Keyword, Text.Whitespace, Name.Label)),
         ],
         'builtin-variables': [
             (
@@ -324,7 +324,7 @@ class TeraTermLexer(RegexLexer):
             (r'[()]', String.Symbol),
         ],
         'all-whitespace': [
-            (r'\s+', Text),
+            (r'\s+', Text.Whitespace),
         ],
     }
 

--- a/pygments/lexers/teraterm.py
+++ b/pygments/lexers/teraterm.py
@@ -12,7 +12,7 @@ import re
 
 from pygments.lexer import RegexLexer, include, bygroups
 from pygments.token import Text, Comment, Operator, Name, String, \
-    Number, Keyword
+    Number, Keyword, Error
 
 __all__ = ['TeraTermLexer']
 
@@ -303,20 +303,11 @@ class TeraTermLexer(RegexLexer):
         ],
         'string-literals': [
             (r'(?i)#(?:[0-9]+|\$[0-9a-f]+)', String.Char),
-            (r"'", String.Single, 'in-single-string'),
-            (r'"', String.Double, 'in-double-string'),
-        ],
-        'in-general-string': [
-            (r'\\[\\nt]', String.Escape),  # Only three escapes are supported.
-            (r'.', String),
-        ],
-        'in-single-string': [
-            (r"'", String.Single, '#pop'),
-            include('in-general-string'),
-        ],
-        'in-double-string': [
-            (r'"', String.Double, '#pop'),
-            include('in-general-string'),
+            (r"'[^'\n]*'", String.Single),
+            (r'"[^"\n]*"', String.Double),
+            # Opening quotes without a closing quote on the same line are errors.
+            (r"('[^']*)(\n)", bygroups(Error, Text.Whitespace)),
+            (r'("[^"]*)(\n)', bygroups(Error, Text.Whitespace)),
         ],
         'operators': [
             (r'and|not|or|xor', Operator.Word),

--- a/tests/examplefiles/ttl/teraterm.ttl
+++ b/tests/examplefiles/ttl/teraterm.ttl
@@ -1,4 +1,4 @@
-messagebox "text \\not escaped \nescaped n" "other\n\rthing"
+messagebox "double string" "title"
 messagebox "goto label /* a string */ ; same string"
 a=10
 b=  'abc'#$41'def'
@@ -21,14 +21,3 @@ else
 endif
 
 if abc messagebox "thing1" "title"
-
-
-; Invalid syntax
-bad = "no closing double quote
-bad = 'no closing single quote
-garbage
-...
-...
-...
-
-endgarbage

--- a/tests/examplefiles/ttl/teraterm.ttl.output
+++ b/tests/examplefiles/ttl/teraterm.ttl.output
@@ -1,124 +1,33 @@
 'messagebox'  Keyword
-' '           Text
-'"'           Literal.String.Double
-'t'           Literal.String
-'e'           Literal.String
-'x'           Literal.String
-'t'           Literal.String
-' '           Literal.String
-'\\\\'        Literal.String.Escape
-'n'           Literal.String
-'o'           Literal.String
-'t'           Literal.String
-' '           Literal.String
-'e'           Literal.String
-'s'           Literal.String
-'c'           Literal.String
-'a'           Literal.String
-'p'           Literal.String
-'e'           Literal.String
-'d'           Literal.String
-' '           Literal.String
-'\\n'         Literal.String.Escape
-'e'           Literal.String
-'s'           Literal.String
-'c'           Literal.String
-'a'           Literal.String
-'p'           Literal.String
-'e'           Literal.String
-'d'           Literal.String
-' '           Literal.String
-'n'           Literal.String
-'"'           Literal.String.Double
-' '           Text
-'"'           Literal.String.Double
-'o'           Literal.String
-'t'           Literal.String
-'h'           Literal.String
-'e'           Literal.String
-'r'           Literal.String
-'\\n'         Literal.String.Escape
-'\\'          Literal.String
-'r'           Literal.String
-'t'           Literal.String
-'h'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'"'           Literal.String.Double
-'\n'          Text
+' '           Text.Whitespace
+'"double string"' Literal.String.Double
+' '           Text.Whitespace
+'"title"'     Literal.String.Double
+'\n'          Text.Whitespace
 
 'messagebox'  Keyword
-' '           Text
-'"'           Literal.String.Double
-'g'           Literal.String
-'o'           Literal.String
-'t'           Literal.String
-'o'           Literal.String
-' '           Literal.String
-'l'           Literal.String
-'a'           Literal.String
-'b'           Literal.String
-'e'           Literal.String
-'l'           Literal.String
-' '           Literal.String
-'/'           Literal.String
-'*'           Literal.String
-' '           Literal.String
-'a'           Literal.String
-' '           Literal.String
-'s'           Literal.String
-'t'           Literal.String
-'r'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-' '           Literal.String
-'*'           Literal.String
-'/'           Literal.String
-' '           Literal.String
-';'           Literal.String
-' '           Literal.String
-'s'           Literal.String
-'a'           Literal.String
-'m'           Literal.String
-'e'           Literal.String
-' '           Literal.String
-'s'           Literal.String
-'t'           Literal.String
-'r'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'"'           Literal.String.Double
-'\n'          Text
+' '           Text.Whitespace
+'"goto label /* a string */ ; same string"' Literal.String.Double
+'\n'          Text.Whitespace
 
 'a'           Name.Variable
 '='           Operator
 '10'          Literal.Number.Integer
-'\n'          Text
+'\n'          Text.Whitespace
 
 'b'           Name.Variable
 '='           Operator
-'  '          Text
-"'"           Literal.String.Single
-'a'           Literal.String
-'b'           Literal.String
-'c'           Literal.String
-"'"           Literal.String.Single
+'  '          Text.Whitespace
+"'abc'"       Literal.String.Single
 '#$41'        Literal.String.Char
-"'"           Literal.String.Single
-'d'           Literal.String
-'e'           Literal.String
-'f'           Literal.String
-"'"           Literal.String.Single
-'\n'          Text
+"'def'"       Literal.String.Single
+'\n'          Text.Whitespace
 
 'c'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 '#65'         Literal.String.Char
-'   '         Text
+'   '         Text.Whitespace
 '/*'          Comment.Multiline
 ' multiline comment ' Comment.Multiline
 '*'           Comment.Multiline
@@ -133,114 +42,108 @@
 '/*'          Comment.Multiline
 '\ncomment '  Comment.Multiline
 '*/'          Comment.Multiline
-' '           Text
+' '           Text.Whitespace
 'd'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '10'          Literal.Number.Integer
-'   '         Text
+'   '         Text.Whitespace
 '; inline comment /* still inline */' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'e'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'd'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '+'           Operator
-' '           Text
+' '           Text.Whitespace
 '20'          Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 '-'           Operator
-' '           Text
+' '           Text.Whitespace
 '('           Literal.String.Symbol
 '('           Literal.String.Symbol
 '$a'          Literal.Number.Hex
-' '           Text
+' '           Text.Whitespace
 '*'           Operator
-' '           Text
+' '           Text.Whitespace
 '2'           Literal.Number.Integer
 ')'           Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 '/'           Operator
-' '           Text
+' '           Text.Whitespace
 '4'           Literal.Number.Integer
 ')'           Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 '<<'          Operator
-' '           Text
+' '           Text.Whitespace
 '3'           Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 '%'           Operator
-' '           Text
+' '           Text.Whitespace
 '('           Literal.String.Symbol
 '2'           Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 '>>'          Operator
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ')'           Literal.String.Symbol
-' '           Text
+' '           Text.Whitespace
 '+'           Operator
-' '           Text
+' '           Text.Whitespace
 'result'      Name.Builtin
-'\n\n\n'      Text
+'\n\n\n'      Text.Whitespace
 
 ':thing'      Name.Label
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'strcompare'  Keyword
-' '           Text
+' '           Text.Whitespace
 'c'           Name.Variable
-' '           Text
-'"'           Literal.String.Double
-'t'           Literal.String
-'h'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'"'           Literal.String.Double
-'\n'          Text
+' '           Text.Whitespace
+'"thing"'     Literal.String.Double
+'\n'          Text.Whitespace
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'result'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'goto'        Keyword
-' '           Text
+' '           Text.Whitespace
 'label_'      Name.Label
-'\n'          Text
+'\n'          Text.Whitespace
 
 'elseif'      Keyword
-' '           Text
+' '           Text.Whitespace
 'result'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '>'           Operator
-' '           Text
+' '           Text.Whitespace
 '-'           Operator
 '1'           Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'goto'        Keyword
-' '           Text
+' '           Text.Whitespace
 '10'          Name.Label
-'\n'          Text
+'\n'          Text.Whitespace
 
 'elseif'      Keyword
-' '           Text
+' '           Text.Whitespace
 'd'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '>'           Operator
-' '           Text
+' '           Text.Whitespace
 '('           Literal.String.Symbol
 '1'           Literal.Number.Integer
 '+'           Operator
@@ -250,139 +153,31 @@
 ')'           Literal.String.Symbol
 '/'           Operator
 '7'           Literal.Number.Integer
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'messagebox'  Keyword
-' '           Text
-'"'           Literal.String.Double
-'t'           Literal.String
-'h'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'"'           Literal.String.Double
-'\n'          Text
+' '           Text.Whitespace
+'"thing"'     Literal.String.Double
+'\n'          Text.Whitespace
 
 'else'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'messagebox'  Keyword
-' '           Text
-'"'           Literal.String.Double
-'d'           Literal.String
-'o'           Literal.String
-'n'           Literal.String
-'e'           Literal.String
-'"'           Literal.String.Double
-'\n'          Text
+' '           Text.Whitespace
+'"done"'      Literal.String.Double
+'\n'          Text.Whitespace
 
 'endif'       Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'abc'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 'messagebox'  Keyword
-' '           Text
-'"'           Literal.String.Double
-'t'           Literal.String
-'h'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'1'           Literal.String
-'"'           Literal.String.Double
-' '           Text
-'"'           Literal.String.Double
-'t'           Literal.String
-'i'           Literal.String
-'t'           Literal.String
-'l'           Literal.String
-'e'           Literal.String
-'"'           Literal.String.Double
-'\n\n\n'      Text
-
-'; Invalid syntax' Comment.Single
-'\n'          Text
-
-'bad'         Name.Variable
-' '           Text
-'='           Operator
-' '           Text
-'"'           Literal.String.Double
-'n'           Literal.String
-'o'           Literal.String
-' '           Literal.String
-'c'           Literal.String
-'l'           Literal.String
-'o'           Literal.String
-'s'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-' '           Literal.String
-'d'           Literal.String
-'o'           Literal.String
-'u'           Literal.String
-'b'           Literal.String
-'l'           Literal.String
-'e'           Literal.String
-' '           Literal.String
-'q'           Literal.String
-'u'           Literal.String
-'o'           Literal.String
-'t'           Literal.String
-'e'           Literal.String
-'\n'          Text
-
-'bad'         Name.Variable
-' '           Text
-'='           Operator
-' '           Text
-"'"           Literal.String.Single
-'n'           Literal.String
-'o'           Literal.String
-' '           Literal.String
-'c'           Literal.String
-'l'           Literal.String
-'o'           Literal.String
-'s'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-' '           Literal.String
-'s'           Literal.String
-'i'           Literal.String
-'n'           Literal.String
-'g'           Literal.String
-'l'           Literal.String
-'e'           Literal.String
-' '           Literal.String
-'q'           Literal.String
-'u'           Literal.String
-'o'           Literal.String
-'t'           Literal.String
-'e'           Literal.String
-'\n'          Text
-
-'garbage'     Name.Variable
-'\n'          Text
-
-'.'           Text
-'.'           Text
-'.'           Text
-'\n'          Text
-
-'.'           Text
-'.'           Text
-'.'           Text
-'\n'          Text
-
-'.'           Text
-'.'           Text
-'.'           Text
-'\n\n'        Text
-
-'endgarbage'  Name.Variable
-'\n'          Text
+' '           Text.Whitespace
+'"thing1"'    Literal.String.Double
+' '           Text.Whitespace
+'"title"'     Literal.String.Double
+'\n'          Text.Whitespace

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, py39, py310, pypy3, lint
+envlist = py{36, 37, 38, 39, 310}, lint
 
 [testenv]
 deps =


### PR DESCRIPTION
This patch:

* Tokenizes whitespace as `Text.Whitespace`, to help address #1905.
* Tokenizes strings in their entirety, rather than one character at a time.
* Removes backslash escape sequences for string literals. They're not special in Tera Term string literals and I have no idea why I added those in the first place!
* Updates tox.ini to drop testing for CPython 3.5 and PyPy3. This now matches CI.

Related to #1905