### PR TITLE
Objective-J: fix catastrophic backtracking in comment regex

### DIFF
--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -801,7 +801,7 @@ class ObjectiveJLexer(RegexLexer):
     mimetypes = ['text/x-objective-j']
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/[*].*?[*]/)*'
+    _ws = r'(?:\s|//[^\n]*\n|/[*](?:[^*]|[*][^/])*[*]/)*'
 
     flags = re.DOTALL | re.MULTILINE
 


### PR DESCRIPTION
This use of *? was both incorrect and catastrophically backtracking
when embedding this regex into a larger regex with a trailing pattern,
since it could match much more than intended and try exponentially
many positions in that process.
