### PR TITLE
pytest: do not raise DeprecationWarnings as errors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,11 +23,7 @@ jobs:
         pip install -r requirements.txt
         pip install .
     - name: Test package
-      run: make test TEST=-v
-      if: runner.os == 'Linux'
-    - name: Test package
-      run: pytest
-      if: runner.os != 'Linux'
+      run: pytest -W error
 
   check:
     runs-on: ubuntu-latest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    error::FutureWarning
-    error::DeprecationWarning


### PR DESCRIPTION
This "fixes" test failures seen with Pillow >= 9.2.0, and any future such cases.