### PR TITLE
Disable highlighting of Some Escape Codes for Python bytes Literals

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -142,7 +142,7 @@ class PythonLexer(RegexLexer):
              combined('fstringescape', 'dqf')),
             ("([fF])(')", bygroups(String.Affix, String.Single),
              combined('fstringescape', 'sqf')),
-            # raw strings
+            # raw bytes and strings
             ('(?i)(rb|br|r)(""")',
              bygroups(String.Affix, String.Double), 'tdqs'),
             ("(?i)(rb|br|r)(''')",
@@ -152,14 +152,24 @@ class PythonLexer(RegexLexer):
             ("(?i)(rb|br|r)(')",
              bygroups(String.Affix, String.Single), 'sqs'),
             # non-raw strings
-            ('([uUbB]?)(""")', bygroups(String.Affix, String.Double),
+            ('([uU]?)(""")', bygroups(String.Affix, String.Double),
              combined('stringescape', 'tdqs')),
-            ("([uUbB]?)(''')", bygroups(String.Affix, String.Single),
+            ("([uU]?)(''')", bygroups(String.Affix, String.Single),
              combined('stringescape', 'tsqs')),
-            ('([uUbB]?)(")', bygroups(String.Affix, String.Double),
+            ('([uU]?)(")', bygroups(String.Affix, String.Double),
              combined('stringescape', 'dqs')),
-            ("([uUbB]?)(')", bygroups(String.Affix, String.Single),
+            ("([uU]?)(')", bygroups(String.Affix, String.Single),
              combined('stringescape', 'sqs')),
+            # non-raw bytes
+            ('([bB])(""")', bygroups(String.Affix, String.Double),
+             combined('bytesescape', 'tdqs')),
+            ("([bB])(''')", bygroups(String.Affix, String.Single),
+             combined('bytesescape', 'tsqs')),
+            ('([bB])(")', bygroups(String.Affix, String.Double),
+             combined('bytesescape', 'dqs')),
+            ("([bB])(')", bygroups(String.Affix, String.Single),
+             combined('bytesescape', 'sqs')),
+            
             (r'[^\S\n]+', Text),
             include('numbers'),
             (r'!=|==|<<|>>|:=|[-~+/*%=<>&^|.]', Operator),
@@ -343,9 +353,12 @@ class PythonLexer(RegexLexer):
             include('rfstringescape'),
             include('stringescape'),
         ],
+        'bytesescape': [
+            (r'\\([\\abfnrtv"\']|\n|x[a-fA-F0-9]{2}|[0-7]{1,3})', String.Escape)
+        ],
         'stringescape': [
-            (r'\\([\\abfnrtv"\']|\n|N\{.*?\}|u[a-fA-F0-9]{4}|'
-             r'U[a-fA-F0-9]{8}|x[a-fA-F0-9]{2}|[0-7]{1,3})', String.Escape)
+            (r'\\(N\{.*?\}|u[a-fA-F0-9]{4}|U[a-fA-F0-9]{8})', String.Escape),
+            include('bytesescape')
         ],
         'fstrings-single': fstring_rules(String.Single),
         'fstrings-double': fstring_rules(String.Double),

--- a/tests/snippets/python/test_bytes_escape_codes.txt
+++ b/tests/snippets/python/test_bytes_escape_codes.txt
@@ -1,0 +1,24 @@
+---input---
+b'\\ \n \x12 \777 \u1234 \U00010348 \N{Plus-Minus Sign}'
+
+---tokens---
+'b'           Literal.String.Affix
+"'"           Literal.String.Single
+'\\\\'        Literal.String.Escape
+' '           Literal.String.Single
+'\\n'         Literal.String.Escape
+' '           Literal.String.Single
+'\\x12'       Literal.String.Escape
+' '           Literal.String.Single
+'\\777'       Literal.String.Escape
+' '           Literal.String.Single
+'\\'          Literal.String.Single
+'u1234 '      Literal.String.Single
+'\\'          Literal.String.Single
+'U00010348 '  Literal.String.Single
+'\\'          Literal.String.Single
+'N'           Literal.String.Single
+'{'           Literal.String.Single
+'Plus-Minus Sign}' Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text

--- a/tests/snippets/python/test_string_escape_codes.txt
+++ b/tests/snippets/python/test_string_escape_codes.txt
@@ -1,0 +1,20 @@
+---input---
+'\\ \n \x12 \777 \u1234 \U00010348 \N{Plus-Minus Sign}'
+
+---tokens---
+"'"           Literal.String.Single
+'\\\\'        Literal.String.Escape
+' '           Literal.String.Single
+'\\n'         Literal.String.Escape
+' '           Literal.String.Single
+'\\x12'       Literal.String.Escape
+' '           Literal.String.Single
+'\\777'       Literal.String.Escape
+' '           Literal.String.Single
+'\\u1234'     Literal.String.Escape
+' '           Literal.String.Single
+'\\U00010348' Literal.String.Escape
+' '           Literal.String.Single
+'\\N{Plus-Minus Sign}' Literal.String.Escape
+"'"           Literal.String.Single
+'\n'          Text


### PR DESCRIPTION
Hi!  I saw escape codes of the form `"\N{name}"`, `"\uxxxx"` and `"\Uxxxxxxxx"` are currently highlighted within bytes literals, but according to https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals these escape codes are only recognized in string literals so this PR removes highlighting of these three forms from bytes literals.

I've added a couple of golden tests for escape code highlighting in string and bytes literals, apologies if this is elsewhere I couldn't find anything similar.

Let me know what you think, thanks :slightly_smiling_face: 
