### PR TITLE
cmdline: silently ignore ``BrokenPipeError``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,8 @@ Version 2.13.0
   ``importlib.metadata`` nor ``importlib_metadata`` is found, but it
   will be slower.
 
+- Silently ignore ``BrokenPipeError`` in the command-line interface
+  (#2193).
 - The ``HtmlFormatter`` now uses the ``linespans`` attribute for
   ``anchorlinenos`` if the ``lineanchors`` attribute is unset (#2026).
 - The ``highlight``, ``lex`` and ``format`` functions no longer

--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -638,6 +638,9 @@ def main(args=sys.argv):
 
     try:
         return main_inner(parser, argns)
+    except BrokenPipeError:
+        # someone closed our stdout, e.g. by quitting a pager.
+        return 0
     except Exception:
         if argns.v:
             print(file=sys.stderr)


### PR DESCRIPTION
This has come up a few times, and I see no good reason to catch
and report this error.

Fixes #2193