### PR TITLE
Add { and } to punctuation for GNU Assembly lexer

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -95,7 +95,7 @@ class GasLexer(RegexLexer):
             (r'/[*][\w\W]*?[*]/', Comment.Multiline)
         ],
         'punctuation': [
-            (r'[-*,.()\[\]!:]+', Punctuation)
+            (r'[-*,.()\[\]!:{}]+', Punctuation)
         ]
     }
 


### PR DESCRIPTION
This allows lexing instructions like:

    vpscatterqd %ymm0, 0x404050(,%zmm2,4) {%k1}