### PR TITLE
nix: allow single quotes inside single-quoted strings

### DIFF
--- a/pygments/lexers/nix.py
+++ b/pygments/lexers/nix.py
@@ -102,6 +102,7 @@ class NixLexer(RegexLexer):
             (r"''\t", String.Escape),
             (r"''", String.Single, '#pop'),
             (r'\$\{', String.Interpol, 'antiquote'),
+            (r"'", String.Single),
             (r"[^']", String.Single),
         ],
         'doublequote': [

--- a/tests/examplefiles/nixos/example.nix
+++ b/tests/examplefiles/nixos/example.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
 
   # escape example
   postInstall = ''
-    mv $out/sbin $out/bin ''' ''${
+    mv $out/sbin 'foo' $out/bin ''' ''${
    ${ if true then ${ "" } else false }
   '';
 

--- a/tests/examplefiles/nixos/example.nix.output
+++ b/tests/examplefiles/nixos/example.nix.output
@@ -1193,6 +1193,12 @@
 'i'           Literal.String.Single
 'n'           Literal.String.Single
 ' '           Literal.String.Single
+"'"           Literal.String.Single
+'f'           Literal.String.Single
+'o'           Literal.String.Single
+'o'           Literal.String.Single
+"'"           Literal.String.Single
+' '           Literal.String.Single
 '$'           Literal.String.Single
 'o'           Literal.String.Single
 'u'           Literal.String.Single


### PR DESCRIPTION
Fixes https://github.com/pygments/pygments/issues/1793. Confirmed on https://github.com/pygments/pygments/issues/1793#issuecomment-1332895574.