### PR TITLE
languages doc page: mapping of languages with aliases

### DIFF
--- a/doc/_templates/languages.html
+++ b/doc/_templates/languages.html
@@ -10,9 +10,9 @@
 {% for language in languages %}
 <li>
     {% if language.url %}
-    <a href="{{language.url}}">{{language.name}}</a>
+    <a href="{{language.url}}">{{language.name}}</a> - {{ ', '.join(language.aliases) }}
     {% else %}
-    {{language.name}}
+    {{language.name}} - {{ ', '.join(language.aliases) }}
     {% endif %}
 </li>
 {% endfor %}


### PR DESCRIPTION
it's a naive and minimal implementation to fix #2202

it could be enhanced to display a table or to surround aliases in an inline code style with a mono font and a style added to it