### PR TITLE
Fix #2224: Issues with .properties format using whitespace delimited key

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -128,14 +128,24 @@ class PropertiesLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'^(\w+)([ \t])(\w+\s*)$', bygroups(Name.Attribute, Whitespace, String)),
-            (r'^\w+(\\[ \t]\w*)*$', Name.Attribute),
-            (r'(^ *)([#!].*)', bygroups(Whitespace, Comment)),
-            # More controversial comments
-            (r'(^ *)((?:;|//).*)', bygroups(Whitespace, Comment)),
-            (r'(.*?)([ \t]*)([=:])([ \t]*)(.*(?:(?<=\\)\n.*)*)',
-             bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String)),
-            (r'\s', Whitespace),
+            (r'\s+', Whitespace),
+            (r'[!#].*|/{2}.*', Comment.Single),
+            # search for first separator
+            (r'.+?[^\\](?:\\{2})*?(?=[ \f\t=:])', Name.Attribute, "separator"),
+            # empty key
+            (r'(.+?)', Name.Attribute),
+        ],
+        'separator': [
+            (r'([ \f\t]*)([=:]*)([ \f\t]*)(.*(?<!\\)(?:\\{2})*)(\\)(?!\\)$',
+             bygroups(Whitespace, Operator, Whitespace, String, Text), "value", "#pop"),
+            (r'([ \f\t]*)([=:]*)([ \f\t]*)(.*)',
+             bygroups(Whitespace, Operator, Whitespace, String), "#pop"),
+        ],
+        'value': [     # line continuation
+            (r'\s+', Whitespace),
+            (r'(\s*)(.*(?<!\\)(?:\\{2})*)(\\)(?!\\)([ \t]*)',
+             bygroups(Whitespace, String, Text, Whitespace)),
+            (r'.*$', String, "#pop"),
         ],
     }
 

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -136,6 +136,7 @@ class PropertiesLexer(RegexLexer):
             (r'(.+?)', Name.Attribute),
         ],
         'separator': [
+            # search for line continuation escape
             (r'([ \f\t]*)([=:]*)([ \f\t]*)(.*(?<!\\)(?:\\{2})*)(\\)(?!\\)$',
              bygroups(Whitespace, Operator, Whitespace, String, Text), "value", "#pop"),
             (r'([ \f\t]*)([=:]*)([ \f\t]*)(.*)',
@@ -143,6 +144,7 @@ class PropertiesLexer(RegexLexer):
         ],
         'value': [     # line continuation
             (r'\s+', Whitespace),
+            # search for line continuation escape
             (r'(\s*)(.*(?<!\\)(?:\\{2})*)(\\)(?!\\)([ \t]*)',
              bygroups(Whitespace, String, Text, Whitespace)),
             (r'.*$', String, "#pop"),

--- a/tests/examplefiles/properties/java.properties
+++ b/tests/examplefiles/properties/java.properties
@@ -1,16 +1,24 @@
-foo = bar
-foo: bar
-foo.oof: \
-    bar=baz; \
-    asdf
+#https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Properties.htm
+# mixing spaces
+	Truth = Beauty
+  Truth:Beauty
+Truth	Beauty
+Truth                    :Beauty
+ 
+! line continuations and escapes
+ fruits                           apple, banana, pear, \
+                                  cantaloupe, watermelon, \
+                                  kiwi, mango
+key = \
+    value1 \\\
+    and value2\\
+key\ 2 = value
+key\\ 3 = value3
 
-// comment
-# comment
-; comment
-
-x:a\
-b
-x: a \
-  b
-
-x = \
+! empty keys and edge cases
+key1 =
+key2
+key3 the value3
+key4 the:value4
+key5 the=value5
+key6=the value6

--- a/tests/examplefiles/properties/java.properties.output
+++ b/tests/examplefiles/properties/java.properties.output
@@ -1,50 +1,97 @@
-'foo'         Name.Attribute
+'#https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Properties.htm' Comment.Single
+'\n'          Text.Whitespace
+
+'# mixing spaces' Comment.Single
+'\n\t'        Text.Whitespace
+'Truth'       Name.Attribute
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'bar'         Literal.String
-'\n'          Text.Whitespace
-
-'foo'         Name.Attribute
+'Beauty'      Literal.String
+'\n  '        Text.Whitespace
+'Truth'       Name.Attribute
 ':'           Operator
-' '           Text.Whitespace
-'bar'         Literal.String
+'Beauty'      Literal.String
 '\n'          Text.Whitespace
 
-'foo.oof'     Name.Attribute
+'Truth'       Name.Attribute
+'\t'          Text.Whitespace
+'Beauty'      Literal.String
+'\n'          Text.Whitespace
+
+'Truth'       Name.Attribute
+'                    ' Text.Whitespace
 ':'           Operator
-' '           Text.Whitespace
-'\\\n    bar=baz; \\\n    asdf' Literal.String
+'Beauty'      Literal.String
+'\n \n'       Text.Whitespace
+
+'! line continuations and escapes' Comment.Single
+'\n '         Text.Whitespace
+'fruits'      Name.Attribute
+'                           ' Text.Whitespace
+'apple, banana, pear, ' Literal.String
+'\\'          Text
+'\n                                  ' Text.Whitespace
+'cantaloupe, watermelon, ' Literal.String
+'\\'          Text
+'\n                                  ' Text.Whitespace
+'kiwi, mango' Literal.String
 '\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'// comment'  Comment
-'\n'          Text.Whitespace
-
-'# comment'   Comment
-'\n'          Text.Whitespace
-
-'; comment'   Comment
-'\n'          Text.Whitespace
-
-'\n'          Text.Whitespace
-
-'x'           Name.Attribute
-':'           Operator
-'a\\\nb'      Literal.String
-'\n'          Text.Whitespace
-
-'x'           Name.Attribute
-':'           Operator
-' '           Text.Whitespace
-'a \\\n  b'   Literal.String
-'\n'          Text.Whitespace
-
-'\n'          Text.Whitespace
-
-'x'           Name.Attribute
+'key'         Name.Attribute
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'\\\n'        Literal.String
+'\\'          Text
+'\n    '      Text.Whitespace
+'value1 \\\\' Literal.String
+'\\'          Text
+'\n    '      Text.Whitespace
+'and value2\\\\' Literal.String
+'\n'          Text.Whitespace
+
+'key\\ 2'     Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'value'       Literal.String
+'\n'          Text.Whitespace
+
+'key\\\\'     Name.Attribute
+' '           Text.Whitespace
+'3 = value3'  Literal.String
+'\n\n'        Text.Whitespace
+
+'! empty keys and edge cases' Comment.Single
+'\n'          Text.Whitespace
+
+'key1'        Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'\n'          Text.Whitespace
+
+'k'           Name.Attribute
+'e'           Name.Attribute
+'y'           Name.Attribute
+'2'           Name.Attribute
+'\n'          Text.Whitespace
+
+'key3'        Name.Attribute
+' '           Text.Whitespace
+'the value3'  Literal.String
+'\n'          Text.Whitespace
+
+'key4'        Name.Attribute
+' '           Text.Whitespace
+'the:value4'  Literal.String
+'\n'          Text.Whitespace
+
+'key5'        Name.Attribute
+' '           Text.Whitespace
+'the=value5'  Literal.String
+'\n'          Text.Whitespace
+
+'key6'        Name.Attribute
+'='           Operator
+'the value6'  Literal.String
+'\n'          Text.Whitespace


### PR DESCRIPTION
Added:
- support for space delimitor in every case, included multiline value
- check for odd number of backslash escapes
- "!" as comment start
- support for escape of spaces and separators

Dropped:
- undocumented ";" and "//" comment start