### PR TITLE
Add StarOfficeStyle

### DIFF
--- a/pygments/styles/staroffice.py
+++ b/pygments/styles/staroffice.py
@@ -1,0 +1,15 @@
+from pygments.style import Style
+from pygments.token import Keyword, Name, Comment, String, Error, \
+     Number, Operator, Generic
+
+class StarofficeStyle(Style):
+    default_style = ""
+    styles = {
+        Comment:                '#808080',   # Gray
+        Error:                  '#800000',   # Red
+        Keyword:                '#000080',   # Blue
+        Name:                   '#008000',   # Green
+        Number:                 '#FF0000',   # Lightred
+        Operator:               '#000080',   # Blue
+        String:                 '#FF0000',   # Lightred
+    }


### PR DESCRIPTION
StarOffice style is a theme used in the user interface and carries through to OpenOffice and LibreOffice, and the documentation.

Reference:
* [Color Config Entry](https://github.com/LibreOffice/core/blob/master/svtools/source/config/colorcfg.cxx#L447-L453)
* [Color Types](https://github.com/LibreOffice/core/blob/e4a57dcdabc9ae7d381025e008b90635c1b7b10c/include/tools/color.hxx#L448)