### PR TITLE
Accept colon(s) in YAML key names

### DIFF
--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -231,7 +231,7 @@ class YamlLexer(ExtendedRegexLexer):
             # whitespaces separating tokens
             (r'[ ]+', Whitespace),
             # key with colon
-            (r'''([^#,:?\[\]{}"'\n]+)(:)(?=[ ]|$)''',
+            (r'''([^#,?\[\]{}"'\n]+)(:)(?=[ ]|$)''',
              bygroups(Name.Tag, set_indent(Punctuation, implicit=True))),
             # tags, anchors and aliases,
             include('descriptors'),

--- a/tests/snippets/yaml/test_yaml_colon_in_key.txt
+++ b/tests/snippets/yaml/test_yaml_colon_in_key.txt
@@ -1,0 +1,11 @@
+# Colon in the key name is accepted by the YAML specs too
+
+---input---
+foo:bar: value
+
+---tokens---
+'foo:bar'     Name.Tag
+':'           Punctuation
+' '           Text.Whitespace
+'value'       Literal.Scalar.Plain
+'\n'          Text.Whitespace

--- a/tests/snippets/yaml/test_yaml_colon_in_key_double.txt
+++ b/tests/snippets/yaml/test_yaml_colon_in_key_double.txt
@@ -1,0 +1,11 @@
+# Colons in the key name is accepted by the YAML specs too
+
+---input---
+foo::bar: value
+
+---tokens---
+'foo::bar'    Name.Tag
+':'           Punctuation
+' '           Text.Whitespace
+'value'       Literal.Scalar.Plain
+'\n'          Text.Whitespace

--- a/tests/snippets/yaml/test_yaml_colon_in_key_start.txt
+++ b/tests/snippets/yaml/test_yaml_colon_in_key_start.txt
@@ -1,0 +1,11 @@
+# Colon at the beginning of the key name is accepted by the YAML specs too
+
+---input---
+:foo: value
+
+---tokens---
+':foo'        Name.Tag
+':'           Punctuation
+' '           Text.Whitespace
+'value'       Literal.Scalar.Plain
+'\n'          Text.Whitespace


### PR DESCRIPTION
as it's ok according to the YAML specs and is widely used in the real world, f.e. in Puppet's Hiera (https://puppet.com/docs/puppet/7/hiera_quick.html#values_common_data)