### PR TITLE
Fix minor documentation around WoWToCLexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -143,6 +143,7 @@ Other contributors, listed alphabetically, are:
 * Louis Mandel -- X10 lexer
 * Louis Marchand -- Eiffel lexer
 * Simone Margaritelli -- Hybris lexer
+* Tim Martin - World of Warcraft TOC lexer
 * Kirk McDonald -- D lexer
 * Gordon McGregor -- SystemVerilog lexer
 * Stephen McKamey -- Duel/JBST lexer

--- a/pygments/lexers/wowtoc.py
+++ b/pygments/lexers/wowtoc.py
@@ -2,7 +2,9 @@
     pygments.lexers.wowtoc
     ~~~~~~~~~~~~~~~~~~~~~~
 
-    Lexer for World of Warcraft TOC files, which describe game addon metadata.
+    Lexer for World of Warcraft TOC files
+    
+    TOC files describe game addons.
 
     :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
@@ -44,7 +46,7 @@ class WoWTocLexer(RegexLexer):
     """
     Lexer for World of Warcraft TOC files.
 
-    .. versionadded:: 2.13
+    .. versionadded:: 2.14
     """
 
     name = "World of Warcraft TOC"


### PR DESCRIPTION
Three minor documentation things I left out from my work today with @Jean-Abou-Samra:

- State the correct release version (2.14, not 2.13)
- Trim down the headline, so it looks better as a section heading on https://pygments.org/docs/lexers/ (was too descriptive before)
- Add myself to the AUTHORS file 😎

Thanks!