### PR TITLE
Remove unneeded _format_unencoded_with_lineno function from IRCFormatter

### DIFF
--- a/pygments/formatters/irc.py
+++ b/pygments/formatters/irc.py
@@ -128,38 +128,12 @@ class IRCFormatter(Formatter):
         self._lineno = 0
 
     def _write_lineno(self, outfile):
-        self._lineno += 1
-        outfile.write("\n%04d: " % self._lineno)
-
-    def _format_unencoded_with_lineno(self, tokensource, outfile):
-        self._write_lineno(outfile)
-
-        for ttype, value in tokensource:
-            if value.endswith("\n"):
-                self._write_lineno(outfile)
-                value = value[:-1]
-            color = self.colorscheme.get(ttype)
-            while color is None:
-                ttype = ttype.parent
-                color = self.colorscheme.get(ttype)
-            if color:
-                color = color[self.darkbg]
-                spl = value.split('\n')
-                for line in spl[:-1]:
-                    self._write_lineno(outfile)
-                    if line:
-                        outfile.write(ircformat(color, line[:-1]))
-                if spl[-1]:
-                    outfile.write(ircformat(color, spl[-1]))
-            else:
-                outfile.write(value)
-
-        outfile.write("\n")
+        if self.linenos:
+            self._lineno += 1
+            outfile.write("%04d: " % self._lineno)
 
     def format_unencoded(self, tokensource, outfile):
-        if self.linenos:
-            self._format_unencoded_with_lineno(tokensource, outfile)
-            return
+        self._write_lineno(outfile)
 
         for ttype, value in tokensource:
             color = self.colorscheme.get(ttype)
@@ -173,6 +147,7 @@ class IRCFormatter(Formatter):
                     if line:
                         outfile.write(ircformat(color, line))
                     outfile.write('\n')
+                    self._write_lineno(outfile)
                 if spl[-1]:
                     outfile.write(ircformat(color, spl[-1]))
             else:

--- a/tests/test_irc_formatter.py
+++ b/tests/test_irc_formatter.py
@@ -12,7 +12,7 @@ from pygments.lexers import PythonLexer
 from pygments.formatters import IRCFormatter
 
 tokensource = list(PythonLexer().get_tokens("lambda x: 123"))
-
+newlinetokensource = list(PythonLexer().get_tokens("from \\\n\\\n    os import  path\n"))
 
 def test_correct_output():
     hfmt = IRCFormatter()
@@ -20,3 +20,11 @@ def test_correct_output():
     hfmt.format(tokensource, houtfile)
 
     assert '\x0302lambda\x03 x: \x0302123\x03\n' == houtfile.getvalue()
+
+def test_linecount_output():
+    hfmt = IRCFormatter(linenos = True)
+    houtfile = StringIO()
+    hfmt.format(newlinetokensource, houtfile)
+
+    expected_out = '0001: \x0302from\x03 \\\n0002: \\\n0003:     \x1d\x0310os\x03\x1d \x0302import\x03  path\n0004: '
+    assert expected_out == houtfile.getvalue()


### PR DESCRIPTION
This PR removes `_format_unencoded_with_lineno ` from `IRCFormatter` to avoid code duplication and fix a bug where the newline and the linenumber would be inserted too early.