### PR TITLE
Add 1.18 generics support for go lexer

### DIFF
--- a/pygments/lexers/go.py
+++ b/pygments/lexers/go.py
@@ -52,7 +52,7 @@ class GoLexer(RegexLexer):
                 'int', 'int8', 'int16', 'int32', 'int64',
                 'float', 'float32', 'float64',
                 'complex64', 'complex128', 'byte', 'rune',
-                'string', 'bool', 'error', 'uintptr',
+                'string', 'bool', 'error', 'uintptr', 'any', 'comparable',
                 'print', 'println', 'panic', 'recover', 'close', 'complex',
                 'real', 'imag', 'len', 'cap', 'append', 'copy', 'delete',
                 'new', 'make'), suffix=r'\b(\()'),
@@ -62,7 +62,7 @@ class GoLexer(RegexLexer):
                 'int', 'int8', 'int16', 'int32', 'int64',
                 'float', 'float32', 'float64',
                 'complex64', 'complex128', 'byte', 'rune',
-                'string', 'bool', 'error', 'uintptr'), suffix=r'\b'),
+                'string', 'bool', 'error', 'uintptr', 'any', 'comparable'), suffix=r'\b'),
              Keyword.Type),
             # imaginary_lit
             (r'\d+i', Number),
@@ -91,7 +91,8 @@ class GoLexer(RegexLexer):
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
             # Tokens
             (r'(<<=|>>=|<<|>>|<=|>=|&\^=|&\^|\+=|-=|\*=|/=|%=|&=|\|=|&&|\|\|'
-             r'|<-|\+\+|--|==|!=|:=|\.\.\.|[+\-*/%&])', Operator),
+             r'|<-|\+\+|--|==|!=|:=|\.\.\.|[+\-*/%&]'
+             r'|~|\|)', Operator),
             (r'[|^<>=!()\[\]{}.,;:]', Punctuation),
             # identifier
             (r'[^\W\d]\w*', Name.Other),

--- a/tests/examplefiles/go/generics.go
+++ b/tests/examplefiles/go/generics.go
@@ -1,0 +1,21 @@
+package generics
+
+type Int interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+func Abs[T Int](v T) T {
+	if v < 0 {
+		return -v
+	} else {
+		return v
+	}
+}
+
+func Equal[T comparable](a, b T) bool {
+	return a == b
+}
+
+func PtrOf[T any](v T) *T {
+	return &v
+}

--- a/tests/examplefiles/go/generics.go.output
+++ b/tests/examplefiles/go/generics.go.output
@@ -1,0 +1,173 @@
+'package'     Keyword.Namespace
+' '           Text.Whitespace
+'generics'    Name.Other
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'type'        Keyword.Declaration
+' '           Text.Whitespace
+'Int'         Name.Other
+' '           Text.Whitespace
+'interface'   Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'~'           Operator
+'int'         Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'~'           Operator
+'int8'        Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'~'           Operator
+'int16'       Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'~'           Operator
+'int32'       Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'~'           Operator
+'int64'       Keyword.Type
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'Abs'         Name.Other
+'['           Punctuation
+'T'           Name.Other
+' '           Text.Whitespace
+'Int'         Name.Other
+']'           Punctuation
+'('           Punctuation
+'v'           Name.Other
+' '           Text.Whitespace
+'T'           Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'T'           Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'v'           Name.Other
+' '           Text.Whitespace
+'<'           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'-'           Operator
+'v'           Name.Other
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'v'           Name.Other
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'Equal'       Name.Other
+'['           Punctuation
+'T'           Name.Other
+' '           Text.Whitespace
+'comparable'  Keyword.Type
+']'           Punctuation
+'('           Punctuation
+'a'           Name.Other
+','           Punctuation
+' '           Text.Whitespace
+'b'           Name.Other
+' '           Text.Whitespace
+'T'           Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'a'           Name.Other
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'b'           Name.Other
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'PtrOf'       Name.Other
+'['           Punctuation
+'T'           Name.Other
+' '           Text.Whitespace
+'any'         Keyword.Type
+']'           Punctuation
+'('           Punctuation
+'v'           Name.Other
+' '           Text.Whitespace
+'T'           Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'*'           Operator
+'T'           Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'&'           Operator
+'v'           Name.Other
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
- Add new predeclared identifiers: `any` and `comparable`
- Add new operator for type parameters: `~` and `|`

Ref: https://go.dev/ref/spec

Close #2164 