### PR TITLE
CFamilyLexer: refuse quotes between parentheses for function definiti…

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -132,9 +132,9 @@ class CFamilyLexer(RegexLexer):
              r'(' + _possible_comments + r')'    # possible comments
              r'(' + _namespaced_ident + r')'             # method name
              r'(' + _possible_comments + r')'    # possible comments
-             r'(\([^;]*?\))'                          # signature
+             r'(\([^;"\']*?\))'                          # signature
              r'(' + _possible_comments + r')'    # possible comments
-             r'([^;{/]*)(\{)',
+             r'([^;{/"\']*)(\{)',
              bygroups(using(this), using(this, state='whitespace'), Name.Function, using(this, state='whitespace'),
                       using(this), using(this, state='whitespace'), using(this), Punctuation),
              'function'),
@@ -143,9 +143,9 @@ class CFamilyLexer(RegexLexer):
              r'(' + _possible_comments + r')'    # possible comments
              r'(' + _namespaced_ident + r')'             # method name
              r'(' + _possible_comments + r')'    # possible comments
-             r'(\([^;]*?\))'                          # signature
+             r'(\([^;"\']*?\))'                          # signature
              r'(' + _possible_comments + r')'    # possible comments
-             r'([^;/]*)(;)',
+             r'([^;/"\']*)(;)',
              bygroups(using(this), using(this, state='whitespace'), Name.Function, using(this, state='whitespace'),
                       using(this), using(this, state='whitespace'), using(this), Punctuation)),
             include('types'),

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -944,7 +944,7 @@
 '    '        Text.Whitespace
 'string'      Name
 ' '           Text.Whitespace
-'getOpenTag'  Name.Function
+'getOpenTag'  Name
 '('           Punctuation
 'const'       Keyword
 ' '           Text.Whitespace

--- a/tests/snippets/c/test_string_resembling_decl_end.txt
+++ b/tests/snippets/c/test_string_resembling_decl_end.txt
@@ -1,0 +1,41 @@
+---input---
+// This should not be recognized as a function declaration followed by
+// garbage.
+string xyz(");");
+
+// This should not be recognized as a function definition.
+
+string xyz("){ }");
+
+---tokens---
+'// This should not be recognized as a function declaration followed by\n' Comment.Single
+
+'// garbage.\n' Comment.Single
+
+'string'      Name
+' '           Text.Whitespace
+'xyz'         Name
+'('           Punctuation
+'"'           Literal.String
+');'          Literal.String
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// This should not be recognized as a function definition.\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'string'      Name
+' '           Text.Whitespace
+'xyz'         Name
+'('           Punctuation
+'"'           Literal.String
+'){ }'        Literal.String
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
…ons and declarations

Something like

id id2("){ ... }");

is no longer wrongly recognized as a "function"

id id2(") {
  ...
}
");

As the difference in the tests shows, this has the unfortunate side
effect that we no longer highlight something like

int f(param="default");

as a function declaration, but it is hard to imagine another way to
fix this (cf. “most vexing parse” problem).

Fixes #2207