### PR TITLE
gen_mapfiles.py: convert Path to str before adding to sys.path

### DIFF
--- a/scripts/gen_mapfiles.py
+++ b/scripts/gen_mapfiles.py
@@ -15,7 +15,7 @@ import sys
 
 top_src_dir = Path(__file__).parent.parent
 pygments_package = top_src_dir / 'pygments'
-sys.path.insert(0, pygments_package.parent.resolve())
+sys.path.insert(0, str(pygments_package.parent.resolve()))
 
 from pygments.util import docstring_headline
 


### PR DESCRIPTION
pathlib.Path entries in sys.path are actually ignored.  See
https://github.com/python/cpython/issues/96482