### PR TITLE
Update GitHub actions.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,14 +15,14 @@ jobs:
       max-parallel: 4
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install package
       run: |
-        python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install .
     - name: Test package
@@ -31,8 +31,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
     - name: Run make check
       run: make check
     - name: Fail if the basic checks failed
@@ -42,8 +42,8 @@ jobs:
   check-mapfiles:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
     - name: Regenerate mapfiles
       run: make mapfiles
     - name: Fail if mapfiles changed
@@ -56,8 +56,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Check out regexlint


### PR DESCRIPTION
The https://github.com/actions/setup-python action is at version 4, so use that, and update checkout to v3 while we're at it. Turn on caching in the hope it'll make things faster one day, and stop trying to pull the latest `pip` version every time.