### PR TITLE
fix solidity lexer not picking up many of the operators (e.g. boolean and)

### DIFF
--- a/pygments/lexers/solidity.py
+++ b/pygments/lexers/solidity.py
@@ -60,7 +60,7 @@ class SolidityLexer(RegexLexer):
             include('constants'),
             (r'[a-zA-Z_]\w*', Text),
             (r'[~!%^&*+=|?:<>/-]', Operator),
-            (r'[.;:{}(),\[\]]', Punctuation)
+            (r'[.;{}(),\[\]]', Punctuation)
         ],
         'comments': [
             (r'//(\n|[\w\W]*?[^\\]\n)', Comment.Single),

--- a/pygments/lexers/solidity.py
+++ b/pygments/lexers/solidity.py
@@ -59,7 +59,7 @@ class SolidityLexer(RegexLexer):
             (datatype, Keyword.Type),
             include('constants'),
             (r'[a-zA-Z_]\w*', Text),
-            (r'[!<=>+*/-]', Operator),
+            (r'[~!%^&*+=|?:<>/-]', Operator),
             (r'[.;:{}(),\[\]]', Punctuation)
         ],
         'comments': [

--- a/tests/examplefiles/solidity/test.sol
+++ b/tests/examplefiles/solidity/test.sol
@@ -11,7 +11,6 @@ pragma solidity >=0.4.0 <0.7.0;
 */
 
 contract ContractName {
-
     address public publicaddress;
 
     uint varname1 = 1234;
@@ -20,16 +19,20 @@ contract ContractName {
     string astringsingle = 'test "string" value\' single';
     string astringdouble = "test 'string' value\" double";
 
+    address public shipper;
+    address private arbiter;
+    address astronaut;
+
     enum State {
-      NotStarted,
-      WorkInProgress,
-      Done
+        NotStarted,
+        WorkInProgress,
+        Done
     }
     State public state;
 
     struct AStruct {
         string name;
-        uint8 type;
+        uint8 atype;
     }
 
     mapping(address => AStruct) registry;
@@ -39,36 +42,79 @@ contract ContractName {
     event Withdraw(uint256 value);
 
     function addRegistry(string _name, uint8 _type) {
-        AStruct memory newItem = AStruct({
-            name: _name,
-            type: _type
-        });
+        AStruct memory newItem = AStruct({name: _name, atype: _type});
 
         registry[msg.sender] = newItem;
     }
 
-    function getHash(AStruct item) returns(uint) {
-        return uint(keccak256(item.name, item.type));
+    function getHash(AStruct item) returns (uint) {
+        return uint(keccak256(item.name, item.atype));
     }
 
     function pay() public payable {
-      require(msg.sender == astronaut);
-      state = State.Paid;
-      Paid(msg.value);
+        require(msg.sender == astronaut);
+        state = State.Paid;
+        Paid(msg.value);
     }
 
     function receive() public {
-      require(msg.sender == arbiter);
-      require(state == State.Paid);
-      state = State.Received;
-      Received(now);
+        require(msg.sender == arbiter);
+        require(state == State.Paid);
+        state = State.Received;
+        Received(now);
     }
 
     function withdraw() public {
-      require(msg.sender == shipper);
-      require(state == State.Received);
-      state = State.Withdrawn;
-      Withdraw(this.balance);
-      shipper.transfer(this.balance);
+        require(msg.sender == shipper);
+        require(state == State.Received);
+        state = State.Withdrawn;
+        Withdraw(this.balance);
+        shipper.transfer(this.balance);
+    }
+
+    function max(uint a, uint b) public returns (uint) {
+        if (a > b && b < a) {
+            return a;
+        } else {
+            return b;
+        }
+    }
+
+    function operators() public {
+        uint a = 20;
+        uint b = 10;
+        // arithmetic
+        uint _sum = a + b;
+        uint _diff = a - b;
+        uint _mul = a * b;
+        uint _div = a / b;
+        uint _mod = a % b;
+        uint _dec = --b;
+        uint _inc = ++a;
+
+        // comparison
+        bool _eq = a == b;
+        bool _noteq = a != b;
+        bool _greater = a > b;
+        bool _less = a < b;
+        bool _geq = a >= b;
+        bool _leq = a <= b;
+
+        // logical boolean
+        bool x = true;
+        bool y = false;
+        bool _and = x && y;
+        bool _or = a || b;
+        bool _not = !a;
+
+        // bitwise
+        uint64 i = 20;
+        uint64 j = 10;
+        uint64 _bitand = i & j;
+        uint64 _bitor = i | j;
+        uint64 _bitxor = i ^ j;
+        uint64 _leftshift = i << j;
+        uint64 _rightshift = i >> j;
+        uint64 _bitnot = ~i;
     }
 }

--- a/tests/examplefiles/solidity/test.sol.output
+++ b/tests/examplefiles/solidity/test.sol.output
@@ -30,7 +30,7 @@
 'ContractName' Name.Entity
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n\n    '    Text.Whitespace
+'\n    '      Text.Whitespace
 'address'     Keyword.Type
 ' '           Text.Whitespace
 'public '     Keyword
@@ -73,18 +73,35 @@
 '"test \'string\' value\\" double"' Literal.String.Double
 ';'           Punctuation
 '\n\n    '    Text.Whitespace
+'address'     Keyword.Type
+' '           Text.Whitespace
+'public '     Keyword
+'shipper'     Name.Variable
+';'           Punctuation
+'\n    '      Text.Whitespace
+'address'     Keyword.Type
+' '           Text.Whitespace
+'private '    Keyword
+'arbiter'     Name.Variable
+';'           Punctuation
+'\n    '      Text.Whitespace
+'address'     Keyword.Type
+' '           Text.Whitespace
+'astronaut'   Name.Variable
+';'           Punctuation
+'\n\n    '    Text.Whitespace
 'enum'        Keyword.Type
 ' '           Text.Whitespace
 'State'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'NotStarted'  Text
 ','           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'WorkInProgress' Text
 ','           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'Done'        Text
 '\n    '      Text.Whitespace
 '}'           Punctuation
@@ -109,7 +126,7 @@
 '\n        '  Text.Whitespace
 'uint8'       Keyword.Type
 ' '           Text.Whitespace
-'type'        Name.Variable
+'atype'       Name.Variable
 ';'           Punctuation
 '\n    '      Text.Whitespace
 '}'           Punctuation
@@ -184,18 +201,16 @@
 'AStruct'     Text
 '('           Punctuation
 '{'           Punctuation
-'\n            ' Text.Whitespace
 'name'        Text
-':'           Punctuation
+':'           Operator
 ' '           Text.Whitespace
 '_name'       Text
 ','           Punctuation
-'\n            ' Text.Whitespace
-'type'        Text
-':'           Punctuation
+' '           Text.Whitespace
+'atype'       Text
+':'           Operator
 ' '           Text.Whitespace
 '_type'       Text
-'\n        '  Text.Whitespace
 '}'           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -222,6 +237,7 @@
 ')'           Punctuation
 ' '           Text.Whitespace
 'returns'     Keyword.Type
+' '           Text.Whitespace
 '('           Punctuation
 'uint'        Keyword.Type
 ')'           Punctuation
@@ -241,7 +257,7 @@
 ' '           Text.Whitespace
 'item'        Text
 '.'           Punctuation
-'type'        Text
+'atype'       Text
 ')'           Punctuation
 ')'           Punctuation
 ';'           Punctuation
@@ -259,7 +275,7 @@
 'payable'     Keyword.Type
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'require'     Keyword.Type
 '('           Punctuation
 'msg.sender'  Keyword
@@ -270,7 +286,7 @@
 'astronaut'   Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'state'       Text
 ' '           Text.Whitespace
 '='           Operator
@@ -279,7 +295,7 @@
 '.'           Punctuation
 'Paid'        Text
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'Paid'        Text
 '('           Punctuation
 'msg.value'   Keyword
@@ -297,7 +313,7 @@
 'public'      Keyword.Type
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'require'     Keyword.Type
 '('           Punctuation
 'msg.sender'  Keyword
@@ -308,7 +324,7 @@
 'arbiter'     Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'require'     Keyword.Type
 '('           Punctuation
 'state'       Text
@@ -321,7 +337,7 @@
 'Paid'        Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'state'       Text
 ' '           Text.Whitespace
 '='           Operator
@@ -330,7 +346,7 @@
 '.'           Punctuation
 'Received'    Text
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'Received'    Text
 '('           Punctuation
 'now'         Text
@@ -348,7 +364,7 @@
 'public'      Keyword.Type
 ' '           Text.Whitespace
 '{'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'require'     Keyword.Type
 '('           Punctuation
 'msg.sender'  Keyword
@@ -359,7 +375,7 @@
 'shipper'     Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'require'     Keyword.Type
 '('           Punctuation
 'state'       Text
@@ -372,7 +388,7 @@
 'Received'    Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'state'       Text
 ' '           Text.Whitespace
 '='           Operator
@@ -381,7 +397,7 @@
 '.'           Punctuation
 'Withdrawn'   Text
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'Withdraw'    Text
 '('           Punctuation
 'this'        Keyword.Type
@@ -389,7 +405,7 @@
 'balance'     Text
 ')'           Punctuation
 ';'           Punctuation
-'\n      '    Text.Whitespace
+'\n        '  Text.Whitespace
 'shipper'     Text
 '.'           Punctuation
 'transfer'    Text
@@ -398,6 +414,433 @@
 '.'           Punctuation
 'balance'     Text
 ')'           Punctuation
+';'           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n\n    '    Text.Whitespace
+'function'    Keyword.Type
+' '           Text.Whitespace
+'max'         Name.Variable
+'('           Punctuation
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name.Variable
+','           Punctuation
+' '           Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'b'           Name.Variable
+')'           Punctuation
+' '           Text.Whitespace
+'public'      Keyword.Type
+' '           Text.Whitespace
+'returns'     Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'uint'        Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'if'          Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Text
+' '           Text.Whitespace
+'>'           Operator
+' '           Text.Whitespace
+'b'           Text
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'b'           Text
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'a'           Text
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'return'      Keyword.Type
+' '           Text.Whitespace
+'a'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'return'      Keyword.Type
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'}'           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n\n    '    Text.Whitespace
+'function'    Keyword.Type
+' '           Text.Whitespace
+'operators'   Name.Variable
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'public'      Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'20'          Literal.Number.Decimal
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'b'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'10'          Literal.Number.Decimal
+';'           Punctuation
+'\n        '  Text.Whitespace
+'// arithmetic\n' Comment.Single
+
+'        '    Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_sum'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_diff'       Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_mul'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_div'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_mod'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'%'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_dec'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'-'           Operator
+'-'           Operator
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint'        Keyword.Type
+' '           Text.Whitespace
+'_inc'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'+'           Operator
+'+'           Operator
+'a'           Text
+';'           Punctuation
+'\n\n        ' Text.Whitespace
+'// comparison\n' Comment.Single
+
+'        '    Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_eq'         Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_noteq'      Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'!'           Operator
+'='           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_greater'    Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'>'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_less'       Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_geq'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'>'           Operator
+'='           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_leq'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'<'           Operator
+'='           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n\n        ' Text.Whitespace
+'// logical boolean\n' Comment.Single
+
+'        '    Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'x'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Keyword.Type
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'y'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'false'       Keyword.Type
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_and'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'x'           Text
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'y'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_or'         Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'|'           Operator
+'|'           Operator
+' '           Text.Whitespace
+'b'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'_not'        Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'!'           Operator
+'a'           Text
+';'           Punctuation
+'\n\n        ' Text.Whitespace
+'// bitwise\n' Comment.Single
+
+'        '    Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'i'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'20'          Literal.Number.Decimal
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'j'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'10'          Literal.Number.Decimal
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_bitand'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'i'           Text
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'j'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_bitor'      Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'i'           Text
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'j'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_bitxor'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'i'           Text
+' '           Text.Whitespace
+'^'           Operator
+' '           Text.Whitespace
+'j'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_leftshift'  Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'i'           Text
+' '           Text.Whitespace
+'<'           Operator
+'<'           Operator
+' '           Text.Whitespace
+'j'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_rightshift' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'i'           Text
+' '           Text.Whitespace
+'>'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'j'           Text
+';'           Punctuation
+'\n        '  Text.Whitespace
+'uint64'      Keyword.Type
+' '           Text.Whitespace
+'_bitnot'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'~'           Operator
+'i'           Text
 ';'           Punctuation
 '\n    '      Text.Whitespace
 '}'           Punctuation


### PR DESCRIPTION
I noticed that the lexer for Solidity would not pick up boolean operators. Odd that nobody noticed this. To fix it I switched to the same regex for operators in the solidity lexer as in the `CFamilyLexer`. I updated the testcase with a function that covers all the operators I am aware of.