### PR TITLE
Patch CVE-2007-4559

### DIFF
--- a/pygments/lexers/_php_builtins.py
+++ b/pygments/lexers/_php_builtins.py
@@ -3298,7 +3298,21 @@ if __name__ == '__main__':  # pragma: no cover
     def get_php_references():
         download = urlretrieve(PHP_MANUAL_URL)
         with tarfile.open(download[0]) as tar:
-            tar.extractall()
+            
+            def is_within_directory(directory, target):
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                return prefix == abs_directory
+
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
+                
+            safe_extract(tar)
         yield from glob.glob("%s%s" % (PHP_MANUAL_DIR, PHP_REFERENCE_GLOB))
         os.remove(download[0])
 


### PR DESCRIPTION
This pull request patches CVE-2007-4559. Extracting a maliciously crafted `.tar` file could enable it to perform a directory path traversal attack.

There's an unsanitised `tar.extractall()` call in the php lexer, this PR implements the solution proposed by the Trellix Team to check if a tar can be safely extracted. The `Exception` class is raised if not, meaning that the tar is malicious.

Read more - <https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html>

Cool work :)