### PR TITLE
Add Support for EDK-II DSC file format

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -138,6 +138,7 @@ LEXERS = {
     'EarlGreyLexer': ('pygments.lexers.javascript', 'Earl Grey', ('earl-grey', 'earlgrey', 'eg'), ('*.eg',), ('text/x-earl-grey',)),
     'EasytrieveLexer': ('pygments.lexers.scripting', 'Easytrieve', ('easytrieve',), ('*.ezt', '*.mac'), ('text/x-easytrieve',)),
     'EbnfLexer': ('pygments.lexers.parsers', 'EBNF', ('ebnf',), ('*.ebnf',), ('text/x-ebnf',)),
+    'Edk2DscLexer': ('pygments.lexers.edk2dsc', 'DSC', ('dsc',), ('*.dsc',), ()),
     'EiffelLexer': ('pygments.lexers.eiffel', 'Eiffel', ('eiffel',), ('*.e',), ('text/x-eiffel',)),
     'ElixirConsoleLexer': ('pygments.lexers.erlang', 'Elixir iex session', ('iex',), (), ('text/x-elixir-shellsession',)),
     'ElixirLexer': ('pygments.lexers.erlang', 'Elixir', ('elixir', 'ex', 'exs'), ('*.ex', '*.eex', '*.exs', '*.leex'), ('text/x-elixir',)),

--- a/pygments/lexers/edk2dsc.py
+++ b/pygments/lexers/edk2dsc.py
@@ -1,0 +1,41 @@
+"""
+    pygments.lexers.edk2dsc
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    Lexers for edk2dsc.
+    :copyright: Copyright 2006-2022 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, include, words
+from pygments.token import Literal, Comment, Name, Whitespace
+
+__all__ = ['Edk2DscLexer']
+
+
+class Edk2DscLexer(RegexLexer):
+    """
+    For edk2dsc source code.
+    """
+
+    name = 'DSC'
+    aliases = ['dsc']
+    filenames = ['*.dsc']
+    url = 'https://edk2-docs.gitbook.io/edk-ii-dsc-specification/'
+
+    tokens = {
+        'root': [
+            (r'^\s+', Whitespace),
+            (r'#.*?$', Comment.Single),
+
+            include('comments'),
+
+            # treat anything as word
+            (r'\S+', Name)
+        ],
+
+        'comments': [
+            (r'^\s*#.*$', Comment),
+            (r'\n', Whitespace),
+            (r'[^\S\n]+', Whitespace),
+        ],
+    }

--- a/tests/examplefiles/dsc/test.dsc
+++ b/tests/examplefiles/dsc/test.dsc
@@ -1,0 +1,85 @@
+## @file
+# EFI/PI MdePkg Package
+#
+# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>
+# Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>
+# Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
+#
+#    SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME                  = Mde
+  PLATFORM_GUID                  = 082F8BFC-0455-4859-AE3C-ECD64FB81642
+  PLATFORM_VERSION               = 1.08
+  DSC_SPECIFICATION              = 0x00010005
+  OUTPUT_DIRECTORY               = Build/Mde
+  SUPPORTED_ARCHITECTURES        = IA32|X64|EBC|ARM|AARCH64|RISCV64|LOONGARCH64
+  BUILD_TARGETS                  = DEBUG|RELEASE|NOOPT
+  SKUID_IDENTIFIER               = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
+
+!include MdePkg/MdeLibs.dsc.inc
+
+[PcdsFeatureFlag]
+  gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport|TRUE
+
+[PcdsFixedAtBuild]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
+  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0xE0000000
+
+[LibraryClasses]
+  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+
+[Components]
+  MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
+  MdePkg/Library/BaseCacheMaintenanceLib/BaseCacheMaintenanceLib.inf
+  MdePkg/Library/BaseCacheMaintenanceLibNull/BaseCacheMaintenanceLibNull.inf
+  MdePkg/Library/BaseCpuLib/BaseCpuLib.inf
+  MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.inf
+  MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf
+  MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf
+  MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+  MdePkg/Library/BaseLib/BaseLib.inf
+  MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf
+  MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf
+  MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
+  MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf
+
+[Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
+  #
+  # Add UEFI Target Based Unit Tests
+  #
+  MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestsUefi.inf
+
+  #
+  # Build PEIM, DXE_DRIVER, SMM_DRIVER, UEFI Shell components that test SafeIntLib
+  #
+  MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibPei.inf
+  MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibDxe.inf
+  MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibSmm.inf
+  MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibUefiShell.inf
+
+[Components.IA32, Components.X64, Components.AARCH64]
+  MdePkg/Library/BaseRngLib/BaseRngLib.inf
+
+[Components.IA32, Components.X64]
+  MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
+  MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf
+
+[Components.EBC]
+  MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
+  MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+
+[Components.ARM, Components.AARCH64]
+  MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicArmVirt.inf
+  MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+
+[BuildOptions]

--- a/tests/examplefiles/dsc/test.dsc.output
+++ b/tests/examplefiles/dsc/test.dsc.output
@@ -1,0 +1,335 @@
+'## @file'    Comment.Single
+'\n'          Text.Whitespace
+
+'# EFI/PI MdePkg Package' Comment.Single
+'\n'          Text.Whitespace
+
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'# Copyright (c) 2007 - 2022, Intel Corporation. All rights reserved.<BR>' Comment.Single
+'\n'          Text.Whitespace
+
+'# Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>' Comment.Single
+'\n'          Text.Whitespace
+
+'# (C) Copyright 2020 Hewlett Packard Enterprise Development LP<BR>' Comment.Single
+'\n'          Text.Whitespace
+
+'# Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>' Comment.Single
+'\n'          Text.Whitespace
+
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'#    SPDX-License-Identifier: BSD-2-Clause-Patent' Comment.Single
+'\n'          Text.Whitespace
+
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'##'          Comment.Single
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Defines]'   Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'PLATFORM_NAME' Name
+'                  ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'Mde'         Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'PLATFORM_GUID' Name
+'                  ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'082F8BFC-0455-4859-AE3C-ECD64FB81642' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'PLATFORM_VERSION' Name
+'               ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'1.08'        Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'DSC_SPECIFICATION' Name
+'              ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'0x00010005'  Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'OUTPUT_DIRECTORY' Name
+'               ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'Build/Mde'   Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'SUPPORTED_ARCHITECTURES' Name
+'        '    Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'IA32|X64|EBC|ARM|AARCH64|RISCV64|LOONGARCH64' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'BUILD_TARGETS' Name
+'                  ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'DEBUG|RELEASE|NOOPT' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'SKUID_IDENTIFIER' Name
+'               ' Text.Whitespace
+'='           Name
+' '           Text.Whitespace
+'DEFAULT'     Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'!include'    Name
+' '           Text.Whitespace
+'UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'!include'    Name
+' '           Text.Whitespace
+'MdePkg/MdeLibs.dsc.inc' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[PcdsFeatureFlag]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gEfiMdePkgTokenSpaceGuid.PcdUgaConsumeSupport|TRUE' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[PcdsFixedAtBuild]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x0f' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress|0xE0000000' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[LibraryClasses]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseCacheMaintenanceLib/BaseCacheMaintenanceLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseCacheMaintenanceLibNull/BaseCacheMaintenanceLibNull.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseCpuLib/BaseCpuLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseCpuLibNull/BaseCpuLibNull.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseDebugLibNull/BaseDebugLibNull.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseDebugLibSerialPort/BaseDebugLibSerialPort.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseLib/BaseLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseOrderedCollectionRedBlackTreeLib/BaseOrderedCollectionRedBlackTreeLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BasePciCf8Lib/BasePciCf8Lib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/SmmCpuRendezvousLibNull/SmmCpuRendezvousLibNull.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components.IA32,' Name
+' '           Text.Whitespace
+'Components.X64,' Name
+' '           Text.Whitespace
+'Components.ARM,' Name
+' '           Text.Whitespace
+'Components.AARCH64]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'# Add UEFI Target Based Unit Tests' Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestsUefi.inf' Name
+'\n'          Text.Whitespace
+
+'\n  '        Text.Whitespace
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'# Build PEIM, DXE_DRIVER, SMM_DRIVER, UEFI Shell components that test SafeIntLib' Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'#'           Comment.Single
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibPei.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibDxe.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibSmm.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibUefiShell.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components.IA32,' Name
+' '           Text.Whitespace
+'Components.X64,' Name
+' '           Text.Whitespace
+'Components.AARCH64]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseRngLib/BaseRngLib.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components.IA32,' Name
+' '           Text.Whitespace
+'Components.X64]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components.EBC]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[Components.ARM,' Name
+' '           Text.Whitespace
+'Components.AARCH64]' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicArmVirt.inf' Name
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[BuildOptions]' Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
EDK-II is open source UEFI Based Bootloader.
DSC Specification:https://edk2-docs.gitbook.io/edk-ii-dsc-specification

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>