### PR TITLE
CFamilyLexer: Fix matching of function parameters

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -129,22 +129,22 @@ class CFamilyLexer(RegexLexer):
             include('keywords'),
             # functions
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
-             r'(' + _possible_comments + r')'    # possible comments
+             r'(' + _possible_comments + r')'
              r'(' + _namespaced_ident + r')'             # method name
-             r'(' + _possible_comments + r')'    # possible comments
-             r'(\([^;"\']*?\))'                          # signature
-             r'(' + _possible_comments + r')'    # possible comments
+             r'(' + _possible_comments + r')'
+             r'(\([^;"\')]*?\))'                         # signature
+             r'(' + _possible_comments + r')'
              r'([^;{/"\']*)(\{)',
              bygroups(using(this), using(this, state='whitespace'), Name.Function, using(this, state='whitespace'),
                       using(this), using(this, state='whitespace'), using(this), Punctuation),
              'function'),
             # function declarations
             (r'(' + _namespaced_ident + r'(?:[&*\s])+)'  # return arguments
-             r'(' + _possible_comments + r')'    # possible comments
+             r'(' + _possible_comments + r')'
              r'(' + _namespaced_ident + r')'             # method name
-             r'(' + _possible_comments + r')'    # possible comments
-             r'(\([^;"\']*?\))'                          # signature
-             r'(' + _possible_comments + r')'    # possible comments
+             r'(' + _possible_comments + r')'
+             r'(\([^;"\')]*?\))'                         # signature
+             r'(' + _possible_comments + r')'
              r'([^;/"\']*)(;)',
              bygroups(using(this), using(this, state='whitespace'), Name.Function, using(this, state='whitespace'),
                       using(this), using(this, state='whitespace'), using(this), Punctuation)),

--- a/tests/examplefiles/cpp/functions.cpp
+++ b/tests/examplefiles/cpp/functions.cpp
@@ -88,3 +88,19 @@ class raz {
 else if(flag && func_call()) {}
 new T();
 const operator int() const {} // so int is lexed as type and not function.name
+
+class foo bar : public raz
+{
+  Q_OBJECT
+  /// \cond INCLUDE_QPROPERTIES
+  Q_PROPERTY(arg1 arg2)
+  /// \endcond
+
+public:
+  /*!
+    Lorem ipsum core vanditi.
+  */
+  enum duck { dog, // Comment.
+              cat  // Comment (see \ref replot).
+  };
+};

--- a/tests/examplefiles/cpp/functions.cpp.output
+++ b/tests/examplefiles/cpp/functions.cpp.output
@@ -1427,3 +1427,76 @@
 '}'           Punctuation
 ' '           Text.Whitespace
 '// so int is lexed as type and not function.name\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'class'       Keyword
+' '           Text.Whitespace
+'foo'         Name.Class
+' '           Text.Whitespace
+'bar'         Name
+' '           Text.Whitespace
+':'           Operator
+' '           Text.Whitespace
+'public'      Keyword
+' '           Text.Whitespace
+'raz'         Name
+'\n'          Text.Whitespace
+
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'Q_OBJECT'    Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'/// \\cond INCLUDE_QPROPERTIES\n' Comment.Single
+
+'  '          Text.Whitespace
+'Q_PROPERTY'  Name
+'('           Punctuation
+'arg1'        Name
+' '           Text.Whitespace
+'arg2'        Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'/// \\endcond\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'public'      Keyword
+':'           Operator
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'/*!\n    Lorem ipsum core vanditi.\n  */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'enum'        Keyword
+' '           Text.Whitespace
+'duck'        Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'dog'         Name
+','           Punctuation
+' '           Text.Whitespace
+'// Comment.\n' Comment.Single
+
+'              ' Text.Whitespace
+'cat'         Name
+'  '          Text.Whitespace
+'// Comment (see \\ref replot).\n' Comment.Single
+
+'  '          Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This fixes an issue where in code like this:

```
int foo(float bar) // hello() {}
```

The lexer would match `(float bar) // hello()` as the parameters of the function `foo`, instead of just `(float bar)`.

In addition, a similar test case to what was originally reported in #2208 is added.