### PR TITLE
Added support for F# script files, aka .fsx files

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -153,7 +153,7 @@ LEXERS = {
     'EvoqueXmlLexer': ('pygments.lexers.templates', 'XML+Evoque', ('xml+evoque',), ('*.xml',), ('application/xml+evoque',)),
     'ExeclineLexer': ('pygments.lexers.shell', 'execline', ('execline',), ('*.exec',), ()),
     'EzhilLexer': ('pygments.lexers.ezhil', 'Ezhil', ('ezhil',), ('*.n',), ('text/x-ezhil',)),
-    'FSharpLexer': ('pygments.lexers.dotnet', 'F#', ('fsharp', 'f#'), ('*.fs', '*.fsi'), ('text/x-fsharp',)),
+    'FSharpLexer': ('pygments.lexers.dotnet', 'F#', ('fsharp', 'f#'), ('*.fs', '*.fsi', '*.fsx'), ('text/x-fsharp',)),
     'FStarLexer': ('pygments.lexers.ml', 'FStar', ('fstar',), ('*.fst', '*.fsti'), ('text/x-fstar',)),
     'FactorLexer': ('pygments.lexers.factor', 'Factor', ('factor',), ('*.factor',), ('text/x-factor',)),
     'FancyLexer': ('pygments.lexers.ruby', 'Fancy', ('fancy', 'fy'), ('*.fy', '*.fancypack'), ('text/x-fancysrc',)),

--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -577,7 +577,7 @@ class FSharpLexer(RegexLexer):
     name = 'F#'
     url = 'https://fsharp.org/'
     aliases = ['fsharp', 'f#']
-    filenames = ['*.fs', '*.fsi']
+    filenames = ['*.fs', '*.fsi', '*.fsx']
     mimetypes = ['text/x-fsharp']
 
     keywords = [


### PR DESCRIPTION
I noticed this was missing and was causing issues for me as I use fsx files and even though the syntax is more or less the same it's still helpful to get the highlight without having to rename the file.