### PR TITLE
Add Support for EDK-II DSC DEC file format

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -217,7 +217,7 @@ LEXERS = {
     'Inform6Lexer': ('pygments.lexers.int_fiction', 'Inform 6', ('inform6', 'i6'), ('*.inf',), ()),
     'Inform6TemplateLexer': ('pygments.lexers.int_fiction', 'Inform 6 template', ('i6t',), ('*.i6t',), ()),
     'Inform7Lexer': ('pygments.lexers.int_fiction', 'Inform 7', ('inform7', 'i7'), ('*.ni', '*.i7x'), ()),
-    'IniLexer': ('pygments.lexers.configs', 'INI', ('ini', 'cfg', 'dosini'), ('*.ini', '*.cfg', '*.inf', '.editorconfig', '*.service', '*.socket', '*.device', '*.mount', '*.automount', '*.swap', '*.target', '*.path', '*.timer', '*.slice', '*.scope'), ('text/x-ini', 'text/inf')),
+    'IniLexer': ('pygments.lexers.configs', 'INI', ('ini', 'cfg', 'dosini'), ('*.ini', '*.cfg', '*.inf', '.editorconfig', '*.dsc', '*.dec', '*.service', '*.socket', '*.device', '*.mount', '*.automount', '*.swap', '*.target', '*.path', '*.timer', '*.slice', '*.scope'), ('text/x-ini', 'text/inf')),
     'IoLexer': ('pygments.lexers.iolang', 'Io', ('io',), ('*.io',), ('text/x-iosrc',)),
     'IokeLexer': ('pygments.lexers.jvm', 'Ioke', ('ioke', 'ik'), ('*.ik',), ('text/x-iokesrc',)),
     'IrcLogsLexer': ('pygments.lexers.textfmts', 'IRC logs', ('irc',), ('*.weechatlog',), ('text/x-irclog',)),

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -33,7 +33,7 @@ class IniLexer(RegexLexer):
     name = 'INI'
     aliases = ['ini', 'cfg', 'dosini']
     filenames = [
-        '*.ini', '*.cfg', '*.inf', '.editorconfig',
+        '*.ini', '*.cfg', '*.inf', '.editorconfig', '*.dsc', '*.dec',
         # systemd unit files
         # https://www.freedesktop.org/software/systemd/man/systemd.unit.html
         '*.service', '*.socket', '*.device', '*.mount', '*.automount',


### PR DESCRIPTION
EDK-II is open source UEFI Based Bootloader.
DSC Specification:https://edk2-docs.gitbook.io/edk-ii-dsc-specification
DEC Specification:https://edk2-docs.gitbook.io/edk-ii-dec-specification/

Signed-off-by: Ashraf Ali S <ashraf.ali.s@intel.com>