### PR TITLE
Add tl-b lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -489,6 +489,7 @@ LEXERS = {
     'ThingsDBLexer': ('pygments.lexers.thingsdb', 'ThingsDB', ('ti', 'thingsdb'), ('*.ti',), ()),
     'ThriftLexer': ('pygments.lexers.dsls', 'Thrift', ('thrift',), ('*.thrift',), ('application/x-thrift',)),
     'TiddlyWiki5Lexer': ('pygments.lexers.markup', 'tiddler', ('tid',), ('*.tid',), ('text/vnd.tiddlywiki',)),
+    'TlbLexer': ('pygments.lexers.tlb', 'Tl-b', ('tlb',), ('*.tlb',), ()),
     'TodotxtLexer': ('pygments.lexers.textfmts', 'Todotxt', ('todotxt',), ('todo.txt', '*.todotxt'), ('text/x-todo',)),
     'TransactSqlLexer': ('pygments.lexers.sql', 'Transact-SQL', ('tsql', 't-sql'), ('*.sql',), ('text/x-tsql',)),
     'TreetopLexer': ('pygments.lexers.parsers', 'Treetop', ('treetop',), ('*.treetop', '*.tt'), ()),

--- a/pygments/lexers/tlb.py
+++ b/pygments/lexers/tlb.py
@@ -1,0 +1,58 @@
+"""
+    pygments.lexers.tlb
+    ~~~~~~~~~~~~~~~~~~~
+
+    Lexers for TL-b.
+
+    :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, include, words
+from pygments.token import Operator, Name, \
+    Number, Whitespace, Punctuation, Comment
+
+__all__ = ['TlbLexer']
+
+
+class TlbLexer(RegexLexer):
+    """
+    For TL-b source code.
+    """
+
+    name = 'Tl-b'
+    aliases = ['tlb']
+    filenames = ['*.tlb']
+
+    tokens = {
+        'root': [
+            (r'\n', Whitespace),
+            (r'\s+', Whitespace),
+
+            include('comments'),
+
+            (r'[0-9]+', Number),
+            (words((
+                '+', '-', '*', '=', '?', '~', '.',
+                '^', '==', '<', '>', '<=', '>=', '!='
+            )), Operator),
+            (r'#(_|[0-9a-f]+_?)', Name.Tag),
+            (r'\$(_|[01]*)', Name.Tag),
+            (words(('##', '#<', '#<=', '#')), Name.Tag),
+
+            (r'[a-zA-Z_][0-9a-zA-Z_]*', Name),
+
+            (r'[;():\[\]{}]', Punctuation)
+        ],
+
+        'comments': [
+            (r'//([^\n]*)', Comment.Singleline),
+            (r'/\*', Comment.Multiline, 'comment'),
+        ],
+        'comment': [
+            (r'[^/*]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline),
+        ],
+    }

--- a/tests/examplefiles/tlb/block.tlb
+++ b/tests/examplefiles/tlb/block.tlb
@@ -1,0 +1,868 @@
+unit$_ = Unit;
+true$_ = True;
+// EMPTY False;
+bool_false$0 = Bool;
+bool_true$1 = Bool;
+bool_false$0 = BoolFalse;
+bool_true$1 = BoolTrue;
+nothing$0 {X:Type} = Maybe X;
+just$1 {X:Type} value:X = Maybe X;
+left$0 {X:Type} {Y:Type} value:X = Either X Y;
+right$1 {X:Type} {Y:Type} value:Y = Either X Y;
+pair$_ {X:Type} {Y:Type} first:X second:Y = Both X Y;
+
+bit$_ (## 1) = Bit;
+/*
+ *
+ *   FROM hashmap.tlb
+ *
+ */
+// ordinary Hashmap / HashmapE, with fixed length keys
+//
+hm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+          {n = (~m) + l} node:(HashmapNode m X) = Hashmap n X;
+
+hmn_leaf#_ {X:Type} value:X = HashmapNode 0 X;
+hmn_fork#_ {n:#} {X:Type} left:^(Hashmap n X) 
+           right:^(Hashmap n X) = HashmapNode (n + 1) X;
+
+hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= m} s:(n * Bit) = HmLabel ~n m;
+hml_long$10 {m:#} n:(#<= m) s:(n * Bit) = HmLabel ~n m;
+hml_same$11 {m:#} v:Bit n:(#<= m) = HmLabel ~n m;
+
+unary_zero$0 = Unary ~0;
+unary_succ$1 {n:#} x:(Unary ~n) = Unary ~(n + 1);
+
+hme_empty$0 {n:#} {X:Type} = HashmapE n X;
+hme_root$1 {n:#} {X:Type} root:^(Hashmap n X) = HashmapE n X;
+
+// true#_ = True;
+_ {n:#} _:(Hashmap n True) = BitstringSet n;
+
+//  HashmapAug, hashmap with an extra value 
+//   (augmentation) of type Y at every node
+//
+ahm_edge#_ {n:#} {X:Type} {Y:Type} {l:#} {m:#} 
+  label:(HmLabel ~l n) {n = (~m) + l} 
+  node:(HashmapAugNode m X Y) = HashmapAug n X Y;
+ahmn_leaf#_ {X:Type} {Y:Type} extra:Y value:X = HashmapAugNode 0 X Y;
+ahmn_fork#_ {n:#} {X:Type} {Y:Type} left:^(HashmapAug n X Y)
+  right:^(HashmapAug n X Y) extra:Y = HashmapAugNode (n + 1) X Y;
+
+ahme_empty$0 {n:#} {X:Type} {Y:Type} extra:Y 
+          = HashmapAugE n X Y;
+ahme_root$1 {n:#} {X:Type} {Y:Type} root:^(HashmapAug n X Y) 
+  extra:Y = HashmapAugE n X Y;
+
+// VarHashmap / VarHashmapE, with variable-length keys
+//
+vhm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+           {n = (~m) + l} node:(VarHashmapNode m X) 
+           = VarHashmap n X;
+vhmn_leaf$00 {n:#} {X:Type} value:X = VarHashmapNode n X;
+vhmn_fork$01 {n:#} {X:Type} left:^(VarHashmap n X) 
+             right:^(VarHashmap n X) value:(Maybe X) 
+             = VarHashmapNode (n + 1) X;
+vhmn_cont$1 {n:#} {X:Type} branch:Bit child:^(VarHashmap n X) 
+            value:X = VarHashmapNode (n + 1) X;
+
+// nothing$0 {X:Type} = Maybe X;
+// just$1 {X:Type} value:X = Maybe X;
+
+vhme_empty$0 {n:#} {X:Type} = VarHashmapE n X;
+vhme_root$1 {n:#} {X:Type} root:^(VarHashmap n X) 
+            = VarHashmapE n X;
+
+//
+// PfxHashmap / PfxHashmapE, with variable-length keys
+//                           constituting a prefix code
+//
+
+phm_edge#_ {n:#} {X:Type} {l:#} {m:#} label:(HmLabel ~l n) 
+           {n = (~m) + l} node:(PfxHashmapNode m X) 
+           = PfxHashmap n X;
+
+phmn_leaf$0 {n:#} {X:Type} value:X = PfxHashmapNode n X;
+phmn_fork$1 {n:#} {X:Type} left:^(PfxHashmap n X) 
+            right:^(PfxHashmap n X) = PfxHashmapNode (n + 1) X;
+
+phme_empty$0 {n:#} {X:Type} = PfxHashmapE n X;
+phme_root$1 {n:#} {X:Type} root:^(PfxHashmap n X) 
+            = PfxHashmapE n X;
+/*
+ *
+ *  END hashmap.tlb
+ *
+ */
+//
+// TON BLOCK LAYOUT
+//
+addr_none$00 = MsgAddressExt;
+addr_extern$01 len:(## 9) external_address:(bits len) 
+             = MsgAddressExt;
+anycast_info$_ depth:(#<= 30) { depth >= 1 }
+   rewrite_pfx:(bits depth) = Anycast;
+addr_std$10 anycast:(Maybe Anycast) 
+   workchain_id:int8 address:bits256  = MsgAddressInt;
+addr_var$11 anycast:(Maybe Anycast) addr_len:(## 9) 
+   workchain_id:int32 address:(bits addr_len) = MsgAddressInt;
+_ _:MsgAddressInt = MsgAddress;
+_ _:MsgAddressExt = MsgAddress;
+//
+var_uint$_ {n:#} len:(#< n) value:(uint (len * 8))
+         = VarUInteger n;
+var_int$_ {n:#} len:(#< n) value:(int (len * 8)) 
+        = VarInteger n;
+nanograms$_ amount:(VarUInteger 16) = Grams;  
+//
+extra_currencies$_ dict:(HashmapE 32 (VarUInteger 32)) 
+                 = ExtraCurrencyCollection;
+currencies$_ grams:Grams other:ExtraCurrencyCollection 
+           = CurrencyCollection;
+//
+int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
+  src:MsgAddressInt dest:MsgAddressInt 
+  value:CurrencyCollection ihr_fee:Grams fwd_fee:Grams
+  created_lt:uint64 created_at:uint32 = CommonMsgInfo;
+ext_in_msg_info$10 src:MsgAddressExt dest:MsgAddressInt 
+  import_fee:Grams = CommonMsgInfo;
+ext_out_msg_info$11 src:MsgAddressInt dest:MsgAddressExt
+  created_lt:uint64 created_at:uint32 = CommonMsgInfo;
+
+int_msg_info$0 ihr_disabled:Bool bounce:Bool bounced:Bool
+  src:MsgAddress dest:MsgAddressInt 
+  value:CurrencyCollection ihr_fee:Grams fwd_fee:Grams
+  created_lt:uint64 created_at:uint32 = CommonMsgInfoRelaxed;
+ext_out_msg_info$11 src:MsgAddress dest:MsgAddressExt
+  created_lt:uint64 created_at:uint32 = CommonMsgInfoRelaxed;
+
+tick_tock$_ tick:Bool tock:Bool = TickTock;
+
+_ split_depth:(Maybe (## 5)) special:(Maybe TickTock)
+  code:(Maybe ^Cell) data:(Maybe ^Cell)
+  library:(HashmapE 256 SimpleLib) = StateInit;
+  
+simple_lib$_ public:Bool root:^Cell = SimpleLib;
+
+message$_ {X:Type} info:CommonMsgInfo
+  init:(Maybe (Either StateInit ^StateInit))
+  body:(Either X ^X) = Message X;
+
+message$_ {X:Type} info:CommonMsgInfoRelaxed
+  init:(Maybe (Either StateInit ^StateInit))
+  body:(Either X ^X) = MessageRelaxed X;
+  
+_ (Message Any) = MessageAny;
+
+//
+interm_addr_regular$0 use_dest_bits:(#<= 96) 
+  = IntermediateAddress;
+interm_addr_simple$10 workchain_id:int8 addr_pfx:uint64 
+  = IntermediateAddress;
+interm_addr_ext$11 workchain_id:int32 addr_pfx:uint64
+  = IntermediateAddress;
+msg_envelope#4 cur_addr:IntermediateAddress 
+  next_addr:IntermediateAddress fwd_fee_remaining:Grams 
+  msg:^(Message Any) = MsgEnvelope;
+//
+msg_import_ext$000 msg:^(Message Any) transaction:^Transaction 
+              = InMsg;
+msg_import_ihr$010 msg:^(Message Any) transaction:^Transaction 
+    ihr_fee:Grams proof_created:^Cell = InMsg;
+msg_import_imm$011 in_msg:^MsgEnvelope
+    transaction:^Transaction fwd_fee:Grams = InMsg;
+msg_import_fin$100 in_msg:^MsgEnvelope 
+    transaction:^Transaction fwd_fee:Grams = InMsg;
+msg_import_tr$101  in_msg:^MsgEnvelope out_msg:^MsgEnvelope 
+    transit_fee:Grams = InMsg;
+msg_discard_fin$110 in_msg:^MsgEnvelope transaction_id:uint64 
+    fwd_fee:Grams = InMsg;
+msg_discard_tr$111 in_msg:^MsgEnvelope transaction_id:uint64 
+    fwd_fee:Grams proof_delivered:^Cell = InMsg;
+//
+import_fees$_ fees_collected:Grams 
+  value_imported:CurrencyCollection = ImportFees;
+
+_ (HashmapAugE 256 InMsg ImportFees) = InMsgDescr;
+
+msg_export_ext$000 msg:^(Message Any)
+    transaction:^Transaction = OutMsg;
+msg_export_imm$010 out_msg:^MsgEnvelope 
+    transaction:^Transaction reimport:^InMsg = OutMsg;
+msg_export_new$001 out_msg:^MsgEnvelope 
+    transaction:^Transaction = OutMsg;
+msg_export_tr$011  out_msg:^MsgEnvelope 
+    imported:^InMsg = OutMsg;
+msg_export_deq$1100 out_msg:^MsgEnvelope
+    import_block_lt:uint63 = OutMsg;
+msg_export_deq_short$1101 msg_env_hash:bits256
+    next_workchain:int32 next_addr_pfx:uint64
+    import_block_lt:uint64 = OutMsg;
+msg_export_tr_req$111 out_msg:^MsgEnvelope 
+    imported:^InMsg = OutMsg;
+msg_export_deq_imm$100 out_msg:^MsgEnvelope 
+    reimport:^InMsg = OutMsg;
+
+_ enqueued_lt:uint64 out_msg:^MsgEnvelope = EnqueuedMsg;
+
+_ (HashmapAugE 256 OutMsg CurrencyCollection) = OutMsgDescr;
+
+_ (HashmapAugE 352 EnqueuedMsg uint64) = OutMsgQueue;
+
+processed_upto$_ last_msg_lt:uint64 last_msg_hash:bits256 = ProcessedUpto;
+// key is [ shard:uint64 mc_seqno:uint32 ]  
+_ (HashmapE 96 ProcessedUpto) = ProcessedInfo;
+
+ihr_pending$_ import_lt:uint64 = IhrPendingSince;
+_ (HashmapE 320 IhrPendingSince) = IhrPendingInfo;
+
+_ out_queue:OutMsgQueue proc_info:ProcessedInfo
+  ihr_pending:IhrPendingInfo = OutMsgQueueInfo;
+//
+storage_used$_ cells:(VarUInteger 7) bits:(VarUInteger 7) 
+  public_cells:(VarUInteger 7) = StorageUsed;
+
+storage_used_short$_ cells:(VarUInteger 7) 
+  bits:(VarUInteger 7) = StorageUsedShort;
+
+storage_info$_ used:StorageUsed last_paid:uint32
+              due_payment:(Maybe Grams) = StorageInfo;
+
+account_none$0 = Account;
+account$1 addr:MsgAddressInt storage_stat:StorageInfo
+          storage:AccountStorage = Account;
+
+account_storage$_ last_trans_lt:uint64
+    balance:CurrencyCollection state:AccountState 
+  = AccountStorage;
+
+account_uninit$00 = AccountState;
+account_active$1 _:StateInit = AccountState;
+account_frozen$01 state_hash:bits256 = AccountState;
+
+acc_state_uninit$00 = AccountStatus;
+acc_state_frozen$01 = AccountStatus;
+acc_state_active$10 = AccountStatus;
+acc_state_nonexist$11 = AccountStatus;
+
+/* duplicates
+tick_tock$_ tick:Bool tock:Bool = TickTock;
+
+_ split_depth:(Maybe (## 5)) special:(Maybe TickTock)
+  code:(Maybe ^Cell) data:(Maybe ^Cell)
+  library:(Maybe ^Cell) = StateInit;
+*/
+
+account_descr$_ account:^Account last_trans_hash:bits256 
+  last_trans_lt:uint64 = ShardAccount;
+
+depth_balance$_ split_depth:(#<= 30) balance:CurrencyCollection = DepthBalanceInfo;
+
+_ (HashmapAugE 256 ShardAccount DepthBalanceInfo) = ShardAccounts;
+
+transaction$0111 account_addr:bits256 lt:uint64 
+  prev_trans_hash:bits256 prev_trans_lt:uint64 now:uint32
+  outmsg_cnt:uint15
+  orig_status:AccountStatus end_status:AccountStatus
+  ^[ in_msg:(Maybe ^(Message Any)) out_msgs:(HashmapE 15 ^(Message Any)) ]
+  total_fees:CurrencyCollection state_update:^(HASH_UPDATE Account)
+  description:^TransactionDescr = Transaction;
+
+merkle_update#02 {X:Type} old_hash:bits256 new_hash:bits256
+  old:^X new:^X = MERKLE_UPDATE X;
+update_hashes#72 {X:Type} old_hash:bits256 new_hash:bits256
+  = HASH_UPDATE X;
+merkle_proof#03 {X:Type} virtual_hash:bits256 depth:uint16 virtual_root:^X = MERKLE_PROOF X;
+
+acc_trans#5 account_addr:bits256
+            transactions:(HashmapAug 64 ^Transaction CurrencyCollection)
+            state_update:^(HASH_UPDATE Account)
+          = AccountBlock;
+
+_ (HashmapAugE 256 AccountBlock CurrencyCollection) = ShardAccountBlocks;
+//
+tr_phase_storage$_ storage_fees_collected:Grams 
+  storage_fees_due:(Maybe Grams)
+  status_change:AccStatusChange
+  = TrStoragePhase;
+
+acst_unchanged$0 = AccStatusChange;  // x -> x
+acst_frozen$10 = AccStatusChange;    // init -> frozen
+acst_deleted$11 = AccStatusChange;   // frozen -> deleted
+
+tr_phase_credit$_ due_fees_collected:(Maybe Grams)
+  credit:CurrencyCollection = TrCreditPhase;
+
+tr_phase_compute_skipped$0 reason:ComputeSkipReason
+  = TrComputePhase;
+tr_phase_compute_vm$1 success:Bool msg_state_used:Bool 
+  account_activated:Bool gas_fees:Grams
+  ^[ gas_used:(VarUInteger 7)
+  gas_limit:(VarUInteger 7) gas_credit:(Maybe (VarUInteger 3))
+  mode:int8 exit_code:int32 exit_arg:(Maybe int32)
+  vm_steps:uint32
+  vm_init_state_hash:bits256 vm_final_state_hash:bits256 ]
+  = TrComputePhase;
+cskip_no_state$00 = ComputeSkipReason;
+cskip_bad_state$01 = ComputeSkipReason;
+cskip_no_gas$10 = ComputeSkipReason;
+
+tr_phase_action$_ success:Bool valid:Bool no_funds:Bool
+  status_change:AccStatusChange
+  total_fwd_fees:(Maybe Grams) total_action_fees:(Maybe Grams)
+  result_code:int32 result_arg:(Maybe int32) tot_actions:uint16
+  spec_actions:uint16 skipped_actions:uint16 msgs_created:uint16 
+  action_list_hash:bits256 tot_msg_size:StorageUsedShort 
+  = TrActionPhase;
+
+tr_phase_bounce_negfunds$00 = TrBouncePhase;
+tr_phase_bounce_nofunds$01 msg_size:StorageUsedShort
+  req_fwd_fees:Grams = TrBouncePhase;
+tr_phase_bounce_ok$1 msg_size:StorageUsedShort 
+  msg_fees:Grams fwd_fees:Grams = TrBouncePhase;
+//
+trans_ord$0000 credit_first:Bool
+  storage_ph:(Maybe TrStoragePhase)
+  credit_ph:(Maybe TrCreditPhase)
+  compute_ph:TrComputePhase action:(Maybe ^TrActionPhase)
+  aborted:Bool bounce:(Maybe TrBouncePhase)
+  destroyed:Bool
+  = TransactionDescr;
+
+trans_storage$0001 storage_ph:TrStoragePhase
+  = TransactionDescr;
+
+trans_tick_tock$001 is_tock:Bool storage_ph:TrStoragePhase
+  compute_ph:TrComputePhase action:(Maybe ^TrActionPhase)
+  aborted:Bool destroyed:Bool = TransactionDescr;
+//
+split_merge_info$_ cur_shard_pfx_len:(## 6)
+  acc_split_depth:(## 6) this_addr:bits256 sibling_addr:bits256
+  = SplitMergeInfo;
+trans_split_prepare$0100 split_info:SplitMergeInfo
+  storage_ph:(Maybe TrStoragePhase)
+  compute_ph:TrComputePhase action:(Maybe ^TrActionPhase)
+  aborted:Bool destroyed:Bool
+  = TransactionDescr;
+trans_split_install$0101 split_info:SplitMergeInfo
+  prepare_transaction:^Transaction
+  installed:Bool = TransactionDescr;
+
+trans_merge_prepare$0110 split_info:SplitMergeInfo
+  storage_ph:TrStoragePhase aborted:Bool
+  = TransactionDescr;
+trans_merge_install$0111 split_info:SplitMergeInfo
+  prepare_transaction:^Transaction
+  storage_ph:(Maybe TrStoragePhase)
+  credit_ph:(Maybe TrCreditPhase)
+  compute_ph:TrComputePhase action:(Maybe ^TrActionPhase)
+  aborted:Bool destroyed:Bool
+  = TransactionDescr;
+
+smc_info#076ef1ea actions:uint16 msgs_sent:uint16
+  unixtime:uint32 block_lt:uint64 trans_lt:uint64 
+  rand_seed:bits256 balance_remaining:CurrencyCollection
+  myself:MsgAddressInt = SmartContractInfo;
+//
+//
+out_list_empty$_ = OutList 0;
+out_list$_ {n:#} prev:^(OutList n) action:OutAction
+  = OutList (n + 1);
+action_send_msg#0ec3c86d mode:(## 8) 
+  out_msg:^(MessageRelaxed Any) = OutAction;
+action_set_code#ad4de08e new_code:^Cell = OutAction;
+action_reserve_currency#36e6b809 mode:(## 8)
+  currency:CurrencyCollection = OutAction;
+libref_hash$0 lib_hash:bits256 = LibRef;
+libref_ref$1 library:^Cell = LibRef;
+action_change_library#26fa1dd4 mode:(## 7) { mode <= 2 }
+  libref:LibRef = OutAction;
+
+out_list_node$_ prev:^Cell action:OutAction = OutListNode;
+//
+//
+shard_ident$00 shard_pfx_bits:(#<= 60) 
+  workchain_id:int32 shard_prefix:uint64 = ShardIdent;
+
+ext_blk_ref$_ end_lt:uint64
+  seq_no:uint32 root_hash:bits256 file_hash:bits256 
+  = ExtBlkRef;
+
+block_id_ext$_ shard_id:ShardIdent seq_no:uint32
+  root_hash:bits256 file_hash:bits256 = BlockIdExt;
+
+master_info$_ master:ExtBlkRef = BlkMasterInfo;
+
+shard_state#9023afe2 global_id:int32
+  shard_id:ShardIdent 
+  seq_no:uint32 vert_seq_no:#
+  gen_utime:uint32 gen_lt:uint64
+  min_ref_mc_seqno:uint32
+  out_msg_queue_info:^OutMsgQueueInfo
+  before_split:(## 1)
+  accounts:^ShardAccounts
+  ^[ overload_history:uint64 underload_history:uint64
+  total_balance:CurrencyCollection
+  total_validator_fees:CurrencyCollection
+  libraries:(HashmapE 256 LibDescr)
+  master_ref:(Maybe BlkMasterInfo) ]
+  custom:(Maybe ^McStateExtra)
+  = ShardStateUnsplit;
+  
+_ ShardStateUnsplit = ShardState;
+split_state#5f327da5 left:^ShardStateUnsplit right:^ShardStateUnsplit = ShardState;
+
+shared_lib_descr$00 lib:^Cell publishers:(Hashmap 256 True)
+  = LibDescr;
+
+block_info#9bc7a987 version:uint32 
+  not_master:(## 1) 
+  after_merge:(## 1) before_split:(## 1) 
+  after_split:(## 1) 
+  want_split:Bool want_merge:Bool
+  key_block:Bool vert_seqno_incr:(## 1)
+  flags:(## 8) { flags <= 1 }
+  seq_no:# vert_seq_no:# { vert_seq_no >= vert_seqno_incr } 
+  { prev_seq_no:# } { ~prev_seq_no + 1 = seq_no } 
+  shard:ShardIdent gen_utime:uint32
+  start_lt:uint64 end_lt:uint64
+  gen_validator_list_hash_short:uint32
+  gen_catchain_seqno:uint32
+  min_ref_mc_seqno:uint32
+  prev_key_block_seqno:uint32
+  gen_software:flags . 0?GlobalVersion
+  master_ref:not_master?^BlkMasterInfo 
+  prev_ref:^(BlkPrevInfo after_merge)
+  prev_vert_ref:vert_seqno_incr?^(BlkPrevInfo 0)
+  = BlockInfo;
+
+prev_blk_info$_ prev:ExtBlkRef = BlkPrevInfo 0;
+prev_blks_info$_ prev1:^ExtBlkRef prev2:^ExtBlkRef = BlkPrevInfo 1;
+
+block#11ef55aa global_id:int32
+  info:^BlockInfo value_flow:^ValueFlow
+  state_update:^(MERKLE_UPDATE ShardState) 
+  extra:^BlockExtra = Block;
+
+block_extra in_msg_descr:^InMsgDescr
+  out_msg_descr:^OutMsgDescr
+  account_blocks:^ShardAccountBlocks
+  rand_seed:bits256
+  created_by:bits256
+  custom:(Maybe ^McBlockExtra) = BlockExtra;
+//
+value_flow ^[ from_prev_blk:CurrencyCollection 
+  to_next_blk:CurrencyCollection
+  imported:CurrencyCollection
+  exported:CurrencyCollection ]
+  fees_collected:CurrencyCollection
+  ^[
+  fees_imported:CurrencyCollection
+  recovered:CurrencyCollection
+  created:CurrencyCollection
+  minted:CurrencyCollection
+  ] = ValueFlow;
+
+//
+//
+bt_leaf$0 {X:Type} leaf:X = BinTree X;
+bt_fork$1 {X:Type} left:^(BinTree X) right:^(BinTree X) 
+          = BinTree X;
+
+fsm_none$0 = FutureSplitMerge;
+fsm_split$10 split_utime:uint32 interval:uint32 = FutureSplitMerge;
+fsm_merge$11 merge_utime:uint32 interval:uint32 = FutureSplitMerge;
+
+shard_descr#b seq_no:uint32 reg_mc_seqno:uint32
+  start_lt:uint64 end_lt:uint64
+  root_hash:bits256 file_hash:bits256 
+  before_split:Bool before_merge:Bool
+  want_split:Bool want_merge:Bool
+  nx_cc_updated:Bool flags:(## 3) { flags = 0 }
+  next_catchain_seqno:uint32 next_validator_shard:uint64
+  min_ref_mc_seqno:uint32 gen_utime:uint32
+  split_merge_at:FutureSplitMerge
+  fees_collected:CurrencyCollection
+  funds_created:CurrencyCollection = ShardDescr;
+
+shard_descr_new#a seq_no:uint32 reg_mc_seqno:uint32
+  start_lt:uint64 end_lt:uint64
+  root_hash:bits256 file_hash:bits256 
+  before_split:Bool before_merge:Bool
+  want_split:Bool want_merge:Bool
+  nx_cc_updated:Bool flags:(## 3) { flags = 0 }
+  next_catchain_seqno:uint32 next_validator_shard:uint64
+  min_ref_mc_seqno:uint32 gen_utime:uint32
+  split_merge_at:FutureSplitMerge
+  ^[ fees_collected:CurrencyCollection
+     funds_created:CurrencyCollection ] = ShardDescr;
+
+_ (HashmapE 32 ^(BinTree ShardDescr)) = ShardHashes;
+
+bta_leaf$0 {X:Type} {Y:Type} extra:Y leaf:X = BinTreeAug X Y;
+bta_fork$1 {X:Type} {Y:Type} left:^(BinTreeAug X Y) 
+           right:^(BinTreeAug X Y) extra:Y = BinTreeAug X Y;
+
+_ fees:CurrencyCollection create:CurrencyCollection = ShardFeeCreated;
+_ (HashmapAugE 96 ShardFeeCreated ShardFeeCreated) = ShardFees;
+
+_ config_addr:bits256 config:^(Hashmap 32 ^Cell) 
+  = ConfigParams;
+
+validator_info$_
+  validator_list_hash_short:uint32 
+  catchain_seqno:uint32
+  nx_cc_updated:Bool
+= ValidatorInfo;
+
+validator_base_info$_
+  validator_list_hash_short:uint32 
+  catchain_seqno:uint32
+= ValidatorBaseInfo;
+
+_ key:Bool max_end_lt:uint64 = KeyMaxLt;
+_ key:Bool blk_ref:ExtBlkRef = KeyExtBlkRef;
+
+_ (HashmapAugE 32 KeyExtBlkRef KeyMaxLt) = OldMcBlocksInfo;
+
+
+counters#_ last_updated:uint32 total:uint64 cnt2048:uint64 cnt65536:uint64 = Counters; 
+creator_info#4 mc_blocks:Counters shard_blocks:Counters = CreatorStats; 
+block_create_stats#17 counters:(HashmapE 256 CreatorStats) = BlockCreateStats;
+block_create_stats_ext#34 counters:(HashmapAugE 256 CreatorStats uint32) = BlockCreateStats;
+
+masterchain_state_extra#cc26
+  shard_hashes:ShardHashes
+  config:ConfigParams
+  ^[ flags:(## 16) { flags <= 1 }
+     validator_info:ValidatorInfo
+     prev_blocks:OldMcBlocksInfo
+     after_key_block:Bool
+     last_key_block:(Maybe ExtBlkRef)
+     block_create_stats:(flags . 0)?BlockCreateStats ]
+  global_balance:CurrencyCollection
+= McStateExtra;
+
+ed25519_pubkey#8e81278a pubkey:bits256 = SigPubKey;  // 288 bits
+ed25519_signature#5 R:bits256 s:bits256 = CryptoSignatureSimple;  // 516 bits
+_ CryptoSignatureSimple = CryptoSignature;
+sig_pair$_ node_id_short:bits256 sign:CryptoSignature = CryptoSignaturePair;  // 256+x ~ 772 bits
+
+certificate#4 temp_key:SigPubKey valid_since:uint32 valid_until:uint32 = Certificate;  // 356 bits
+certificate_env#a419b7d certificate:Certificate = CertificateEnv;  // 384 bits
+signed_certificate$_ certificate:Certificate certificate_signature:CryptoSignature
+  = SignedCertificate;  // 356+516 = 872 bits
+// certificate_signature is the signature of CertificateEnv (with embedded certificate) with persistent key
+chained_signature#f signed_cert:^SignedCertificate temp_key_signature:CryptoSignatureSimple
+  = CryptoSignature;   // 4+(356+516)+516 = 520 bits+ref (1392 bits total)
+// temp_key_signature is the signature of whatever was originally intended to be signed with temp_key from certificate
+
+masterchain_block_extra#cca5
+  key_block:(## 1)
+  shard_hashes:ShardHashes
+  shard_fees:ShardFees
+  ^[ prev_blk_signatures:(HashmapE 16 CryptoSignaturePair)
+     recover_create_msg:(Maybe ^InMsg)
+     mint_msg:(Maybe ^InMsg) ]
+  config:key_block?ConfigParams
+= McBlockExtra;
+
+//
+//  CONFIGURATION PARAMETERS
+//
+
+validator#53 public_key:SigPubKey weight:uint64 = ValidatorDescr;
+validator_addr#73 public_key:SigPubKey weight:uint64 adnl_addr:bits256 = ValidatorDescr;
+validators#11 utime_since:uint32 utime_until:uint32 
+  total:(## 16) main:(## 16) { main <= total } { main >= 1 } 
+  list:(Hashmap 16 ValidatorDescr) = ValidatorSet;
+validators_ext#12 utime_since:uint32 utime_until:uint32 
+  total:(## 16) main:(## 16) { main <= total } { main >= 1 } 
+  total_weight:uint64 list:(HashmapE 16 ValidatorDescr) = ValidatorSet;
+
+_ config_addr:bits256 = ConfigParam 0;
+_ elector_addr:bits256 = ConfigParam 1;
+_ minter_addr:bits256 = ConfigParam 2;  // ConfigParam 0 is used if absent
+_ fee_collector_addr:bits256 = ConfigParam 3;  // ConfigParam 1 is used if absent
+_ dns_root_addr:bits256 = ConfigParam 4;  // root TON DNS resolver
+
+_ mint_new_price:Grams mint_add_price:Grams = ConfigParam 6;
+_ to_mint:ExtraCurrencyCollection = ConfigParam 7;
+
+capabilities#c4 version:uint32 capabilities:uint64 = GlobalVersion;
+_ GlobalVersion = ConfigParam 8;  // all zero if absent
+_ mandatory_params:(Hashmap 32 True) = ConfigParam 9;
+_ critical_params:(Hashmap 32 True) = ConfigParam 10;
+
+cfg_vote_cfg#36 min_tot_rounds:uint8 max_tot_rounds:uint8 min_wins:uint8 max_losses:uint8 min_store_sec:uint32 max_store_sec:uint32 bit_price:uint32 cell_price:uint32 = ConfigProposalSetup;
+cfg_vote_setup#91 normal_params:^ConfigProposalSetup critical_params:^ConfigProposalSetup = ConfigVotingSetup;
+_ ConfigVotingSetup = ConfigParam 11;
+
+cfg_proposal#f3 param_id:int32 param_value:(Maybe ^Cell) if_hash_equal:(Maybe uint256) 
+  = ConfigProposal;
+cfg_proposal_status#ce expires:uint32 proposal:^ConfigProposal is_critical:Bool
+  voters:(HashmapE 16 True) remaining_weight:int64 validator_set_id:uint256 
+  rounds_remaining:uint8 wins:uint8 losses:uint8 = ConfigProposalStatus;
+
+wfmt_basic#1 vm_version:int32 vm_mode:uint64 = WorkchainFormat 1;
+wfmt_ext#0 min_addr_len:(## 12) max_addr_len:(## 12) addr_len_step:(## 12)
+  { min_addr_len >= 64 } { min_addr_len <= max_addr_len } 
+  { max_addr_len <= 1023 } { addr_len_step <= 1023 }
+  workchain_type_id:(## 32) { workchain_type_id >= 1 }
+  = WorkchainFormat 0;
+
+workchain#a6 enabled_since:uint32 actual_min_split:(## 8) 
+  min_split:(## 8) max_split:(## 8) { actual_min_split <= min_split }
+//workchain#a5 enabled_since:uint32 min_split:(## 8) max_split:(## 8)
+//  { min_split <= max_split } { max_split <= 60 }
+  basic:(## 1) active:Bool accept_msgs:Bool flags:(## 13) { flags = 0 }
+  zerostate_root_hash:bits256 zerostate_file_hash:bits256
+  version:uint32 format:(WorkchainFormat basic)
+  = WorkchainDescr;
+
+_ workchains:(HashmapE 32 WorkchainDescr) = ConfigParam 12;
+
+complaint_prices#1a deposit:Grams bit_price:Grams cell_price:Grams = ComplaintPricing; 
+_ ComplaintPricing = ConfigParam 13;
+
+block_grams_created#6b masterchain_block_fee:Grams basechain_block_fee:Grams
+  = BlockCreateFees;
+_ BlockCreateFees = ConfigParam 14;
+
+_ validators_elected_for:uint32 elections_start_before:uint32 
+  elections_end_before:uint32 stake_held_for:uint32
+  = ConfigParam 15;
+  
+_ max_validators:(## 16) max_main_validators:(## 16) min_validators:(## 16) 
+  { max_validators >= max_main_validators } 
+  { max_main_validators >= min_validators } 
+  { min_validators >= 1 }
+  = ConfigParam 16;
+
+_ min_stake:Grams max_stake:Grams min_total_stake:Grams max_stake_factor:uint32 = ConfigParam 17;
+
+_#cc utime_since:uint32 bit_price_ps:uint64 cell_price_ps:uint64 
+  mc_bit_price_ps:uint64 mc_cell_price_ps:uint64 = StoragePrices;
+_ (Hashmap 32 StoragePrices) = ConfigParam 18;
+
+gas_prices#dd gas_price:uint64 gas_limit:uint64 gas_credit:uint64 
+  block_gas_limit:uint64 freeze_due_limit:uint64 delete_due_limit:uint64 
+  = GasLimitsPrices;
+
+gas_prices_ext#de gas_price:uint64 gas_limit:uint64 special_gas_limit:uint64 gas_credit:uint64 
+  block_gas_limit:uint64 freeze_due_limit:uint64 delete_due_limit:uint64 
+  = GasLimitsPrices;
+
+gas_flat_pfx#d1 flat_gas_limit:uint64 flat_gas_price:uint64 other:GasLimitsPrices
+  = GasLimitsPrices;
+
+config_mc_gas_prices#_ GasLimitsPrices = ConfigParam 20;
+config_gas_prices#_ GasLimitsPrices = ConfigParam 21;
+
+param_limits#c3 underload:# soft_limit:# { underload <= soft_limit }
+  hard_limit:# { soft_limit <= hard_limit } = ParamLimits;
+block_limits#5d bytes:ParamLimits gas:ParamLimits lt_delta:ParamLimits
+  = BlockLimits;
+  
+config_mc_block_limits#_ BlockLimits = ConfigParam 22;
+config_block_limits#_ BlockLimits = ConfigParam 23;
+
+// msg_fwd_fees = (lump_price + ceil((bit_price * msg.bits + cell_price * msg.cells)/2^16)) nanograms
+// ihr_fwd_fees = ceil((msg_fwd_fees * ihr_price_factor)/2^16) nanograms
+// bits in the root cell of a message are not included in msg.bits (lump_price pays for them)
+msg_forward_prices#ea lump_price:uint64 bit_price:uint64 cell_price:uint64
+  ihr_price_factor:uint32 first_frac:uint16 next_frac:uint16 = MsgForwardPrices;
+
+// used for messages to/from masterchain
+config_mc_fwd_prices#_ MsgForwardPrices = ConfigParam 24;
+// used for all other messages
+config_fwd_prices#_ MsgForwardPrices = ConfigParam 25;
+
+catchain_config#c1 mc_catchain_lifetime:uint32 shard_catchain_lifetime:uint32 
+  shard_validators_lifetime:uint32 shard_validators_num:uint32 = CatchainConfig;
+
+catchain_config_new#c2 flags:(## 7) { flags = 0 } shuffle_mc_validators:Bool
+  mc_catchain_lifetime:uint32 shard_catchain_lifetime:uint32
+  shard_validators_lifetime:uint32 shard_validators_num:uint32 = CatchainConfig;
+
+consensus_config#d6 round_candidates:# { round_candidates >= 1 }
+  next_candidate_delay_ms:uint32 consensus_timeout_ms:uint32
+  fast_attempts:uint32 attempt_duration:uint32 catchain_max_deps:uint32
+  max_block_bytes:uint32 max_collated_bytes:uint32 = ConsensusConfig;
+
+consensus_config_new#d7 flags:(## 7) { flags = 0 } new_catchain_ids:Bool
+  round_candidates:(## 8) { round_candidates >= 1 }
+  next_candidate_delay_ms:uint32 consensus_timeout_ms:uint32
+  fast_attempts:uint32 attempt_duration:uint32 catchain_max_deps:uint32
+  max_block_bytes:uint32 max_collated_bytes:uint32 = ConsensusConfig;
+
+consensus_config_v3#d8 flags:(## 7) { flags = 0 } new_catchain_ids:Bool
+  round_candidates:(## 8) { round_candidates >= 1 }
+  next_candidate_delay_ms:uint32 consensus_timeout_ms:uint32
+  fast_attempts:uint32 attempt_duration:uint32 catchain_max_deps:uint32
+  max_block_bytes:uint32 max_collated_bytes:uint32 
+  proto_version:uint16 = ConsensusConfig;
+
+consensus_config_v4#d9 flags:(## 7) { flags = 0 } new_catchain_ids:Bool
+  round_candidates:(## 8) { round_candidates >= 1 }
+  next_candidate_delay_ms:uint32 consensus_timeout_ms:uint32
+  fast_attempts:uint32 attempt_duration:uint32 catchain_max_deps:uint32
+  max_block_bytes:uint32 max_collated_bytes:uint32
+  proto_version:uint16 catchain_max_blocks_coeff:uint32 = ConsensusConfig;
+
+_ CatchainConfig = ConfigParam 28;
+_ ConsensusConfig = ConfigParam 29;
+
+_ fundamental_smc_addr:(HashmapE 256 True) = ConfigParam 31;
+_ prev_validators:ValidatorSet = ConfigParam 32;
+_ prev_temp_validators:ValidatorSet = ConfigParam 33;
+_ cur_validators:ValidatorSet = ConfigParam 34;
+_ cur_temp_validators:ValidatorSet = ConfigParam 35;
+_ next_validators:ValidatorSet = ConfigParam 36;
+_ next_temp_validators:ValidatorSet = ConfigParam 37;
+
+validator_temp_key#3 adnl_addr:bits256 temp_public_key:SigPubKey seqno:# valid_until:uint32 = ValidatorTempKey;
+signed_temp_key#4 key:^ValidatorTempKey signature:CryptoSignature = ValidatorSignedTempKey;
+_ (HashmapE 256 ValidatorSignedTempKey) = ConfigParam 39;
+
+misbehaviour_punishment_config_v1#01 
+  default_flat_fine:Grams default_proportional_fine:uint32
+  severity_flat_mult:uint16 severity_proportional_mult:uint16
+  unpunishable_interval:uint16
+  long_interval:uint16 long_flat_mult:uint16 long_proportional_mult:uint16
+  medium_interval:uint16 medium_flat_mult:uint16 medium_proportional_mult:uint16
+   = MisbehaviourPunishmentConfig;
+_ MisbehaviourPunishmentConfig = ConfigParam 40;
+
+oracle_bridge_params#_ bridge_address:bits256 oracle_mutlisig_address:bits256 oracles:(HashmapE 256 uint256) external_chain_address:bits256 = OracleBridgeParams;
+_ OracleBridgeParams = ConfigParam 71; // Ethereum bridge
+_ OracleBridgeParams = ConfigParam 72; // Binance Smart Chain bridge
+_ OracleBridgeParams = ConfigParam 73; // Polygon bridge
+
+//
+//  PROOFS
+//
+block_signatures_pure#_ sig_count:uint32 sig_weight:uint64
+  signatures:(HashmapE 16 CryptoSignaturePair) = BlockSignaturesPure;
+block_signatures#11 validator_info:ValidatorBaseInfo pure_signatures:BlockSignaturesPure = BlockSignatures;
+block_proof#c3 proof_for:BlockIdExt root:^Cell signatures:(Maybe ^BlockSignatures) = BlockProof;
+
+chain_empty$_ = ProofChain 0;
+chain_link$_ {n:#} root:^Cell prev:n?^(ProofChain n) = ProofChain (n + 1);
+top_block_descr#d5 proof_for:BlockIdExt signatures:(Maybe ^BlockSignatures) 
+  len:(## 8) { len >= 1 } { len <= 8 } chain:(ProofChain len) = TopBlockDescr;
+
+//
+//  COLLATED DATA
+//
+top_block_descr_set#4ac789f3 collection:(HashmapE 96 ^TopBlockDescr) = TopBlockDescrSet;
+
+//
+//  VALIDATOR MISBEHAVIOR COMPLAINTS
+//
+prod_info#34 utime:uint32 mc_blk_ref:ExtBlkRef state_proof:^(MERKLE_PROOF Block)
+  prod_proof:^(MERKLE_PROOF ShardState) = ProducerInfo;
+no_blk_gen from_utime:uint32 prod_info:^ProducerInfo = ComplaintDescr;
+no_blk_gen_diff prod_info_old:^ProducerInfo prod_info_new:^ProducerInfo = ComplaintDescr;
+validator_complaint#bc validator_pubkey:bits256 description:^ComplaintDescr created_at:uint32 severity:uint8 reward_addr:uint256 paid:Grams suggested_fine:Grams suggested_fine_part:uint32 = ValidatorComplaint;
+complaint_status#2d complaint:^ValidatorComplaint voters:(HashmapE 16 True) vset_id:uint256 weight_remaining:int64 = ValidatorComplaintStatus;
+
+//
+//  TVM REFLECTION
+//
+vm_stk_null#00 = VmStackValue;
+vm_stk_tinyint#01 value:int64 = VmStackValue;
+vm_stk_int#0201_ value:int257 = VmStackValue;
+vm_stk_nan#02ff = VmStackValue;
+vm_stk_cell#03 cell:^Cell = VmStackValue;
+_ cell:^Cell st_bits:(## 10) end_bits:(## 10) { st_bits <= end_bits }
+  st_ref:(#<= 4) end_ref:(#<= 4) { st_ref <= end_ref } = VmCellSlice;
+vm_stk_slice#04 _:VmCellSlice = VmStackValue;
+vm_stk_builder#05 cell:^Cell = VmStackValue;
+vm_stk_cont#06 cont:VmCont = VmStackValue;
+vm_tupref_nil$_ = VmTupleRef 0;
+vm_tupref_single$_ entry:^VmStackValue = VmTupleRef 1;
+vm_tupref_any$_ {n:#} ref:^(VmTuple (n + 2)) = VmTupleRef (n + 2);
+vm_tuple_nil$_ = VmTuple 0;
+vm_tuple_tcons$_ {n:#} head:(VmTupleRef n) tail:^VmStackValue = VmTuple (n + 1);
+vm_stk_tuple#07 len:(## 16) data:(VmTuple len) = VmStackValue;
+
+vm_stack#_ depth:(## 24) stack:(VmStackList depth) = VmStack;
+vm_stk_cons#_ {n:#} rest:^(VmStackList n) tos:VmStackValue = VmStackList (n + 1);
+vm_stk_nil#_ = VmStackList 0;
+
+_ cregs:(HashmapE 4 VmStackValue) = VmSaveList;
+gas_limits#_ remaining:int64 _:^[ max_limit:int64 cur_limit:int64 credit:int64 ]
+  = VmGasLimits;
+_ libraries:(HashmapE 256 ^Cell) = VmLibraries;
+
+vm_ctl_data$_ nargs:(Maybe uint13) stack:(Maybe VmStack) save:VmSaveList
+cp:(Maybe int16) = VmControlData;
+vmc_std$00 cdata:VmControlData code:VmCellSlice = VmCont;
+vmc_envelope$01 cdata:VmControlData next:^VmCont = VmCont;
+vmc_quit$1000 exit_code:int32 = VmCont;
+vmc_quit_exc$1001 = VmCont;
+vmc_repeat$10100 count:uint63 body:^VmCont after:^VmCont = VmCont; 
+vmc_until$110000 body:^VmCont after:^VmCont = VmCont;
+vmc_again$110001 body:^VmCont = VmCont;
+vmc_while_cond$110010 cond:^VmCont body:^VmCont
+after:^VmCont = VmCont;
+vmc_while_body$110011 cond:^VmCont body:^VmCont
+after:^VmCont = VmCont;
+vmc_pushint$1111 value:int32 next:^VmCont = VmCont;
+
+//
+//  DNS RECORDS
+//
+_ (HashmapE 256 DNSRecord) = DNS_RecordSet;
+
+chunk_ref$_ {n:#} ref:^(TextChunks (n + 1)) = TextChunkRef (n + 1);
+chunk_ref_empty$_ = TextChunkRef 0;
+text_chunk$_ {n:#} len:(## 8) data:(bits (len * 8)) next:(TextChunkRef n) = TextChunks (n + 1);
+text_chunk_empty$_ = TextChunks 0;
+text$_ chunks:(## 8) rest:(TextChunks chunks) = Text;
+dns_text#1eda _:Text = DNSRecord;
+
+dns_next_resolver#ba93 resolver:MsgAddressInt = DNSRecord;  // usually in record #-1
+
+dns_adnl_address#ad01 adnl_addr:bits256 flags:(## 8) { flags <= 1 }
+  proto_list:flags . 0?ProtoList = DNSRecord;  // often in record #2
+proto_list_nil$0 = ProtoList;
+proto_list_next$1 head:Protocol tail:ProtoList = ProtoList;
+proto_http#4854 = Protocol;
+
+dns_smc_address#9fd3 smc_addr:MsgAddressInt flags:(## 8) { flags <= 1 }
+  cap_list:flags . 0?SmcCapList = DNSRecord;   // often in record #1
+cap_list_nil$0 = SmcCapList;
+cap_list_next$1 head:SmcCapability tail:SmcCapList = SmcCapList;
+cap_method_seqno#5371 = SmcCapability;
+cap_method_pubkey#71f4 = SmcCapability;
+cap_is_wallet#2177 = SmcCapability;
+cap_name#ff name:Text = SmcCapability;
+
+//
+// PAYMENT CHANNELS
+//
+
+chan_config$_  init_timeout:uint32 close_timeout:uint32 a_key:bits256 b_key:bits256 
+  a_addr:^MsgAddressInt b_addr:^MsgAddressInt channel_id:uint64 min_A_extra:Grams = ChanConfig;
+
+chan_state_init$000  signed_A:Bool signed_B:Bool min_A:Grams min_B:Grams expire_at:uint32 A:Grams B:Grams = ChanState;
+chan_state_close$001 signed_A:Bool signed_B:Bool promise_A:Grams promise_B:Grams expire_at:uint32 A:Grams B:Grams = ChanState;
+chan_state_payout$010 A:Grams B:Grams = ChanState;
+
+chan_promise$_ channel_id:uint64 promise_A:Grams promise_B:Grams = ChanPromise;
+chan_signed_promise#_ sig:(Maybe ^bits512) promise:ChanPromise = ChanSignedPromise;
+
+chan_msg_init#27317822 inc_A:Grams inc_B:Grams min_A:Grams min_B:Grams channel_id:uint64 = ChanMsg;
+chan_msg_close#f28ae183 extra_A:Grams extra_B:Grams promise:ChanSignedPromise  = ChanMsg;
+chan_msg_timeout#43278a28 = ChanMsg;
+chan_msg_payout#37fe7810 = ChanMsg;
+
+chan_signed_msg$_ sig_A:(Maybe ^bits512) sig_B:(Maybe ^bits512) msg:ChanMsg = ChanSignedMsg;
+
+chan_op_cmd#912838d1 msg:ChanSignedMsg = ChanOp;
+
+
+chan_data$_ config:^ChanConfig state:^ChanState = ChanData;
+

--- a/tests/examplefiles/tlb/block.tlb.output
+++ b/tests/examplefiles/tlb/block.tlb.output
@@ -1,0 +1,9989 @@
+'unit'        Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Unit'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'true'        Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'True'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'// EMPTY False;' Comment.Singleline
+'\n'          Text.Whitespace
+
+'bool_false'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Bool'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bool_true'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Bool'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bool_false'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BoolFalse'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bool_true'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BoolTrue'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'nothing'     Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Maybe'       Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'just'        Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Maybe'       Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'left'        Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Either'      Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'right'       Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Either'      Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'pair'        Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'first'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'second'      Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Both'        Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'bit'         Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Bit'         Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'/*'          Comment.Multiline
+'\n '         Comment.Multiline
+'*'           Comment.Multiline
+'\n '         Comment.Multiline
+'*'           Comment.Multiline
+'   FROM hashmap.tlb\n ' Comment.Multiline
+'*'           Comment.Multiline
+'\n '         Comment.Multiline
+'*/'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'// ordinary Hashmap / HashmapE, with fixed length keys' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'hm_edge'     Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'l'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'label'       Name
+':'           Operator
+'('           Punctuation
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'l'           Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' \n          ' Text.Whitespace
+'{'           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'~'           Operator
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'l'           Name
+'}'           Punctuation
+' '           Text.Whitespace
+'node'        Name
+':'           Operator
+'('           Punctuation
+'HashmapNode' Name
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Hashmap'     Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'hmn_leaf'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapNode' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'hmn_fork'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapNode' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'hml_short'   Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'Unary'       Name
+' '           Text.Whitespace
+'~'           Operator
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'m'           Name
+'}'           Punctuation
+' '           Text.Whitespace
+'s'           Name
+':'           Operator
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'Bit'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'n'           Name
+' '           Text.Whitespace
+'m'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'hml_long'    Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'n'           Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'s'           Name
+':'           Operator
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'Bit'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'n'           Name
+' '           Text.Whitespace
+'m'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'hml_same'    Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'v'           Name
+':'           Operator
+'Bit'         Name
+' '           Text.Whitespace
+'n'           Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'n'           Name
+' '           Text.Whitespace
+'m'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'unary_zero'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Unary'       Name
+' '           Text.Whitespace
+'~'           Operator
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'unary_succ'  Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'x'           Name
+':'           Operator
+'('           Punctuation
+'Unary'       Name
+' '           Text.Whitespace
+'~'           Operator
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Unary'       Name
+' '           Text.Whitespace
+'~'           Operator
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'hme_empty'   Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapE'    Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'hme_root'    Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapE'    Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// true#_ = True;' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BitstringSet' Name
+' '           Text.Whitespace
+'n'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//  HashmapAug, hashmap with an extra value ' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//   (augmentation) of type Y at every node' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'ahm_edge'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'l'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'label'       Name
+':'           Operator
+'('           Punctuation
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'l'           Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'~'           Operator
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'l'           Name
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'node'        Name
+':'           Operator
+'('           Punctuation
+'HashmapAugNode' Name
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapAug'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ahmn_leaf'   Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapAugNode' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ahmn_fork'   Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'HashmapAug'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'HashmapAug'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapAugNode' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ahme_empty'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' \n          ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapAugE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ahme_root'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'HashmapAug'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+' \n  '       Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HashmapAugE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// VarHashmap / VarHashmapE, with variable-length keys' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'vhm_edge'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'l'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'label'       Name
+':'           Operator
+'('           Punctuation
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'l'           Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'{'           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'~'           Operator
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'l'           Name
+'}'           Punctuation
+' '           Text.Whitespace
+'node'        Name
+':'           Operator
+'('           Punctuation
+'VarHashmapNode' Name
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vhmn_leaf'   Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmapNode' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vhmn_fork'   Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VarHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n             ' Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VarHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n             ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmapNode' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vhmn_cont'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'branch'      Name
+':'           Operator
+'Bit'         Name
+' '           Text.Whitespace
+'child'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VarHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n            ' Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmapNode' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// nothing$0 {X:Type} = Maybe X;' Comment.Singleline
+'\n'          Text.Whitespace
+
+'// just$1 {X:Type} value:X = Maybe X;' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'vhme_empty'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmapE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vhme_root'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VarHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n            ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarHashmapE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'// PfxHashmap / PfxHashmapE, with variable-length keys' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//                           constituting a prefix code' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'phm_edge'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'l'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'m'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'label'       Name
+':'           Operator
+'('           Punctuation
+'HmLabel'     Name
+' '           Text.Whitespace
+'~'           Operator
+'l'           Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'{'           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'~'           Operator
+'m'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'l'           Name
+'}'           Punctuation
+' '           Text.Whitespace
+'node'        Name
+':'           Operator
+'('           Punctuation
+'PfxHashmapNode' Name
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'PfxHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'phmn_leaf'   Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'PfxHashmapNode' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'phmn_fork'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'PfxHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n            ' Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'PfxHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'PfxHashmapNode' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'phme_empty'  Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'PfxHashmapE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'phme_root'   Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'PfxHashmap'  Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n            ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'PfxHashmapE' Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'/*'          Comment.Multiline
+'\n '         Comment.Multiline
+'*'           Comment.Multiline
+'\n '         Comment.Multiline
+'*'           Comment.Multiline
+'  END hashmap.tlb\n ' Comment.Multiline
+'*'           Comment.Multiline
+'\n '         Comment.Multiline
+'*/'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'// TON BLOCK LAYOUT' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'addr_none'   Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddressExt' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'addr_extern' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'9'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'external_address' Name
+':'           Operator
+'('           Punctuation
+'bits'        Name
+' '           Text.Whitespace
+'len'         Name
+')'           Punctuation
+' \n             ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddressExt' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'anycast_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'depth'       Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'30'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'depth'       Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'   '         Text.Whitespace
+'rewrite_pfx' Name
+':'           Operator
+'('           Punctuation
+'bits'        Name
+' '           Text.Whitespace
+'depth'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Anycast'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'addr_std'    Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'anycast'     Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Anycast'     Name
+')'           Punctuation
+' \n   '      Text.Whitespace
+'workchain_id' Name
+':'           Operator
+'int8'        Name
+' '           Text.Whitespace
+'address'     Name
+':'           Operator
+'bits256'     Name
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddressInt' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'addr_var'    Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'anycast'     Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Anycast'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'addr_len'    Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'9'           Literal.Number
+')'           Punctuation
+' \n   '      Text.Whitespace
+'workchain_id' Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'address'     Name
+':'           Operator
+'('           Punctuation
+'bits'        Name
+' '           Text.Whitespace
+'addr_len'    Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddressInt' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddress'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'MsgAddressExt' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgAddress'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'var_uint'    Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'#<'          Name.Tag
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'('           Punctuation
+'uint'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'len'         Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'         '   Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarUInteger' Name
+' '           Text.Whitespace
+'n'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'var_int'     Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'#<'          Name.Tag
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'('           Punctuation
+'int'         Name
+' '           Text.Whitespace
+'('           Punctuation
+'len'         Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+' \n        ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VarInteger'  Name
+' '           Text.Whitespace
+'n'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'nanograms'   Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'amount'      Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Grams'       Name
+';'           Punctuation
+'  \n'        Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'extra_currencies' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'dict'        Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'32'          Literal.Number
+')'           Punctuation
+')'           Punctuation
+' \n                 ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ExtraCurrencyCollection' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'currencies'  Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'grams'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'other'       Name
+':'           Operator
+'ExtraCurrencyCollection' Name
+' \n           ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CurrencyCollection' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'int_msg_info' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'ihr_disabled' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'bounce'      Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'bounced'     Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'src'         Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'dest'        Name
+':'           Operator
+'MsgAddressInt' Name
+' \n  '       Text.Whitespace
+'value'       Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'ihr_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created_lt'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'created_at'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CommonMsgInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ext_in_msg_info' Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'src'         Name
+':'           Operator
+'MsgAddressExt' Name
+' '           Text.Whitespace
+'dest'        Name
+':'           Operator
+'MsgAddressInt' Name
+' \n  '       Text.Whitespace
+'import_fee'  Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CommonMsgInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ext_out_msg_info' Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'src'         Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'dest'        Name
+':'           Operator
+'MsgAddressExt' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created_lt'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'created_at'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CommonMsgInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'int_msg_info' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'ihr_disabled' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'bounce'      Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'bounced'     Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'src'         Name
+':'           Operator
+'MsgAddress'  Name
+' '           Text.Whitespace
+'dest'        Name
+':'           Operator
+'MsgAddressInt' Name
+' \n  '       Text.Whitespace
+'value'       Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'ihr_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created_lt'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'created_at'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CommonMsgInfoRelaxed' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'ext_out_msg_info' Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'src'         Name
+':'           Operator
+'MsgAddress'  Name
+' '           Text.Whitespace
+'dest'        Name
+':'           Operator
+'MsgAddressExt' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created_lt'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'created_at'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CommonMsgInfoRelaxed' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'tick_tock'   Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'tick'        Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'tock'        Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TickTock'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'split_depth' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'5'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'special'     Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TickTock'    Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'code'        Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'Cell'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'data'        Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'Cell'        Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'library'     Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'SimpleLib'   Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'StateInit'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  \n'        Text.Whitespace
+
+'simple_lib'  Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'public'      Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SimpleLib'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'message'     Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'info'        Name
+':'           Operator
+'CommonMsgInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'init'        Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'('           Punctuation
+'Either'      Name
+' '           Text.Whitespace
+'StateInit'   Name
+' '           Text.Whitespace
+'^'           Operator
+'StateInit'   Name
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'body'        Name
+':'           Operator
+'('           Punctuation
+'Either'      Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'^'           Operator
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Message'     Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'message'     Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'info'        Name
+':'           Operator
+'CommonMsgInfoRelaxed' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'init'        Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'('           Punctuation
+'Either'      Name
+' '           Text.Whitespace
+'StateInit'   Name
+' '           Text.Whitespace
+'^'           Operator
+'StateInit'   Name
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'body'        Name
+':'           Operator
+'('           Punctuation
+'Either'      Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'^'           Operator
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MessageRelaxed' Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  \n'        Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MessageAny'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'interm_addr_regular' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'use_dest_bits' Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'96'          Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'IntermediateAddress' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'interm_addr_simple' Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'workchain_id' Name
+':'           Operator
+'int8'        Name
+' '           Text.Whitespace
+'addr_pfx'    Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'IntermediateAddress' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'interm_addr_ext' Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'workchain_id' Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'addr_pfx'    Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'IntermediateAddress' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_envelope' Name
+'#4'          Name.Tag
+' '           Text.Whitespace
+'cur_addr'    Name
+':'           Operator
+'IntermediateAddress' Name
+' \n  '       Text.Whitespace
+'next_addr'   Name
+':'           Operator
+'IntermediateAddress' Name
+' '           Text.Whitespace
+'fwd_fee_remaining' Name
+':'           Operator
+'Grams'       Name
+' \n  '       Text.Whitespace
+'msg'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgEnvelope' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'msg_import_ext' Name
+'$000'        Name.Tag
+' '           Text.Whitespace
+'msg'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' \n              ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_import_ihr' Name
+'$010'        Name.Tag
+' '           Text.Whitespace
+'msg'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' \n    '     Text.Whitespace
+'ihr_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'proof_created' Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_import_imm' Name
+'$011'        Name.Tag
+' '           Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_import_fin' Name
+'$100'        Name.Tag
+' '           Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_import_tr' Name
+'$101'        Name.Tag
+'  '          Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'transit_fee' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_discard_fin' Name
+'$110'        Name.Tag
+' '           Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' '           Text.Whitespace
+'transaction_id' Name
+':'           Operator
+'uint64'      Name
+' \n    '     Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_discard_tr' Name
+'$111'        Name.Tag
+' '           Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' '           Text.Whitespace
+'transaction_id' Name
+':'           Operator
+'uint64'      Name
+' \n    '     Text.Whitespace
+'fwd_fee'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'proof_delivered' Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsg'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'import_fees' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'fees_collected' Name
+':'           Operator
+'Grams'       Name
+' \n  '       Text.Whitespace
+'value_imported' Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ImportFees'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'InMsg'       Name
+' '           Text.Whitespace
+'ImportFees'  Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'InMsgDescr'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'msg_export_ext' Name
+'$000'        Name.Tag
+' '           Text.Whitespace
+'msg'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_imm' Name
+'$010'        Name.Tag
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'reimport'    Name
+':'           Operator
+'^'           Operator
+'InMsg'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_new' Name
+'$001'        Name.Tag
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_tr' Name
+'$011'        Name.Tag
+'  '          Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'imported'    Name
+':'           Operator
+'^'           Operator
+'InMsg'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_deq' Name
+'$1100'       Name.Tag
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'import_block_lt' Name
+':'           Operator
+'uint63'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_deq_short' Name
+'$1101'       Name.Tag
+' '           Text.Whitespace
+'msg_env_hash' Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'next_workchain' Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'next_addr_pfx' Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'import_block_lt' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_tr_req' Name
+'$111'        Name.Tag
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'imported'    Name
+':'           Operator
+'^'           Operator
+'InMsg'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'msg_export_deq_imm' Name
+'$100'        Name.Tag
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' \n    '     Text.Whitespace
+'reimport'    Name
+':'           Operator
+'^'           Operator
+'InMsg'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsg'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'enqueued_lt' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'MsgEnvelope' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'EnqueuedMsg' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'OutMsg'      Name
+' '           Text.Whitespace
+'CurrencyCollection' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsgDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'352'         Literal.Number
+' '           Text.Whitespace
+'EnqueuedMsg' Name
+' '           Text.Whitespace
+'uint64'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsgQueue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'processed_upto' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'last_msg_lt' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'last_msg_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProcessedUpto' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'// key is [ shard:uint64 mc_seqno:uint32 ]  ' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'96'          Literal.Number
+' '           Text.Whitespace
+'ProcessedUpto' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProcessedInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ihr_pending' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'import_lt'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'IhrPendingSince' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'320'         Literal.Number
+' '           Text.Whitespace
+'IhrPendingSince' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'IhrPendingInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'out_queue'   Name
+':'           Operator
+'OutMsgQueue' Name
+' '           Text.Whitespace
+'proc_info'   Name
+':'           Operator
+'ProcessedInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'ihr_pending' Name
+':'           Operator
+'IhrPendingInfo' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutMsgQueueInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'storage_used' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'cells'       Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'bits'        Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'public_cells' Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'StorageUsed' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'storage_used_short' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'cells'       Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'bits'        Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'StorageUsedShort' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'storage_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'used'        Name
+':'           Operator
+'StorageUsed' Name
+' '           Text.Whitespace
+'last_paid'   Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'              ' Text.Whitespace
+'due_payment' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Grams'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'StorageInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'account_none' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Account'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'account'     Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'addr'        Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'storage_stat' Name
+':'           Operator
+'StorageInfo' Name
+'\n'          Text.Whitespace
+
+'          '  Text.Whitespace
+'storage'     Name
+':'           Operator
+'AccountStorage' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Account'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'account_storage' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'last_trans_lt' Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'balance'     Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'state'       Name
+':'           Operator
+'AccountState' Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountStorage' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'account_uninit' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountState' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'account_active' Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'StateInit'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountState' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'account_frozen' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'state_hash'  Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountState' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'acc_state_uninit' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'acc_state_frozen' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'acc_state_active' Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'acc_state_nonexist' Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/*'          Comment.Multiline
+' duplicates\ntick_tock$_ tick:Bool tock:Bool = TickTock;\n\n_ split_depth:(Maybe (## 5)) special:(Maybe TickTock)\n  code:(Maybe ^Cell) data:(Maybe ^Cell)\n  library:(Maybe ^Cell) = StateInit;\n' Comment.Multiline
+
+'*/'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'account_descr' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'account'     Name
+':'           Operator
+'^'           Operator
+'Account'     Name
+' '           Text.Whitespace
+'last_trans_hash' Name
+':'           Operator
+'bits256'     Name
+' \n  '       Text.Whitespace
+'last_trans_lt' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardAccount' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'depth_balance' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'split_depth' Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'30'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'balance'     Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DepthBalanceInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'ShardAccount' Name
+' '           Text.Whitespace
+'DepthBalanceInfo' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardAccounts' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'transaction' Name
+'$0111'       Name.Tag
+' '           Text.Whitespace
+'account_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'lt'          Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'prev_trans_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'prev_trans_lt' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'now'         Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'outmsg_cnt'  Name
+':'           Operator
+'uint15'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'orig_status' Name
+':'           Operator
+'AccountStatus' Name
+' '           Text.Whitespace
+'end_status'  Name
+':'           Operator
+'AccountStatus' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'in_msg'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'out_msgs'    Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'15'          Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'('           Punctuation
+'Message'     Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'total_fees'  Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'state_update' Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'HASH_UPDATE' Name
+' '           Text.Whitespace
+'Account'     Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'description' Name
+':'           Operator
+'^'           Operator
+'TransactionDescr' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Transaction' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'merkle_update' Name
+'#02'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'old_hash'    Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'new_hash'    Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'old'         Name
+':'           Operator
+'^'           Operator
+'X'           Name
+' '           Text.Whitespace
+'new'         Name
+':'           Operator
+'^'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MERKLE_UPDATE' Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'update_hashes' Name
+'#72'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'old_hash'    Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'new_hash'    Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'HASH_UPDATE' Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'merkle_proof' Name
+'#03'         Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'virtual_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'depth'       Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'virtual_root' Name
+':'           Operator
+'^'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MERKLE_PROOF' Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'acc_trans'   Name
+'#5'          Name.Tag
+' '           Text.Whitespace
+'account_addr' Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'            ' Text.Whitespace
+'transactions' Name
+':'           Operator
+'('           Punctuation
+'HashmapAug'  Name
+' '           Text.Whitespace
+'64'          Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'Transaction' Name
+' '           Text.Whitespace
+'CurrencyCollection' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'            ' Text.Whitespace
+'state_update' Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'HASH_UPDATE' Name
+' '           Text.Whitespace
+'Account'     Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'          '  Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccountBlock' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'AccountBlock' Name
+' '           Text.Whitespace
+'CurrencyCollection' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardAccountBlocks' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'tr_phase_storage' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'storage_fees_collected' Name
+':'           Operator
+'Grams'       Name
+' \n  '       Text.Whitespace
+'storage_fees_due' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Grams'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'status_change' Name
+':'           Operator
+'AccStatusChange' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrStoragePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'acst_unchanged' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccStatusChange' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// x -> x'   Comment.Singleline
+'\n'          Text.Whitespace
+
+'acst_frozen' Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccStatusChange' Name
+';'           Punctuation
+'    '        Text.Whitespace
+'// init -> frozen' Comment.Singleline
+'\n'          Text.Whitespace
+
+'acst_deleted' Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'AccStatusChange' Name
+';'           Punctuation
+'   '         Text.Whitespace
+'// frozen -> deleted' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'tr_phase_credit' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'due_fees_collected' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Grams'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'credit'      Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrCreditPhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'tr_phase_compute_skipped' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'reason'      Name
+':'           Operator
+'ComputeSkipReason' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrComputePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'tr_phase_compute_vm' Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'success'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'msg_state_used' Name
+':'           Operator
+'Bool'        Name
+' \n  '       Text.Whitespace
+'account_activated' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'gas_fees'    Name
+':'           Operator
+'Grams'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'gas_used'    Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gas_limit'   Name
+':'           Operator
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'gas_credit'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'('           Punctuation
+'VarUInteger' Name
+' '           Text.Whitespace
+'3'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'mode'        Name
+':'           Operator
+'int8'        Name
+' '           Text.Whitespace
+'exit_code'   Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'exit_arg'    Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'int32'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'vm_steps'    Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'vm_init_state_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'vm_final_state_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrComputePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cskip_no_state' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComputeSkipReason' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cskip_bad_state' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComputeSkipReason' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cskip_no_gas' Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComputeSkipReason' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'tr_phase_action' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'success'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'valid'       Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'no_funds'    Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'status_change' Name
+':'           Operator
+'AccStatusChange' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'total_fwd_fees' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Grams'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'total_action_fees' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'Grams'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'result_code' Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'result_arg'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'int32'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'tot_actions' Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'spec_actions' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'skipped_actions' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'msgs_created' Name
+':'           Operator
+'uint16'      Name
+' \n  '       Text.Whitespace
+'action_list_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'tot_msg_size' Name
+':'           Operator
+'StorageUsedShort' Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrActionPhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'tr_phase_bounce_negfunds' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrBouncePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'tr_phase_bounce_nofunds' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'msg_size'    Name
+':'           Operator
+'StorageUsedShort' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'req_fwd_fees' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrBouncePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'tr_phase_bounce_ok' Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'msg_size'    Name
+':'           Operator
+'StorageUsedShort' Name
+' \n  '       Text.Whitespace
+'msg_fees'    Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'fwd_fees'    Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TrBouncePhase' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'trans_ord'   Name
+'$0000'       Name.Tag
+' '           Text.Whitespace
+'credit_first' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrStoragePhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'credit_ph'   Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrCreditPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'compute_ph'  Name
+':'           Operator
+'TrComputePhase' Name
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'TrActionPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'aborted'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'bounce'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrBouncePhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'destroyed'   Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'trans_storage' Name
+'$0001'       Name.Tag
+' '           Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'TrStoragePhase' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'trans_tick_tock' Name
+'$001'        Name.Tag
+' '           Text.Whitespace
+'is_tock'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'TrStoragePhase' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'compute_ph'  Name
+':'           Operator
+'TrComputePhase' Name
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'TrActionPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'aborted'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'destroyed'   Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'split_merge_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'cur_shard_pfx_len' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'6'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'acc_split_depth' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'6'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'this_addr'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'sibling_addr' Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SplitMergeInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'trans_split_prepare' Name
+'$0100'       Name.Tag
+' '           Text.Whitespace
+'split_info'  Name
+':'           Operator
+'SplitMergeInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrStoragePhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'compute_ph'  Name
+':'           Operator
+'TrComputePhase' Name
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'TrActionPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'aborted'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'destroyed'   Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'trans_split_install' Name
+'$0101'       Name.Tag
+' '           Text.Whitespace
+'split_info'  Name
+':'           Operator
+'SplitMergeInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'prepare_transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'installed'   Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'trans_merge_prepare' Name
+'$0110'       Name.Tag
+' '           Text.Whitespace
+'split_info'  Name
+':'           Operator
+'SplitMergeInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'TrStoragePhase' Name
+' '           Text.Whitespace
+'aborted'     Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'trans_merge_install' Name
+'$0111'       Name.Tag
+' '           Text.Whitespace
+'split_info'  Name
+':'           Operator
+'SplitMergeInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'prepare_transaction' Name
+':'           Operator
+'^'           Operator
+'Transaction' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'storage_ph'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrStoragePhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'credit_ph'   Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'TrCreditPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'compute_ph'  Name
+':'           Operator
+'TrComputePhase' Name
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'TrActionPhase' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'aborted'     Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'destroyed'   Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TransactionDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'smc_info'    Name
+'#076ef1ea'   Name.Tag
+' '           Text.Whitespace
+'actions'     Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'msgs_sent'   Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'unixtime'    Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'block_lt'    Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'trans_lt'    Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'rand_seed'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'balance_remaining' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'myself'      Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmartContractInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'out_list_empty' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutList'     Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'out_list'    Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'prev'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'OutList'     Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'OutAction'   Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutList'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'action_send_msg' Name
+'#0ec3c86d'   Name.Tag
+' '           Text.Whitespace
+'mode'        Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'out_msg'     Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'MessageRelaxed' Name
+' '           Text.Whitespace
+'Any'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutAction'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'action_set_code' Name
+'#ad4de08e'   Name.Tag
+' '           Text.Whitespace
+'new_code'    Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutAction'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'action_reserve_currency' Name
+'#36e6b809'   Name.Tag
+' '           Text.Whitespace
+'mode'        Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'currency'    Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutAction'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'libref_hash' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'lib_hash'    Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'LibRef'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'libref_ref'  Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'library'     Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'LibRef'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'action_change_library' Name
+'#26fa1dd4'   Name.Tag
+' '           Text.Whitespace
+'mode'        Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'mode'        Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'libref'      Name
+':'           Operator
+'LibRef'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutAction'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'out_list_node' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'prev'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'action'      Name
+':'           Operator
+'OutAction'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OutListNode' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'shard_ident' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'shard_pfx_bits' Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'60'          Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'workchain_id' Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'shard_prefix' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardIdent'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ext_blk_ref' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'end_lt'      Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'root_hash'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'file_hash'   Name
+':'           Operator
+'bits256'     Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ExtBlkRef'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'block_id_ext' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'shard_id'    Name
+':'           Operator
+'ShardIdent'  Name
+' '           Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'root_hash'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'file_hash'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockIdExt'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'master_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'master'      Name
+':'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlkMasterInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'shard_state' Name
+'#9023afe2'   Name.Tag
+' '           Text.Whitespace
+'global_id'   Name
+':'           Operator
+'int32'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'shard_id'    Name
+':'           Operator
+'ShardIdent'  Name
+' \n  '       Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'vert_seq_no' Name
+':'           Operator
+'#'           Name.Tag
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gen_utime'   Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'gen_lt'      Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'min_ref_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'out_msg_queue_info' Name
+':'           Operator
+'^'           Operator
+'OutMsgQueueInfo' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'before_split' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'accounts'    Name
+':'           Operator
+'^'           Operator
+'ShardAccounts' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'overload_history' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'underload_history' Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'total_balance' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'total_validator_fees' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'libraries'   Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'LibDescr'    Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'master_ref'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'BlkMasterInfo' Name
+')'           Punctuation
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'custom'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'McStateExtra' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardStateUnsplit' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  \n'        Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'ShardStateUnsplit' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardState'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'split_state' Name
+'#5f327da5'   Name.Tag
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'ShardStateUnsplit' Name
+' '           Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'ShardStateUnsplit' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardState'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'shared_lib_descr' Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'lib'         Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'publishers'  Name
+':'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'LibDescr'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'block_info'  Name
+'#9bc7a987'   Name.Tag
+' '           Text.Whitespace
+'version'     Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'not_master'  Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'after_merge' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'before_split' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'after_split' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'want_split'  Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'want_merge'  Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'key_block'   Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'vert_seqno_incr' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'vert_seq_no' Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'vert_seq_no' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'vert_seqno_incr' Name
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'prev_seq_no' Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'~'           Operator
+'prev_seq_no' Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'seq_no'      Name
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'shard'       Name
+':'           Operator
+'ShardIdent'  Name
+' '           Text.Whitespace
+'gen_utime'   Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'start_lt'    Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'end_lt'      Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gen_validator_list_hash_short' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gen_catchain_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'min_ref_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'prev_key_block_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gen_software' Name
+':'           Operator
+'flags'       Name
+' '           Text.Whitespace
+'.'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+'?'           Operator
+'GlobalVersion' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'master_ref'  Name
+':'           Operator
+'not_master'  Name
+'?'           Operator
+'^'           Operator
+'BlkMasterInfo' Name
+' \n  '       Text.Whitespace
+'prev_ref'    Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'BlkPrevInfo' Name
+' '           Text.Whitespace
+'after_merge' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'prev_vert_ref' Name
+':'           Operator
+'vert_seqno_incr' Name
+'?'           Operator
+'^'           Operator
+'('           Punctuation
+'BlkPrevInfo' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockInfo'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'prev_blk_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'prev'        Name
+':'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlkPrevInfo' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'prev_blks_info' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'prev1'       Name
+':'           Operator
+'^'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'prev2'       Name
+':'           Operator
+'^'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlkPrevInfo' Name
+' '           Text.Whitespace
+'1'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'block'       Name
+'#11ef55aa'   Name.Tag
+' '           Text.Whitespace
+'global_id'   Name
+':'           Operator
+'int32'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'info'        Name
+':'           Operator
+'^'           Operator
+'BlockInfo'   Name
+' '           Text.Whitespace
+'value_flow'  Name
+':'           Operator
+'^'           Operator
+'ValueFlow'   Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'state_update' Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'MERKLE_UPDATE' Name
+' '           Text.Whitespace
+'ShardState'  Name
+')'           Punctuation
+' \n  '       Text.Whitespace
+'extra'       Name
+':'           Operator
+'^'           Operator
+'BlockExtra'  Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Block'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'block_extra' Name
+' '           Text.Whitespace
+'in_msg_descr' Name
+':'           Operator
+'^'           Operator
+'InMsgDescr'  Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'out_msg_descr' Name
+':'           Operator
+'^'           Operator
+'OutMsgDescr' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'account_blocks' Name
+':'           Operator
+'^'           Operator
+'ShardAccountBlocks' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'rand_seed'   Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created_by'  Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'custom'      Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'McBlockExtra' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockExtra'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'value_flow'  Name
+' '           Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'from_prev_blk' Name
+':'           Operator
+'CurrencyCollection' Name
+' \n  '       Text.Whitespace
+'to_next_blk' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'imported'    Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'exported'    Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fees_collected' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fees_imported' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'recovered'   Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'created'     Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'minted'      Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValueFlow'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'bt_leaf'     Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'leaf'        Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BinTree'     Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bt_fork'     Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'BinTree'     Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'BinTree'     Name
+' '           Text.Whitespace
+'X'           Name
+')'           Punctuation
+' \n          ' Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BinTree'     Name
+' '           Text.Whitespace
+'X'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'fsm_none'    Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'FutureSplitMerge' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'fsm_split'   Name
+'$10'         Name.Tag
+' '           Text.Whitespace
+'split_utime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'interval'    Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'FutureSplitMerge' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'fsm_merge'   Name
+'$11'         Name.Tag
+' '           Text.Whitespace
+'merge_utime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'interval'    Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'FutureSplitMerge' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'shard_descr' Name
+'#b'          Name.Tag
+' '           Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'reg_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'start_lt'    Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'end_lt'      Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'root_hash'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'file_hash'   Name
+':'           Operator
+'bits256'     Name
+' \n  '       Text.Whitespace
+'before_split' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'before_merge' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'want_split'  Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'want_merge'  Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'nx_cc_updated' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'3'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_catchain_seqno' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'next_validator_shard' Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'min_ref_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'gen_utime'   Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'split_merge_at' Name
+':'           Operator
+'FutureSplitMerge' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fees_collected' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'funds_created' Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardDescr'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'shard_descr_new' Name
+'#a'          Name.Tag
+' '           Text.Whitespace
+'seq_no'      Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'reg_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'start_lt'    Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'end_lt'      Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'root_hash'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'file_hash'   Name
+':'           Operator
+'bits256'     Name
+' \n  '       Text.Whitespace
+'before_split' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'before_merge' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'want_split'  Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'want_merge'  Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'nx_cc_updated' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'3'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_catchain_seqno' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'next_validator_shard' Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'min_ref_mc_seqno' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'gen_utime'   Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'split_merge_at' Name
+':'           Operator
+'FutureSplitMerge' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'fees_collected' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'funds_created' Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardDescr'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'('           Punctuation
+'BinTree'     Name
+' '           Text.Whitespace
+'ShardDescr'  Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardHashes' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'bta_leaf'    Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'leaf'        Name
+':'           Operator
+'X'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BinTreeAug'  Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bta_fork'    Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'X'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'Y'           Name
+':'           Operator
+'Type'        Name
+'}'           Punctuation
+' '           Text.Whitespace
+'left'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'BinTreeAug'  Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+' \n           ' Text.Whitespace
+'right'       Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'BinTreeAug'  Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'extra'       Name
+':'           Operator
+'Y'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BinTreeAug'  Name
+' '           Text.Whitespace
+'X'           Name
+' '           Text.Whitespace
+'Y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'fees'        Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'create'      Name
+':'           Operator
+'CurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardFeeCreated' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'96'          Literal.Number
+' '           Text.Whitespace
+'ShardFeeCreated' Name
+' '           Text.Whitespace
+'ShardFeeCreated' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ShardFees'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'config_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'config'      Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'Cell'        Name
+')'           Punctuation
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParams' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'validator_info' Name
+'$_'          Name.Tag
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'validator_list_hash_short' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'catchain_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'nx_cc_updated' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'='           Operator
+' '           Text.Whitespace
+'ValidatorInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'validator_base_info' Name
+'$_'          Name.Tag
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'validator_list_hash_short' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'catchain_seqno' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'='           Operator
+' '           Text.Whitespace
+'ValidatorBaseInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'key'         Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'max_end_lt'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'KeyMaxLt'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'key'         Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'blk_ref'     Name
+':'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'KeyExtBlkRef' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'KeyExtBlkRef' Name
+' '           Text.Whitespace
+'KeyMaxLt'    Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OldMcBlocksInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'counters'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'last_updated' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'total'       Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'cnt2048'     Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'cnt65536'    Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Counters'    Name
+';'           Punctuation
+' \n'         Text.Whitespace
+
+'creator_info' Name
+'#4'          Name.Tag
+' '           Text.Whitespace
+'mc_blocks'   Name
+':'           Operator
+'Counters'    Name
+' '           Text.Whitespace
+'shard_blocks' Name
+':'           Operator
+'Counters'    Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CreatorStats' Name
+';'           Punctuation
+' \n'         Text.Whitespace
+
+'block_create_stats' Name
+'#17'         Name.Tag
+' '           Text.Whitespace
+'counters'    Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'CreatorStats' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockCreateStats' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'block_create_stats_ext' Name
+'#34'         Name.Tag
+' '           Text.Whitespace
+'counters'    Name
+':'           Operator
+'('           Punctuation
+'HashmapAugE' Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'CreatorStats' Name
+' '           Text.Whitespace
+'uint32'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockCreateStats' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'masterchain_state_extra' Name
+'#cc26'       Name.Tag
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'shard_hashes' Name
+':'           Operator
+'ShardHashes' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'config'      Name
+':'           Operator
+'ConfigParams' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'validator_info' Name
+':'           Operator
+'ValidatorInfo' Name
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'prev_blocks' Name
+':'           Operator
+'OldMcBlocksInfo' Name
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'after_key_block' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'last_key_block' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'ExtBlkRef'   Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'block_create_stats' Name
+':'           Operator
+'('           Punctuation
+'flags'       Name
+' '           Text.Whitespace
+'.'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+')'           Punctuation
+'?'           Operator
+'BlockCreateStats' Name
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'global_balance' Name
+':'           Operator
+'CurrencyCollection' Name
+'\n'          Text.Whitespace
+
+'='           Operator
+' '           Text.Whitespace
+'McStateExtra' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ed25519_pubkey' Name
+'#8e81278a'   Name.Tag
+' '           Text.Whitespace
+'pubkey'      Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SigPubKey'   Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 288 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'ed25519_signature' Name
+'#5'          Name.Tag
+' '           Text.Whitespace
+'R'           Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'s'           Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CryptoSignatureSimple' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 516 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'CryptoSignatureSimple' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CryptoSignature' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'sig_pair'    Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'node_id_short' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'sign'        Name
+':'           Operator
+'CryptoSignature' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CryptoSignaturePair' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 256+x ~ 772 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'certificate' Name
+'#4'          Name.Tag
+' '           Text.Whitespace
+'temp_key'    Name
+':'           Operator
+'SigPubKey'   Name
+' '           Text.Whitespace
+'valid_since' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'valid_until' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Certificate' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 356 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'certificate_env' Name
+'#a419b7d'    Name.Tag
+' '           Text.Whitespace
+'certificate' Name
+':'           Operator
+'Certificate' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CertificateEnv' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 384 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'signed_certificate' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'certificate' Name
+':'           Operator
+'Certificate' Name
+' '           Text.Whitespace
+'certificate_signature' Name
+':'           Operator
+'CryptoSignature' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SignedCertificate' Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// 356+516 = 872 bits' Comment.Singleline
+'\n'          Text.Whitespace
+
+'// certificate_signature is the signature of CertificateEnv (with embedded certificate) with persistent key' Comment.Singleline
+'\n'          Text.Whitespace
+
+'chained_signature' Name
+'#f'          Name.Tag
+' '           Text.Whitespace
+'signed_cert' Name
+':'           Operator
+'^'           Operator
+'SignedCertificate' Name
+' '           Text.Whitespace
+'temp_key_signature' Name
+':'           Operator
+'CryptoSignatureSimple' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CryptoSignature' Name
+';'           Punctuation
+'   '         Text.Whitespace
+'// 4+(356+516)+516 = 520 bits+ref (1392 bits total)' Comment.Singleline
+'\n'          Text.Whitespace
+
+'// temp_key_signature is the signature of whatever was originally intended to be signed with temp_key from certificate' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'masterchain_block_extra' Name
+'#cca5'       Name.Tag
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'key_block'   Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'shard_hashes' Name
+':'           Operator
+'ShardHashes' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'shard_fees'  Name
+':'           Operator
+'ShardFees'   Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'prev_blk_signatures' Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'CryptoSignaturePair' Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'recover_create_msg' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'InMsg'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'mint_msg'    Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'InMsg'       Name
+')'           Punctuation
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'config'      Name
+':'           Operator
+'key_block'   Name
+'?'           Operator
+'ConfigParams' Name
+'\n'          Text.Whitespace
+
+'='           Operator
+' '           Text.Whitespace
+'McBlockExtra' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  CONFIGURATION PARAMETERS' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'validator'   Name
+'#53'         Name.Tag
+' '           Text.Whitespace
+'public_key'  Name
+':'           Operator
+'SigPubKey'   Name
+' '           Text.Whitespace
+'weight'      Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'validator_addr' Name
+'#73'         Name.Tag
+' '           Text.Whitespace
+'public_key'  Name
+':'           Operator
+'SigPubKey'   Name
+' '           Text.Whitespace
+'weight'      Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'adnl_addr'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'validators'  Name
+'#11'         Name.Tag
+' '           Text.Whitespace
+'utime_since' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'utime_until' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'total'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'total'       Name
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'list'        Name
+':'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'ValidatorDescr' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorSet' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'validators_ext' Name
+'#12'         Name.Tag
+' '           Text.Whitespace
+'utime_since' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'utime_until' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'total'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'total'       Name
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'main'        Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'total_weight' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'list'        Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'ValidatorDescr' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorSet' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'config_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'elector_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'1'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'minter_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'2'           Literal.Number
+';'           Punctuation
+'  '          Text.Whitespace
+'// ConfigParam 0 is used if absent' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'fee_collector_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'3'           Literal.Number
+';'           Punctuation
+'  '          Text.Whitespace
+'// ConfigParam 1 is used if absent' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'dns_root_addr' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'4'           Literal.Number
+';'           Punctuation
+'  '          Text.Whitespace
+'// root TON DNS resolver' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'mint_new_price' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'mint_add_price' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'6'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'to_mint'     Name
+':'           Operator
+'ExtraCurrencyCollection' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'7'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'capabilities' Name
+'#c4'         Name.Tag
+' '           Text.Whitespace
+'version'     Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'capabilities' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'GlobalVersion' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'GlobalVersion' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'8'           Literal.Number
+';'           Punctuation
+'  '          Text.Whitespace
+'// all zero if absent' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'mandatory_params' Name
+':'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'9'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'critical_params' Name
+':'           Operator
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'10'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'cfg_vote_cfg' Name
+'#36'         Name.Tag
+' '           Text.Whitespace
+'min_tot_rounds' Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'max_tot_rounds' Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'min_wins'    Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'max_losses'  Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'min_store_sec' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'max_store_sec' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'bit_price'   Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'cell_price'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigProposalSetup' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cfg_vote_setup' Name
+'#91'         Name.Tag
+' '           Text.Whitespace
+'normal_params' Name
+':'           Operator
+'^'           Operator
+'ConfigProposalSetup' Name
+' '           Text.Whitespace
+'critical_params' Name
+':'           Operator
+'^'           Operator
+'ConfigProposalSetup' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigVotingSetup' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'ConfigVotingSetup' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'11'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'cfg_proposal' Name
+'#f3'         Name.Tag
+' '           Text.Whitespace
+'param_id'    Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'param_value' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'Cell'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'if_hash_equal' Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'uint256'     Name
+')'           Punctuation
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigProposal' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cfg_proposal_status' Name
+'#ce'         Name.Tag
+' '           Text.Whitespace
+'expires'     Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'proposal'    Name
+':'           Operator
+'^'           Operator
+'ConfigProposal' Name
+' '           Text.Whitespace
+'is_critical' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'voters'      Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'remaining_weight' Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'validator_set_id' Name
+':'           Operator
+'uint256'     Name
+' \n  '       Text.Whitespace
+'rounds_remaining' Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'wins'        Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'losses'      Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigProposalStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'wfmt_basic'  Name
+'#1'          Name.Tag
+' '           Text.Whitespace
+'vm_version'  Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'vm_mode'     Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'WorkchainFormat' Name
+' '           Text.Whitespace
+'1'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'wfmt_ext'    Name
+'#0'          Name.Tag
+' '           Text.Whitespace
+'min_addr_len' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'12'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'max_addr_len' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'12'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'addr_len_step' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'12'          Literal.Number
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'min_addr_len' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'64'          Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'min_addr_len' Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'max_addr_len' Name
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'max_addr_len' Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1023'        Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'addr_len_step' Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1023'        Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'workchain_type_id' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'32'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'workchain_type_id' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'WorkchainFormat' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'workchain'   Name
+'#a6'         Name.Tag
+' '           Text.Whitespace
+'enabled_since' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'actual_min_split' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'min_split'   Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'max_split'   Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'actual_min_split' Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'min_split'   Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'//workchain#a5 enabled_since:uint32 min_split:(## 8) max_split:(## 8)' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  { min_split <= max_split } { max_split <= 60 }' Comment.Singleline
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'basic'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'active'      Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'accept_msgs' Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'13'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'zerostate_root_hash' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'zerostate_file_hash' Name
+':'           Operator
+'bits256'     Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'version'     Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'format'      Name
+':'           Operator
+'('           Punctuation
+'WorkchainFormat' Name
+' '           Text.Whitespace
+'basic'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'WorkchainDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'workchains'  Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'WorkchainDescr' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'12'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'complaint_prices' Name
+'#1a'         Name.Tag
+' '           Text.Whitespace
+'deposit'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'bit_price'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'cell_price'  Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComplaintPricing' Name
+';'           Punctuation
+' \n'         Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'ComplaintPricing' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'13'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'block_grams_created' Name
+'#6b'         Name.Tag
+' '           Text.Whitespace
+'masterchain_block_fee' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'basechain_block_fee' Name
+':'           Operator
+'Grams'       Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockCreateFees' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'BlockCreateFees' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'14'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'validators_elected_for' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'elections_start_before' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'elections_end_before' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'stake_held_for' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'15'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  \n'        Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'max_validators' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'max_main_validators' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'min_validators' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' \n  '       Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'max_validators' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'max_main_validators' Name
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'max_main_validators' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'min_validators' Name
+' '           Text.Whitespace
+'}'           Punctuation
+' \n  '       Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'min_validators' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'16'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'min_stake'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'max_stake'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'min_total_stake' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'max_stake_factor' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'17'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+'#cc'         Name.Tag
+' '           Text.Whitespace
+'utime_since' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'bit_price_ps' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'cell_price_ps' Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'mc_bit_price_ps' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'mc_cell_price_ps' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'StoragePrices' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'Hashmap'     Name
+' '           Text.Whitespace
+'32'          Literal.Number
+' '           Text.Whitespace
+'StoragePrices' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'18'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'gas_prices'  Name
+'#dd'         Name.Tag
+' '           Text.Whitespace
+'gas_price'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'gas_limit'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'gas_credit'  Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'block_gas_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'freeze_due_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'delete_due_limit' Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'GasLimitsPrices' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'gas_prices_ext' Name
+'#de'         Name.Tag
+' '           Text.Whitespace
+'gas_price'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'gas_limit'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'special_gas_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'gas_credit'  Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'block_gas_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'freeze_due_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'delete_due_limit' Name
+':'           Operator
+'uint64'      Name
+' \n  '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'GasLimitsPrices' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'gas_flat_pfx' Name
+'#d1'         Name.Tag
+' '           Text.Whitespace
+'flat_gas_limit' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'flat_gas_price' Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'other'       Name
+':'           Operator
+'GasLimitsPrices' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'GasLimitsPrices' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'config_mc_gas_prices' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'GasLimitsPrices' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'20'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'config_gas_prices' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'GasLimitsPrices' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'21'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'param_limits' Name
+'#c3'         Name.Tag
+' '           Text.Whitespace
+'underload'   Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'soft_limit'  Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'underload'   Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'soft_limit'  Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'hard_limit'  Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'soft_limit'  Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'hard_limit'  Name
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ParamLimits' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'block_limits' Name
+'#5d'         Name.Tag
+' '           Text.Whitespace
+'bytes'       Name
+':'           Operator
+'ParamLimits' Name
+' '           Text.Whitespace
+'gas'         Name
+':'           Operator
+'ParamLimits' Name
+' '           Text.Whitespace
+'lt_delta'    Name
+':'           Operator
+'ParamLimits' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockLimits' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  \n'        Text.Whitespace
+
+'config_mc_block_limits' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'BlockLimits' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'22'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'config_block_limits' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'BlockLimits' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'23'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// msg_fwd_fees = (lump_price + ceil((bit_price * msg.bits + cell_price * msg.cells)/2^16)) nanograms' Comment.Singleline
+'\n'          Text.Whitespace
+
+'// ihr_fwd_fees = ceil((msg_fwd_fees * ihr_price_factor)/2^16) nanograms' Comment.Singleline
+'\n'          Text.Whitespace
+
+'// bits in the root cell of a message are not included in msg.bits (lump_price pays for them)' Comment.Singleline
+'\n'          Text.Whitespace
+
+'msg_forward_prices' Name
+'#ea'         Name.Tag
+' '           Text.Whitespace
+'lump_price'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'bit_price'   Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'cell_price'  Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'ihr_price_factor' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'first_frac'  Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'next_frac'   Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MsgForwardPrices' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// used for messages to/from masterchain' Comment.Singleline
+'\n'          Text.Whitespace
+
+'config_mc_fwd_prices' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'MsgForwardPrices' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'24'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'// used for all other messages' Comment.Singleline
+'\n'          Text.Whitespace
+
+'config_fwd_prices' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'MsgForwardPrices' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'25'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'catchain_config' Name
+'#c1'         Name.Tag
+' '           Text.Whitespace
+'mc_catchain_lifetime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'shard_catchain_lifetime' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'shard_validators_lifetime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'shard_validators_num' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CatchainConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'catchain_config_new' Name
+'#c2'         Name.Tag
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'shuffle_mc_validators' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'mc_catchain_lifetime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'shard_catchain_lifetime' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'shard_validators_lifetime' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'shard_validators_num' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'CatchainConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'consensus_config' Name
+'#d6'         Name.Tag
+' '           Text.Whitespace
+'round_candidates' Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'round_candidates' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_candidate_delay_ms' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'consensus_timeout_ms' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fast_attempts' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'attempt_duration' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'catchain_max_deps' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'max_block_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'max_collated_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConsensusConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'consensus_config_new' Name
+'#d7'         Name.Tag
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'new_catchain_ids' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'round_candidates' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'round_candidates' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_candidate_delay_ms' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'consensus_timeout_ms' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fast_attempts' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'attempt_duration' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'catchain_max_deps' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'max_block_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'max_collated_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConsensusConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'consensus_config_v3' Name
+'#d8'         Name.Tag
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'new_catchain_ids' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'round_candidates' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'round_candidates' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_candidate_delay_ms' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'consensus_timeout_ms' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fast_attempts' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'attempt_duration' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'catchain_max_deps' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'max_block_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'max_collated_bytes' Name
+':'           Operator
+'uint32'      Name
+' \n  '       Text.Whitespace
+'proto_version' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConsensusConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'consensus_config_v4' Name
+'#d9'         Name.Tag
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'7'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'new_catchain_ids' Name
+':'           Operator
+'Bool'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'round_candidates' Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'round_candidates' Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'next_candidate_delay_ms' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'consensus_timeout_ms' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fast_attempts' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'attempt_duration' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'catchain_max_deps' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'max_block_bytes' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'max_collated_bytes' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'proto_version' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'catchain_max_blocks_coeff' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConsensusConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'CatchainConfig' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'28'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'ConsensusConfig' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'29'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'fundamental_smc_addr' Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'31'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'prev_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'32'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'prev_temp_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'33'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'cur_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'34'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'cur_temp_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'35'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'next_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'36'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'next_temp_validators' Name
+':'           Operator
+'ValidatorSet' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'37'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'validator_temp_key' Name
+'#3'          Name.Tag
+' '           Text.Whitespace
+'adnl_addr'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'temp_public_key' Name
+':'           Operator
+'SigPubKey'   Name
+' '           Text.Whitespace
+'seqno'       Name
+':'           Operator
+'#'           Name.Tag
+' '           Text.Whitespace
+'valid_until' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorTempKey' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'signed_temp_key' Name
+'#4'          Name.Tag
+' '           Text.Whitespace
+'key'         Name
+':'           Operator
+'^'           Operator
+'ValidatorTempKey' Name
+' '           Text.Whitespace
+'signature'   Name
+':'           Operator
+'CryptoSignature' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorSignedTempKey' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'ValidatorSignedTempKey' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'39'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'misbehaviour_punishment_config_v1' Name
+'#01'         Name.Tag
+' \n  '       Text.Whitespace
+'default_flat_fine' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'default_proportional_fine' Name
+':'           Operator
+'uint32'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'severity_flat_mult' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'severity_proportional_mult' Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'unpunishable_interval' Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'long_interval' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'long_flat_mult' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'long_proportional_mult' Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'medium_interval' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'medium_flat_mult' Name
+':'           Operator
+'uint16'      Name
+' '           Text.Whitespace
+'medium_proportional_mult' Name
+':'           Operator
+'uint16'      Name
+'\n'          Text.Whitespace
+
+'   '         Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MisbehaviourPunishmentConfig' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'MisbehaviourPunishmentConfig' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'40'          Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'oracle_bridge_params' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'bridge_address' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'oracle_mutlisig_address' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'oracles'     Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'uint256'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'external_chain_address' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'OracleBridgeParams' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'OracleBridgeParams' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'71'          Literal.Number
+';'           Punctuation
+' '           Text.Whitespace
+'// Ethereum bridge' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'OracleBridgeParams' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'72'          Literal.Number
+';'           Punctuation
+' '           Text.Whitespace
+'// Binance Smart Chain bridge' Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'OracleBridgeParams' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ConfigParam' Name
+' '           Text.Whitespace
+'73'          Literal.Number
+';'           Punctuation
+' '           Text.Whitespace
+'// Polygon bridge' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  PROOFS'  Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'block_signatures_pure' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'sig_count'   Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'sig_weight'  Name
+':'           Operator
+'uint64'      Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'signatures'  Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'CryptoSignaturePair' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockSignaturesPure' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'block_signatures' Name
+'#11'         Name.Tag
+' '           Text.Whitespace
+'validator_info' Name
+':'           Operator
+'ValidatorBaseInfo' Name
+' '           Text.Whitespace
+'pure_signatures' Name
+':'           Operator
+'BlockSignaturesPure' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockSignatures' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'block_proof' Name
+'#c3'         Name.Tag
+' '           Text.Whitespace
+'proof_for'   Name
+':'           Operator
+'BlockIdExt'  Name
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'signatures'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'BlockSignatures' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'BlockProof'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chain_empty' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProofChain'  Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chain_link'  Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'root'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'prev'        Name
+':'           Operator
+'n'           Name
+'?'           Operator
+'^'           Operator
+'('           Punctuation
+'ProofChain'  Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProofChain'  Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'top_block_descr' Name
+'#d5'         Name.Tag
+' '           Text.Whitespace
+'proof_for'   Name
+':'           Operator
+'BlockIdExt'  Name
+' '           Text.Whitespace
+'signatures'  Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'BlockSignatures' Name
+')'           Punctuation
+' \n  '       Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'8'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'chain'       Name
+':'           Operator
+'('           Punctuation
+'ProofChain'  Name
+' '           Text.Whitespace
+'len'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TopBlockDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  COLLATED DATA' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'top_block_descr_set' Name
+'#4ac789f3'   Name.Tag
+' '           Text.Whitespace
+'collection'  Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'96'          Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'TopBlockDescr' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TopBlockDescrSet' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  VALIDATOR MISBEHAVIOR COMPLAINTS' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'prod_info'   Name
+'#34'         Name.Tag
+' '           Text.Whitespace
+'utime'       Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'mc_blk_ref'  Name
+':'           Operator
+'ExtBlkRef'   Name
+' '           Text.Whitespace
+'state_proof' Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'MERKLE_PROOF' Name
+' '           Text.Whitespace
+'Block'       Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'prod_proof'  Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'MERKLE_PROOF' Name
+' '           Text.Whitespace
+'ShardState'  Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProducerInfo' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'no_blk_gen'  Name
+' '           Text.Whitespace
+'from_utime'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'prod_info'   Name
+':'           Operator
+'^'           Operator
+'ProducerInfo' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComplaintDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'no_blk_gen_diff' Name
+' '           Text.Whitespace
+'prod_info_old' Name
+':'           Operator
+'^'           Operator
+'ProducerInfo' Name
+' '           Text.Whitespace
+'prod_info_new' Name
+':'           Operator
+'^'           Operator
+'ProducerInfo' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ComplaintDescr' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'validator_complaint' Name
+'#bc'         Name.Tag
+' '           Text.Whitespace
+'validator_pubkey' Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'description' Name
+':'           Operator
+'^'           Operator
+'ComplaintDescr' Name
+' '           Text.Whitespace
+'created_at'  Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'severity'    Name
+':'           Operator
+'uint8'       Name
+' '           Text.Whitespace
+'reward_addr' Name
+':'           Operator
+'uint256'     Name
+' '           Text.Whitespace
+'paid'        Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'suggested_fine' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'suggested_fine_part' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorComplaint' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'complaint_status' Name
+'#2d'         Name.Tag
+' '           Text.Whitespace
+'complaint'   Name
+':'           Operator
+'^'           Operator
+'ValidatorComplaint' Name
+' '           Text.Whitespace
+'voters'      Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'16'          Literal.Number
+' '           Text.Whitespace
+'True'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'vset_id'     Name
+':'           Operator
+'uint256'     Name
+' '           Text.Whitespace
+'weight_remaining' Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ValidatorComplaintStatus' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  TVM REFLECTION' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'vm_stk_null' Name
+'#00'         Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_tinyint' Name
+'#01'         Name.Tag
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_int'  Name
+'#0201_'      Name.Tag
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'int257'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_nan'  Name
+'#02ff'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_cell' Name
+'#03'         Name.Tag
+' '           Text.Whitespace
+'cell'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'cell'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'st_bits'     Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'10'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'end_bits'    Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'10'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'st_bits'     Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'end_bits'    Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'st_ref'      Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'4'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'end_ref'     Name
+':'           Operator
+'('           Punctuation
+'#<='         Name.Tag
+' '           Text.Whitespace
+'4'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'st_ref'      Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'end_ref'     Name
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCellSlice' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_slice' Name
+'#04'         Name.Tag
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'VmCellSlice' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_builder' Name
+'#05'         Name.Tag
+' '           Text.Whitespace
+'cell'        Name
+':'           Operator
+'^'           Operator
+'Cell'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_cont' Name
+'#06'         Name.Tag
+' '           Text.Whitespace
+'cont'        Name
+':'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_tupref_nil' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmTupleRef'  Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_tupref_single' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'entry'       Name
+':'           Operator
+'^'           Operator
+'VmStackValue' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmTupleRef'  Name
+' '           Text.Whitespace
+'1'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_tupref_any' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'ref'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VmTuple'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmTupleRef'  Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_tuple_nil' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmTuple'     Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_tuple_tcons' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'head'        Name
+':'           Operator
+'('           Punctuation
+'VmTupleRef'  Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'tail'        Name
+':'           Operator
+'^'           Operator
+'VmStackValue' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmTuple'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_tuple' Name
+'#07'         Name.Tag
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'16'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'data'        Name
+':'           Operator
+'('           Punctuation
+'VmTuple'     Name
+' '           Text.Whitespace
+'len'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackValue' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'vm_stack'    Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'depth'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'24'          Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'stack'       Name
+':'           Operator
+'('           Punctuation
+'VmStackList' Name
+' '           Text.Whitespace
+'depth'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStack'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_cons' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'rest'        Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'VmStackList' Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'tos'         Name
+':'           Operator
+'VmStackValue' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackList' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vm_stk_nil'  Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmStackList' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'cregs'       Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'4'           Literal.Number
+' '           Text.Whitespace
+'VmStackValue' Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmSaveList'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'gas_limits'  Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'remaining'   Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'^'           Operator
+'['           Punctuation
+' '           Text.Whitespace
+'max_limit'   Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'cur_limit'   Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+'credit'      Name
+':'           Operator
+'int64'       Name
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmGasLimits' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'libraries'   Name
+':'           Operator
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'^'           Operator
+'Cell'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmLibraries' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'vm_ctl_data' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'nargs'       Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'uint13'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'stack'       Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'VmStack'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'save'        Name
+':'           Operator
+'VmSaveList'  Name
+'\n'          Text.Whitespace
+
+'cp'          Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'int16'       Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmControlData' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_std'     Name
+'$00'         Name.Tag
+' '           Text.Whitespace
+'cdata'       Name
+':'           Operator
+'VmControlData' Name
+' '           Text.Whitespace
+'code'        Name
+':'           Operator
+'VmCellSlice' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_envelope' Name
+'$01'         Name.Tag
+' '           Text.Whitespace
+'cdata'       Name
+':'           Operator
+'VmControlData' Name
+' '           Text.Whitespace
+'next'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_quit'    Name
+'$1000'       Name.Tag
+' '           Text.Whitespace
+'exit_code'   Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_quit_exc' Name
+'$1001'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_repeat'  Name
+'$10100'      Name.Tag
+' '           Text.Whitespace
+'count'       Name
+':'           Operator
+'uint63'      Name
+' '           Text.Whitespace
+'body'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'after'       Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+' \n'         Text.Whitespace
+
+'vmc_until'   Name
+'$110000'     Name.Tag
+' '           Text.Whitespace
+'body'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'after'       Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_again'   Name
+'$110001'     Name.Tag
+' '           Text.Whitespace
+'body'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_while_cond' Name
+'$110010'     Name.Tag
+' '           Text.Whitespace
+'cond'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'body'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+'\n'          Text.Whitespace
+
+'after'       Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_while_body' Name
+'$110011'     Name.Tag
+' '           Text.Whitespace
+'cond'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'body'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+'\n'          Text.Whitespace
+
+'after'       Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'vmc_pushint' Name
+'$1111'       Name.Tag
+' '           Text.Whitespace
+'value'       Name
+':'           Operator
+'int32'       Name
+' '           Text.Whitespace
+'next'        Name
+':'           Operator
+'^'           Operator
+'VmCont'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'VmCont'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'//  DNS RECORDS' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'_'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'HashmapE'    Name
+' '           Text.Whitespace
+'256'         Literal.Number
+' '           Text.Whitespace
+'DNSRecord'   Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DNS_RecordSet' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chunk_ref'   Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'ref'         Name
+':'           Operator
+'^'           Operator
+'('           Punctuation
+'TextChunks'  Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TextChunkRef' Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chunk_ref_empty' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TextChunkRef' Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'text_chunk'  Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'n'           Name
+':'           Operator
+'#'           Name.Tag
+'}'           Punctuation
+' '           Text.Whitespace
+'len'         Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'data'        Name
+':'           Operator
+'('           Punctuation
+'bits'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'len'         Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'next'        Name
+':'           Operator
+'('           Punctuation
+'TextChunkRef' Name
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TextChunks'  Name
+' '           Text.Whitespace
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'text_chunk_empty' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'TextChunks'  Name
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'text'        Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'chunks'      Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'rest'        Name
+':'           Operator
+'('           Punctuation
+'TextChunks'  Name
+' '           Text.Whitespace
+'chunks'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Text'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'dns_text'    Name
+'#1eda'       Name.Tag
+' '           Text.Whitespace
+'_'           Name
+':'           Operator
+'Text'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DNSRecord'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'dns_next_resolver' Name
+'#ba93'       Name.Tag
+' '           Text.Whitespace
+'resolver'    Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DNSRecord'   Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// usually in record #-1' Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'dns_adnl_address' Name
+'#ad01'       Name.Tag
+' '           Text.Whitespace
+'adnl_addr'   Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'proto_list'  Name
+':'           Operator
+'flags'       Name
+' '           Text.Whitespace
+'.'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+'?'           Operator
+'ProtoList'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DNSRecord'   Name
+';'           Punctuation
+'  '          Text.Whitespace
+'// often in record #2' Comment.Singleline
+'\n'          Text.Whitespace
+
+'proto_list_nil' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProtoList'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'proto_list_next' Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'head'        Name
+':'           Operator
+'Protocol'    Name
+' '           Text.Whitespace
+'tail'        Name
+':'           Operator
+'ProtoList'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ProtoList'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'proto_http'  Name
+'#4854'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'Protocol'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'dns_smc_address' Name
+'#9fd3'       Name.Tag
+' '           Text.Whitespace
+'smc_addr'    Name
+':'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'flags'       Name
+':'           Operator
+'('           Punctuation
+'##'          Name.Tag
+' '           Text.Whitespace
+'8'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'flags'       Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'cap_list'    Name
+':'           Operator
+'flags'       Name
+' '           Text.Whitespace
+'.'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+'?'           Operator
+'SmcCapList'  Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'DNSRecord'   Name
+';'           Punctuation
+'   '         Text.Whitespace
+'// often in record #1' Comment.Singleline
+'\n'          Text.Whitespace
+
+'cap_list_nil' Name
+'$0'          Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapList'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cap_list_next' Name
+'$1'          Name.Tag
+' '           Text.Whitespace
+'head'        Name
+':'           Operator
+'SmcCapability' Name
+' '           Text.Whitespace
+'tail'        Name
+':'           Operator
+'SmcCapList'  Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapList'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cap_method_seqno' Name
+'#5371'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapability' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cap_method_pubkey' Name
+'#71f4'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapability' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cap_is_wallet' Name
+'#2177'       Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapability' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'cap_name'    Name
+'#ff'         Name.Tag
+' '           Text.Whitespace
+'name'        Name
+':'           Operator
+'Text'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'SmcCapability' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'// PAYMENT CHANNELS' Comment.Singleline
+'\n'          Text.Whitespace
+
+'//'          Comment.Singleline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_config' Name
+'$_'          Name.Tag
+'  '          Text.Whitespace
+'init_timeout' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'close_timeout' Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'a_key'       Name
+':'           Operator
+'bits256'     Name
+' '           Text.Whitespace
+'b_key'       Name
+':'           Operator
+'bits256'     Name
+' \n  '       Text.Whitespace
+'a_addr'      Name
+':'           Operator
+'^'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'b_addr'      Name
+':'           Operator
+'^'           Operator
+'MsgAddressInt' Name
+' '           Text.Whitespace
+'channel_id'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'min_A_extra' Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanConfig'  Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_state_init' Name
+'$000'        Name.Tag
+'  '          Text.Whitespace
+'signed_A'    Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'signed_B'    Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'min_A'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'min_B'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'expire_at'   Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'A'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'B'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanState'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_state_close' Name
+'$001'        Name.Tag
+' '           Text.Whitespace
+'signed_A'    Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'signed_B'    Name
+':'           Operator
+'Bool'        Name
+' '           Text.Whitespace
+'promise_A'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'promise_B'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'expire_at'   Name
+':'           Operator
+'uint32'      Name
+' '           Text.Whitespace
+'A'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'B'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanState'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_state_payout' Name
+'$010'        Name.Tag
+' '           Text.Whitespace
+'A'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'B'           Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanState'   Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_promise' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'channel_id'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'promise_A'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'promise_B'   Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanPromise' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_signed_promise' Name
+'#_'          Name.Tag
+' '           Text.Whitespace
+'sig'         Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'bits512'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'promise'     Name
+':'           Operator
+'ChanPromise' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanSignedPromise' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_msg_init' Name
+'#27317822'   Name.Tag
+' '           Text.Whitespace
+'inc_A'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'inc_B'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'min_A'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'min_B'       Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'channel_id'  Name
+':'           Operator
+'uint64'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanMsg'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_msg_close' Name
+'#f28ae183'   Name.Tag
+' '           Text.Whitespace
+'extra_A'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'extra_B'     Name
+':'           Operator
+'Grams'       Name
+' '           Text.Whitespace
+'promise'     Name
+':'           Operator
+'ChanSignedPromise' Name
+'  '          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanMsg'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_msg_timeout' Name
+'#43278a28'   Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanMsg'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'chan_msg_payout' Name
+'#37fe7810'   Name.Tag
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanMsg'     Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_signed_msg' Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'sig_A'       Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'bits512'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'sig_B'       Name
+':'           Operator
+'('           Punctuation
+'Maybe'       Name
+' '           Text.Whitespace
+'^'           Operator
+'bits512'     Name
+')'           Punctuation
+' '           Text.Whitespace
+'msg'         Name
+':'           Operator
+'ChanMsg'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanSignedMsg' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_op_cmd' Name
+'#912838d1'   Name.Tag
+' '           Text.Whitespace
+'msg'         Name
+':'           Operator
+'ChanSignedMsg' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanOp'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan_data'   Name
+'$_'          Name.Tag
+' '           Text.Whitespace
+'config'      Name
+':'           Operator
+'^'           Operator
+'ChanConfig'  Name
+' '           Text.Whitespace
+'state'       Name
+':'           Operator
+'^'           Operator
+'ChanState'   Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ChanData'    Name
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
[TL-b](https://ton.org/docs/#/overviews/TL-B) is used for describing (de)serialization schemes for [TON](https://ton.org) objects. 