### PR TITLE
XQuery lexer: Unicode support

### DIFF
--- a/pygments/lexers/webmisc.py
+++ b/pygments/lexers/webmisc.py
@@ -68,17 +68,7 @@ class XQueryLexer(ExtendedRegexLexer):
 
     xquery_parse_state = []
 
-    _ncnamestartchar = (
-       r"[A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|"
-       r"[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|"
-       r"[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|"
-       r"[\U00010000-\U000EFFFF]"
-    )
-    ncnamestartchar = '(?:%s)' % _ncnamestartchar
-    _ncnamechar = _ncnamestartchar + (r"|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|"
-                                     r"[\u203F-\u2040]")
-    ncnamechar = f"(?:{_ncnamechar})"
-    ncname = f"(?:{ncnamestartchar}{ncnamechar}*)"
+    ncname = r"(?:[^\W\d](?:\w|-|[.])*)"
     pitarget_namestartchar = r"(?:[A-KN-WYZ]|_|:|[a-kn-wyz])"
     pitarget_namechar = r"(?:" + pitarget_namestartchar + r"|-|\.|[0-9])"
     pitarget = f"{pitarget_namestartchar}+{pitarget_namechar}*"

--- a/pygments/lexers/webmisc.py
+++ b/pygments/lexers/webmisc.py
@@ -69,9 +69,7 @@ class XQueryLexer(ExtendedRegexLexer):
     xquery_parse_state = []
 
     ncname = r"(?:[^\W\d](?:\w|-|[.])*)"
-    pitarget_namestartchar = r"(?:[A-KN-WYZ]|_|:|[a-kn-wyz])"
-    pitarget_namechar = r"(?:" + pitarget_namestartchar + r"|-|\.|[0-9])"
-    pitarget = f"{pitarget_namestartchar}+{pitarget_namechar}*"
+    pitarget = r"(?![xX][mM][lL]$)(?:[^\W\d][\w.\-:]*)"
     prefixedname = f"{ncname}:{ncname}"
     unprefixedname = ncname
     qname = f"(?:{prefixedname}|{unprefixedname})"

--- a/pygments/lexers/webmisc.py
+++ b/pygments/lexers/webmisc.py
@@ -68,19 +68,17 @@ class XQueryLexer(ExtendedRegexLexer):
 
     xquery_parse_state = []
 
-    # FIX UNICODE LATER
-    # ncnamestartchar = (
-    #    r"[A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|"
-    #    r"[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|"
-    #    r"[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|"
-    #    r"[\u10000-\uEFFFF]"
-    # )
-    ncnamestartchar = r"(?:[A-Z]|_|[a-z])"
-    # FIX UNICODE LATER
-    # ncnamechar = ncnamestartchar + (r"|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|"
-    #                                 r"[\u203F-\u2040]")
-    ncnamechar = r"(?:" + ncnamestartchar + r"|-|\.|[0-9])"
-    ncname = f"(?:{ncnamestartchar}+{ncnamechar}*)"
+    _ncnamestartchar = (
+       r"[A-Z]|_|[a-z]|[\u00C0-\u00D6]|[\u00D8-\u00F6]|[\u00F8-\u02FF]|"
+       r"[\u0370-\u037D]|[\u037F-\u1FFF]|[\u200C-\u200D]|[\u2070-\u218F]|"
+       r"[\u2C00-\u2FEF]|[\u3001-\uD7FF]|[\uF900-\uFDCF]|[\uFDF0-\uFFFD]|"
+       r"[\U00010000-\U000EFFFF]"
+    )
+    ncnamestartchar = '(?:%s)' % _ncnamestartchar
+    _ncnamechar = _ncnamestartchar + (r"|-|\.|[0-9]|\u00B7|[\u0300-\u036F]|"
+                                     r"[\u203F-\u2040]")
+    ncnamechar = f"(?:{_ncnamechar})"
+    ncname = f"(?:{ncnamestartchar}{ncnamechar}*)"
     pitarget_namestartchar = r"(?:[A-KN-WYZ]|_|:|[a-kn-wyz])"
     pitarget_namechar = r"(?:" + pitarget_namestartchar + r"|-|\.|[0-9])"
     pitarget = f"{pitarget_namestartchar}+{pitarget_namechar}*"
@@ -94,20 +92,27 @@ class XQueryLexer(ExtendedRegexLexer):
     stringdouble = r'(?:"(?:' + entityref + r'|' + charref + r'|""|[^&"])*")'
     stringsingle = r"(?:'(?:" + entityref + r"|" + charref + r"|''|[^&'])*')"
 
-    # FIX UNICODE LATER
-    # elementcontentchar = (r'\t|\r|\n|[\u0020-\u0025]|[\u0028-\u003b]|'
-    #                       r'[\u003d-\u007a]|\u007c|[\u007e-\u007F]')
-    elementcontentchar = r'[A-Za-z]|\s|\d|[!"#$%()*+,\-./:;=?@\[\\\]^_\'`|~]'
-    # quotattrcontentchar = (r'\t|\r|\n|[\u0020-\u0021]|[\u0023-\u0025]|'
-    #                        r'[\u0027-\u003b]|[\u003d-\u007a]|\u007c|[\u007e-\u007F]')
-    quotattrcontentchar = r'[A-Za-z]|\s|\d|[!#$%()*+,\-./:;=?@\[\\\]^_\'`|~]'
-    # aposattrcontentchar = (r'\t|\r|\n|[\u0020-\u0025]|[\u0028-\u003b]|'
-    #                        r'[\u003d-\u007a]|\u007c|[\u007e-\u007F]')
-    aposattrcontentchar = r'[A-Za-z]|\s|\d|[!"#$%()*+,\-./:;=?@\[\\\]^_`|~]'
-
     # CHAR elements - fix the above elementcontentchar, quotattrcontentchar,
     #                 aposattrcontentchar
     # x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    # 
+    # Characters for exclusion:
+    #
+    # " U+0022 QUOTATION MARK
+    # & U+0026 AMPERSAND
+    # ' U+0027 APOSTROPHE
+    # < U+003C LESS-THAN SIGN
+    # > U+003E GREATER-THAN SIGN
+    # { U+007B LEFT CURLY BRACKET
+    # } U+007D RIGHT CURLY BRACKET
+    _char_rest = r'|[\u0080-\uD7FF]|[\uE000-\uFFFD]|[\U00010000-\U0010FFFF]'
+    elementcontentchar = (r'\t|\r|\n|[\u0020-\u0025]|[\u0028-\u003b]|' 
+                          r'[\u003d-\u007a]|\u007c|[\u007e-\u007F]' + _char_rest)
+    quotattrcontentchar = (r'\t|\r|\n|[\u0020-\u0021]|[\u0023-\u0025]|'
+                           r'[\u0027-\u003b]|[\u003d-\u007a]|\u007c|[\u007e-\u007F]' + _char_rest)
+    aposattrcontentchar = (r'\t|\r|\n|[\u0020-\u0025]|[\u0028-\u003b]|'
+                           r'[\u003d-\u007a]|\u007c|[\u007e-\u007F]' + _char_rest)
+
 
     flags = re.DOTALL | re.MULTILINE
 

--- a/pygments/lexers/webmisc.py
+++ b/pygments/lexers/webmisc.py
@@ -127,6 +127,13 @@ class XQueryLexer(ExtendedRegexLexer):
         ctx.stack.append(lexer.xquery_parse_state.pop())
         ctx.pos = match.end()
 
+    def popstate_xmlpi_callback(lexer, match, ctx):
+        yield match.start(), String.Doc, match.group(1)
+        ctx.stack.append(lexer.xquery_parse_state.pop())
+        ctx.pos = match.end()
+
+
+
     def popstate_kindtest_callback(lexer, match, ctx):
         yield match.start(), Punctuation, match.group(1)
         next_state = lexer.xquery_parse_state.pop()
@@ -512,13 +519,12 @@ class XQueryLexer(ExtendedRegexLexer):
         ],
         'processing_instruction': [
             (r'\s+', Text, 'processing_instruction_content'),
-            (r'\?>', String.Doc, '#pop'),
+            (r'(\?>)', popstate_xmlpi_callback),
             (pitarget, Name),
         ],
         'processing_instruction_content': [
-            (r'\?>', String.Doc, '#pop'),
-            (r'\t|\r|\n|[\u0020-\uD7FF]|[\uE000-\uFFFD]|[\U00010000-\U0010FFFF]',
-             Literal),
+            (r'(\?>)', popstate_xmlpi_callback),
+            (r'\t|\r|\n|[\u0020-\uD7FF]|[\uE000-\uFFFD]|[\U00010000-\U0010FFFF]', Literal),
         ],
         'cdata_section': [
             (r']]>', String.Doc, '#pop'),

--- a/tests/examplefiles/xquery/test.xqy
+++ b/tests/examplefiles/xquery/test.xqy
@@ -135,4 +135,5 @@ return
 	</outer>
 }
   <tr><td><!-- some commented things-->&nbsp;</td></tr>
+  <tr><td title="Ünicöde in attrïbutes">… and 😎 characters > U+FFFF</td></tr>
 </html>

--- a/tests/examplefiles/xquery/test.xqy
+++ b/tests/examplefiles/xquery/test.xqy
@@ -136,4 +136,5 @@ return
 }
   <tr><td><!-- some commented things-->&nbsp;</td></tr>
   <tr><td title="Ünicöde in attrïbutes">… and 😎 characters > U+FFFF</td></tr>
+  <?procéssing instruction?>
 </html>

--- a/tests/examplefiles/xquery/test.xqy.output
+++ b/tests/examplefiles/xquery/test.xqy.output
@@ -1412,6 +1412,75 @@
 '>'           Name.Tag
 '\n'          Literal
 
+' '           Literal
+' '           Literal
+'<'           Name.Tag
+'tr'          Name.Tag
+'>'           Name.Tag
+'<'           Name.Tag
+'td'          Name.Tag
+' '           Text.Whitespace
+'title'       Name.Tag
+'='           Operator
+'"'           Punctuation
+'Ü'           Name.Attribute
+'n'           Name.Attribute
+'i'           Name.Attribute
+'c'           Name.Attribute
+'ö'           Name.Attribute
+'d'           Name.Attribute
+'e'           Name.Attribute
+' '           Name.Attribute
+'i'           Name.Attribute
+'n'           Name.Attribute
+' '           Name.Attribute
+'a'           Name.Attribute
+'t'           Name.Attribute
+'t'           Name.Attribute
+'r'           Name.Attribute
+'ï'           Name.Attribute
+'b'           Name.Attribute
+'u'           Name.Attribute
+'t'           Name.Attribute
+'e'           Name.Attribute
+'s'           Name.Attribute
+'"'           Punctuation
+'>'           Name.Tag
+'…'           Literal
+' '           Literal
+'a'           Literal
+'n'           Literal
+'d'           Literal
+' '           Literal
+'😎'           Literal
+' '           Literal
+'c'           Literal
+'h'           Literal
+'a'           Literal
+'r'           Literal
+'a'           Literal
+'c'           Literal
+'t'           Literal
+'e'           Literal
+'r'           Literal
+'s'           Literal
+' '           Literal
+'>'           Literal
+' '           Literal
+'U'           Literal
+'+'           Literal
+'F'           Literal
+'F'           Literal
+'F'           Literal
+'F'           Literal
+'</'          Name.Tag
+'td'          Name.Tag
+'>'           Name.Tag
+'</'          Name.Tag
+'tr'          Name.Tag
+'>'           Name.Tag
+'\n'          Literal
+
 '</'          Name.Tag
 'html'        Name.Tag
 '>'           Name.Tag

--- a/tests/examplefiles/xquery/test.xqy.output
+++ b/tests/examplefiles/xquery/test.xqy.output
@@ -1481,6 +1481,25 @@
 '>'           Name.Tag
 '\n'          Literal
 
+' '           Literal
+' '           Literal
+'<?'          Literal.String.Doc
+'procéssing'  Name
+' '           Text
+'i'           Literal
+'n'           Literal
+'s'           Literal
+'t'           Literal
+'r'           Literal
+'u'           Literal
+'c'           Literal
+'t'           Literal
+'i'           Literal
+'o'           Literal
+'n'           Literal
+'?>'          Literal.String.Doc
+'\n'          Literal
+
 '</'          Name.Tag
 'html'        Name.Tag
 '>'           Name.Tag


### PR DESCRIPTION
The XQuery lexer considered non-ascii characters in names and literal XML elements / attributes as errors. This pull request resolves the "fix unicode later" comments in the original source.