### PR TITLE
Force whitespace tokens in bygroups.

### DIFF
--- a/pygments/lexer.py
+++ b/pygments/lexer.py
@@ -19,11 +19,13 @@ from pygments.util import get_bool_opt, get_int_opt, get_list_opt, \
     make_analysator, Future, guess_decode
 from pygments.regexopt import regex_opt
 
+
 __all__ = ['Lexer', 'RegexLexer', 'ExtendedRegexLexer', 'DelegatingLexer',
            'LexerContext', 'include', 'inherit', 'bygroups', 'using', 'this',
            'default', 'words', 'line_re']
 
 line_re = re.compile('.*?\n')
+whitespace_re = re.compile(r'\s+')
 
 _encoding_map = [(b'\xef\xbb\xbf', 'utf-8'),
                  (b'\xff\xfe\0\0', 'utf-32'),
@@ -312,7 +314,12 @@ def bygroups(*args):
                 continue
             elif type(action) is _TokenType:
                 data = match.group(i + 1)
+
                 if data:
+                    if action is not Whitespace and \
+                       whitespace_re.fullmatch(data):
+                        action = Whitespace
+
                     yield match.start(i + 1), action, data
             else:
                 data = match.group(i + 1)

--- a/tests/examplefiles/ada/test.adb.output
+++ b/tests/examplefiles/ada/test.adb.output
@@ -3,55 +3,55 @@
 '--  COL Gene Ressler, 1 December 2007\n' Comment.Single
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Text_IO' Name
 ';'           Punctuation
 '\n\n'        Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Characters.Latin_1' Name
 ';'           Punctuation
 '\n'          Text
 
 'use'         Keyword.Namespace
-'  '          Text
+'  '          Text.Whitespace
 'Ada.Characters.Latin_1' Name
 ';'           Punctuation
 '\n\n'        Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Strings.Fixed' Name
 ';'           Punctuation
 '\n'          Text
 
 'use'         Keyword.Namespace
-'  '          Text
+'  '          Text.Whitespace
 'Ada.Strings.Fixed' Name
 ';'           Punctuation
 '\n\n'        Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Strings' Name
 ';'           Punctuation
 '\n'          Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Strings.Bounded' Name
 ';'           Punctuation
 '\n\n'        Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Binary_Search' Name
 ';'           Punctuation
 '\n\n'        Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Containers.Generic_Array_Sort' Name
 ';'           Punctuation
 '\n\n'        Text
@@ -70,9 +70,9 @@
 
 '   '         Text
 'Constant_123' Name.Constant
-'   '         Text
+'   '         Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 'Character'   Keyword.Type
@@ -91,9 +91,9 @@
 
 '   '         Text
 'MAX_KEYWORD_LENGTH_C' Name.Constant
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 'Natural'     Keyword.Type
@@ -109,9 +109,9 @@
 
 '   '         Text
 'New_Constant' Name.Constant
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 'New_Type'    Name
@@ -129,9 +129,9 @@
 
 '   '         Text
 'KEYWORDS_C'  Name.Constant
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 'Keyword_Array_T' Name
@@ -188,7 +188,7 @@
 '      '      Text
 'Declaration' Name.Label
 ':'           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 'declare'     Keyword.Reserved
 '\n'          Text
 
@@ -216,7 +216,7 @@
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Declaration' Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -224,7 +224,7 @@
 '      '      Text
 'Loop_ID'     Name.Label
 ':'           Punctuation
-'\n         ' Text
+'\n         ' Text.Whitespace
 'loop'        Keyword.Reserved
 '\n'          Text
 
@@ -246,7 +246,7 @@
 
 '         '   Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'loop'        Keyword.Reserved
 ' '           Text
 'Loop'        Keyword.Reserved
@@ -303,14 +303,14 @@
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'blah'        Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -370,7 +370,7 @@
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '"*"'         Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -438,7 +438,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'New_Float'   Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -469,7 +469,7 @@
 '     '       Text
 '('           Punctuation
 'Max'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=>'          Punctuation
 ' '           Text
 'M'           Text
@@ -498,7 +498,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Array_Decl12' Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -507,7 +507,7 @@
 ' '           Text
 '('           Punctuation
 'Positive'    Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'range'       Keyword.Reserved
 ' '           Text
 '<>'          Punctuation
@@ -523,7 +523,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Array_Decl3' Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -532,7 +532,7 @@
 ' '           Text
 '('           Punctuation
 'New_Type'    Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'range'       Keyword.Reserved
 ' '           Text
 'Thing_1'     Name
@@ -553,7 +553,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Boring_Type' Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -573,7 +573,7 @@
 
 '   '         Text
 'subtype'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Sub_Type_check' Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -600,9 +600,9 @@
 
 '   '         Text
 'Initialized_Array' Name.Constant
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 'Transistion_Array_T' Name
@@ -683,7 +683,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Recorder'    Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -723,7 +723,7 @@
 'Recorder'    Name
 ' '           Text
 'use'         Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '8'           Name
 ';'           Punctuation
 '\n'          Text
@@ -733,7 +733,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Null_Record' Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -747,7 +747,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Discriminated_Record' Keyword.Type
 ' '           Text
 '('           Punctuation
@@ -793,7 +793,7 @@
 
 '   '         Text
 'pragma'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Unchecked_Union' Comment.Preproc
 ' '           Text
 '('           Punctuation
@@ -804,7 +804,7 @@
 
 '   '         Text
 'pragma'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Convention'  Comment.Preproc
 ' '           Text
 '('           Punctuation
@@ -821,7 +821,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Person'      Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -871,7 +871,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Programmer'  Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -915,7 +915,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Programmer'  Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -1024,7 +1024,7 @@
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Cyclic_Buffer_Task_Type' Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1044,9 +1044,9 @@
 
 '      '      Text
 'Q_Size'      Name.Constant
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'constant'    Keyword.Reserved
 ' '           Text
 ':='          Punctuation
@@ -1057,7 +1057,7 @@
 
 '      '      Text
 'subtype'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Q_Range'     Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -1186,7 +1186,7 @@
 
 '               ' Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Insert'      Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1269,7 +1269,7 @@
 
 '               ' Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Remove'      Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1306,21 +1306,21 @@
 
 '         '   Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'select'      Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'loop'        Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Cyclic_Buffer_Task_Type' Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1477,7 +1477,7 @@
 '      '      Text
 'Scanner_Loop' Name.Label
 ':'           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 'loop'        Keyword.Reserved
 '\n'          Text
 
@@ -1502,7 +1502,7 @@
 
 '         '   Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword.Reserved
 ';'           Punctuation
 '\n\n'        Text
@@ -1539,14 +1539,14 @@
 
 '         '   Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'loop'        Keyword.Reserved
 ' '           Text
 'Scanner_Loop' Name.Function
@@ -1555,7 +1555,7 @@
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Scan_Next_Token' Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1590,7 +1590,7 @@
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Advance'     Name.Function
 ';'           Punctuation
 '\n'          Text
@@ -1680,7 +1680,7 @@
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
@@ -1694,13 +1694,13 @@
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Image'       Name.Function
 ';'           Punctuation
 '\n\n'        Text
 
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Scanner'     Name.Function
 ';'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/ada/test_ada2022.adb.output
+++ b/tests/examplefiles/ada/test_ada2022.adb.output
@@ -1,16 +1,16 @@
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Text_IO' Name
 ';'           Punctuation
 '            ' Text
 'use'         Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Text_IO' Name
 ';'           Punctuation
 '\n'          Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Ada.Containers.Vectors' Name
 ';'           Punctuation
 '\n\n'        Text
@@ -37,7 +37,7 @@
 '       '     Text
 '('           Punctuation
 'Index_Type'  Name.Variable
-'   '         Text
+'   '         Text.Whitespace
 '=>'          Punctuation
 ' '           Text
 'N'           Text
@@ -52,7 +52,7 @@
 
 '        '    Text
 'Element_Type' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=>'          Punctuation
 ' '           Text
 'I'           Text
@@ -68,7 +68,7 @@
 
 '   '         Text
 'use'         Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Integer_Vectors' Name
 ';'           Punctuation
 '\n\n'        Text
@@ -123,14 +123,14 @@
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'loop'        Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
 
 '   '         Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Increment_All' Name.Function
 ';'           Punctuation
 '\n\n'        Text
@@ -180,7 +180,7 @@
 '\n\n'        Text
 
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Test_Ada2022' Name.Function
 ';'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/ada/test_ada_aspects.ads.output
+++ b/tests/examplefiles/ada/test_ada_aspects.ads.output
@@ -1,11 +1,11 @@
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'System'      Name
 ';'           Punctuation
 '\n'          Text
 
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Interfaces.C' Name
 ';'           Punctuation
 '\n\n'        Text
@@ -19,7 +19,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'R'           Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -76,7 +76,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Float_Int_Union' Keyword.Type
 ' '           Text
 '('           Punctuation
@@ -131,7 +131,7 @@
 
 '      '      Text
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'case'        Keyword.Reserved
 ';'           Punctuation
 '\n'          Text
@@ -149,7 +149,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'my_struct'   Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -213,7 +213,7 @@
 
 '     '       Text
 'with'        Keyword.Namespace
-'\n       '   Text
+'\n       '   Text.Whitespace
 'Import'      Name
 '        '    Text
 '=>'          Punctuation
@@ -242,7 +242,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Percentage'  Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -270,7 +270,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'State'       Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -305,7 +305,7 @@
 'State'       Name
 ' '           Text
 'use'         Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'Off'         Name
 '     '       Text
@@ -336,7 +336,7 @@
 
 '   '         Text
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Registers'   Keyword.Type
 ' '           Text
 'is'          Keyword.Reserved
@@ -404,7 +404,7 @@
 'Long_Float'  Keyword.Type
 ' '           Text
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Volatile'    Name
 ';'           Punctuation
 '\n'          Text
@@ -430,7 +430,7 @@
 'Integer'     Keyword.Type
 ' '           Text
 'with'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'Atomic_Components' Name
 ';'           Punctuation
 '\n\n'        Text
@@ -443,7 +443,7 @@
 'Integer'     Keyword.Type
 ' '           Text
 'with'        Keyword.Namespace
-'\n     '     Text
+'\n     '     Text.Whitespace
 'Atomic'      Name
 ','           Punctuation
 '\n'          Text
@@ -464,7 +464,7 @@
 '\n\n'        Text
 
 'end'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'Test_Ada_Aspects' Name.Function
 ';'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/ahk/demo.ahk.output
+++ b/tests/examplefiles/ahk/demo.ahk.output
@@ -64,7 +64,7 @@
 '\n;;;  single line comment2' Comment.Single
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '::stopi::'   Name.Label
 'viper_off'   Name
@@ -74,7 +74,7 @@
 ' '           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 'a::'         Name.Label
 'send'        Name
@@ -106,7 +106,7 @@
 'n::'         Name.Label
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'send'        Name.Builtin
 ','           Punctuation
 ' '           Text
@@ -114,7 +114,7 @@
 'n'           Name
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'return'      Name.Builtin
 '\n'          Text.Whitespace
 
@@ -261,7 +261,7 @@
 '\n\n; viper' Comment.Single
 '\n'          Text.Whitespace
 
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'i::'         Name.Label
 'viper_off'   Name
@@ -293,7 +293,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 'p::'         Name.Label
 '\n'          Text.Whitespace
@@ -380,7 +380,7 @@
 '  ;; kill next word or sexp' Comment.Single
 '\n'          Text.Whitespace
 
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '#IfWinActive' Name.Builtin
 '\n'          Text.Whitespace
@@ -388,7 +388,7 @@
 '#Persistent' Name.Builtin
 '\n'          Text.Whitespace
 
-'  \n'        Text
+'  \n'        Text.Whitespace
 
 'F2::'        Name.Label
 '     ;; hotkey' Comment.Single
@@ -447,7 +447,7 @@
 ' '           Text
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'msgbox'      Name.Builtin
 ' '           Text
 '%'           Operator
@@ -491,7 +491,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'msgbox'      Name.Builtin
 ' '           Text
 '%'           Operator
@@ -508,12 +508,12 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'ListVars'    Name.Builtin
 '  ; command' Comment.Single
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'msgbox'      Name.Builtin
 ' '           Text
 '%'           Operator
@@ -521,7 +521,7 @@
 'ppm'         Name
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'return'      Name.Builtin
 '\n'          Text.Whitespace
 
@@ -546,7 +546,7 @@
 '{'           Punctuation
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 'fileread'    Name.Builtin
 ','           Punctuation
 ' '           Text
@@ -558,7 +558,7 @@
 'file'        Name
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 'return'      Name.Builtin
 ' '           Text
 'ppm'         Name
@@ -567,7 +567,7 @@
 '}'           Punctuation
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '::hotstring::' Name.Label
 '\n'          Text.Whitespace
@@ -603,7 +603,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 'return'      Name.Builtin
 ' '           Text
 'dim1'        Name
@@ -636,7 +636,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text
+'    '        Text.Whitespace
 'return'      Name.Builtin
 ' '           Text
 'dim2'        Name
@@ -884,7 +884,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'loop'        Name.Builtin
 ','           Punctuation
 ' '           Text
@@ -904,7 +904,7 @@
 '{'           Punctuation
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 'if '         Name.Builtin
 'r'           Name
 '\n'          Text.Whitespace
@@ -939,7 +939,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 'if '         Name.Builtin
 'g'           Name
 '\n'          Text.Whitespace
@@ -978,7 +978,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 'if '         Name.Builtin
 'b'           Name
 '\n'          Text.Whitespace
@@ -1172,7 +1172,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'  '          Text
+'  '          Text.Whitespace
 'return'      Name.Builtin
 ' '           Text
 'ppm'         Name
@@ -1248,7 +1248,7 @@
 '\n\n; Example: Simple image viewer:' Comment.Single
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Gui'         Name.Builtin
 ','           Punctuation
@@ -1358,7 +1358,7 @@
 'return'      Name.Builtin
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 'ButtonLoadNewImage:' Name.Label
 '\n'          Text.Whitespace
@@ -1439,7 +1439,7 @@
 '='           Operator
 '\n'          Text.Whitespace
 
-'    '        Text
+'    '        Text.Whitespace
 'return'      Name.Builtin
 '\n'          Text.Whitespace
 
@@ -1568,7 +1568,7 @@
 'return'      Name.Builtin
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 'GuiClose:'   Name.Label
 '\n'          Text.Whitespace

--- a/tests/examplefiles/arrow/primesieve.arw.output
+++ b/tests/examplefiles/arrow/primesieve.arw.output
@@ -17,7 +17,7 @@
 '| '          Punctuation
 'bool'        Keyword.Type
 '[]'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'primes'      Name.Variable
 '['           Punctuation
 'max'         Name.Variable
@@ -48,7 +48,7 @@
 
 '| \n| '      Punctuation
 'int'         Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'i'           Name.Variable
 '\n'          Text.Whitespace
 
@@ -99,7 +99,7 @@
 
 '|\n| '       Punctuation
 'int'         Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'firstPrime'  Name.Variable
 '\n'          Text.Whitespace
 
@@ -117,7 +117,7 @@
 
 '| | '        Punctuation
 'bool'        Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'firstIsComposite' Name.Variable
 '\n'          Text.Whitespace
 
@@ -219,7 +219,7 @@
 
 '| | | '      Punctuation
 'int'         Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'composite'   Name.Variable
 '\n'          Text.Whitespace
 
@@ -313,7 +313,7 @@
 '\n'          Text.Whitespace
 
 'int'         Keyword.Type
-' '           Text
+' '           Text.Whitespace
 'max'         Name.Variable
 '\n'          Text.Whitespace
 
@@ -326,7 +326,7 @@
 
 'bool'        Keyword.Type
 '[]'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'primes'      Name.Variable
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/autoit/autoit_submit.au3.output
+++ b/tests/examplefiles/autoit/autoit_submit.au3.output
@@ -31,7 +31,7 @@
 'url'         Literal.String
 '"'           Literal.String
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'If'          Name.Builtin
 ' '           Text
@@ -40,7 +40,7 @@
 '='           Operator
 ' '           Text
 '$_IEStatus_NoMatch' Name.Variable
-' '           Text
+' '           Text.Whitespace
 'Then'        Name.Builtin
 '\n'          Text.Whitespace
 
@@ -60,7 +60,7 @@
 'sample.html' Literal.String
 '"'           Literal.String
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'endIf'       Name.Builtin
 '\n'          Text.Whitespace

--- a/tests/examplefiles/bat/example.bat.output
+++ b/tests/examplefiles/bat/example.bat.output
@@ -109,7 +109,7 @@
 '\n\n'        Text
 
 ''            Text
-'     '       Text
+'     '       Text.Whitespace
 ':'           Punctuation
 ')'           Name.Label
 ''            Text
@@ -454,7 +454,7 @@
 ' '           Text
 '1'           Literal.Number.Integer
 '>&'          Punctuation
-' '           Text
+' '           Text.Whitespace
 '2'           Literal.Number.Integer
 '6'           Text
 '9'           Text
@@ -1245,7 +1245,7 @@
 'G'           Literal.String.Backtick
 '%%'          Literal.String.Escape
 'J ``` `\n`  `' Literal.String.Backtick
-'    '        Text
+'    '        Text.Whitespace
 ')'           Punctuation
 ' '           Text
 'do'          Keyword
@@ -1269,7 +1269,7 @@
 "'echo ' "    Literal.String.Single
 '%%'          Literal.String.Escape
 "L0 '\n'  '"  Literal.String.Single
-'      '      Text
+'      '      Text.Whitespace
 ')'           Punctuation
 ' '           Text
 'do'          Keyword
@@ -1911,7 +1911,7 @@
 "'assoc "     Literal.String.Single
 "%+;/p extension'),%" Name.Variable
 "'"           Literal.String.Single
-'\n '         Text
+'\n '         Text.Whitespace
 ')'           Punctuation
 ' '           Text
 'do'          Keyword

--- a/tests/examplefiles/bugs/example.bug.output
+++ b/tests/examplefiles/bugs/example.bug.output
@@ -5,7 +5,7 @@
 '\n'          Text
 
 'model'       Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n   '       Text
 '# PRIORS    ' Comment.Single

--- a/tests/examplefiles/c/ceval.c.output
+++ b/tests/examplefiles/c/ceval.c.output
@@ -11549,7 +11549,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -11658,7 +11658,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ')'           Punctuation
 '\n'          Text.Whitespace

--- a/tests/examplefiles/charmci/Charmci.ci.output
+++ b/tests/examplefiles/charmci/Charmci.ci.output
@@ -1,5 +1,5 @@
 'module'      Keyword
-' '           Text
+' '           Text.Whitespace
 'CkCallback'  Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation

--- a/tests/examplefiles/control/control.output
+++ b/tests/examplefiles/control/control.output
@@ -31,7 +31,7 @@
 ' '           Text
 '('           Text
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '13'          Literal.Number
 ')'           Text
 ',\n'         Text

--- a/tests/examplefiles/cplint/bag_game_mpe.pl.output
+++ b/tests/examplefiles/cplint/bag_game_mpe.pl.output
@@ -83,7 +83,7 @@
 '\n\n'        Text
 
 'win'         Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 'red'         Literal.String.Atom
@@ -94,7 +94,7 @@
 '\n'          Text
 
 'win'         Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 'blue'        Literal.String.Atom

--- a/tests/examplefiles/cplint/dt_umbrella.pl.output
+++ b/tests/examplefiles/cplint/dt_umbrella.pl.output
@@ -57,7 +57,7 @@
 '\n\n'        Text
 
 'broken_umbrella' Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 'rain'        Literal.String.Atom
@@ -69,7 +69,7 @@
 '\n'          Text
 
 'dry'         Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 'rain'        Literal.String.Atom
@@ -80,7 +80,7 @@
 '\n'          Text
 
 'dry'         Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 'rain'        Literal.String.Atom
@@ -97,7 +97,7 @@
 '\n'          Text
 
 'dry'         Name.Function
-' '           Text
+' '           Text.Whitespace
 ':-'          Operator
 ' '           Text
 '\\+'         Literal.String.Atom

--- a/tests/examplefiles/cpp/example.cpp.output
+++ b/tests/examplefiles/cpp/example.cpp.output
@@ -4332,7 +4332,7 @@
 ','           Punctuation
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ')'           Punctuation
 ';'           Punctuation
@@ -4995,7 +4995,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -8782,7 +8782,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -9576,7 +9576,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -11245,7 +11245,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -12831,7 +12831,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ';'           Punctuation
 ' '           Text.Whitespace
@@ -13045,7 +13045,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ' '           Text.Whitespace
 '&'           Operator
@@ -15856,7 +15856,7 @@
 '='           Operator
 ' '           Text.Whitespace
 "'"           Literal.String.Char
-' '           Literal.String.Char
+' '           Text.Whitespace
 "'"           Literal.String.Char
 ' '           Text.Whitespace
 '|'           Operator

--- a/tests/examplefiles/cucumber/example.feature.output
+++ b/tests/examplefiles/cucumber/example.feature.output
@@ -90,7 +90,7 @@
 't'           Name.Function
 '\n'          Name.Function
 
-'  '          Name.Function
+'  '          Text.Whitespace
 'When '       Keyword
 'W'           Name.Function
 'h'           Name.Function
@@ -103,7 +103,7 @@
 ''            Keyword
 '\n'          Name.Function
 
-'  '          Name.Function
+'  '          Text.Whitespace
 'Then '       Keyword
 'I'           Name.Function
 ' '           Name.Function
@@ -131,7 +131,7 @@
 '  # indented comment' Comment
 '\n'          Name.Function
 
-'  '          Name.Function
+'  '          Text.Whitespace
 'Examples'    Keyword
 ':'           Keyword
 '\n    |'     Keyword

--- a/tests/examplefiles/devicetree/example.dts.output
+++ b/tests/examplefiles/devicetree/example.dts.output
@@ -18,30 +18,30 @@
 '\n'          Text.Whitespace
 
 '#include'    Comment.Preproc
-' '           Comment.Multiline
+' '           Text.Whitespace
 '"imx6q.dtsi"' Comment.PreprocFile
 '\n'          Text.Whitespace
 
 '#include'    Comment.Preproc
-' '           Comment.Multiline
+' '           Text.Whitespace
 '<dt-bindings/pwm/pwm.h>' Comment.PreprocFile
 '\n'          Text.Whitespace
 
 '/include/'   Comment.Preproc
-' '           Comment.Multiline
+' '           Text.Whitespace
 '"tps65217.dtsi"' Comment.PreprocFile
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 '/'           Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
 '\t'          Text.Whitespace
 'aliases'     Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -96,7 +96,7 @@
 'memory'      Name.Function
 '@'           Operator
 '10000000'    Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -133,7 +133,7 @@
 
 '        '    Text.Whitespace
 '/delete-property/' Comment.Preproc
-' '           Comment.Multiline
+' '           Text.Whitespace
 'uart'        Comment.Preproc
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -145,7 +145,7 @@
 ':'           Punctuation
 ' '           Text.Whitespace
 'regulator-usb-otg-vbus' Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -206,7 +206,7 @@
 
 '&'           Operator
 'can1'        Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -252,7 +252,7 @@
 
 '&'           Operator
 'ecspi1'      Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -322,7 +322,7 @@
 'flash'       Name.Function
 '@'           Operator
 '0'           Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\t'          Text.Whitespace
 '/* S25FL116K */' Comment.Multiline
@@ -403,7 +403,7 @@
 
 '&'           Operator
 'fec'         Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -468,7 +468,7 @@
 
 '\t'          Text.Whitespace
 'mdio'        Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -503,7 +503,7 @@
 'ethernet-phy' Name.Function
 '@'           Operator
 '0'           Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\t'          Text.Whitespace
 '/* SMSC LAN8710Ai */' Comment.Multiline
@@ -587,7 +587,7 @@
 
 '&'           Operator
 'i2c3'        Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -645,7 +645,7 @@
 'pmic'        Name.Function
 '@'           Operator
 '3c'          Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -723,7 +723,7 @@
 
 '\t\t'        Text.Whitespace
 'regulators'  Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -732,7 +732,7 @@
 ':'           Punctuation
 ' '           Text.Whitespace
 'sw1'         Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -828,7 +828,7 @@
 'touchscreen' Name.Function
 '@'           Operator
 '49'          Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\t'          Text.Whitespace
 '/* TSC2004 */' Comment.Multiline
@@ -933,7 +933,7 @@
 
 '&'           Operator
 'iomuxc'      Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -967,7 +967,7 @@
 ':'           Punctuation
 ' '           Text.Whitespace
 'hog-base-grp' Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1028,7 +1028,7 @@
 ':'           Punctuation
 ' '           Text.Whitespace
 'enet-100M-grp' Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1140,7 +1140,7 @@
 
 '&'           Operator
 'usdhc4'      Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1211,7 +1211,7 @@
 '\n'          Text.Whitespace
 
 '/'           Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1334,7 +1334,7 @@
 
 '\t'          Text.Whitespace
 'soc'         Name.Function
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -1375,7 +1375,7 @@
 'qcom,rpm-rbcpr-stats' Name.Function
 '@'           Operator
 '0x200000'    Literal.Number.Integer
-' '           Comment.Multiline
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/django/django_sample.html+django.output
+++ b/tests/examplefiles/django/django_sample.html+django.output
@@ -1,5 +1,5 @@
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"admin/base_site.html"' Literal.String.Double
@@ -8,7 +8,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'load'        Keyword
 ' '           Text
 'i18n'        Name.Variable
@@ -21,7 +21,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'extrahead'   Name.Variable
@@ -36,7 +36,7 @@
 '\n<script type="text/javascript" src="../../../jsi18n/"></script>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'js'          Name.Variable
@@ -47,55 +47,55 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include_admin_script' Keyword
 ' '           Text
 'js'          Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'stylesheet'  Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'admin_media_prefix' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 'css/forms.css' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'coltype'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'ordered_objects' Name.Variable
@@ -103,25 +103,25 @@
 '%}'          Comment.Preproc
 'colMS'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 'colM'        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bodyclass'   Name.Variable
@@ -143,14 +143,14 @@
 '}}'          Comment.Preproc
 ' change-form' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'userlinks'   Name.Variable
@@ -158,7 +158,7 @@
 '%}'          Comment.Preproc
 '<a href="../../../doc/">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 "'Documentation'" Literal.String.Single
@@ -166,7 +166,7 @@
 '%}'          Comment.Preproc
 '</a> / <a href="../../../password_change/">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 "'Change password'" Literal.String.Single
@@ -174,7 +174,7 @@
 '%}'          Comment.Preproc
 '</a> / <a href="../../../logout/">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 "'Log out'"   Literal.String.Single
@@ -182,21 +182,21 @@
 '%}'          Comment.Preproc
 '</a>'        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'breadcrumbs' Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'not'         Keyword
@@ -206,7 +206,7 @@
 '%}'          Comment.Preproc
 '\n<div class="breadcrumbs">\n     <a href="../../../">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"Home"'      Literal.String.Double
@@ -225,14 +225,14 @@
 '}}'          Comment.Preproc
 '</a> &rsaquo;\n     ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'add'         Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"Add"'       Literal.String.Double
@@ -248,7 +248,7 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -263,26 +263,26 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n</div>\n'  Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -291,14 +291,14 @@
 '<div id="content-main">\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'change'      Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'not'         Keyword
@@ -308,7 +308,7 @@
 '%}'          Comment.Preproc
 '\n  <ul class="object-tools"><li><a href="history/" class="historylink">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"History"'   Literal.String.Double
@@ -316,7 +316,7 @@
 '%}'          Comment.Preproc
 '</a></li>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'has_absolute_url' Name.Variable
@@ -336,7 +336,7 @@
 '}}'          Comment.Preproc
 '/" class="viewsitelink">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"View on site"' Literal.String.Double
@@ -344,24 +344,24 @@
 '%}'          Comment.Preproc
 '</a></li>'   Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 '%}'          Comment.Preproc
 '\n  </ul>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n<form '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'has_file_field' Name.Variable
@@ -369,7 +369,7 @@
 '%}'          Comment.Preproc
 'enctype="multipart/form-data" ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -388,21 +388,21 @@
 '}}'          Comment.Preproc
 '_form">'     Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'form_top'    Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n<div>\n'   Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'is_popup'    Name.Variable
@@ -410,14 +410,14 @@
 '%}'          Comment.Preproc
 '<input type="hidden" name="_popup" value="1" />' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'opts'        Name.Variable
@@ -426,19 +426,19 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'submit_row'  Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'form'        Name.Variable
@@ -447,7 +447,7 @@
 '%}'          Comment.Preproc
 '\n    <p class="errornote">\n    ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'blocktrans'  Keyword
 ' '           Text
 'count'       Name.Variable
@@ -465,27 +465,27 @@
 '%}'          Comment.Preproc
 'Please correct the error below.' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'plural'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 'Please correct the errors below.' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblocktrans' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    </p>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'bound_field_set' Name.Variable
@@ -504,7 +504,7 @@
 '}}'          Comment.Preproc
 '">\n    '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'bound_field_set' Name.Variable
@@ -520,13 +520,13 @@
 '}}'          Comment.Preproc
 '</h2>'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'bound_field_set' Name.Variable
@@ -542,13 +542,13 @@
 '}}'          Comment.Preproc
 '</div>'      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'bound_field_line' Name.Variable
@@ -560,7 +560,7 @@
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'admin_field_line' Keyword
 ' '           Text
 'bound_field_line' Name.Variable
@@ -568,7 +568,7 @@
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'bound_field' Name.Variable
@@ -580,7 +580,7 @@
 '%}'          Comment.Preproc
 '\n            ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter_interface_script_maybe' Keyword
 ' '           Text
 'bound_field' Name.Variable
@@ -588,41 +588,41 @@
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n   </fieldset>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'after_field_sets' Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'change'      Name.Variable
@@ -630,7 +630,7 @@
 '%}'          Comment.Preproc
 '\n   '       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'ordered_objects' Name.Variable
@@ -638,7 +638,7 @@
 '%}'          Comment.Preproc
 '\n   <fieldset class="module"><h2>' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"Ordering"'  Literal.String.Double
@@ -646,7 +646,7 @@
 '%}'          Comment.Preproc
 '</h2>\n   <div class="form-row' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'form'        Name.Variable
@@ -656,13 +656,13 @@
 '%}'          Comment.Preproc
 ' error'      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 ' ">\n   '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'form'        Name.Variable
@@ -678,13 +678,13 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n   <p><label for="id_order_">' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"Order:"'    Literal.String.Double
@@ -699,21 +699,21 @@
 '}}'          Comment.Preproc
 '</p>\n   </div></fieldset>\n   ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'related_object' Name.Variable
@@ -724,42 +724,42 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'edit_inline' Keyword
 ' '           Text
 'related_object' Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'after_related_objects' Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'submit_row'  Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'add'         Name.Variable
@@ -774,14 +774,14 @@
 '").focus();</script>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'auto_populated_fields' Name.Variable
@@ -789,7 +789,7 @@
 '%}'          Comment.Preproc
 '\n   <script type="text/javascript">\n   ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'auto_populated_field_script' Keyword
 ' '           Text
 'auto_populated_fields' Name.Variable
@@ -800,14 +800,14 @@
 '\n   </script>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n</div>\n</form></div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc

--- a/tests/examplefiles/dtd/test.dtd.output
+++ b/tests/examplefiles/dtd/test.dtd.output
@@ -1,11 +1,11 @@
 '<!DOCTYPE'   Keyword
-' '           Text
+' '           Text.Whitespace
 'html'        Name.Tag
 '>'           Keyword
 '\n\n'        Text
 
 '<!DOCTYPE'   Keyword
-' '           Text
+' '           Text.Whitespace
 'html'        Name.Tag
 ' '           Text
 'PUBLIC'      Keyword.Constant
@@ -18,7 +18,7 @@
 '\n\n\n'      Text
 
 '<!DOCTYPE'   Keyword
-' '           Text
+' '           Text.Whitespace
 'html'        Name.Tag
 ' '           Text
 'PUBLIC'      Keyword.Constant
@@ -40,7 +40,7 @@
 '\n\n'        Text
 
 '<!DOCTYPE'   Keyword
-' '           Text
+' '           Text.Whitespace
 'greeting'    Name.Tag
 ' '           Text
 'SYSTEM'      Keyword.Constant
@@ -50,13 +50,13 @@
 '\n\n'        Text
 
 '<!DOCTYPE'   Keyword
-' '           Text
+' '           Text.Whitespace
 'greeting'    Name.Tag
 ' '           Text
 '['           Keyword
 '\n  '        Text
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'greeting'    Name.Tag
 ' '           Text
 '('           Operator
@@ -71,7 +71,7 @@
 '\n\n'        Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'br'          Name.Tag
 ' '           Text
 'EMPTY'       Keyword.Constant
@@ -79,7 +79,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'p'           Name.Tag
 ' '           Text
 '('           Operator
@@ -93,7 +93,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 '%name.para;' Name.Tag
 ' '           Text
 '%content.para;' Name.Entity
@@ -102,7 +102,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'container'   Name.Tag
 ' '           Text
 'ANY'         Keyword.Constant
@@ -110,7 +110,7 @@
 '\n\n'        Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'spec'        Name.Tag
 ' '           Text
 '('           Operator
@@ -127,7 +127,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'div1'        Name.Tag
 ' '           Text
 '('           Operator
@@ -155,7 +155,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'dictionary-body' Name.Tag
 ' '           Text
 '('           Operator
@@ -170,7 +170,7 @@
 '\n\n'        Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'p'           Name.Tag
 ' '           Text
 '('           Operator
@@ -191,7 +191,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'p'           Name.Tag
 ' '           Text
 '('           Operator
@@ -219,7 +219,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'b'           Name.Tag
 ' '           Text
 '('           Operator
@@ -229,7 +229,7 @@
 '\n\n'        Text
 
 '<!ATTLIST'   Keyword
-' '           Text
+' '           Text.Whitespace
 'termdef'     Name.Tag
 '\n          ' Text
 'id'          Name.Attribute
@@ -247,7 +247,7 @@
 '\n'          Text
 
 '<!ATTLIST'   Keyword
-' '           Text
+' '           Text.Whitespace
 'list'        Name.Tag
 '\n          ' Text
 'type'        Name.Attribute
@@ -265,7 +265,7 @@
 '\n'          Text
 
 '<!ATTLIST'   Keyword
-' '           Text
+' '           Text.Whitespace
 'form'        Name.Tag
 '\n          ' Text
 'method'      Name.Attribute
@@ -279,7 +279,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'd'           Name.Entity
 ' '           Text
 '"&#xD;"'     Literal.String.Double
@@ -287,7 +287,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'a'           Name.Entity
 ' '           Text
 '"&#xA;"'     Literal.String.Double
@@ -295,7 +295,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'da'          Name.Entity
 ' '           Text
 '"&#xD;&#xA;"' Literal.String.Double
@@ -303,7 +303,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Entity
 ' '           Text
 'ISOLat2'     Name.Entity
@@ -316,14 +316,14 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'Pub-Status'  Name.Entity
 ' '           Text
 '"This is a pre-release of the\n specification."' Literal.String.Double
 '>'           Keyword
 '\n \n '      Text
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'open-hatch'  Name.Entity
 '\n         ' Text
 'SYSTEM'      Keyword.Constant
@@ -333,7 +333,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'open-hatch'  Name.Entity
 '\n         ' Text
 'PUBLIC'      Keyword.Constant
@@ -345,7 +345,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'hatch-pic'   Name.Entity
 '\n         ' Text
 'SYSTEM'      Keyword.Constant
@@ -360,7 +360,7 @@
 '\n         \n' Text
 
 '<!NOTATION'  Keyword
-' '           Text
+' '           Text.Whitespace
 'gif'         Name.Tag
 ' '           Text
 'PUBLIC'      Keyword.Constant
@@ -370,7 +370,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Entity
 ' '           Text
 'YN'          Name.Entity
@@ -381,7 +381,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'WhatHeSaid'  Name.Entity
 ' '           Text
 '"He said %YN;"' Literal.String.Double
@@ -390,7 +390,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'EndAttr'     Name.Entity
 ' '           Text
 '"27\'"'      Literal.String.Double
@@ -399,7 +399,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Entity
 ' '           Text
 'pub'         Name.Entity
@@ -410,7 +410,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-'   '         Text
+'   '         Text.Whitespace
 'rights'      Name.Entity
 ' '           Text
 '"All rights reserved"' Literal.String.Double
@@ -419,7 +419,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-'   '         Text
+'   '         Text.Whitespace
 'book'        Name.Entity
 '   '         Text
 '"La Peste: Albert Camus,\n&#xA9; 1947 %pub;. &rights;"' Literal.String.Double
@@ -428,7 +428,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'lt'          Name.Entity
 '     '       Text
 '"&#38;#60;"' Literal.String.Double
@@ -436,7 +436,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'gt'          Name.Entity
 '     '       Text
 '"&#62;"'     Literal.String.Double
@@ -444,7 +444,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'amp'         Name.Entity
 '    '        Text
 '"&#38;#38;"' Literal.String.Double
@@ -452,7 +452,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'apos'        Name.Entity
 '   '         Text
 '"&#39;"'     Literal.String.Double
@@ -460,7 +460,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 'quot'        Name.Entity
 '   '         Text
 '"&#34;"'     Literal.String.Double
@@ -468,7 +468,7 @@
 '\n\n'        Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Entity
 ' '           Text
 'draft'       Name.Entity
@@ -479,7 +479,7 @@
 '\n'          Text
 
 '<!ENTITY'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Entity
 ' '           Text
 'final'       Name.Entity
@@ -495,7 +495,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'book'        Name.Tag
 ' '           Text
 '('           Operator
@@ -526,7 +526,7 @@
 '\n'          Text
 
 '<!ELEMENT'   Keyword
-' '           Text
+' '           Text.Whitespace
 'book'        Name.Tag
 ' '           Text
 '('           Operator

--- a/tests/examplefiles/duel/jbst_example1.jbst.output
+++ b/tests/examplefiles/duel/jbst_example1.jbst.output
@@ -16,7 +16,7 @@
 
 '<'           Punctuation
 'script'      Name.Tag
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Attribute
 '='           Operator
 '"text/javascript"' Literal.String

--- a/tests/examplefiles/duel/jbst_example2.jbst.output
+++ b/tests/examplefiles/duel/jbst_example2.jbst.output
@@ -16,7 +16,7 @@
 
 '<'           Punctuation
 'script'      Name.Tag
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Attribute
 '='           Operator
 '"text/javascript"' Literal.String

--- a/tests/examplefiles/easytrieve/example.ezt.output
+++ b/tests/examplefiles/easytrieve/example.ezt.output
@@ -5,7 +5,7 @@
 '* Environtment section.\n' Comment.Single
 
 'PARM'        Keyword.Declaration
-' '           Operator
+' '           Text.Whitespace
 'DEBUG'       Name
 '('           Operator
 'FLOW'        Name
@@ -99,7 +99,7 @@
 '* Activity Section.\n' Comment.Single
 
 'JOB'         Keyword.Declaration
-' '           Operator
+' '           Text.Whitespace
 'INPUT'       Name
 ' '           Text.Whitespace
 'PERSNL'      Name
@@ -119,7 +119,7 @@
 
 '  '          Text.Whitespace
 'PRINT'       Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 'PAY-RPT'     Name
 '\n'          Text.Whitespace
 
@@ -134,7 +134,7 @@
 
 '  '          Text.Whitespace
 'TITLE'       Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 '01'          Literal.Number.Integer
 ' '           Text.Whitespace
 "'PERSONNEL REPORT EXAMPLE-1'" Literal.String
@@ -142,7 +142,7 @@
 
 '  '          Text.Whitespace
 'LINE'        Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 '01'          Literal.Number.Integer
 ' '           Text.Whitespace
 'DEPT'        Name
@@ -164,12 +164,12 @@
 
 '  '          Text.Whitespace
 'DISPLAY'     Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 "'PROCESSING...'" Literal.String
 '\n'          Text.Whitespace
 
 'END-PROC'    Keyword.Reserved
-'\n'          Operator
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -181,9 +181,9 @@
 
 '  '          Text.Whitespace
 'DISPLAY'     Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 "'DONE.'"     Literal.String
 '\n'          Text.Whitespace
 
 'END-PROC'    Keyword.Reserved
-'\n'          Operator
+'\n'          Text.Whitespace

--- a/tests/examplefiles/easytrieve/example.mac.output
+++ b/tests/examplefiles/easytrieve/example.mac.output
@@ -15,7 +15,7 @@
 '&PREFIX.'    Name.Variable
 '-'           Operator
 'LINE'        Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ' '           Text.Whitespace
 '80'          Literal.Number.Integer
@@ -26,7 +26,7 @@
 '&PREFIX.'    Name.Variable
 '-'           Operator
 'KEY'         Keyword.Reserved
-' '           Operator
+' '           Text.Whitespace
 ' '           Text.Whitespace
 '1'           Literal.Number.Integer
 '  '          Text.Whitespace

--- a/tests/examplefiles/fish/example.fish.output
+++ b/tests/examplefiles/fish/example.fish.output
@@ -58,7 +58,7 @@
 '# Powerline glyphs\n' Comment
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_branch_glyph' Text
 '            ' Text
 '\\u'         Literal.String.Escape
@@ -66,7 +66,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_ln_glyph' Text
 '                ' Text
 '\\u'         Literal.String.Escape
@@ -74,7 +74,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_padlock_glyph' Text
 '           ' Text
 '\\u'         Literal.String.Escape
@@ -82,7 +82,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_right_black_arrow_glyph' Text
 ' '           Text
 '\\u'         Literal.String.Escape
@@ -90,7 +90,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_right_arrow_glyph' Text
 '       '     Text
 '\\u'         Literal.String.Escape
@@ -98,7 +98,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_left_black_arrow_glyph' Text
 '  '          Text
 '\\u'         Literal.String.Escape
@@ -106,7 +106,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_left_arrow_glyph' Text
 '        '    Text
 '\\u'         Literal.String.Escape
@@ -116,7 +116,7 @@
 '# Additional glyphs\n' Comment
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_detached_glyph' Text
 '          '  Text
 '\\u'         Literal.String.Escape
@@ -124,28 +124,28 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_nonzero_exit_glyph' Text
 '      '      Text
 "'! '"        Literal.String.Single
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_superuser_glyph' Text
 '         '   Text
 "'$ '"        Literal.String.Single
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_bg_job_glyph' Text
 '            ' Text
 "'% '"        Literal.String.Single
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_hg_glyph' Text
 '                ' Text
 '\\u'         Literal.String.Escape
@@ -155,7 +155,7 @@
 '# Python glyphs\n' Comment
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_superscript_glyph' Text
 '       '     Text
 '\\u'         Literal.String.Escape
@@ -169,7 +169,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_virtualenv_glyph' Text
 '        '    Text
 '\\u'         Literal.String.Escape
@@ -177,7 +177,7 @@
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_pypy_glyph' Text
 '              ' Text
 '\\u'         Literal.String.Escape
@@ -187,126 +187,126 @@
 '# Colors\n'  Comment
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_green' Text
 '   '         Text
 'addc10'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_med_green' Text
 '  '          Text
 '189303'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_green' Text
 '   '         Text
 '0c4801'      Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_red' Text
 '     '       Text
 'C99'         Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_med_red' Text
 '    '        Text
 'ce000f'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_red' Text
 '     '       Text
 '600'         Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_slate_blue' Text
 ' '           Text
 '255e87'      Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_orange' Text
 '  '          Text
 'f6b117'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_orange' Text
 '  '          Text
 '3a2a03'      Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_grey' Text
 '    '        Text
 '333'         Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_med_grey' Text
 '   '         Text
 '999'         Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_grey' Text
 '    '        Text
 'ccc'         Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_brown' Text
 '   '         Text
 '4d2600'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_med_brown' Text
 '  '          Text
 '803F00'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_brown' Text
 '   '         Text
 'BF5E00'      Text
 '\n\n'        Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_dk_blue' Text
 '    '        Text
 '1E2933'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_med_blue' Text
 '   '         Text
 '275379'      Text
 '\n'          Text
 
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_lt_blue' Text
 '    '        Text
 '326D9E'      Text
@@ -321,7 +321,7 @@
 '\n'          Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_git' Text
 ' '           Text
 '-d'          Text
@@ -343,7 +343,7 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'command '    Name.Builtin
 'git'         Text
 ' '           Text
@@ -360,10 +360,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_hg' Text
 ' '           Text
 '-d'          Text
@@ -385,7 +385,7 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'command '    Name.Builtin
 'hg'          Text
 ' '           Text
@@ -401,10 +401,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_git_branch' Text
 ' '           Text
 '-d'          Text
@@ -471,7 +471,7 @@
 ')'           Operator
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'ref'         Text
 ' '           Text
 '"'           Literal.String.Double
@@ -481,7 +481,7 @@
 '"'           Literal.String.Double
 '\n  '        Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '$ref'        Name.Variable
@@ -498,10 +498,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_hg_branch' Text
 ' '           Text
 '-d'          Text
@@ -562,10 +562,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_pretty_parent' Text
 ' '           Text
 '-d'          Text
@@ -611,10 +611,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_git_project_dir' Text
 ' '           Text
 '-d'          Text
@@ -632,10 +632,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_hg_project_dir' Text
 ' '           Text
 '-d'          Text
@@ -651,10 +651,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_project_pwd' Text
 ' '           Text
 '-d'          Text
@@ -696,7 +696,7 @@
 '\n'          Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_start_segment' Text
 ' '           Text
 '-d'          Text
@@ -802,11 +802,11 @@
 ']'           Operator
 '\n    '      Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_current_bg' Text
 ' '           Text
 '$argv'       Name.Variable
@@ -816,10 +816,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_path_segment' Text
 ' '           Text
 '-d'          Text
@@ -827,7 +827,7 @@
 "'Display a shortened form of a directory'" Literal.String.Single
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-w'          Text
@@ -844,7 +844,7 @@
 '$__bobthefish_med_grey' Name.Variable
 '\n  '        Text
 'else'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 '__bobthefish_start_segment' Text
 ' '           Text
 '$__bobthefish_dk_red' Name.Variable
@@ -852,7 +852,7 @@
 '$__bobthefish_lt_red' Name.Variable
 '\n  '        Text
 'end'         Keyword
-'\n\n  '      Text
+'\n\n  '      Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -877,7 +877,7 @@
 '/'           Text
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'directory'   Text
 ' '           Text
 "'/'"         Literal.String.Single
@@ -889,7 +889,7 @@
 '"'           Literal.String.Double
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'directory'   Text
 ' '           Text
 "'~'"         Literal.String.Single
@@ -899,7 +899,7 @@
 "'*'"         Literal.String.Single
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'parent'      Text
 '    '        Text
 '('           Operator
@@ -912,7 +912,7 @@
 ')'           Operator
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'parent'      Text
 '    '        Text
 '"'           Literal.String.Double
@@ -921,7 +921,7 @@
 '"'           Literal.String.Double
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'directory'   Text
 ' '           Text
 '('           Operator
@@ -934,7 +934,7 @@
 ')'           Operator
 '\n  '        Text
 'end'         Keyword
-'\n\n  '      Text
+'\n\n  '      Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -943,7 +943,7 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -973,10 +973,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_finish_segments' Text
 ' '           Text
 '-d'          Text
@@ -1025,7 +1025,7 @@
 'normal'      Text
 '\n  '        Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-g'          Text
@@ -1047,7 +1047,7 @@
 '\n'          Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_status' Text
 ' '           Text
 '-d'          Text
@@ -1088,7 +1088,7 @@
 ']'           Operator
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'nonzero'     Text
 ' '           Text
 '$__bobthefish_nonzero_exit_glyph' Name.Variable
@@ -1125,7 +1125,7 @@
 ']'           Operator
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'superuser'   Text
 ' '           Text
 '$__bobthefish_superuser_glyph' Name.Variable
@@ -1158,13 +1158,13 @@
 ']'           Operator
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'bg_jobs'     Text
 ' '           Text
 '$__bobthefish_bg_job_glyph' Name.Variable
 '\n  '        Text
 'end'         Keyword
-'\n\n  '      Text
+'\n\n  '      Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -1178,7 +1178,7 @@
 '"'           Literal.String.Double
 '\n\n  '      Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1226,7 +1226,7 @@
 '$__bobthefish_nonzero_exit_glyph' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'if'          Keyword
 ' '           Text
 '['           Operator
@@ -1250,7 +1250,7 @@
 '$__bobthefish_superuser_glyph' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'if'          Keyword
 ' '           Text
 '['           Operator
@@ -1274,18 +1274,18 @@
 '$__bobthefish_bg_job_glyph' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'set_color '  Name.Builtin
 'normal'      Text
 '\n  '        Text
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_user' Text
 ' '           Text
 '-d'          Text
@@ -1368,15 +1368,15 @@
 "' '"         Literal.String.Single
 '\n    '      Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_hg' Text
 ' '           Text
 '-d'          Text
@@ -1397,7 +1397,7 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1423,9 +1423,9 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flags'       Text
 ' '           Text
 '""'          Literal.String.Double
@@ -1447,7 +1447,7 @@
 '$__bobthefish_dk_green' Name.Variable
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1455,19 +1455,19 @@
 '"'           Literal.String.Double
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_bg'     Text
 ' '           Text
 '$__bobthefish_med_red' Name.Variable
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_fg'     Text
 ' '           Text
 'fff'         Text
 '\n  '        Text
 'end'         Keyword
-'\n\n  '      Text
+'\n\n  '      Text.Whitespace
 '__bobthefish_path_segment' Text
 ' '           Text
 '('           Operator
@@ -1534,7 +1534,7 @@
 ')'           Operator
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1542,7 +1542,7 @@
 '"'           Literal.String.Double
 '\n    '      Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-w'          Text
@@ -1558,7 +1558,7 @@
 '999'         Text
 '\n    '      Text
 'else'        Keyword
-'\n      '    Text
+'\n      '    Text.Whitespace
 '__bobthefish_start_segment' Text
 ' '           Text
 '$__bobthefish_med_red' Name.Variable
@@ -1566,7 +1566,7 @@
 '$__bobthefish_lt_red' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1578,7 +1578,7 @@
 "' '"         Literal.String.Single
 '\n  '        Text
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
 '\n\n'        Text
@@ -1586,7 +1586,7 @@
 '# TODO: clean up the fugly $ahead business\n' Comment
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_git' Text
 ' '           Text
 '-d'          Text
@@ -1613,7 +1613,7 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1643,7 +1643,7 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1677,7 +1677,7 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1760,9 +1760,9 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'new'         Text
 ' '           Text
 "'…'"         Literal.String.Single
@@ -1789,9 +1789,9 @@
 ';'           Punctuation
 ' '           Text
 'and'         Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flags'       Text
 ' '           Text
 '"'           Literal.String.Double
@@ -1816,7 +1816,7 @@
 '$__bobthefish_dk_green' Name.Variable
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1830,21 +1830,21 @@
 '"'           Literal.String.Double
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_bg'     Text
 ' '           Text
 '$__bobthefish_med_red' Name.Variable
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_fg'     Text
 ' '           Text
 'fff'         Text
 '\n  '        Text
 'else'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1852,21 +1852,21 @@
 '"'           Literal.String.Double
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_bg'     Text
 ' '           Text
 '$__bobthefish_lt_orange' Name.Variable
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_fg'     Text
 ' '           Text
 '$__bobthefish_dk_orange' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'end'         Keyword
-'\n\n  '      Text
+'\n\n  '      Text.Whitespace
 '__bobthefish_path_segment' Text
 ' '           Text
 '('           Operator
@@ -1917,7 +1917,7 @@
 ')'           Operator
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -1925,7 +1925,7 @@
 '"'           Literal.String.Double
 '\n    '      Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-w'          Text
@@ -1941,7 +1941,7 @@
 '999'         Text
 '\n    '      Text
 'else'        Keyword
-'\n      '    Text
+'\n      '    Text.Whitespace
 '__bobthefish_start_segment' Text
 ' '           Text
 '$__bobthefish_med_red' Name.Variable
@@ -1949,7 +1949,7 @@
 '$__bobthefish_lt_red' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '-n'          Text
@@ -1961,13 +1961,13 @@
 "' '"         Literal.String.Single
 '\n  '        Text
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_dir' Text
 ' '           Text
 '-d'          Text
@@ -1982,10 +1982,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_virtualfish_virtualenv' Text
 '\n  '        Text
 'set'         Keyword
@@ -1996,10 +1996,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_virtualenv_python_version' Text
 ' '           Text
 '-d'          Text
@@ -2019,7 +2019,7 @@
 ')'           Operator
 '\n    '      Text
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 'python2'     Text
 '\n      '    Text
 'echo'        Keyword
@@ -2030,7 +2030,7 @@
 ']'           Operator
 '\n    '      Text
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 'python3'     Text
 '\n      '    Text
 'echo'        Keyword
@@ -2041,7 +2041,7 @@
 ']'           Operator
 '\n    '      Text
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 'pypy'        Text
 '\n      '    Text
 'echo'        Keyword
@@ -2049,13 +2049,13 @@
 '$__bobthefish_pypy_glyph' Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_virtualenv' Text
 ' '           Text
 '-d'          Text
@@ -2079,10 +2079,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_prompt_virtualfish' Text
 ' '           Text
 '-d'          Text
@@ -2090,13 +2090,13 @@
 '"Display activated virtual environment (only for virtualfish, virtualenv\'s activate.fish changes prompt by itself)"' Literal.String.Double
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_bg'     Text
 ' '           Text
 '$__bobthefish_lt_blue' Name.Variable
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'flag_fg'     Text
 ' '           Text
 '$__bobthefish_dk_blue' Name.Variable
@@ -2143,7 +2143,7 @@
 '\n'          Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_prompt' Name.Builtin
 ' '           Text
 '-d'          Text
@@ -2155,15 +2155,15 @@
 '__bobthefish_prompt_user' Text
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_virtualfish_virtualenv' Text
 '\n    '      Text
 '__bobthefish_prompt_virtualfish' Text
 '\n  '        Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_git' Text
 '       '     Text
 '# TODO: do this right.\n' Comment
@@ -2175,9 +2175,9 @@
 
 '  '          Text
 'else'        Keyword
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 '__bobthefish_in_hg' Text
 '   '         Text
 '# __bobthefish_git_project_dir vs __bobthefish_hg_project_dir\n' Comment
@@ -2189,11 +2189,11 @@
 
 '  '          Text
 'else'        Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 '__bobthefish_prompt_dir' Text
 '\n  '        Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 '__bobthefish_finish_segments' Text
 '\n'          Text
 
@@ -2225,7 +2225,7 @@
 '\n'          Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'funced'      Name.Builtin
 ' '           Text
 '--description' Text
@@ -2253,7 +2253,7 @@
 'funcname'    Text
 '\n    '      Text
 'while'       Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-q'          Text
@@ -2280,7 +2280,7 @@
 ' '           Text
 'funced\n                ' Name.Builtin
 'return'      Keyword
-' '           Text
+' '           Text.Whitespace
 '0'           Text
 '\n\n            ' Text
 'case'        Keyword
@@ -2290,7 +2290,7 @@
 '--editor'    Text
 '\n                ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'editor'      Text
 ' '           Text
 '$argv'       Name.Variable
@@ -2314,7 +2314,7 @@
 '--interactive' Text
 '\n                ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'interactive' Text
 ' '           Text
 '1'           Text
@@ -2324,7 +2324,7 @@
 '--'          Text
 '\n                ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'funcname'    Text
 ' '           Text
 '$funcname'   Name.Variable
@@ -2369,7 +2369,7 @@
 'normal'      Text
 '\n                ' Text
 'return'      Keyword
-' '           Text
+' '           Text.Whitespace
 '1'           Text
 '\n\n            ' Text
 'case'        Keyword
@@ -2379,7 +2379,7 @@
 "'.*'"        Literal.String.Single
 '\n                ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'funcname'    Text
 ' '           Text
 '$funcname'   Name.Variable
@@ -2390,7 +2390,7 @@
 ']'           Operator
 '\n        '  Text
 'end'         Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-e'          Text
@@ -2401,9 +2401,9 @@
 ']'           Operator
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'begin'       Keyword
 ';'           Punctuation
 ' '           Text
@@ -2418,9 +2418,9 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -2430,7 +2430,7 @@
 ';'           Punctuation
 ' '           Text
 'end'         Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'set_color '  Name.Builtin
 'red'         Text
 '\n        '  Text
@@ -2442,11 +2442,11 @@
 'normal'      Text
 '\n        '  Text
 'return'      Keyword
-' '           Text
+' '           Text.Whitespace
 '1'           Text
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -2462,7 +2462,7 @@
 "'-*'"        Literal.String.Single
 '\n        '  Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'init'        Text
 ' '           Text
 'function'    Keyword
@@ -2479,7 +2479,7 @@
 "'*'"         Literal.String.Single
 '\n        '  Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'init'        Text
 ' '           Text
 'function'    Keyword
@@ -2495,7 +2495,7 @@
 
 '    '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-n'          Text
@@ -2512,15 +2512,15 @@
 '\n        '  Text
 'eval '       Name.Builtin
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'editor_cmd'  Text
 ' '           Text
 '$editor'     Name.Variable
 '\n        '  Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Builtin
 ' '           Text
 '-f'          Text
@@ -2544,19 +2544,19 @@
 '"'           Literal.String.Double
 '\n            ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'editor'      Text
 ' '           Text
 'fish\n        ' Name.Builtin
 'end'         Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'end'         Keyword
 '\n\n    '    Text
 '# If no editor is specified, use fish\n' Comment
 
 '    '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-z'          Text
@@ -2566,14 +2566,14 @@
 '"'           Literal.String.Double
 '\n        '  Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'editor'      Text
 ' '           Text
 'fish\n    '  Name.Builtin
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'begin'       Keyword
 ';'           Punctuation
 ' '           Text
@@ -2588,7 +2588,7 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '"'           Literal.String.Double
@@ -2601,7 +2601,7 @@
 ';'           Punctuation
 ' '           Text
 'end'         Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -2609,7 +2609,7 @@
 'IFS'         Text
 '\n        '  Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'functions'   Name.Builtin
 ' '           Text
 '-q'          Text
@@ -2622,7 +2622,7 @@
 
 '            ' Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'init'        Text
 ' '           Text
 '('           Operator
@@ -2640,7 +2640,7 @@
 ')'           Operator
 '\n        '  Text
 'end'         Keyword
-'\n\n        ' Text
+'\n\n        ' Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -2661,7 +2661,7 @@
 'IFS'         Text
 '\n        '  Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'read'        Name.Builtin
 ' '           Text
 '-p'          Text
@@ -2702,13 +2702,13 @@
 ')'           Operator
 '\n        '  Text
 'end'         Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'return'      Keyword
-' '           Text
+' '           Text.Whitespace
 '0'           Text
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-q'          Text
@@ -2717,7 +2717,7 @@
 ';'           Punctuation
 ' '           Text
 'or'          Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -2748,7 +2748,7 @@
 ')'           Operator
 '\n    '      Text
 'while'       Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-f'          Text
@@ -2756,7 +2756,7 @@
 '$tmpname'    Name.Variable
 '\n        '  Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'tmpname'     Text
 ' '           Text
 '('           Operator
@@ -2775,9 +2775,9 @@
 ')'           Operator
 '\n    '      Text
 'end'         Keyword
-'\n\n    '    Text
+'\n\n    '    Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'functions'   Name.Builtin
 ' '           Text
 '-q'          Text
@@ -2797,7 +2797,7 @@
 '$tmpname'    Name.Variable
 '\n    '      Text
 'else'        Keyword
-'\n        '  Text
+'\n        '  Text.Whitespace
 'echo'        Keyword
 ' '           Text
 '$init'       Name.Variable
@@ -2807,9 +2807,9 @@
 '$tmpname'    Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'eval'        Name.Builtin
 ' '           Text
 '$editor'     Name.Variable
@@ -2821,7 +2821,7 @@
 '$tmpname'    Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-l'          Text
@@ -2898,7 +2898,7 @@
 '\n\n'        Text
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-q'          Text
@@ -2906,7 +2906,7 @@
 'XDG_CONFIG_HOME' Text
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'configdir'   Text
 ' '           Text
 '$XDG_CONFIG_HOME' Name.Variable
@@ -2928,9 +2928,9 @@
 '\n'          Text
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-q'          Text
@@ -2938,7 +2938,7 @@
 'fish_function_path' Text
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_function_path' Text
 ' '           Text
 '$configdir'  Name.Variable
@@ -2952,12 +2952,12 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'contains'    Name.Builtin
 ' '           Text
 '$__fish_datadir' Name.Variable
@@ -2966,7 +2966,7 @@
 '$fish_function_path' Name.Variable
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_function_path' Text
 '['           Operator
 '-1'          Text
@@ -2977,12 +2977,12 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 '-q'          Text
@@ -2990,7 +2990,7 @@
 'fish_complete_path' Text
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_complete_path' Text
 ' '           Text
 '$configdir'  Name.Variable
@@ -3004,12 +3004,12 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'contains'    Name.Builtin
 ' '           Text
 '$__fish_datadir' Name.Variable
@@ -3018,7 +3018,7 @@
 '$fish_complete_path' Name.Variable
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_complete_path' Text
 '['           Operator
 '-1'          Text
@@ -3048,7 +3048,7 @@
 '\n'          Text
 
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-d'          Text
@@ -3056,9 +3056,9 @@
 '/usr/xpg4/bin' Text
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'contains'    Name.Builtin
 ' '           Text
 '/usr/xpg4/bin' Text
@@ -3066,7 +3066,7 @@
 '$PATH'       Name.Variable
 '\n    '      Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'PATH'        Text
 ' '           Text
 '/usr/xpg4/bin' Text
@@ -3074,7 +3074,7 @@
 '$PATH'       Name.Variable
 '\n  '        Text
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
 '\n\n'        Text
@@ -3115,11 +3115,11 @@
 '$USER'       Name.Variable
 '\n  '        Text
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 'root'        Text
 '\n  '        Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'path_list'   Text
 ' '           Text
 '$path_list'  Name.Variable
@@ -3132,10 +3132,10 @@
 '\n'          Text
 
 'end'         Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 'i'           Text
 ' '           Text
 'in'          Keyword
@@ -3143,9 +3143,9 @@
 '$path_list'  Name.Variable
 '\n  '        Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'contains'    Name.Builtin
 ' '           Text
 '$i'          Name.Variable
@@ -3153,7 +3153,7 @@
 '$PATH'       Name.Variable
 '\n    '      Text
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Keyword
 ' '           Text
 '-d'          Text
@@ -3161,7 +3161,7 @@
 '$i'          Name.Variable
 '\n      '    Text
 'set'         Keyword
-' '           Text
+' '           Text.Whitespace
 'PATH'        Text
 ' '           Text
 '$PATH'       Name.Variable
@@ -3169,9 +3169,9 @@
 '$i'          Name.Variable
 '\n    '      Text
 'end'         Keyword
-'\n  '        Text
+'\n  '        Text.Whitespace
 'end'         Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword
 '\n\n'        Text
@@ -3183,7 +3183,7 @@
 '#\n'         Comment
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'fish_sigtrap_handler' Text
 ' '           Text
 '--on-signal' Text
@@ -3212,7 +3212,7 @@
 '#\n'         Comment
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__fish_on_interactive' Text
 ' '           Text
 '--on-event'  Text

--- a/tests/examplefiles/genshitext/genshitext_example.genshitext.output
+++ b/tests/examplefiles/genshitext/genshitext_example.genshitext.output
@@ -1,4 +1,4 @@
-'   '         Text
+'   '         Text.Whitespace
 '## a comment' Comment
 '\n'          Other
 
@@ -15,7 +15,7 @@
 'comment'     Other
 '\n'          Other
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '#'           Comment.Preproc
 'if'          Keyword
@@ -47,10 +47,10 @@
 'choose'      Keyword
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'when'        Keyword
-' '           Text
+' '           Text.Whitespace
 '0'           Literal.Number.Integer
 ' '           Text
 '=='          Operator
@@ -65,15 +65,15 @@
 '0'           Other
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'end'         Keyword
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'when'        Keyword
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ' '           Text
 '=='          Operator
@@ -88,12 +88,12 @@
 '1'           Other
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'end'         Keyword
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'otherwise'   Keyword
 '\n'          Other
@@ -105,18 +105,18 @@
 '2'           Other
 '\n'          Other
 
-'  '          Text
+'  '          Text.Whitespace
 '#'           Comment.Preproc
 'end'         Keyword
 '\n'          Other
 
 '#'           Comment.Preproc
 'end'         Keyword
-' '           Text
+' '           Text.Whitespace
 '-- comment about choose' Comment
 '\n'          Other
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '#'           Comment.Preproc
 'for'         Keyword
@@ -141,11 +141,11 @@
 'end'         Keyword
 '\n'          Other
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '#'           Comment.Preproc
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'greeting'    Name.Function
 '('           Punctuation
 'name'        Name
@@ -176,11 +176,11 @@
 '}'           Comment.Preproc
 '\n'          Other
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '#'           Comment.Preproc
 'with'        Keyword
-' '           Text
+' '           Text.Whitespace
 'y'           Name
 '='           Operator
 '7'           Literal.Number.Integer

--- a/tests/examplefiles/hexdump/hexdump_debugexe.output
+++ b/tests/examplefiles/hexdump/hexdump_debugexe.output
@@ -3075,7 +3075,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -3555,7 +3555,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -3635,7 +3635,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -3675,7 +3675,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -3755,7 +3755,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -3875,7 +3875,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -8235,7 +8235,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -8355,7 +8355,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label
@@ -10115,7 +10115,7 @@
 ' '           Text.Whitespace
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'                ' Literal.String
+'                ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000'        Name.Label

--- a/tests/examplefiles/hexdump/hexdump_hd.output
+++ b/tests/examplefiles/hexdump/hexdump_hd.output
@@ -3151,7 +3151,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3643,7 +3643,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3725,7 +3725,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3810,7 +3810,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3933,7 +3933,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -8402,7 +8402,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -8525,7 +8525,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 
@@ -10329,7 +10329,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '|'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '|'           Punctuation
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/hexdump/hexdump_hexdump.output
+++ b/tests/examplefiles/hexdump/hexdump_hexdump.output
@@ -8305,7 +8305,7 @@
 ' '           Text.Whitespace
 ' '           Text.Whitespace
 '   '         Text.Whitespace
-'                    ' Literal.String
+'                    ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0001343'     Name.Label

--- a/tests/examplefiles/hexdump/hexdump_od.output
+++ b/tests/examplefiles/hexdump/hexdump_od.output
@@ -2997,7 +2997,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3465,7 +3465,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3543,7 +3543,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3624,7 +3624,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -3741,7 +3741,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -7992,7 +7992,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -8109,7 +8109,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 
@@ -9825,7 +9825,7 @@
 '20'          Literal.Number.Hex
 '  '          Text.Whitespace
 '>'           Punctuation
-'                ' Literal.String
+'                ' Text.Whitespace
 '<'           Punctuation
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/hexdump/hexdump_xxd.output
+++ b/tests/examplefiles/hexdump/hexdump_xxd.output
@@ -2305,7 +2305,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '00004d0'     Name.Label
@@ -2665,7 +2665,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000590'     Name.Label
@@ -2725,7 +2725,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '00005b0'     Name.Label
@@ -2755,7 +2755,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '00005c0'     Name.Label
@@ -2815,7 +2815,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '00005e0'     Name.Label
@@ -2905,7 +2905,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000610'     Name.Label
@@ -6175,7 +6175,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000ce0'     Name.Label
@@ -6265,7 +6265,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000d10'     Name.Label
@@ -7585,7 +7585,7 @@
 '20'          Literal.Number.Hex
 '20'          Literal.Number.Hex
 '   '         Text.Whitespace
-'               ' Literal.String
+'               ' Text.Whitespace
 '\n'          Text.Whitespace
 
 '0000fd0'     Name.Label

--- a/tests/examplefiles/html+handlebars/demo.hbs.output
+++ b/tests/examplefiles/html+handlebars/demo.hbs.output
@@ -86,14 +86,14 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 'myPartial'   Name.Variable
 '}}'          Comment.Preproc
 '\n'          Text
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 'myPartial'   Name.Variable
 ' '           Text
 'var'         Name.Attribute
@@ -105,7 +105,7 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 'myPartial'   Name.Variable
 ' '           Text
 'var'         Name.Attribute
@@ -116,7 +116,7 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'myPartial'   Name.Function
 ')'           Punctuation
@@ -125,7 +125,7 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'myPartial'   Name.Function
 ')'           Punctuation
@@ -138,12 +138,12 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'lookup'      Keyword
-' '           Text
+' '           Text.Whitespace
 '.'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"myPartial"' Literal.String.Double
 ')'           Punctuation
 '}}'          Comment.Preproc
@@ -151,13 +151,13 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 ' '           Text
 'lookup'      Keyword
-' '           Text
+' '           Text.Whitespace
 '.'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"myPartial"' Literal.String.Double
 ' '           Text
 ')'           Punctuation
@@ -171,10 +171,10 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'lookup'      Keyword
-' '           Text
+' '           Text.Whitespace
 '../foo'      Name.Variable
 ' '           Text
 '"myPartial"' Literal.String.Double
@@ -189,7 +189,7 @@
 
 '{{'          Comment.Preproc
 '>'           Keyword
-' '           Text
+' '           Text.Whitespace
 '@partial-block' Keyword
 '}}'          Comment.Preproc
 '\n\n'        Text

--- a/tests/examplefiles/html/example.xhtml.output
+++ b/tests/examplefiles/html/example.xhtml.output
@@ -8,7 +8,7 @@
 '\n    '      Text
 '<'           Punctuation
 'script'      Name.Tag
-' '           Text
+' '           Text.Whitespace
 'lang'        Name.Attribute
 '='           Operator
 '"javascript"' Literal.String

--- a/tests/examplefiles/http/http_request_example.output
+++ b/tests/examplefiles/http/http_request_example.output
@@ -1,11 +1,11 @@
 'POST'        Name.Function
-' '           Text
+' '           Text.Whitespace
 '/demo/submit/' Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.1'         Literal.Number
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Host'        Name.Attribute
 ''            Text

--- a/tests/examplefiles/http/http_response_example.output
+++ b/tests/examplefiles/http/http_response_example.output
@@ -1,11 +1,11 @@
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.1'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 '200'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 'OK'          Name.Exception
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Date'        Name.Attribute
 ''            Text

--- a/tests/examplefiles/hybris/hybris_File.hy.output
+++ b/tests/examplefiles/hybris/hybris_File.hy.output
@@ -2,7 +2,7 @@
 '\n'          Text
 
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'std.io.file' Name.Namespace
 ';'           Operator
 '\n'          Text
@@ -10,7 +10,7 @@
 '\n'          Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'File'        Name.Class
 ' '           Text
 '{'           Operator

--- a/tests/examplefiles/jags/example.jag.output
+++ b/tests/examplefiles/jags/example.jag.output
@@ -88,7 +88,7 @@
 '\n'          Text
 
 'data'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n   '       Text
 'for'         Keyword.Reserved
@@ -197,7 +197,7 @@
 '\n'          Text
 
 'model'       Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 '# 2-parameter Rasch model' Comment.Single

--- a/tests/examplefiles/jcl/example.jcl.output
+++ b/tests/examplefiles/jcl/example.jcl.output
@@ -202,7 +202,7 @@
 'O'           Literal.String
 'S'           Literal.String
 'T'           Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '//'          Keyword.Pseudo
 ' '           Literal.String

--- a/tests/examplefiles/julia/string.jl.output
+++ b/tests/examplefiles/julia/string.jl.output
@@ -10,7 +10,7 @@
 '\n'          Text.Whitespace
 
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'StringIndexError' Keyword.Type
 ' '           Text.Whitespace
 '<:'          Operator

--- a/tests/examplefiles/logos/logos_example.xm.output
+++ b/tests/examplefiles/logos/logos_example.xm.output
@@ -1,10 +1,10 @@
 '%hook'       Keyword
-' '           Text
+' '           Text.Whitespace
 'ABC'         Name.Class
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'id'          Keyword.Type
 ')'           Punctuation
@@ -36,17 +36,17 @@
 '\n'          Text.Whitespace
 
 '%end'        Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '%subclass'   Keyword
-' '           Text
+' '           Text.Whitespace
 'DEF'         Name.Class
 ': '          Text
 'NSObject'    Name.Builtin.Pseudo
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'id'          Keyword.Type
 ')'           Punctuation
@@ -78,20 +78,20 @@
 '\n'          Text.Whitespace
 
 '%end'        Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '%group'      Keyword
-' '           Text
+' '           Text.Whitespace
 'OptionalHooks' Name.Class
 '\n'          Text.Whitespace
 
 '%hook'       Keyword
-' '           Text
+' '           Text.Whitespace
 'ABC'         Name.Class
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -118,13 +118,13 @@
 '\n'          Text.Whitespace
 
 '%end'        Keyword
-'\n'          Text
+'\n'          Text.Whitespace
 
 '%end'        Keyword
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '%ctor'       Keyword
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/mako/test.mao.output
+++ b/tests/examplefiles/mako/test.mao.output
@@ -38,7 +38,7 @@
 '/'           Literal.String.Single
 "'"           Literal.String.Single
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\t\t\t/ '    Other
 '${'          Comment.Preproc
@@ -49,7 +49,7 @@
 '\n\t\t'      Text.Whitespace
 '%'           Comment.Preproc
 ' endif'      Keyword
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\t</title>\n\t<link type="text/css" rel="stylesheet" href="/style.css" />\n</head>\n<body>\n\t<div class="header-wrapper">\n\t    <header>\n\t        <nav>\n\t            <ul>\n' Other
 
@@ -71,7 +71,7 @@
 "'"           Literal.String.Single
 ']'           Punctuation
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\t\t\t\t\t\t<li>\n\t\t\t\t\t\t<a href="' Other
 '${'          Comment.Preproc
@@ -97,7 +97,7 @@
 ' '           Text
 'item'        Name
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\t\t\t\t\t\t\t<img src="' Other
 '${'          Comment.Preproc
@@ -113,9 +113,9 @@
 '\t\t\t\t\t\t\t' Text.Whitespace
 '%'           Comment.Preproc
 ' endif'      Keyword
-'\n'          Other
+'\n'          Text.Whitespace
 
-'\t\t\t\t\t\t\t' Other
+'\t\t\t\t\t\t\t' Text.Whitespace
 '${'          Comment.Preproc
 'item'        Name
 '['           Punctuation
@@ -129,7 +129,7 @@
 '\t\t\t\t\t'  Text.Whitespace
 '%'           Comment.Preproc
 ' endfor'     Keyword
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\t\t\t\t</ul>\n\t    \t</nav>\n\t    </header>\n\t</div>\n\t<div id="container">\n\t\t<section id="content">\n\t\t' Other
 '${'          Comment.Preproc

--- a/tests/examplefiles/md/example.md.output
+++ b/tests/examplefiles/md/example.md.output
@@ -1,10 +1,10 @@
 '# this is a header' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 '## this is a 2nd level header' Generic.Subheading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -98,7 +98,7 @@
 'is'          Text
 ' '           Text
 'italic:'     Text
-' '           Text
+' '           Text.Whitespace
 '*italic*'    Generic.Emph
 '\n'          Text.Whitespace
 
@@ -109,7 +109,7 @@
 'is'          Text
 ' '           Text
 'italic:'     Text
-' '           Text
+' '           Text.Whitespace
 '_italic_'    Generic.Emph
 '\n'          Text.Whitespace
 
@@ -182,9 +182,9 @@
 'is'          Text
 ' '           Text
 'bold:'       Text
-' '           Text
+' '           Text.Whitespace
 '**bold**'    Generic.Strong
-' '           Text
+' '           Text.Whitespace
 '**two or more words**' Generic.Strong
 '\n'          Text.Whitespace
 
@@ -195,9 +195,9 @@
 'is'          Text
 ' '           Text
 'bold:'       Text
-' '           Text
+' '           Text.Whitespace
 '__bold__'    Generic.Strong
-' '           Text
+' '           Text.Whitespace
 '__two or more words__' Generic.Strong
 '\n'          Text.Whitespace
 
@@ -238,7 +238,7 @@
 'is'          Text
 ' '           Text
 'strikethrough:' Text
-' '           Text
+' '           Text.Whitespace
 '~~bold~~'    Generic.Deleted
 '\n'          Text.Whitespace
 
@@ -270,7 +270,7 @@
 'italics'     Text
 ' '           Text
 'inside:'     Text
-' '           Text
+' '           Text.Whitespace
 '**the next _word_ should have been italics**' Generic.Strong
 '\n'          Text.Whitespace
 
@@ -288,7 +288,7 @@
 'this'        Text
 ' '           Text
 'sentence'    Text
-' '           Text
+' '           Text.Whitespace
 '`has monospace`' Literal.String.Backtick
 ' '           Text
 'in'          Text
@@ -366,9 +366,9 @@
 '\n'          Text
 
 'from'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'pygments'    Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword.Namespace
 ' '           Text
 'token'       Name

--- a/tests/examplefiles/modelica/Constants.mo.output
+++ b/tests/examplefiles/modelica/Constants.mo.output
@@ -546,7 +546,7 @@
 ' '           Text
 'href'        Name.Attribute
 '='           Operator
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\\"http://physics.nist.gov/cuu/Constants/\\"' Literal.String
 '>'           Punctuation

--- a/tests/examplefiles/mupad/function.mu.output
+++ b/tests/examplefiles/mupad/function.mu.output
@@ -1,5 +1,5 @@
 'a::b'        Name.Function
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 ')'           Punctuation
 '\n'          Text.Whitespace

--- a/tests/examplefiles/myghty/test.myt.output
+++ b/tests/examplefiles/myghty/test.myt.output
@@ -50,16 +50,16 @@
 
 '    '        Text
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'string'      Name.Namespace
 ','           Operator
-' '           Text
+' '           Text.Whitespace
 're'          Name.Namespace
 '\n'          Text
 
 '    '        Text
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'highlight'   Name.Namespace
 '\n'          Text
 
@@ -321,7 +321,7 @@
 '</h3>\n'     Other
 
 '%'           Name.Tag
-'\n'          Other
+'\n'          Text.Whitespace
 
 '\n    '      Text
 '<div class="sectiontext">\n    ' Other
@@ -349,7 +349,7 @@
 ' '           Text
 '1'           Literal.Number.Integer
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '%'           Name.Tag
 '   '         Text
@@ -376,7 +376,7 @@
 'depth'       Name
 ')'           Punctuation
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '    '        Text
 '<a href="#'  Other
@@ -394,13 +394,13 @@
 '" class="toclink">back to section top</a>\n' Other
 
 '%'           Name.Tag
-'\n'          Other
+'\n'          Text.Whitespace
 
 '%'           Name.Tag
 ' '           Text
 'else'        Keyword
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '    '        Text
 '<a href="#'  Other
@@ -434,7 +434,7 @@
 
 '%'           Name.Tag
 ' '           Text
-'\n'          Other
+'\n'          Text.Whitespace
 
 '</div>\n\n'  Other
 
@@ -456,7 +456,7 @@
 
 '        '    Text
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 're'          Name.Namespace
 '\n'          Text
 
@@ -652,7 +652,7 @@
 
 '    '        Text
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'fix_indent'  Name.Function
 '('           Punctuation
 'f'           Name
@@ -913,7 +913,7 @@
 
 '    '        Text
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'hlight'      Name.Function
 '('           Punctuation
 'match'       Name
@@ -1037,7 +1037,7 @@
 ' '           Text
 'None'        Keyword.Constant
 ':'           Punctuation
-'\n'          Other
+'\n'          Text.Whitespace
 
 '    '        Text
 '<div class="codetitle">' Other
@@ -1049,7 +1049,7 @@
 '</div>\n'    Other
 
 '%'           Name.Tag
-'\n'          Other
+'\n'          Text.Whitespace
 
 '<%'          Name.Tag
 ' '           Text
@@ -1413,7 +1413,7 @@
 '>'           Operator
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 '\'\'\'PYESC<& nav.myt:link, href=href, text=link, class_="codepoplink" &>PYESC\'\'\'' Literal.String.Doc
 '\n'          Text
 

--- a/tests/examplefiles/newspeak/example.ns2.output
+++ b/tests/examplefiles/newspeak/example.ns2.output
@@ -5,11 +5,11 @@
 '\n\n'        Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ShapesExperiment' Name.Class
-' '           Text
+' '           Text.Whitespace
 'usingLib:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'platform'    Name.Variable
 ' '           Text
 '='           Operator
@@ -23,7 +23,7 @@
 '|'           Operator
 '\n\t'        Text
 'CanvasDependent' Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'platform'    Name.Variable
@@ -32,7 +32,7 @@
 '.'           Punctuation
 '\n\t'        Text
 'Presenter'   Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'platform'    Name.Variable
@@ -41,7 +41,7 @@
 '.'           Punctuation
 '\n\t'        Text
 'Subject'     Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'platform'    Name.Variable
@@ -50,7 +50,7 @@
 '.'           Punctuation
 '\n\t'        Text
 'EllipseShape' Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'platform'    Name.Variable
@@ -59,7 +59,7 @@
 '.'           Punctuation
 '\n\t'        Text
 'Color'       Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'platform'    Name.Variable
@@ -78,9 +78,9 @@
 '\n\n'        Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ShapesExperimentSubject' Name.Class
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'Subject'     Name.Variable
@@ -104,7 +104,7 @@
 '\n'          Text
 
 'createPresenter' Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -115,7 +115,7 @@
 'new'         Name.Variable
 ' '           Text
 'subject:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'self'        Name.Variable
 '.'           Punctuation
 '\n'          Text
@@ -127,9 +127,9 @@
 '\n\n'        Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ShapesExperimentPresenter' Name.Class
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'Presenter'   Name.Variable
@@ -154,7 +154,7 @@
 '\n'          Text
 
 'controlPoint' Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -170,7 +170,7 @@
 '\n\n'        Text
 
 'definition'  Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -194,7 +194,7 @@
 '10'          Literal.Number.Integer
 ' '           Text
 'display:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'controlPoint' Name.Variable
 '.'           Punctuation
 ' \n               ' Text
@@ -207,7 +207,7 @@
 '10'          Literal.Number.Integer
 ' '           Text
 'display:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'controlPoint' Name.Variable
 '.'           Punctuation
 '\n          ' Text
@@ -223,9 +223,9 @@
 '\n\n'        Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ControlPoint' Name.Class
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'CanvasDependent' Name.Variable
@@ -249,7 +249,7 @@
 '\n'          Text
 
 'addVisualsTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'container'   Name.Variable
 ' '           Text
 '='           Operator
@@ -259,7 +259,7 @@
 'container'   Name.Variable
 ' '           Text
 'add:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'visual'      Name.Variable
 '.'           Punctuation
 '\n      '    Text
@@ -271,7 +271,7 @@
 '\n\n'        Text
 
 'createVisual' Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -300,7 +300,7 @@
 's'           Name.Variable
 ' '           Text
 'color:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'Color'       Name.Variable
 ' '           Text
 'red'         Name.Variable

--- a/tests/examplefiles/newspeak/minimal.ns2.output
+++ b/tests/examplefiles/newspeak/minimal.ns2.output
@@ -1,7 +1,7 @@
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'A'           Name.Class
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -9,7 +9,7 @@
 '|'           Operator
 ' '           Text
 'a'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'self'        Keyword
@@ -24,7 +24,7 @@
 '('           Punctuation
 '\n    '      Text
 'm'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Punctuation
@@ -51,9 +51,9 @@
 '\n'          Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'B'           Name.Class
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'C'           Name.Variable
@@ -63,13 +63,13 @@
 '|'           Operator
 ' '           Text
 'b0'          Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '0.'          Literal.Number.Float
 ' '           Text
 'b1'          Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 'b0'          Name.Variable

--- a/tests/examplefiles/objective-c/objc_example.m.output
+++ b/tests/examplefiles/objective-c/objc_example.m.output
@@ -81,7 +81,7 @@
 '// Class forward declaration\n' Comment.Single
 
 '@class'      Keyword
-' '           Text
+' '           Text.Whitespace
 'MyClass'     Name.Builtin.Pseudo
 ';'           Text
 '\n'          Text.Whitespace
@@ -91,7 +91,7 @@
 '// Empty classes\n' Comment.Single
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'EmptyClass'  Name.Class
 '\n'          Text.Whitespace
 
@@ -99,9 +99,9 @@
 '\n'          Text.Whitespace
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'EmptyClass2' Name.Class
-'\n'          Text
+'\n'          Text.Whitespace
 
 '{'           Punctuation
 '\n'          Text.Whitespace
@@ -113,11 +113,11 @@
 '\n'          Text.Whitespace
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'EmptyClass3' Name.Class
 ' : '         Text
 'EmptyClass2' Name.Class
-'\n'          Text
+'\n'          Text.Whitespace
 
 '{'           Punctuation
 '\n'          Text.Whitespace
@@ -133,11 +133,11 @@
 '// Custom class inheriting from built-in\n' Comment.Single
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'MyClass'     Name.Builtin.Pseudo
 ' : '         Text
 'NSObject'    Name.Builtin.Pseudo
-'\n'          Text
+'\n'          Text.Whitespace
 
 '{'           Punctuation
 '\n'          Text.Whitespace
@@ -247,7 +247,7 @@
 '// Class methods\n' Comment.Single
 
 '+'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -262,7 +262,7 @@
 '\n'          Text.Whitespace
 
 '+'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -272,7 +272,7 @@
 ' '           Text.Whitespace
 '*'           Operator
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'arg'         Name.Variable
 ';'           Punctuation
 ' '           Text.Whitespace
@@ -306,7 +306,7 @@
 '// Class extension to declare private property\n' Comment.Single
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'MyClass'     Name.Builtin.Pseudo
 ' '           Text.Whitespace
 '('           Punctuation
@@ -326,7 +326,7 @@
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -342,9 +342,9 @@
 '// Special category\n' Comment.Single
 
 '@interface'  Keyword
-' '           Text
+' '           Text.Whitespace
 'MyClass'     Name.Builtin.Pseudo
-' '           Text
+' '           Text.Whitespace
 '(Special)'   Name.Label
 '\n'          Text.Whitespace
 
@@ -366,7 +366,7 @@
 '\n'          Text.Whitespace
 
 '@implementation' Keyword
-' '           Text
+' '           Text.Whitespace
 'MyClass'     Name.Builtin.Pseudo
 '\n'          Text.Whitespace
 
@@ -385,7 +385,7 @@
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'id'          Keyword.Type
 ')'           Punctuation
@@ -1121,7 +1121,7 @@
 '\n'          Text.Whitespace
 
 '-'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -1170,7 +1170,7 @@
 '\n'          Text.Whitespace
 
 '+'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -1187,7 +1187,7 @@
 '\n'          Text.Whitespace
 
 '+'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'void'        Keyword.Type
 ')'           Punctuation
@@ -1197,7 +1197,7 @@
 ' '           Text.Whitespace
 '*'           Operator
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'arg'         Name.Variable
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/perl/perl_misc.output
+++ b/tests/examplefiles/perl/perl_misc.output
@@ -5,19 +5,19 @@
 '\n'          Text
 
 'use'         Keyword
-' '           Text
+' '           Text.Whitespace
 'strict'      Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
 'use'         Keyword
-' '           Text
+' '           Text.Whitespace
 'warnings'    Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
 'use'         Keyword
-' '           Text
+' '           Text.Whitespace
 'Time::HiRes' Name.Namespace
 ' '           Text
 "'usleep'"    Literal.String

--- a/tests/examplefiles/perl/perl_perl5db.output
+++ b/tests/examplefiles/perl/perl_perl5db.output
@@ -23,7 +23,7 @@
 '\n\n'        Text
 
 'sub'         Keyword
-' '           Text
+' '           Text.Whitespace
 'eval'        Name.Function
 ' '           Text
 '{'           Punctuation
@@ -533,12 +533,12 @@
 '{'           Punctuation
 '\n\t'        Text
 'require'     Keyword
-' '           Text
+' '           Text.Whitespace
 'threads'     Name.Namespace
 ';'           Punctuation
 '\n\t'        Text
 'require'     Keyword
-' '           Text
+' '           Text.Whitespace
 'threads::shared' Name.Namespace
 ';'           Punctuation
 '\n\t'        Text
@@ -1722,7 +1722,7 @@
 '{'           Punctuation
 ' '           Text
 'require'     Keyword
-' '           Text
+' '           Text.Whitespace
 'Config'      Name.Namespace
 ' '           Text
 '}'           Punctuation
@@ -2078,7 +2078,7 @@
 '\n'          Text
 
 'sub'         Keyword
-' '           Text
+' '           Text.Whitespace
 'safe_do'     Name.Function
 ' '           Text
 '{'           Punctuation
@@ -2137,7 +2137,7 @@
 ';\nperldb: Must not source insecure rcfile $file.\n        You or the superuser must be the owner, and it must not \n        be writable by anyone but its owner.\n' Literal.String
 
 'EO_GRIPE'    Literal.String.Delimiter
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        '    Text
 'return'      Keyword
@@ -2196,7 +2196,7 @@
 '\n'          Text
 
 'sub'         Keyword
-' '           Text
+' '           Text.Whitespace
 'is_safe_file' Name.Function
 ' '           Text
 '{'           Punctuation
@@ -3445,7 +3445,7 @@
 '# to the socket.' Comment.Single
 '\n        '  Text
 'require'     Keyword
-' '           Text
+' '           Text.Whitespace
 'IO::Socket'  Name.Namespace
 ';'           Punctuation
 '\n        '  Text

--- a/tests/examplefiles/perl/perl_regex-delims.output
+++ b/tests/examplefiles/perl/perl_regex-delims.output
@@ -2,13 +2,13 @@
 '\n\n'        Text
 
 'use'         Keyword
-' '           Text
+' '           Text.Whitespace
 'strict'      Name.Namespace
 ';'           Punctuation
 '\n'          Text
 
 'use'         Keyword
-' '           Text
+' '           Text.Whitespace
 'warnings'    Name.Namespace
 ';'           Punctuation
 '\n\n'        Text

--- a/tests/examplefiles/perl6/RoleQ.pm6.output
+++ b/tests/examplefiles/perl6/RoleQ.pm6.output
@@ -1,7 +1,7 @@
 'role'        Keyword
-' '           Text
+' '           Text.Whitespace
 'q'           Name
-' '           Text
+' '           Text.Whitespace
 '{'           Text
 '\n'          Text
 
@@ -233,7 +233,7 @@
 '\n'          Text
 
 'role'        Keyword
-' '           Text
+' '           Text.Whitespace
 'q'           Name
 'q'           Name
 ' '           Text

--- a/tests/examplefiles/php/test.php.output
+++ b/tests/examplefiles/php/test.php.output
@@ -64,7 +64,7 @@
 '\n\n'        Text
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Zip\\Zippಠ_ಠ_' Name.Class
 ' '           Text
 '{'           Punctuation
@@ -77,7 +77,7 @@
 '\n'          Text
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Zip'         Name.Class
 ' '           Text
 'extends'     Keyword
@@ -89,7 +89,7 @@
 "/**\n  *  Outputs the zip file\n  *\n  *  This function creates the zip file with the dirs and files given.\n  *  If the optional parameter $file is given, the zip file is will be\n  *  saved at that location. Otherwise the function returns the zip file's content.\n  *\n  *  @access                   public\n  *\n  *  @link                     http://www.pkware.com/business_and_developers/developer/popups/appnote.txt\n  *  @param  string $filename  The path where the zip file will be saved\n  *\n  *  @return bool|string       Returns either true if the fil is sucessfully created or the content of the zip file\n  */" Literal.String.Doc
 '\n  '        Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'out'         Name.Function
 '('           Punctuation
 '$filename'   Name.Variable
@@ -1950,7 +1950,7 @@
 "/**\n  *  Load a zip file\n  *\n  *  This function loads the files and dirs from a zip file from the harddrive.\n  *\n  *  @access                public\n  *\n  *  @param  string $file   The path to the zip file\n  *  @param  bool   $reset  Reset the files and dirs before adding the zip file's content?\n  *\n  *  @return bool           Returns true if the file was loaded sucessfully\n  */" Literal.String.Doc
 '\n  '        Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'load_file'   Name.Function
 '('           Punctuation
 '$file'       Name.Variable
@@ -2028,7 +2028,7 @@
 "/**\n  *  Load a zip string\n  *\n  *  This function loads the files and dirs from a string\n  *\n  *  @access                 public\n  *\n  *  @param  string $string  The string the zip is generated from\n  *  @param  bool   $reset   Reset the files and dirs before adding the zip file's content?\n  *\n  *  @return bool            Returns true if the string was loaded sucessfully\n  */" Literal.String.Doc
 '\n  '        Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'load_string' Name.Function
 '('           Punctuation
 '$string'     Name.Variable
@@ -2937,7 +2937,7 @@
 '\n\n'        Text
 
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '&'           Operator
 'byref'       Name.Function
 '()'          Punctuation
@@ -2963,7 +2963,7 @@
 '// Test highlighting of magic methods and variables\n' Comment.Single
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'MagicClass'  Name.Class
 ' '           Text
 '{'           Punctuation
@@ -2981,7 +2981,7 @@
 'public'      Keyword
 ' '           Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__construct' Name.Function.Magic
 '('           Punctuation
 '$some_var'   Name.Variable
@@ -3012,7 +3012,7 @@
 'public'      Keyword
 ' '           Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 '__toString'  Name.Function.Magic
 '()'          Punctuation
 ' '           Text
@@ -3030,7 +3030,7 @@
 'public'      Keyword
 ' '           Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'nonMagic'    Name.Function
 '()'          Punctuation
 ' '           Text
@@ -3083,7 +3083,7 @@
 '\n\n     Test the heredocs...\n\n     ' Literal.String
 'EOF'         Literal.String.Delimiter
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text
 
@@ -3096,7 +3096,7 @@
 
 'some_delimiter' Literal.String.Delimiter
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text
 

--- a/tests/examplefiles/pony/example.pony.output
+++ b/tests/examplefiles/pony/example.pony.output
@@ -20,9 +20,9 @@
 '\n'          Text
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'trn'         Keyword
-' '           Text
+' '           Text.Whitespace
 'Foo'         Name.Class
 '['           Punctuation
 'A'           Name.Type
@@ -56,9 +56,9 @@
 
 '  '          Text
 'fun'         Keyword
-' '           Text
+' '           Text.Whitespace
 'val'         Keyword
-' '           Text
+' '           Text.Whitespace
 'dofoo'       Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -89,13 +89,13 @@
 '\n'          Text
 
 'actor'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Main'        Name.Class
 '\n'          Text
 
 '  '          Text
 'new'         Keyword
-' '           Text
+' '           Text.Whitespace
 'create'      Name.Function
 '('           Punctuation
 'env'         Name

--- a/tests/examplefiles/pot/de.MoinMoin.po.output
+++ b/tests/examplefiles/pot/de.MoinMoin.po.output
@@ -31,12 +31,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -108,7 +108,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -119,7 +119,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -135,12 +135,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please provide a valid email address!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bitte eine gültige E-Mail-Adresse angeben!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -150,12 +150,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Found no account matching the given email address \'%(email)s\'!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -165,12 +165,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Use UserPreferences to change your settings or create an account."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -183,12 +183,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Empty user name. Please enter a user name."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Leerer Benutzername, bitte geben Sie einen Benutzernamen ein."' Literal.String
 '\n'          Text.Whitespace
 
@@ -198,7 +198,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -212,7 +212,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -231,43 +231,43 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This user name already belongs to somebody else."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dieser Benutzername gehört bereits jemand anderem."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Passwords don\'t match!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Passworte sind nicht gleich!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please specify a password!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bitte geben Sie ein Passwort an!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -278,7 +278,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -291,24 +291,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This email already belongs to somebody else."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese E-Mail-Adresse gehört bereits jemand anderem."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"User account created! You can use this account to login now..."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -318,12 +318,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Use UserPreferences to change settings of the selected user account"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -339,240 +339,240 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The theme \'%(theme_name)s\' could not be loaded!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Das Theme \'%(theme_name)s\' konnte nicht geladen werden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"User preferences saved!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Persönliche Einstellungen gespeichert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Default"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Standardeinstellung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<Browser setting>"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<Browsereinstellung>"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"the one preferred"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"der Bevorzugte"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"free choice"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Freie Auswahl"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Select User"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Benutzer auswählen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Save"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Speichern"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Cancel"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abbrechen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Preferred theme"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bevorzugter Stil"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editor Preference"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bevorzugter Editor"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editor shown on UI"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Angezeigter Editor"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Time zone"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeitzone"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your time is"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die lokale Zeit ist"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Server time is"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Zeit des Servers ist"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Date format"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datumsformat"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Preferred language"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bevorzugte Sprache"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"General options"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Allgemeine Optionen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Quick links"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expressverweise"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This list does not work, unless you have entered a valid email address!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -585,48 +585,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribed wiki pages (one regex per line)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abonnierte Wiki-Seiten (ein regulärer Ausdruck pro Zeile)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Create Profile"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Benutzer anlegen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mail me my account data"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"E-Mail mit den Zugangsdaten senden"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Email"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"E-Mail"'    Literal.String
 '\n'          Text.Whitespace
 
@@ -636,7 +636,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -647,7 +647,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -660,48 +660,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Name"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Name"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Password"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Passwort"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Login"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anmelden"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Action"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Aktion"'    Literal.String
 '\n'          Text.Whitespace
 
@@ -711,12 +711,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected \\"=\\" to follow \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"\\"=\\" fehlt hinter dem Attribut \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -726,60 +726,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected a value for key \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attribut \\"%(token)s\\" wurde kein Wert zugewiesen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to edit this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht editieren."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page is immutable!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Seite ist gegen Änderungen geschützt!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Cannot edit old revisions!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alte Versionen können nicht editiert werden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The lock you held timed out. Be prepared for editing conflicts!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -795,12 +795,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Draft of \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Entwurf von \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -810,12 +810,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"\\"%(pagename)s\\" editieren"' Literal.String
 '\n'          Text.Whitespace
 
@@ -825,12 +825,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Preview of \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Vorschau für \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -840,12 +840,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your edit lock on %(lock_page)s has expired!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihre Sperre der Seite %(lock_page)s ist abgelaufen!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -855,12 +855,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your edit lock on %(lock_page)s will expire in # minutes."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihre Sperre der Seite %(lock_page)s läuft in # Minuten ab."' Literal.String
 '\n'          Text.Whitespace
 
@@ -870,43 +870,43 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your edit lock on %(lock_page)s will expire in # seconds."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihre Sperre der Seite %(lock_page)s läuft in # Sekunden ab."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Someone else deleted this page while you were editing!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ein anderer Benutzer hat diese Seite inzwischen gelöscht!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Someone else changed this page while you were editing!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ein anderer Benutzer hat diese Seite inzwischen geändert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -917,7 +917,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -933,12 +933,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Content loaded from draft]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Inhalt der Seite mit dem Entwurf geladen]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -948,12 +948,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Content of new page loaded from %s]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Inhalt der neuen Seite auf Basis der Vorlage %s]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -963,12 +963,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Template %s not found]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Vorlage %s nicht gefunden]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -978,12 +978,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[You may not read %s]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Sie dürfen %s nicht lesen]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -993,7 +993,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1013,7 +1013,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1041,36 +1041,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Describe %s here."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%s hier beschreiben..."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Check Spelling"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rechtschreibung prüfen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Save Changes"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Änderungen speichern"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1080,7 +1080,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1097,7 +1097,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1116,60 +1116,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Preview"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Vorschau anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Text mode"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Text-Modus"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Load Draft"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Entwurf laden"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Comment:"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kommentar:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<No addition>"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<Keine Änderung>"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1179,55 +1179,55 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Add to: %(category)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zu %(category)s hinzufügen:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Trivial change"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Triviale Änderung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Remove trailing whitespace from each line"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Leerzeichen am Ende jeder Zeile entfernen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The wiki is currently not reachable."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Das Wiki ist derzeit nicht erreichbar."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1235,7 +1235,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1245,12 +1245,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid username or password."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültiger Username oder Passwort."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1260,7 +1260,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1271,7 +1271,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1287,36 +1287,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The package needs a newer version of MoinMoin (at least %s)."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Das Paket erfordert eine neuere Version von MoinMoin (mindestens %s)."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The theme name is not set."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Theme-Name ist nicht gesetzt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Installing theme files is only supported for standalone type servers."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1332,12 +1332,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Installation of \'%(filename)s\' failed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Installation von \'%(filename)s\' fehlgeschlagen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1347,12 +1347,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The file %s is not a MoinMoin package file."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Datei %s ist keine MoinMoin-Paket-Datei."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1362,36 +1362,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The page %s does not exist."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Seite %s existiert nicht."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid package file header."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültiger Paket-Datei-Header."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Package file format unsupported."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Paket-Datei-Format nicht unterstützt."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1401,12 +1401,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unknown function %(func)s in line %(lineno)i."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unbekannte Funktion %(func)s in Zeile %(lineno)i."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1416,84 +1416,84 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The file %s was not found in the package."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Datei %s wurde im Paket nicht gefunden."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your changes are not saved!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihre Änderungen sind nicht gesichert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page name is too long, try shorter name."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seitenname ist zu lang, bitte kürzen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"GUI Mode"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"GUI-Modus"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit was cancelled."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editierung wurde abgebrochen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You can\'t copy to an empty pagename."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie können eine Seite nicht auf einen leeren Seitennamen kopieren."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to copy this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht kopieren!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1503,7 +1503,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1514,7 +1514,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1530,12 +1530,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Could not copy page because of file system error: %s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1545,24 +1545,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to rename this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht umbenennen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You can\'t rename to an empty pagename."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie können eine Seite nicht auf einen leeren Seitennamen umbenennen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1572,7 +1572,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1586,7 +1586,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1602,12 +1602,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Could not rename page because of file system error: %s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1617,24 +1617,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to delete this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht löschen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Thank you for your changes. Your attention to detail is appreciated."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Danke für die Änderung und die Sorgfalt beim Editieren."' Literal.String
 '\n'          Text.Whitespace
 
@@ -1644,12 +1644,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page \\"%s\\" was successfully deleted!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite \\"%s\\" wurde erfolgreich gelöscht!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1659,7 +1659,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1688,7 +1688,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1722,7 +1722,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1736,7 +1736,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1752,24 +1752,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New page:\\n"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neue Seite:\\n"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No differences found!\\n"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es wurden keine Änderungen gefunden!\\n"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1779,12 +1779,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%(sitename)s] %(trivial)sUpdate of \\"%(pagename)s\\" by %(username)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1794,24 +1794,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Trivial "'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Triviale "' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Status of sending notification mails:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Status des Versands der Änderungsnachrichten:"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1821,12 +1821,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%(lang)s] %(recipients)s: %(status)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%(lang)s] %(recipients)s: %(status)s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -1836,72 +1836,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page could not get locked. Unexpected error (errno=%d)."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite konnte nicht gesperrt werden. Unerwarteter Fehler (errno=%d)."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page could not get locked. Missing \'current\' file?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite konnte nicht gesperrt werden. Fehlende Datei \'current\'?"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to edit this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht editieren!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You cannot save empty pages."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Leere Seiten können nicht gespeichert werden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You already saved this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie haben diese Seite bereits gesichert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You already edited this page! Please do not use the back button."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1914,19 +1914,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You did not change the page content, not saved!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Der Seiteninhalt wurde nicht verändert und folglich nicht gesichert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1934,7 +1934,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1950,7 +1950,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1961,7 +1961,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1977,7 +1977,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -1985,7 +1985,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2001,7 +2001,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2012,7 +2012,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2025,12 +2025,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Use the Preview button to extend the locking period."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mit \\"Vorschau anzeigen\\" können Sie diesen Zeitraum verlängern."' Literal.String
 '\n'          Text.Whitespace
 
@@ -2040,7 +2040,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2051,7 +2051,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2067,7 +2067,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2090,7 +2090,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2115,12 +2115,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<unknown>"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"<unbekannt>"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2130,7 +2130,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2150,7 +2150,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2178,7 +2178,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2207,7 +2207,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2247,19 +2247,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%(sitename)s] Your wiki account data"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%(sitename)s] Ihre Wiki-Acount-Daten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2270,7 +2270,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2286,12 +2286,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revision %(rev)d as of %(date)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revision %(rev)d vom %(date)s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2301,12 +2301,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Redirected from page \\"%(page)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Hierher umgeleitet von Seite \\"%(page)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -2316,36 +2316,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This page redirects to page \\"%(page)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite wird umgeleitet auf \\"%(page)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Create New Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neue Seite anlegen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to view this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht ansehen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -2355,7 +2355,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2366,7 +2366,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2379,48 +2379,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"seconds"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sekunden"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Previous"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Vorherige"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Next"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nächste"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"current"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"aktuelle"'  Literal.String
 '\n'          Text.Whitespace
 
@@ -2430,72 +2430,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"last modified: %s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"zuletzt geändert: %s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"match"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Treffer"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"matches"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Treffer"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Go To Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Gehe zu Seite"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Include system pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Systemseiten einschließen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Exclude system pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Systemseiten ausschließen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2505,12 +2505,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please use a more selective search term instead of {{{\\"%s\\"}}}"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -2523,12 +2523,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"ERROR in regex \'%s\'"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"FEHLER in regulärem Ausdruck \'%s\'"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2538,12 +2538,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bad timestamp \'%s\'"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültige Zeitangabe \'%s\'"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2553,72 +2553,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unsupported navigation scheme \'%(scheme)s\'!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nicht bekanntes Navigationsschema \'%(scheme)s\'!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No parent page found!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite ist keine Unterseite!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Slideshow"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diaschau"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Start"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Start"'     Literal.String
 '\n'          Text.Whitespace
 
@@ -2628,60 +2628,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Slide %(pos)d of %(size)d"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite %(pos)d von %(size)d"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search Titles"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Titel durchsuchen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Display context of search results"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Umgebung der Treffer anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Case-sensitive searching"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Groß-/Kleinschreibung beachten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search Text"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Text durchsuchen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2691,24 +2691,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Not supported mimetype of file: %s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MIME-Typ der Datei wird nicht unterstützt: %s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Embedded"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Eingebettet"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2718,12 +2718,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Upload new attachment \\"%(filename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuen Dateianhang \\"%(filename)s\\" hochladen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2733,12 +2733,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid MonthCalendar calparms \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültige MonthCalendaer calparms \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2748,48 +2748,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid MonthCalendar arguments \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültige MonthCalendar-Argumente: \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No orphaned pages in this wiki."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es existieren keine verwaisten Seiten in diesem Wiki."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Python Version"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Python Version"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MoinMoin Version"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MoinMoin Version"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2799,60 +2799,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Release %s [Revision %s]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Version %s [Revision %s]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"4Suite Version"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"4Suite Version"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Number of pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seitenanzahl"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Number of system pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anzahl der Systemseiten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Accumulated page sizes"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kumulierte Seitengrößen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2862,12 +2862,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Disk usage of %(data_dir)s/pages/"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Plattenbelegung von %(data_dir)s/pages/"' Literal.String
 '\n'          Text.Whitespace
 
@@ -2877,228 +2877,228 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Disk usage of %(data_dir)s/"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Plattenbelegung von %(data_dir)s/"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Entries in edit log"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Einträge in der Änderungshistorie"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"NONE"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"KEINE"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Global extension macros"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Globale Erweiterungsmakros"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Local extension macros"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lokale Erweiterungsmakros"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Global extension actions"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Globale Erweiterungsaktionen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Local extension actions"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lokale Erweiterungsaktionen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Global parsers"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Globale Parser"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Local extension parsers"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lokale Erweiterungsparser"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Disabled"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Deaktiviert"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Enabled"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Aktiviert"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"index available"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Index verfügbar"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"index unavailable"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Index nicht verfügbar"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"N/A"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"k.A."'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian and/or Python Xapian bindings not installed"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian und/oder Python-Xapian-Bindings nicht installiert"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian search"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian-Suche"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian Version"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian-Version"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian stemming"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Xapian-Wortstamm-Bildung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Active threads"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Aktive Threads"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3108,12 +3108,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No quotes on %(pagename)s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine Zitate auf Seite %(pagename)s gefunden."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3123,12 +3123,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Upload of attachment \'%(filename)s\'."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' wurde angelegt."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3138,12 +3138,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' deleted."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' wurde gelöscht."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3153,12 +3153,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Drawing \'%(filename)s\' saved."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeichnung \'%(filename)s\' wurde gesichert."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3168,12 +3168,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revert to revision %(rev)d."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revision %(rev)d restauriert."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3183,12 +3183,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Renamed from \'%(oldpagename)s\'."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Umbenannt von \'%(oldpagename)s\'."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3198,24 +3198,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(mins)dm ago"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"vor %(mins)dm"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(no bookmark set)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(kein Lesezeichen gesetzt)"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3225,48 +3225,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(currently set to %s)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(derzeit %s)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Delete bookmark"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lesezeichen löschen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Set bookmark"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lesezeichen setzen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Bookmark reached]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[Lesezeichen erreicht]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3276,12 +3276,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid include arguments \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültige \\"Include\\"-Argumente: \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3291,48 +3291,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nothing found for \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Textmarkierung \\"%s\\" nicht gefunden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"edit"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"ändern"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Contents"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Inhaltsverzeichnis"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You need to provide a chart type!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es muss ein Diagrammtyp angegeben werden!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3342,204 +3342,204 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bad chart type \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unbekannter Diagrammtyp \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search for items"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nach Items suchen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"containing all the following terms"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"die alle folgenden Ausdrücke enthalten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"containing one or more of the following terms"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"die einen oder mehrere der folgenden Ausdrücke enthalten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"not containing the following terms"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"die folgende Ausdrücke nicht enthalten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"belonging to one of the following categories"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"die einer der folgenden Kategorien angehören"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"last modified since (e.g. last 2 weeks)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"die zuletzt geändert wurden seit (z.B. \'last 2 weeks\')"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"any language"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"jede Sprache"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"any mimetype"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"jeder MIME-Typ"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Language"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sprache"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"File Type"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateityp"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search only in titles"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nur Titel durchsuchen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Case-sensitive search"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Groß-/Kleinschreibung bei der Suche beachten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Exclude underlay"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Underlay ausschließen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No system items"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine System-Items"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search in all page revisions"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"In allen Seitenrevisionen suchen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Go get it!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Los geht\'s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3549,48 +3549,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Check your argument %s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Überprüfen Sie das Argument %s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Markup"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Notation"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Display"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anzeige"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No wanted pages in this wiki."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es existieren keine gewünschten Seiten in diesem Wiki."' Literal.String
 '\n'          Text.Whitespace
 
@@ -3600,120 +3600,120 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Connection to mailserver \'%(server)s\' failed: %(reason)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verbindung zum Mailserver \'%(server)s\' gestört: %(reason)s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mail not sent"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"E-Mail wurde nicht versandt"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mail sent OK"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"E-Mail wurde erfolgreich versandt"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Date"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datum"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"From"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Von"'       Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"To"'        Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"An"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Content"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Inhalt"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachments"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhänge"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"XSLT option disabled, please look at HelpOnConfiguration."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"XSLT-Option ist abgeschaltet, siehe HelpOnConfiguration."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"XSLT processing is not available, please install 4suite 1.x."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -3729,12 +3729,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(errortype)s processing error"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verarbeitungsfehler vom Typ \\"%(errortype)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -3744,12 +3744,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected \\"%(wanted)s\\" after \\"%(key)s\\", got \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Erwartete \\"%(wanted)s\\" nach \\"%(key)s\\", bekam \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -3759,12 +3759,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected an integer \\"%(key)s\\" before \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Erwartete eine Ganzzahl \\"%(key)s\\" vor \\"%(token)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -3774,12 +3774,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected an integer \\"%(arg)s\\" after \\"%(key)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Erwartete eine Ganzzahl \\"%(arg)s\\" nach \\"%(key)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -3789,19 +3789,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Expected a color value \\"%(arg)s\\" after \\"%(key)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Erwartete einen Farbwert \\"%(arg)s\\" nach \\"%(key)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -3809,7 +3809,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -3822,12 +3822,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"**Maximum number of allowed includes exceeded**"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"**Maximale Anzahl erlaubter Includes überschritten**"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3837,12 +3837,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"**Could not find the referenced page: %s**"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"**Konnte die referenzierte Seite nicht finden: %s**"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3852,12 +3852,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Inlined image: %(url)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Eingebettetes Bild: %(url)s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3867,12 +3867,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Create new drawing \\"%(filename)s (opens in new window)\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neue Zeichnung \\"%(filename)s\\" anlegen (öffnet ein neues Fenster)"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3882,12 +3882,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit drawing %(filename)s (opens in new window)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeichnung %(filename)s bearbeiten (öffnet ein neues Fenster)"' Literal.String
 '\n'          Text.Whitespace
 
@@ -3897,120 +3897,120 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Clickable drawing: %(filename)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anklickbare Zeichnung %(filename)s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Toggle line numbers"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeilennummern ein/ausschalten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[all]"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[alle]"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[not empty]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[nicht leer]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[empty]"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[leer]"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"filter"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Filter"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Line"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeile"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No differences found!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es wurden keine Änderungen gefunden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Deletions are marked like this."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Gelöschter Text ist auf diese Art markiert."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Additions are marked like this."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Hinzugefügter Text ist auf diese Art markiert."' Literal.String
 '\n'          Text.Whitespace
 
@@ -4020,7 +4020,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -4028,7 +4028,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -4041,300 +4041,300 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"User"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Benutzer"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diffs"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"DifferenzAnzeige"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Info"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Info"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unsubscribe"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nicht abonnieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribe"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abonnieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Raw"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rohform"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"XML"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"XML"'       Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Print"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Druckansicht"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"View"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anzeigen"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Home"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Heim"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Up"'        Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Hoch"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[RSS]"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[RSS]"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[DELETED]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[GELÖSCHT]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[UPDATED]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[AKTUALISIERT]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[RENAMED]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[UMBENANNT]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[CONFLICT]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[KONFLIKT]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[NEW]"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[NEU]"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[DIFF]"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[DIFF]"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[BOTTOM]"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[FUSS]"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[TOP]"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[KOPF]"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Click to do a full-text search for this title"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Hier klicken für eine Liste der Seiten, die auf diese verweisen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Preferences"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Einstellungen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Logout"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abmelden"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Clear message"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nachricht löschen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -4344,12 +4344,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"last edited %(time)s by %(editor)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"zuletzt geändert am %(time)s durch %(editor)s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -4359,348 +4359,348 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"last modified %(time)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"zuletzt geändert %(time)s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search:"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Suchen:"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Text"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Text"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Titles"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Titel"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Search"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Suche"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"More Actions:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Weitere Aktionen:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"------------------------"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"------------------------"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Raw Text"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rohform"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Print View"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Druckansicht"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Delete Cache"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Cache löschen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rename Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite umbenennen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Copy Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite kopieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Delete Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite löschen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Like Pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ähnliche Seiten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Local Site Map"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"ÜbersichtsKarte"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"My Pages"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Meine Seiten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribe User"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abo für Benutzer"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Remove Spam"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Spam entfernen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revert to this revision"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Revision restaurieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Package Pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seiten paketieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Render as Docbook"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Docbook ausgeben"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sync Pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seiten synchronisieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Do"'        Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Los!"'      Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Comments"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kommentare"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit (Text)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editieren (Text)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit (GUI)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editieren (GUI)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Immutable Page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Geschützte Seite"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Remove Link"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verweis entfernen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Add Link"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verweis hinzufügen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -4710,36 +4710,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show %s days."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%s Tage anzeigen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki Markup"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki Quelltext"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"DeleteCache"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"CacheLöschen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -4749,324 +4749,324 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(cached %s)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(gecached %s)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Or try one of these actions:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Oder benutze eine dieser Aktionen:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"FrontPage"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"StartSeite"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"RecentChanges"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"AktuelleÄnderungen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"TitleIndex"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"TitelIndex"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"WordIndex"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"WortIndex"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"FindPage"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SeiteFinden"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SiteNavigation"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"WegWeiser"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"HelpContents"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"HilfeInhalt"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"HelpOnFormatting"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"HilfeZumFormatieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"UserPreferences"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"BenutzerEinstellungen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"WikiLicense"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"WikiLizenz"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MissingPage"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"FehlendeSeite"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MissingHomePage"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"FehlendePersönlicheSeite"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mon"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mo"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Tue"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Di"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wed"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Mi"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Thu"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Do"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fri"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fr"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sat"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sa"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sun"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"So"'        Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"AttachFile"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"DateiAnhänge"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"DeletePage"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SeiteLöschen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"LikePages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"ÄhnlicheSeiten"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"LocalSiteMap"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"ÜbersichtsKarte"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"RenamePage"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SeiteUmbenennen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SpellCheck"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"RechtSchreibung"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5076,12 +5076,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unknown action %(action_name)s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unbekannte Aktion %(action_name)s."' Literal.String
 '\n'          Text.Whitespace
 
@@ -5091,144 +5091,144 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to do %(action_name)s on this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen die Aktion %(action_name)s auf dieser Seite nicht benutzen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Login and try again."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Melden Sie sich an und probieren Sie es noch einmal."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Charts are not available!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Diagrammoption ist nicht verfügbar!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page Size Distribution"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verteilung der Seitengrößen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"page size upper bound [bytes]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Obere Grenze der Seitengröße [bytes]"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"# of pages of this size"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anzahl der Seiten in dieser Größenklasse"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"User agent"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Browsertyp"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Others"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sonstige"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Distribution of User-Agent Types"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verteilung der Zugriffe auf Browsertypen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Views/day"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lesezugriffe/Tag"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edits/day"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Schreibzugriffe/Tag"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page hits and edits"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seitenzugriffe und Änderungen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5238,19 +5238,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(chart_title)s for %(filterpage)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(chart_title)s für %(filterpage)s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5261,7 +5261,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5274,31 +5274,31 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"date"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datum"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"# of hits"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anzahl der Zugriffe"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5354,7 +5354,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5415,7 +5415,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5479,7 +5479,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5546,24 +5546,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"UnSubscribe"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nicht abonnieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Publish my email (not my wiki homepage) in author info"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5576,240 +5576,240 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Open editor on double click"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editor per Doppelklick öffnen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"After login, jump to last visited page"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nach dem Anmelden zur zuletzt besuchten Seite springen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show comment sections"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kommentarabschnitte anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show question mark for non-existing pagelinks"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verweise auf unbekannte Seiten mit Fragezeichen markieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show page trail"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kürzlich besuchte Seiten anzeigen (Verlauf)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show icon toolbar"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Werkzeugleiste mit Bildsymbolen anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show top/bottom links in headings"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verweise zum Anfang und Ende der Seite in Überschriften anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show fancy diffs"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unterschiede farbig markiert anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Add spaces to displayed wiki names"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Angezeigte Wikinamen mit Leerzeichen trennen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Remember login information"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Speichere Login-Informationen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribe to trivial changes"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Triviale Änderungen abonnieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Disable this account forever"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dieses Benutzerkonto für immer deaktivieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(Use Firstname\'\'\'\'\'\'Lastname)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(Vorname\'\'\'\'\'\'Nachname verwenden)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alias-Name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alias-Name"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Password repeat"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Passwort wiederholen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(Only for password change or new account)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(Nur für Passwort-Änderung oder neue Benutzerkonten)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"User CSS URL"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Benutzer CSS URL"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(Leave it empty for disabling user CSS)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Leer lassen, um benutzerdefiniertes CSS auszuschalten)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editor size"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Größe des Texteingabefelds"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Do it."'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ausführen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5819,12 +5819,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Execute action %(actionname)s?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Aktion %(actionname)s ausführen?"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5834,12 +5834,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Action %(actionname)s is excluded in this wiki!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Aktion %(actionname)s ist ausgeschlossen in diesem Wiki!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5849,12 +5849,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to use action %(actionname)s on this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen die Aktion %(actionname)s auf dieser Seite nicht benutzen!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5864,12 +5864,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please use the interactive user interface to use action %(actionname)s!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5879,84 +5879,84 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You must login to add a quicklink."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie müssen sich anmelden, um einen Expressverweis hinzuzufügen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your quicklink to this page has been removed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihr Expressverweis für diese Seite wurde entfernt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your quicklink to this page could not be removed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihr Expressverweis für diese Seite konnte nicht entfernt werden."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"A quicklink to this page has been added for you."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ein Expressverweis für diese Seite wurde hinzugefügt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"A quicklink to this page could not be added for you."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ein Expressverweis für diese Seite konnte nicht hinzugefügt werden."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Missing password. Please enter user name and password."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fehlendes Passwort. Bitte geben Sie Benutzername und Passwort ein."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sorry, login failed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Login fehlgeschlagen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -5966,12 +5966,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%d attachments]"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[%d Anhänge]"' Literal.String
 '\n'          Text.Whitespace
 
@@ -5981,7 +5981,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -5992,7 +5992,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6008,24 +6008,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(target)s\' already exists."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(target)s\' existiert bereits."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Filename of attachment not specified!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateiname des Anhangs fehlt oder ist leer!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -6035,19 +6035,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' does not exist!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' existiert nicht!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6064,7 +6064,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6089,72 +6089,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"del"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"löschen"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"move"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"verschieben"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"get"'       Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"laden"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"view"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"anzeigen"'  Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"unzip"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"auspacken"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"install"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"installieren"' Literal.String
 '\n'          Text.Whitespace
 
@@ -6164,43 +6164,43 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No attachments stored for %(pagename)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es wurden keine Anhänge für die Seite %(pagename)s gespeichert."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit drawing"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Zeichnung editieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New Attachment"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Dateianhang"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6217,7 +6217,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6242,103 +6242,103 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"File to upload"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Dateianhang"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rename to"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Umbenennen auf"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Overwrite existing attachment of same name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Anhänge gleichen Namens überschreiben"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Upload"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datei hochladen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attached Files"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Gespeicherte Dateianhänge"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to attach a file to this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Anhänge an diese Seite anhängen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"File attachments are not allowed in this wiki!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhänge sind in diesem Wiki nicht erlaubt!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to save a drawing on this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen auf dieser Seite keine Zeichnung speichern."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6349,7 +6349,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6362,48 +6362,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to delete attachments on this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Anhänge dieser Seite löschen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to move attachments from this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Anhänge von dieser Seite verschieben."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Move aborted!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verschieben abgebrochen!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please use the interactive user interface to move attachments!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6416,48 +6416,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to get attachments from this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen auf keine Anhänge dieser Seite zugreifen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to unzip attachments of this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Anhänge dieser Seite auspacken."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to install files."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Dateien installieren."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to view attachments of this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Anhänge dieser Seite ansehen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6467,12 +6467,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unsupported upload action: %s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unbekannte Aktion für Dateianhang: %s"' Literal.String
 '\n'          Text.Whitespace
 
@@ -6482,12 +6482,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachments for \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhänge für \\"%(pagename)s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -6497,7 +6497,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6508,7 +6508,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6524,12 +6524,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(target)s\' (remote name \'%(filename)s\') already exists."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6545,12 +6545,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' already exists."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' existiert bereits."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6560,24 +6560,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' moved to %(page)s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' auf Seite %(page)s verschoben."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nothing changed"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine Änderung."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6587,12 +6587,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page %(newpagename)s does not exists or you don\'t have enough rights."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6605,12 +6605,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Move aborted because empty page name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie können eine Seite nicht auf einen leeren Seitennamen umbenennen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6620,12 +6620,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please use a valid filename for attachment \'%(filename)s\'."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6635,48 +6635,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Move aborted because empty attachment name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verschieben wegen eines leeren Anhangsnamens abgebrochen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Move"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verschieben"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New page name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Seitenname"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New attachment name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Name des Dateianhangs"' Literal.String
 '\n'          Text.Whitespace
 
@@ -6686,12 +6686,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' installed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' wurde installiert."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6701,7 +6701,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6712,7 +6712,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6728,7 +6728,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6739,7 +6739,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6755,12 +6755,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\' unzipped."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\' wurde ausgepackt."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6770,7 +6770,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6781,7 +6781,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6800,12 +6800,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The file %(filename)s is not a .zip file."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Datei %(filename)s ist keine .zip-Datei."' Literal.String
 '\n'          Text.Whitespace
 
@@ -6815,72 +6815,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Attachment \'%(filename)s\'"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang \'%(filename)s\'"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Package script:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Paket-Skript:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"File Name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateiname"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Modified"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Modifiziert"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Size"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Größe"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unknown file type, cannot display this attachment inline."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -6896,72 +6896,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"attachment:%(filename)s of %(pagename)s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"[[Verbatim(attachment:)]]%(filename)s für %(pagename)s"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This page is already deleted or was never created!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite wurde bereits gelöscht oder wurde bisher nicht angelegt!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rename all /subpages too?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alle /UnterSeiten auch umbenennen?"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New name"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Name"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optional reason for the renaming"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optionale Begründung für das Umbenennen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Really rename this page?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite wirklich umbenennen?"' Literal.String
 '\n'          Text.Whitespace
 
@@ -6971,72 +6971,72 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Full Link List for \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Liste aller Seitenverweise für \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Editor"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Autor"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Pages"'     Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seiten"'    Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Select Author"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Autor auswählen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revert all!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alle restaurieren!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to use this action."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Aktion nicht ausführen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7046,31 +7046,31 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Rolled back changes to the page %s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Änderungen an der Seite %s rückgängig gemacht"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Exception while calling rollback function:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fehler beim Aufrufen der Rollback-Funktion:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7084,7 +7084,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7100,31 +7100,31 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Operation was canceled."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Operation wurde abgebrochen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The only supported directions are BOTH and DOWN."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es werden nur die Richtungen BOTH und DOWN unterstützt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7135,7 +7135,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7148,7 +7148,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7159,7 +7159,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7172,48 +7172,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The \'\'remoteWiki\'\' is unknown."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Das \'\'remoteWiki\'\' ist nicht bekannt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"A severe error occured:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ein schwerwiegender Fehler ist aufgetreten:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronisation finished. Look below for the status messages."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronisierung beendet, siehe Status-Nachrichten unten."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronisation started -"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronisierung gestartet -"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7223,7 +7223,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7234,7 +7234,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7250,12 +7250,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"After filtering: %s pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nach dem Filtern: %s Seiten"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7265,12 +7265,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Skipped page %s because of no write access to local page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7286,12 +7286,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Deleted page %s locally."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lokale Seite %s gelöscht."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7301,12 +7301,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Error while deleting page %s locally:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fehler beim lokalen Löschen der Seite %s:"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7316,12 +7316,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Deleted page %s remotely."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ferne Seite %s gelöscht."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7331,12 +7331,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Error while deleting page %s remotely:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Fehler beim fernen Löschen der Seite %s:"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7346,7 +7346,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7357,7 +7357,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7376,7 +7376,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7387,7 +7387,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7406,7 +7406,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7417,7 +7417,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7433,12 +7433,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronising page %s with remote page %s ..."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Synchronisiere Seite %s mit der entfernten Seite %s ..."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7448,12 +7448,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The page %s was deleted remotely but changed locally."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite %s wurde lokal geändert, aber ferne gelöscht."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7463,7 +7463,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7474,7 +7474,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7493,12 +7493,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Skipped page %s because of a locally or remotely unresolved conflict."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7514,7 +7514,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7525,7 +7525,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7541,7 +7541,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7552,7 +7552,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7568,12 +7568,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page %s successfully merged."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite \\"%s\\" wurde erfolgreich zusammengeführt."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7583,12 +7583,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page %s contains conflicts that were introduced on the remote side."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite %s enthält von der fernen Seite eingeführte Konflikte."' Literal.String
 '\n'          Text.Whitespace
 
@@ -7598,43 +7598,43 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page %s merged with conflicts."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite %s wurde mit Konflikten zusammengeführt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Load"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Laden"'     Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New Page or New Attachment"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neue Seite oder neuer Dateianhang"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7645,7 +7645,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7658,36 +7658,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"attachment"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Dateianhang"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"overwrite"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"überschreiben"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"New Name"'  Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Neuer Name"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7697,12 +7697,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(including %(localwords)d %(pagelink)s)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(inklusive %(localwords)d %(pagelink)s)"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7712,7 +7712,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7723,7 +7723,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7741,48 +7741,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Add checked words to dictionary"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Markierte Wörter zum Wörterbuch hinzufügen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No spelling errors found!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine Rechtschreibfehler gefunden!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You can\'t save spelling words."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie können keine Rechtschreibkorrektur-Wörter abspeichern."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You can\'t check spelling on a page you can\'t read."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7795,60 +7795,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are now logged out."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie sind nun abgemeldet."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to subscribe to a page you can\'t read."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen keine Seiten abonnieren, die Sie nicht lesen dürfen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This wiki is not enabled for mail processing."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"In diesem Wiki ist Mail-Verarbeitung nicht eingeschaltet."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You must log in to use subscriptions."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie müssen sich anmelden, um Abonnements verwenden zu können."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Add your email address in your UserPreferences to use subscriptions."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7861,36 +7861,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Your subscription to this page has been removed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ihr Abonnementsfür diese Seite wurde entfernt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Can\'t remove regular expression subscription!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kann nicht Abonnement mit regulärem Ausdruck entfernen."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Edit the subscription regular expressions in your UserPreferences."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7903,24 +7903,24 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You have been subscribed to this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Seite wurde zur Liste abonnierter Seiten hinzugefügt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You could not get subscribed to this page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -7930,12 +7930,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"General Information"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Allgemeine Informationen"' Literal.String
 '\n'          Text.Whitespace
 
@@ -7945,96 +7945,96 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Page size: %d"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seitengröße: %d"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"SHA digest of this page\'s content is:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Signatur des Seiteninhalts nach dem SHA-Verfahren:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The following users subscribed to this page:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Nachfolgende Benutzer haben diese Seite abonniert:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"This page links to the following pages:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite verweist auf die folgenden Seiten:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diff"'      Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Differenz"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Comment"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kommentar"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Revision History"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Versionshistorie"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No log entries found."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine Log-Einträge gefunden."' Literal.String
 '\n'          Text.Whitespace
 
@@ -8044,12 +8044,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Info for \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Info für \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8059,48 +8059,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Show \\"%(title)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"\\"%(title)s\\" anzeigen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"General Page Infos"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Allgemeine Seiten-Informationen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please log in first."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Bitte melden Sie sich vorher an."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Please first create a homepage before creating additional pages."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8113,7 +8113,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8192,7 +8192,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8268,12 +8268,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"MyPages management"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Verwaltung meiner Seiten"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8283,12 +8283,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribe users to the page %s"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seite %s für Benutzer abonnieren"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8298,36 +8298,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Subscribed for %s:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Abonnenten von %s:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Not a user:"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Kein Benutzer:"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to perform this action."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Aktion nicht ausführen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -8337,19 +8337,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(!) Only pages changed since \'\'\'%s\'\'\' are being displayed!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(!) Nur Seiten, die seit \'\'\'%s\'\'\' geändert wurden, werden angezeigt!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8360,7 +8360,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8376,12 +8376,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Title Search: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Titelsuche: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8391,12 +8391,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Advanced Search: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Erweiterte Suche: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8406,12 +8406,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Full Text Search: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Volltextsuche: \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8421,7 +8421,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8432,7 +8432,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8448,7 +8448,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8459,7 +8459,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8475,31 +8475,31 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(!) Consider performing a"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(!) Erwägen Sie eine"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"full-text search with your search terms"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Volltextsuche mit Ihren Suchbegriffen"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8510,7 +8510,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8523,12 +8523,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Click here to perform a full-text search with your search terms!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Hier klicken für eine Volltextsuche mit diesen Suchbegriffen!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8538,7 +8538,7 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8551,7 +8551,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8572,12 +8572,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Restoring backup: %(filename)s to target dir: %(targetdir)s failed."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8590,19 +8590,19 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki Backup / Restore"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Wiki Sicherung / Wiederherstellung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8652,7 +8652,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8709,36 +8709,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Backup"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datensicherung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Restore"'   Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Datenwiederherstellung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to do remote backup."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen kein Remote-Backup ausführen."' Literal.String
 '\n'          Text.Whitespace
 
@@ -8748,31 +8748,31 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unknown backup subaction: %s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unbekannte backup Unteraktion: %s."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"You are not allowed to revert this page!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Sie dürfen diese Seite nicht restaurieren!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8786,7 +8786,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -8808,12 +8808,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Local Site Map for \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Lokale Seitenverweise für \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8823,12 +8823,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No pages like \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Keine Seite ähnlich wie \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8838,12 +8838,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Invalid filename \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ungültiger Dateiname \\"%s\\"!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8853,60 +8853,60 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Created the package %s containing the pages %s."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Paket %s, das die Seiten %s enthält wurde erzeugt."' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Package pages"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seiten paketieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Package name"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Paketname"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"List of page names - separated by a comma"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Liste von Seitennamen - getrennt durch ein Komma"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"No older revisions available!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Es sind keine älteren Versionen dieser Seite verfügbar!"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8916,12 +8916,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diff for \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Änderungen von \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -8931,12 +8931,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Differences between revisions %d and %d"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Unterschiede zwischen den Revisionen %d und %d"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8946,12 +8946,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(spanning %d versions)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(über %d Versionen hinweg)"' Literal.String
 '\n'          Text.Whitespace
 
@@ -8961,36 +8961,36 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"The page was saved %(count)d times, though!"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Die Seite wurde jedoch %(count)d mal gespeichert!"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(ignoring whitespace)"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"(ignoriere Leerraum)"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ignore changes in the amount of whitespace"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Ausschließlich Leerraum betreffende Änderungen ignorieren"' Literal.String
 '\n'          Text.Whitespace
 
@@ -9000,12 +9000,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Exactly one page like \\"%s\\" found, redirecting to page."' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Genau eine Seite wie \\"%s\\" gefunden, leite dorthin weiter."' Literal.String
 '\n'          Text.Whitespace
 
@@ -9015,12 +9015,12 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Pages like \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Seiten ähnlich wie \\"%s\\""' Literal.String
 '\n'          Text.Whitespace
 
@@ -9030,55 +9030,55 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(matchcount)d %(matches)s for \\"%(title)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"%(matchcount)d %(matches)s passen zu \\"%(title)s\\""' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Copy all /subpages too?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alle /UnterSeiten auch kopieren?"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optional reason for the copying"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optionale Begründung für das Kopieren"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Really copy this page?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite wirklich kopieren?"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -9086,7 +9086,7 @@
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '""'          Literal.String
 '\n'          Text.Whitespace
 
@@ -9099,48 +9099,48 @@
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Delete"'    Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Löschen"'   Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Delete all /subpages too?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Alle /UnterSeiten auch löschen?"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optional reason for the deletion"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Optionale Begründung für die Löschung"' Literal.String
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'msgid'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Really delete this page?"' Literal.String
 '\n'          Text.Whitespace
 
 'msgstr'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '"Diese Seite wirklich löschen?"' Literal.String
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/praat/example.praat.output
+++ b/tests/examplefiles/praat/example.praat.output
@@ -1386,7 +1386,7 @@
 'Previous'    Literal.String
 '"'           Literal.String
 ','           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 '...'         Punctuation
 'if'          Keyword
 ' '           Text.Whitespace
@@ -1410,7 +1410,7 @@
 ' '           Text.Whitespace
 'fi'          Keyword
 ','           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 '...'         Punctuation
 '3'           Literal.Number
 ','           Punctuation
@@ -1430,7 +1430,7 @@
 'Stop'        Literal.String
 '"'           Literal.String
 ','           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 '...'         Punctuation
 'if'          Keyword
 ' '           Text.Whitespace
@@ -1454,7 +1454,7 @@
 ' '           Text.Whitespace
 'fi'          Keyword
 ','           Punctuation
-'\n      '    Text
+'\n      '    Text.Whitespace
 '...'         Punctuation
 '2'           Literal.Number
 ','           Punctuation
@@ -1581,7 +1581,7 @@
 'no'          Literal.String
 '"'           Literal.String
 ','           Punctuation
-'\n    '      Text
+'\n    '      Text.Whitespace
 '...'         Punctuation
 '0.03'        Literal.Number
 ','           Punctuation
@@ -1668,7 +1668,7 @@
 ' '           Text.Whitespace
 '0'           Literal.Number
 ','           Punctuation
-'\n    '      Text
+'\n    '      Text.Whitespace
 '...'         Punctuation
 '"'           Literal.String
 'file subject speaker' Literal.String
@@ -1691,7 +1691,7 @@
 '"'           Literal.String
 ' '           Text.Whitespace
 '+'           Operator
-'\n    '      Text
+'\n    '      Text.Whitespace
 '...'         Punctuation
 '"'           Literal.String
 'duration response' Literal.String
@@ -2021,17 +2021,17 @@
 'sendpraat'   Keyword
 ' '           Text.Whitespace
 'Praat'       Literal.String
-'\n  '        Text
+'\n  '        Text.Whitespace
 '...'         Punctuation
 "'newline$'"  Literal.String.Interpol
 ' '           Text.Whitespace
 'Create Sound as pure tone... "tone" 1 0 0.4 44100 440 0.2 0.01 0.01' Literal.String
-'\n  '        Text
+'\n  '        Text.Whitespace
 '...'         Punctuation
 "'newline$'"  Literal.String.Interpol
 ' '           Text.Whitespace
 'Play'        Literal.String
-'\n  '        Text
+'\n  '        Text.Whitespace
 '...'         Punctuation
 "'newline$'"  Literal.String.Interpol
 ' '           Text.Whitespace

--- a/tests/examplefiles/psysh/psysh_test.psysh.output
+++ b/tests/examplefiles/psysh/psysh_test.psysh.output
@@ -146,7 +146,7 @@
 
 '>>> '        Generic.Prompt
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Baz'         Name.Class
 ' '           Text
 '{'           Punctuation
@@ -157,7 +157,7 @@
 'public'      Keyword
 ' '           Text
 'function'    Keyword
-' '           Text
+' '           Text.Whitespace
 'getBaz'      Name.Function
 '()'          Punctuation
 ':'           Operator

--- a/tests/examplefiles/pycon/pycon_ctrlc_traceback.output
+++ b/tests/examplefiles/pycon/pycon_ctrlc_traceback.output
@@ -2,7 +2,7 @@
 
 '>>> '        Generic.Prompt
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'os'          Name.Namespace
 '\n'          Text
 
@@ -125,7 +125,7 @@
 
 '>>> '        Generic.Prompt
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'A'           Name.Class
 '('           Punctuation
 'Exception'   Name.Exception
@@ -139,7 +139,7 @@
 
 '>>> '        Generic.Prompt
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'B'           Name.Class
 '('           Punctuation
 'Exception'   Name.Exception
@@ -524,7 +524,7 @@
 
 '>>> '        Generic.Prompt
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'somemodule'  Name.Namespace
 '\n'          Text
 

--- a/tests/examplefiles/python/linecontinuation.py.output
+++ b/tests/examplefiles/python/linecontinuation.py.output
@@ -41,9 +41,9 @@
 '\n'          Text
 
 'from'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'os'          Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword.Namespace
 ' '           Text
 'path'        Name
@@ -64,13 +64,13 @@
 '\n'          Text
 
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'os'          Name.Namespace
 '.'           Name.Namespace
 'path'        Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
-' '           Text
+' '           Text.Whitespace
 'something'   Name.Namespace
 '\n'          Text
 
@@ -108,7 +108,7 @@
 '\n'          Text
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Spam'        Name.Class
 ':'           Punctuation
 ' '           Text
@@ -118,7 +118,7 @@
 '\n'          Text
 
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Spam'        Name.Class
 '('           Punctuation
 'object'      Name.Builtin

--- a/tests/examplefiles/python/py3_test.txt.output
+++ b/tests/examplefiles/python/py3_test.txt.output
@@ -1,5 +1,5 @@
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'Käse'        Name.Class
 ':'           Punctuation
 '\n'          Text

--- a/tests/examplefiles/python/switch_case.txt.output
+++ b/tests/examplefiles/python/switch_case.txt.output
@@ -8,7 +8,7 @@
 ':'           Punctuation
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
 ' '           Text
 '['           Punctuation
@@ -38,7 +38,7 @@
 '1'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
 ' '           Text
 "'"           Literal.String.Single
@@ -59,7 +59,7 @@
 '2'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
 ' '           Text
 "'"           Literal.String.Single
@@ -78,9 +78,9 @@
 '3'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 '['           Punctuation
 "'"           Literal.String.Single
 'to'          Literal.String.Single
@@ -98,7 +98,7 @@
 '4'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
 ' '           Text
 'else_bar'    Name
@@ -111,9 +111,9 @@
 '5'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 '_'           Keyword
 ':'           Punctuation
 '\n'          Text
@@ -136,7 +136,7 @@
 ':'           Punctuation
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
 ' '           Text
 '_Direction'  Name
@@ -151,9 +151,9 @@
 '1'           Literal.Number.Integer
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 '_'           Keyword
 ' '           Text
 'as'          Keyword

--- a/tests/examplefiles/python/unicodedoc.py.output
+++ b/tests/examplefiles/python/unicodedoc.py.output
@@ -1,12 +1,12 @@
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'foo'         Name.Function
 '('           Punctuation
 ')'           Punctuation
 ':'           Punctuation
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'ur'          Literal.String.Affix
 '"""unicode-raw"""' Literal.String.Doc
 '\n'          Text
@@ -14,14 +14,14 @@
 '\n'          Text
 
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'bar'         Name.Function
 '('           Punctuation
 ')'           Punctuation
 ':'           Punctuation
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 'u'           Literal.String.Affix
 '"""unicode"""' Literal.String.Doc
 '\n'          Text
@@ -29,7 +29,7 @@
 '\n'          Text
 
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'baz'         Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -46,13 +46,13 @@
 '\n'          Text
 
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'zap'         Name.Function
 '('           Punctuation
 ')'           Punctuation
 ':'           Punctuation
 '\n'          Text
 
-'    '        Text
+'    '        Text.Whitespace
 '"""docstring"""' Literal.String.Doc
 '\n'          Text

--- a/tests/examplefiles/qvto/sample.qvto.output
+++ b/tests/examplefiles/qvto/sample.qvto.output
@@ -1,5 +1,5 @@
 'transformation' Keyword.Word
-' '           Text
+' '           Text.Whitespace
 'Foo'         Name.Class
 '('           Punctuation
 'uml'         Name

--- a/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
+++ b/tests/examplefiles/ragel-cpp/ragel-cpp_rlscan.output
@@ -1770,7 +1770,7 @@
 ' '           Text.Whitespace
 'nofinal'     Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1878,7 +1878,7 @@
 ' '           Text.Whitespace
 'init'        Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1944,7 +1944,7 @@
 ' '           Text.Whitespace
 'exec'        Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/ragel-cpp/ragel-cpp_snippet.output
+++ b/tests/examplefiles/ragel-cpp/ragel-cpp_snippet.output
@@ -5,7 +5,7 @@
 ' '           Text.Whitespace
 'init'        Name.Variable
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\t'          Text.Whitespace
 '/* Read in a block. */' Comment.Multiline

--- a/tests/examplefiles/rb/example.rb.output
+++ b/tests/examplefiles/rb/example.rb.output
@@ -404,7 +404,7 @@
 'METHOD_NAME' Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' '           Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -416,7 +416,7 @@
 'METHOD_NAME_EX' Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '\n\t '       Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -454,7 +454,7 @@
 'GLOBAL_VARIABLE' Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' '           Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -474,7 +474,7 @@
 'DOUBLEQ'     Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' "  [^"'     Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -501,7 +501,7 @@
 'SINGLEQ'     Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 " '  [^'"     Literal.String.Regex
 '\\\\'        Literal.String.Regex
@@ -515,7 +515,7 @@
 'STRING'      Name.Constant
 '  '          Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' '           Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -531,7 +531,7 @@
 'SHELL'       Name.Constant
 '   '         Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' `  [^`'     Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -558,7 +558,7 @@
 'REGEXP'      Name.Constant
 '  '          Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' '           Literal.String.Regex
 '\\/'         Literal.String.Regex
@@ -593,7 +593,7 @@
 'DECIMAL'     Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '\\'          Literal.String.Regex
 'd+(?:_'      Literal.String.Regex
@@ -606,7 +606,7 @@
 'OCTAL'       Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '0_?[0-7]+(?:_[0-7]+)*' Literal.String.Regex
 '/'           Literal.String.Regex
@@ -614,7 +614,7 @@
 'HEXADECIMAL' Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*' Literal.String.Regex
 '/'           Literal.String.Regex
@@ -622,7 +622,7 @@
 'BINARY'      Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '0b[01]+(?:_[01]+)*' Literal.String.Regex
 '/'           Literal.String.Regex
@@ -630,7 +630,7 @@
 'EXPONENT'    Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' [eE] [+-]? ' Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -642,7 +642,7 @@
 'FLOAT'       Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ' '           Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -668,7 +668,7 @@
 'INTEGER'     Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '#{'          Literal.String.Interpol
 'OCTAL'       Name.Constant
@@ -1047,7 +1047,7 @@
 'matched'     Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^[A-Z]'      Literal.String.Regex
 '/'           Literal.String.Regex
@@ -1557,7 +1557,7 @@
 ']'           Operator
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '[~=!<>|&^,'  Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -4690,7 +4690,7 @@
 ']'           Operator
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^Microsoft-IIS' Literal.String.Regex
 '/i'          Literal.String.Regex
@@ -4958,7 +4958,7 @@
 'pattern'     Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^(.+)'       Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -5414,7 +5414,7 @@
 'pattern'     Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^(.+)'       Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -6222,7 +6222,7 @@
 'str'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^HTTP'       Literal.String.Regex
 '\\/'         Literal.String.Regex
@@ -6239,7 +6239,7 @@
 'pattern'     Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^HTTP'       Literal.String.Regex
 '\\/'         Literal.String.Regex
@@ -6279,7 +6279,7 @@
 'str'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^status: [0-9]{3} ?.*$' Literal.String.Regex
 '/i'          Literal.String.Regex
@@ -6292,7 +6292,7 @@
 'pattern'     Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^status: ([0-9]{3}) ?(.*)$' Literal.String.Regex
 '/i'          Literal.String.Regex
@@ -6455,7 +6455,7 @@
 'p1'          Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^([0-9]{3}) ?(.*)$' Literal.String.Regex
 '/'           Literal.String.Regex
@@ -6463,7 +6463,7 @@
 'p2'          Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^HTTP'       Literal.String.Regex
 '\\/'         Literal.String.Regex
@@ -6475,7 +6475,7 @@
 'p3'          Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^status: ([0-9]{3}) ?(.*)$' Literal.String.Regex
 '/i'          Literal.String.Regex
@@ -6840,7 +6840,7 @@
 ']'           Operator
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^text'       Literal.String.Regex
 '\\/'         Literal.String.Regex
@@ -9754,7 +9754,7 @@
 'ATTRIBUTE_SCAN' Name.Constant
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '\n\t\t\t\t(?!$)  ' Literal.String.Regex
 '#'           Literal.String.Regex

--- a/tests/examplefiles/rb/multiline_regexes.rb.output
+++ b/tests/examplefiles/rb/multiline_regexes.rb.output
@@ -14,7 +14,7 @@
 'foo'         Name
 ' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 'is also\none' Literal.String.Regex
 '/'           Literal.String.Regex

--- a/tests/examplefiles/rb/pleac.in.rb.output
+++ b/tests/examplefiles/rb/pleac.in.rb.output
@@ -489,7 +489,7 @@
 ']'           Operator
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 'pattern'     Literal.String.Regex
 '/'           Literal.String.Regex
@@ -2309,7 +2309,7 @@
 'string'      Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^[+-]?'      Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -2340,7 +2340,7 @@
 'string'      Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^-?(?:'      Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -4348,7 +4348,7 @@
 'num'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^0'          Literal.String.Regex
 '/'           Literal.String.Regex
@@ -4431,7 +4431,7 @@
 'to_s'        Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '([^'         Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -5449,7 +5449,7 @@
 '"'           Literal.String.Double
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '('           Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -6003,7 +6003,7 @@
 'hop'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 'from'        Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -6027,7 +6027,7 @@
 'hop'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 'by'          Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -6799,7 +6799,7 @@
 'p'           Name.Builtin
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 ','           Literal.String.Regex
 '/'           Literal.String.Regex
@@ -7290,7 +7290,7 @@
 'l'           Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^gc'         Literal.String.Regex
 '/'           Literal.String.Regex
@@ -7597,7 +7597,7 @@
 'l'           Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '('           Literal.String.Regex
 '\\'          Literal.String.Regex
@@ -8143,7 +8143,7 @@
 'u'           Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^gnat '      Literal.String.Regex
 '/'           Literal.String.Regex
@@ -8302,7 +8302,7 @@
 'i'           Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^'           Literal.String.Regex
 '#{'          Literal.String.Interpol
@@ -8407,7 +8407,7 @@
 'pid'         Name
 ' '           Text.Whitespace
 '=~'          Operator
-' '           Text
+' '           Text.Whitespace
 '/'           Literal.String.Regex
 '^'           Literal.String.Regex
 '\\'          Literal.String.Regex

--- a/tests/examplefiles/rhtml/test.rhtml.output
+++ b/tests/examplefiles/rhtml/test.rhtml.output
@@ -270,7 +270,7 @@
 
 '<'           Punctuation
 'script'      Name.Tag
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Attribute
 '='           Operator
 '"text/javascript"' Literal.String

--- a/tests/examplefiles/rst/functional.rst.output
+++ b/tests/examplefiles/rst/functional.rst.output
@@ -1,8 +1,8 @@
 'Functional Programming HOWTO' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '================================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -53,7 +53,7 @@
 '\n'          Text.Whitespace
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'contents'    Operator.Word
 '::'          Punctuation
 '\n'          Text.Whitespace
@@ -61,10 +61,10 @@
 '\n'          Text.Whitespace
 
 'Introduction' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '----------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -86,7 +86,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' Most programming languages are ' Text
@@ -104,7 +104,7 @@
 '  C, Pascal, and even Unix shells are procedural languages.' Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' In '        Text
@@ -130,7 +130,7 @@
 '  etc.'      Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' '           Text
@@ -153,7 +153,7 @@
 '  of object-oriented features.' Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' '           Text
@@ -333,7 +333,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' Formal provability.' Text
@@ -354,10 +354,10 @@
 '\n'          Text.Whitespace
 
 'Formal provability' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -463,10 +463,10 @@
 '\n'          Text.Whitespace
 
 'Modularity'  Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -493,10 +493,10 @@
 '\n'          Text.Whitespace
 
 'Ease of debugging and testing ' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -541,10 +541,10 @@
 '\n'          Text.Whitespace
 
 'Composability' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -590,10 +590,10 @@
 '\n'          Text.Whitespace
 
 'Iterators'   Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-----------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -674,11 +674,11 @@
 
 'You can experiment with the iteration interface manually' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '>>> L = [1,2,3]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    >>> it = iter(L)\n    >>> print it\n    <iterator object at 0x8116870>\n    >>> it.next()\n    1\n    >>> it.next()\n    2\n    >>> it.next()\n    3\n    >>> it.next()\n    Traceback (most recent call last):\n      File "<stdin>", line 1, in ?\n    StopIteration\n    >>>      \n\n' Literal.String
 
@@ -705,11 +705,11 @@
 
 'an iterator.  These two statements are equivalent' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'for i in iter(obj):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '            print i\n\n        for i in obj:\n            print i\n\n' Literal.String
 
@@ -725,11 +725,11 @@
 '``'          Literal.String
 ' constructor functions' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '>>> L = [1,2,3]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    >>> iterator = iter(L)\n    >>> t = tuple(iterator)\n    >>> t\n    (1, 2, 3)\n\n' Literal.String
 
@@ -740,11 +740,11 @@
 
 'will return N elements, you can unpack them into an N-tuple' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '>>> L = [1,2,3]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    >>> iterator = iter(L)\n    >>> a,b,c = iterator\n    >>> a,b,c\n    (1, 2, 3)\n\n' Literal.String
 
@@ -841,10 +841,10 @@
 '\n'          Text.Whitespace
 
 'Data Types That Support Iterators' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -868,11 +868,11 @@
 
 "over the dictionary's keys" Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 ">>> m = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6," Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "    ...      'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}\n    >>> for key in m:\n    ...     print key, m[key]\n    Mar 3\n    Feb 2\n    Aug 8\n    Sep 9\n    May 5\n    Jun 6\n    Jul 7\n    Jan 1\n    Apr 4\n    Nov 11\n    Dec 12\n    Oct 10\n\n" Literal.String
 
@@ -930,11 +930,11 @@
 '``'          Literal.String
 ' tuples'     Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 ">>> L = [('Italy', 'Rome'), ('France', 'Paris'), ('US', 'Washington DC')]" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "    >>> dict(iter(L))\n    {'Italy': 'Rome', 'US': 'Washington DC', 'France': 'Paris'}\n\n" Literal.String
 
@@ -949,11 +949,11 @@
 
 'read each line of a file like this' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'for line in file:' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        # do something for each line\n        ...\n\n' Literal.String
 
@@ -962,19 +962,19 @@
 
 "the set's elements" Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'S = set((2, 3, 5, 7, 11, 13))' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    for i in S:\n        print i\n\n\n\n' Literal.String
 
 'Generator expressions and list comprehensions' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '----------------------------------------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1013,11 +1013,11 @@
 
 'stream of strings with the following code' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 "line_list = ['  line 1\\n', 'line 2  \\n', ...]" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n        # Generator expression -- returns iterator\n        stripped_iter = (line.strip() for line in line_list)\n\n        # List comprehension -- returns list\n        stripped_list = [line.strip() for line in line_list]\n\n' Literal.String
 
@@ -1027,11 +1027,11 @@
 '``'          Literal.String
 ' condition'  Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'stripped_list = [line.strip() for line in line_list' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '                         if line != ""]\n\n' Literal.String
 
@@ -1074,11 +1074,11 @@
 
 'expressions have the form' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '( expression for expr in sequence1 ' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '                 if condition1\n                 for expr2 in sequence2\n                 if condition2\n                 for expr3 in sequence3 ...\n                 if condition3\n                 for exprN in sequenceN\n                 if conditionN )\n\n' Literal.String
 
@@ -1128,13 +1128,13 @@
 
 'function you can write' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'obj_total = sum(obj.count for obj in list_all_objects())' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'The '        Text
 '``'          Literal.String
@@ -1187,11 +1187,11 @@
 
 'equivalent to the following Python code' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'for expr1 in sequence1:' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        if not (condition1):\n            continue   # Skip this element\n        for expr2 in sequence2:\n            if not (condition2):\n                continue    # Skip this element\n            ...\n            for exprN in sequenceN:\n                 if not (conditionN):\n                     continue   # Skip this element\n\n                 # Output the value of \n                 # the expression.\n\n' Literal.String
 
@@ -1213,11 +1213,11 @@
 
 'lists of length 3, the output list is 9 elements long' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "seq1 = 'abc'" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "    seq2 = (1,2,3)\n    >>> [ (x,y) for x in seq1 for y in seq2]\n    [('a', 1), ('a', 2), ('a', 3), \n     ('b', 1), ('b', 2), ('b', 3), \n     ('c', 1), ('c', 2), ('c', 3)]\n\n" Literal.String
 
@@ -1235,19 +1235,19 @@
 
 'while the second one is correct' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '# Syntax error' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    [ x,y for x in seq1 for y in seq2]\n    # Correct\n    [ (x,y) for x in seq1 for y in seq2]\n\n\n' Literal.String
 
 'Generators'  Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-----------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1299,11 +1299,11 @@
 
 "Here's the simplest example of a generator function" Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def generate_ints(N):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        for i in range(N):\n            yield i\n\n' Literal.String
 
@@ -1383,11 +1383,11 @@
 '``'          Literal.String
 ' generator'  Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '>>> gen = generate_ints(3)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    >>> gen\n    <generator object at 0x8117f90>\n    >>> gen.next()\n    0\n    >>> gen.next()\n    1\n    >>> gen.next()\n    2\n    >>> gen.next()\n    Traceback (most recent call last):\n      File "stdin", line 1, in ?\n      File "stdin", line 2, in generate_ints\n    StopIteration\n\n' Literal.String
 
@@ -1505,11 +1505,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '# A recursive generator that generates Tree leaves in in-order.' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    def inorder(t):\n        if t:\n            for x in inorder(t.left):\n                yield x\n\n            yield t.label\n\n            for x in inorder(t.right):\n                yield x\n\n' Literal.String
 
@@ -1539,10 +1539,10 @@
 '\n'          Text.Whitespace
 
 'Passing values into a generator' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1577,13 +1577,13 @@
 
 'to a variable or otherwise operated on' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'val = (yield i)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'I recommend that you ' Text
 '**always**'  Generic.Strong
@@ -1679,11 +1679,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def counter (maximum):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        i = 0\n        while i < maximum:\n            val = (yield i)\n            # If value provided, change counter\n            if val is not None:\n                i = val\n            else:\n                i += 1\n\n' Literal.String
 
@@ -1767,7 +1767,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' '           Text
@@ -1787,7 +1787,7 @@
 "  where the generator's execution is paused." Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' '           Text
@@ -1899,10 +1899,10 @@
 '\n'          Text.Whitespace
 
 'Built-in functions' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '----------------------------------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1943,11 +1943,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def upper(s):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "        return s.upper()\n    map(upper, ['sentence', 'fragment']) =>\n      ['SENTENCE', 'FRAGMENT']\n\n    [upper(s) for s in ['sentence', 'fragment']] =>\n      ['SENTENCE', 'FRAGMENT']\n\n" Literal.String
 
@@ -2003,21 +2003,21 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def is_even(x):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        return (x % 2) == 0\n\n    filter(is_even, range(10)) =>\n      [0, 2, 4, 6, 8]\n\n' Literal.String
 
 'This can also be written as a list comprehension' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '>>> [x for x in range(10) if is_even(x)]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    [0, 2, 4, 6, 8]\n\n' Literal.String
 
@@ -2112,11 +2112,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'import operator' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "    reduce(operator.concat, ['A', 'BB', 'C']) =>\n      'ABBC'\n    reduce(operator.concat, []) =>\n      TypeError: reduce() of empty sequence with no initial value\n    reduce(operator.mul, [1,2,3], 1) =>\n      6\n    reduce(operator.mul, [], 1) =>\n      1\n\n" Literal.String
 
@@ -2140,11 +2140,11 @@
 '``'          Literal.String
 ' to compute it' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'reduce(operator.add, [1,2,3,4], 0) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      10\n    sum([1,2,3,4]) =>\n      10\n    sum([]) =>\n      0\n\n' Literal.String
 
@@ -2161,11 +2161,11 @@
 '``'          Literal.String
 ' loop'       Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 '# Instead of:' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    product = reduce(operator.mul, [1,2,3], 1)\n\n    # You can write:\n    product = 1\n    for i in [1,2,3]:\n        product *= i\n\n\n' Literal.String
 
@@ -2181,11 +2181,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "enumerate(['subject', 'verb', 'object']) =>" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "      (0, 'subject'), (1, 'verb'), (2, 'object')\n\n" Literal.String
 
@@ -2197,11 +2197,11 @@
 
 'and recording the indexes at which certain conditions are met' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "f = open('data.txt', 'r')" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "    for i, line in enumerate(f):\n        if line.strip() == '':\n            print 'Blank line at line #%i' % i\n\n" Literal.String
 
@@ -2242,11 +2242,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'import random' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    # Generate 8 random numbers between [0, 10000)\n    rand_list = random.sample(range(10000), 8)\n    rand_list =>\n      [769, 7953, 9828, 6431, 8442, 9878, 6213, 2207]\n    sorted(rand_list) =>\n      [769, 2207, 6213, 6431, 7953, 8442, 9828, 9878]\n    sorted(rand_list, reverse=True) =>\n      [9878, 9828, 8442, 7953, 6431, 6213, 2207, 769]\n\n' Literal.String
 
@@ -2287,19 +2287,19 @@
 
 'returns True if all of the elements are true values' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'any([0,1,0]) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      True\n    any([0,0,0]) =>\n      False\n    any([1,1,1]) =>\n      True\n    all([0,1,0]) =>\n      False\n    all([0,0,0]) => \n      False\n    all([1,1,1]) =>\n      True\n\n\n' Literal.String
 
 'Small functions and the lambda statement' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '----------------------------------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2316,11 +2316,11 @@
 
 "don't need to define a new function at all" Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'stripped_lines = [line.strip() for line in lines]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        existing_files = filter(os.path.exists, file_list)\n\n' Literal.String
 
@@ -2342,11 +2342,11 @@
 
 'and creates a small function that returns the value of the expression' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'lowercase = lambda x: x.lower()' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "\n        print_assign = lambda name, value: name + '=' + str(value)\n\n        adder = lambda x, y: x+y\n\n" Literal.String
 
@@ -2359,11 +2359,11 @@
 
 'function in the usual way' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'def lowercase(x):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "            return x.lower()\n\n        def print_assign(name, value):\n            return name + '=' + str(value)\n\n        def adder(x,y):\n            return x + y\n\n" Literal.String
 
@@ -2418,13 +2418,13 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'total = reduce(lambda a, b: (0, a[1] + b[1]), items)[1]' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'You can figure it out, but it takes time to disentangle the expression' Text
 '\n'          Text.Whitespace
@@ -2437,11 +2437,11 @@
 '``'          Literal.String
 ' statements makes things a little bit better' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def combine (a, b):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        return 0, a[1] + b[1]\n\n    total = reduce(combine, items)[1]\n\n' Literal.String
 
@@ -2451,11 +2451,11 @@
 '``'          Literal.String
 ' loop'       Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'     '       Literal.String
+'     '       Text.Whitespace
 'total = 0'   Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '     for a, b in items:\n         total += b\n\n' Literal.String
 
@@ -2465,13 +2465,13 @@
 '``'          Literal.String
 ' built-in and a generator expression' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'     '       Literal.String
+'     '       Text.Whitespace
 'total = sum(b for a,b in items)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'Many uses of ' Text
 '``'          Literal.String
@@ -2496,7 +2496,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '1)'          Literal.Number
 ' Write a lambda function.' Text
@@ -2534,10 +2534,10 @@
 '\n'          Text.Whitespace
 
 'The itertools module' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-----------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2560,7 +2560,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' Functions that create a new iterator based on an existing iterator.' Text
@@ -2581,10 +2581,10 @@
 '\n'          Text.Whitespace
 
 'Creating new iterators' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2599,11 +2599,11 @@
 
 'starting number, which defaults to 0' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'itertools.count() =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...\n        itertools.count(10) =>\n          10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...\n\n' Literal.String
 
@@ -2622,11 +2622,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'itertools.cycle([1,2,3,4,5]) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '          1, 2, 3, 4, 5, 1, 2, 3, 4, 5, ...\n\n' Literal.String
 
@@ -2649,11 +2649,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "itertools.repeat('abc') =>" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "      abc, abc, abc, abc, abc, abc, abc, abc, abc, abc, ...\n    itertools.repeat('abc', 5) =>\n      abc, abc, abc, abc, abc\n\n" Literal.String
 
@@ -2675,11 +2675,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "itertools.chain(['a', 'b', 'c'], (1, 2, 3)) =>" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      a, b, c, 1, 2, 3\n\n' Literal.String
 
@@ -2691,11 +2691,11 @@
 
 'and returns them in a tuple' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "itertools.izip(['a', 'b', 'c'], (1, 2, 3)) =>" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "      ('a', 1), ('b', 2), ('c', 3)\n\n" Literal.String
 
@@ -2735,11 +2735,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "itertools.izip(['a', 'b'], (1, 2, 3)) =>" Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "      ('a', 1), ('b', 2)\n\n" Literal.String
 
@@ -2810,11 +2810,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'itertools.islice(range(10), 8) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      0, 1, 2, 3, 4, 5, 6, 7\n    itertools.islice(range(10), 2, 8) =>\n      2, 3, 4, 5, 6, 7\n    itertools.islice(range(10), 2, 8, 2) =>\n      2, 4, 6\n\n' Literal.String
 
@@ -2849,19 +2849,19 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'itertools.tee( itertools.count() ) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '           iterA, iterB\n\n        where iterA ->\n           0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...\n\n        and   iterB ->\n           0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...\n\n\n' Literal.String
 
 'Calling functions on elements' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2884,11 +2884,11 @@
 'f(iterA[0], iterB[0]), f(iterA[1], iterB[1]),\nf(iterA[2], iterB[2]), ...' Literal.String
 '``'          Literal.String
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'itertools.imap(operator.add, [5, 6, 5], [1, 2, 3]) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      6, 8, 8\n\n' Literal.String
 
@@ -2951,19 +2951,19 @@
 
 'arguments'   Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'itertools.starmap(os.path.join, ' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "                      [('/usr', 'bin', 'java'), ('/bin', 'python'),\n                       ('/usr', 'bin', 'perl'),('/usr', 'bin', 'ruby')])\n    =>\n      /usr/bin/java, /bin/python, /usr/bin/perl, /usr/bin/ruby\n\n\n" Literal.String
 
 'Selecting elements' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2983,11 +2983,11 @@
 
 'which the predicate returns true' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def is_even(x):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        return (x % 2) == 0\n\n    itertools.ifilter(is_even, itertools.count()) =>\n      0, 2, 4, 6, 8, 10, 12, 14, ...\n\n' Literal.String
 
@@ -2999,11 +2999,11 @@
 
 'returning all elements for which the predicate returns false' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'itertools.ifilterfalse(is_even, itertools.count()) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      1, 3, 5, 7, 9, 11, 13, 15, ...\n\n' Literal.String
 
@@ -3022,11 +3022,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'def less_than_10(x):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        return (x < 10)\n\n    itertools.takewhile(less_than_10, itertools.count()) =>\n      0, 1, 2, 3, 4, 5, 6, 7, 8, 9\n\n    itertools.takewhile(is_even, itertools.count()) =>\n      0\n\n' Literal.String
 
@@ -3045,19 +3045,19 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'itertools.dropwhile(less_than_10, itertools.count()) =>' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '      10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...\n\n    itertools.dropwhile(is_even, itertools.count()) =>\n      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ...\n\n\n' Literal.String
 
 'Grouping elements' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3101,11 +3101,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 "city_list = [('Decatur', 'AL'), ('Huntsville', 'AL'), ('Selma', 'AL'), " Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 "                 ('Anchorage', 'AK'), ('Nome', 'AK'),\n                 ('Flagstaff', 'AZ'), ('Phoenix', 'AZ'), ('Tucson', 'AZ'), \n                 ...\n                ]\n\n    def get_state ((city, state)):\n        return state\n\n    itertools.groupby(city_list, get_state) =>\n      ('AL', iterator-1),\n      ('AK', iterator-2),\n      ('AZ', iterator-3), ...\n\n    where\n    iterator-1 =>\n      ('Decatur', 'AL'), ('Huntsville', 'AL'), ('Selma', 'AL')\n    iterator-2 => \n      ('Anchorage', 'AK'), ('Nome', 'AK')\n    iterator-3 =>\n      ('Flagstaff', 'AZ'), ('Phoenix', 'AZ'), ('Tucson', 'AZ')\n\n" Literal.String
 
@@ -3129,10 +3129,10 @@
 '\n'          Text.Whitespace
 
 'The functools module' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '----------------------------------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3220,19 +3220,19 @@
 
 "Here's a small but realistic example" Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'    '        Literal.String
+'    '        Text.Whitespace
 'import functools' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n    def log (message, subsystem):\n        "Write the contents of \'message\' to the specified subsystem."\n        print \'%s: %s\' % (subsystem, message)\n        ...\n\n    server_log = functools.partial(log, subsystem=\'server\')\n    server_log(\'Unable to open socket\')\n\n\n' Literal.String
 
 'The operator module' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3258,7 +3258,7 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' Math operations' Text
@@ -3388,10 +3388,10 @@
 '\n'          Text.Whitespace
 
 'The functional module' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '---------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3476,11 +3476,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 '>>> def add(a, b):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        ...     return a + b\n        ...\n        >>> def double(a):\n        ...     return 2 * a\n        ...\n        >>> compose(double, add)(5, 6)\n        22\n\n' Literal.String
 
@@ -3490,11 +3490,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 '>>> double(add(5, 6))' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        22\n                    \n' Literal.String
 
@@ -3546,23 +3546,23 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'compose(f, g)(5, 6)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'                    \n' Literal.String
+'                    \n' Text.Whitespace
 
 'is equivalent to' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'f(g(5, 6))'  Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'                    \n' Literal.String
+'                    \n' Text.Whitespace
 
 'while'       Text
 '\n'          Text.Whitespace
@@ -3570,23 +3570,23 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'compose(f, g, unpack=True)(5, 6)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'                    \n' Literal.String
+'                    \n' Text.Whitespace
 
 'is equivalent to' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'f(*g(5, 6))' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'Even though ' Text
 '``'          Literal.String
@@ -3627,11 +3627,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'from functional import compose, partial' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        \n        multi_compose = partial(reduce, compose)\n        \n' Literal.String
 
@@ -3659,11 +3659,11 @@
 '``'          Literal.String
 ' that converts its arguments to string' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'from functional import compose, partial' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        \n        join = compose("".join, partial(map, str))\n\n\n' Literal.String
 
@@ -3691,11 +3691,11 @@
 '\n'          Text.Whitespace
 
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 '>>> def triple(a, b, c):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        ...     return (a, b, c)\n        ...\n        >>> triple(5, 6, 7)\n        (5, 6, 7)\n        >>>\n        >>> flipped_triple = flip(triple)\n        >>> flipped_triple(5, 6, 7)\n        (7, 6, 5)\n\n' Literal.String
 
@@ -3726,23 +3726,23 @@
 
 'This means that a call such as' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'foldl(f, 0, [1, 2, 3])' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 'is equivalent to' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'f(f(f(0, 1), 2), 3)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 '    '        Text
 '\n'          Text.Whitespace
@@ -3752,11 +3752,11 @@
 '``'          Literal.String
 ' is roughly equivalent to the following recursive function' Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'def foldl(func, start, seq):' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '            if len(seq) == 0:\n                return start\n\n            return foldl(func, func(start, seq[0]), seq[1:])\n\n' Literal.String
 
@@ -3773,13 +3773,13 @@
 
 'so'          Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'reduce(f, [1, 2, 3], 0)' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
-'\n\n'        Literal.String
+'\n\n'        Text.Whitespace
 
 'We can use ' Text
 '``'          Literal.String
@@ -3804,19 +3804,19 @@
 '``'          Literal.String
 ' idiom'      Text
 '::'          Literal.String.Escape
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
-'        '    Literal.String
+'        '    Text.Whitespace
 'from functional import foldl, partial' Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '        from operator import concat\n        \n        join = partial(foldl, concat, "")\n\n\n' Literal.String
 
 'Revision History and Acknowledgements' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '------------------------------------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3890,18 +3890,18 @@
 '\n'          Text.Whitespace
 
 'References'  Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--------------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
 'General'     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3983,10 +3983,10 @@
 '\n'          Text.Whitespace
 
 'Python-specific' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -4039,10 +4039,10 @@
 '\n'          Text.Whitespace
 
 'Python documentation' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 "'''''''''''''''''''''''''''" Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/rst/jinjadesignerdoc.rst.output
+++ b/tests/examplefiles/rst/jinjadesignerdoc.rst.output
@@ -1,11 +1,11 @@
 '======================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Designer Documentation' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -15,10 +15,10 @@
 '\n'          Text.Whitespace
 
 'Basics'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -123,7 +123,7 @@
 '    '        Text
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -177,7 +177,7 @@
 '    '        Text
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -391,10 +391,10 @@
 '\n\n'        Other
 
 'Filters'     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======='     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -476,10 +476,10 @@
 '\n'          Text.Whitespace
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'admonition'  Operator.Word
 '::'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'note'        Text
 '\n'          Text.Whitespace
 
@@ -582,10 +582,10 @@
 '\n\n'        Other
 
 'Tests'       Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '====='       Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -612,7 +612,7 @@
 '2'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'numeric'     Name.Function
 ' '           Text
 '}}'          Comment.Preproc
@@ -624,7 +624,7 @@
 '"foobar"'    Literal.String.Double
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'numeric'     Name.Function
 ' '           Text
 '}}'          Comment.Preproc
@@ -636,7 +636,7 @@
 "'FOO'"       Literal.String.Single
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'upper'       Name.Function
 ' '           Text
 '}}'          Comment.Preproc
@@ -657,10 +657,10 @@
 '\n'          Text.Whitespace
 
 'Global Functions' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -710,10 +710,10 @@
 '\n'          Text.Whitespace
 
 'Loops'       Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '====='       Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -757,7 +757,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'user'        Name.Variable
@@ -804,7 +804,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -831,7 +831,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1014,7 +1014,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -1066,7 +1066,7 @@
 '    '        Text
 '  '          Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'item'        Name.Variable
@@ -1090,7 +1090,7 @@
 'ul'          Name.Tag
 '>'           Punctuation
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1102,7 +1102,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1141,10 +1141,10 @@
 '\n'          Text.Whitespace
 
 'Cycling'     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======='     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1183,7 +1183,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'message'     Name.Variable
@@ -1204,7 +1204,7 @@
 '='           Operator
 '"'           Literal.String
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'cycle'       Keyword
 ' '           Text
 "'row1'"      Literal.String.Single
@@ -1230,7 +1230,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1273,7 +1273,7 @@
 '='           Operator
 '"color: '    Literal.String
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'cycle'       Keyword
 ' '           Text
 'rowcolors'   Name.Variable
@@ -1289,10 +1289,10 @@
 '\n\n'        Text
 
 'Conditions'  Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '=========='  Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1318,7 +1318,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'user'        Name.Variable
@@ -1341,7 +1341,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'elif'        Keyword
 ' '           Text
 'user'        Name.Variable
@@ -1364,7 +1364,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1384,7 +1384,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1414,7 +1414,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'amount'      Name.Variable
@@ -1448,7 +1448,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1476,17 +1476,17 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Text
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'admonition'  Operator.Word
 '::'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'Note'        Text
 '\n'          Text.Whitespace
 
@@ -1514,10 +1514,10 @@
 '\n'          Text.Whitespace
 
 'Operators'   Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '========='   Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1714,7 +1714,7 @@
 'Note that there is no support for any bit operations or something similar.' Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Literal.Number
 ' special note regarding ' Text
@@ -1762,10 +1762,10 @@
 '\n'          Text.Whitespace
 
 'Boolean Values' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '==============' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1822,7 +1822,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 '['           Operator
@@ -1836,7 +1836,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 '{'           Operator
@@ -1850,7 +1850,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 '['           Operator
@@ -1865,7 +1865,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 '"foobar"'    Literal.String.Double
@@ -1877,10 +1877,10 @@
 '    this is also true because the string is not empty.\n\n' Other
 
 'Slicing'     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======='     Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -1900,7 +1900,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -1921,7 +1921,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -1944,7 +1944,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -1979,10 +1979,10 @@
 '\n'          Text.Whitespace
 
 'Macros'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2005,7 +2005,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'show_user'   Name.Variable
@@ -2065,7 +2065,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2087,7 +2087,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'user'        Name.Variable
@@ -2113,7 +2113,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2135,7 +2135,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'show_dialog' Name.Variable
@@ -2209,7 +2209,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2230,10 +2230,10 @@
 '\n\n'        Text
 
 'Inheritance' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '===========' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2259,10 +2259,10 @@
 '\n'          Text.Whitespace
 
 'Base Template' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2336,14 +2336,14 @@
 'title'       Name.Tag
 '>'           Punctuation
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'title'       Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2357,14 +2357,14 @@
 '    '        Text
 '  '          Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'html_head'   Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2397,14 +2397,14 @@
 '    '        Text
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2432,7 +2432,7 @@
 '    '        Text
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'footer'      Name.Variable
@@ -2461,7 +2461,7 @@
 '    '        Text
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2500,10 +2500,10 @@
 '\n'          Text.Whitespace
 
 'Child Template' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--------------' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2523,7 +2523,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.html"' Literal.String.Double
@@ -2533,7 +2533,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'title'       Name.Variable
@@ -2541,7 +2541,7 @@
 '%}'          Comment.Preproc
 'Index'       Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2549,7 +2549,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'html_head'   Name.Variable
@@ -2561,7 +2561,7 @@
 '  '          Text
 '<'           Punctuation
 'style'       Name.Tag
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Attribute
 '='           Operator
 '"text/css"'  Literal.String
@@ -2600,7 +2600,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2611,7 +2611,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -2655,7 +2655,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2701,7 +2701,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"layout/default.html"' Literal.String.Double
@@ -2727,10 +2727,10 @@
 '\n'          Text.Whitespace
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'admonition'  Operator.Word
 '::'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'Note'        Text
 '\n'          Text.Whitespace
 
@@ -2767,10 +2767,10 @@
 '\n'          Text.Whitespace
 
 'Template Inclusion' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '==================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2803,7 +2803,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"myhelpers.html"' Literal.String.Double
@@ -2839,10 +2839,10 @@
 '\n'          Text.Whitespace
 
 'Filtering Blocks' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2865,9 +2865,9 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'escape'      Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -2884,7 +2884,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2906,9 +2906,9 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lower'       Name.Function
 '|'           Operator
 'escape'      Name.Function
@@ -2921,7 +2921,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -2937,10 +2937,10 @@
 '\n'          Text.Whitespace
 
 'Defining Variables' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '==================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -2964,7 +2964,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -2994,10 +2994,10 @@
 '\n'          Text.Whitespace
 
 'Scopes'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '======'      Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3043,7 +3043,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'angryhello'  Name.Variable
@@ -3056,7 +3056,7 @@
 '    '        Text
 '  '          Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'angryname'   Name.Variable
@@ -3096,7 +3096,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3142,10 +3142,10 @@
 '\n'          Text.Whitespace
 
 'Undefined Variables' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '===================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3218,9 +3218,9 @@
 'undefined'   Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '}}'          Comment.Preproc
@@ -3337,10 +3337,10 @@
 '    still returns `undefined`.\n\n' Other
 
 'Escaping'    Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '========'    Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3394,9 +3394,9 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'raw'         Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n'          Text
 
@@ -3420,17 +3420,17 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endraw'      Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 'Reserved Keywords' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '=================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3537,7 +3537,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'macro_'      Name.Variable
@@ -3563,7 +3563,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3584,10 +3584,10 @@
 '\n'          Text.Whitespace
 
 'Internationalization' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '====================' Generic.Heading
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
@@ -3612,7 +3612,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3623,7 +3623,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endtrans'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3631,7 +3631,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 '"This is a translatable string"' Literal.String.Double
@@ -3673,7 +3673,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 'users'       Name.Variable
@@ -3688,7 +3688,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'pluralize'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3705,7 +3705,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endtrans'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3713,7 +3713,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'trans'       Keyword
 ' '           Text
 'first'       Name.Variable
@@ -3748,7 +3748,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'pluralize'   Keyword
 ' '           Text
 'users'       Name.Variable
@@ -3773,7 +3773,7 @@
 
 '    '        Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endtrans'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3821,10 +3821,10 @@
 '\n'          Text.Whitespace
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'admonition'  Operator.Word
 '::'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'note'        Text
 '\n'          Text.Whitespace
 
@@ -3855,7 +3855,7 @@
 
 '        '    Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'count'       Name.Variable
@@ -3878,7 +3878,7 @@
 
 '        '    Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3889,14 +3889,14 @@
 
 '        '    Text
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 '_slicing chapter:' Name.Tag
 ' http'       Text
 ':'           Text
@@ -3904,7 +3904,7 @@
 '\n'          Text.Whitespace
 
 '..'          Punctuation
-' '           Text
+' '           Text.Whitespace
 '_range function:' Name.Tag
 ' http'       Text
 ':'           Text

--- a/tests/examplefiles/scdoc/scdoc_manual.scd.output
+++ b/tests/examplefiles/scdoc/scdoc_manual.scd.output
@@ -75,7 +75,7 @@
 
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 '*name*'      Generic.Strong
 '('           Text
 '_section_)'  Text
@@ -89,10 +89,10 @@
 'header"]]'   Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*name*'      Generic.Strong
-' '           Text
+' '           Text.Whitespace
 'is'          Text
 ' '           Text
 'the'         Text
@@ -114,9 +114,9 @@
 'writing,'    Text
 ' '           Text
 'and'         Text
-' '           Text
+' '           Text.Whitespace
 '_section_'   Generic.Emph
-' '           Text
+' '           Text.Whitespace
 'is'          Text
 ' '           Text
 'the'         Text
@@ -131,7 +131,7 @@
 'for'         Text
 ' '           Text
 '(see'        Text
-' '           Text
+' '           Text.Whitespace
 '*man*'       Generic.Strong
 '('           Text
 '1)'          Text
@@ -193,9 +193,9 @@
 'page,'       Text
 ' '           Text
 'and'         Text
-' '           Text
+' '           Text.Whitespace
 '*must*'      Generic.Strong
-' '           Text
+' '           Text.Whitespace
 'be'          Text
 '\n'          Text.Whitespace
 
@@ -379,13 +379,13 @@
 'be'          Text
 ' '           Text
 'made'        Text
-' '           Text
+' '           Text.Whitespace
 '*bold*'      Generic.Strong
-' '           Text
+' '           Text.Whitespace
 'or'          Text
-' '           Text
+' '           Text.Whitespace
 '_underlined_' Generic.Emph
-' '           Text
+' '           Text.Whitespace
 'with'        Text
 ' '           Text
 'asterisks'   Text
@@ -508,7 +508,7 @@
 'and'         Text
 ' '           Text
 'most'        Text
-' '           Text
+' '           Text.Whitespace
 '_formatting_' Generic.Emph
 '.'           Text
 '\n'          Text.Whitespace
@@ -593,40 +593,40 @@
 'this:'       Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Item'        Text
 ' '           Text
 '1'           Text
 '\n'          Text.Whitespace
 
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Item'        Text
 ' '           Text
 '2'           Text
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Subitem'     Text
 ' '           Text
 '1'           Text
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Subitem'     Text
 ' '           Text
 '2'           Text
 '\n'          Text.Whitespace
 
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Item'        Text
 ' '           Text
 '3'           Text
@@ -701,10 +701,10 @@
 '```'         Literal.String
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Item'        Text
 ' '           Text
 '1'           Text
@@ -736,7 +736,7 @@
 '\n'          Text.Whitespace
 
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'Item'        Text
 ' '           Text
 '2'           Text
@@ -746,9 +746,9 @@
 'shorter'     Text
 '\n'          Text.Whitespace
 
-'\t'          Text
+'\t'          Text.Whitespace
 '-'           Keyword
-' '           Text
+' '           Text.Whitespace
 'But'         Text
 ' '           Text
 'its'         Text
@@ -1196,23 +1196,23 @@
 '\n'          Text.Whitespace
 
 '[['          Text
-' '           Text
+' '           Text.Whitespace
 '*Foo*'       Generic.Strong
-'\n'          Text
+'\n'          Text.Whitespace
 
 ':-'          Text
-' '           Text
+' '           Text.Whitespace
 '_Bar_'       Generic.Emph
-'\n'          Text
+'\n'          Text.Whitespace
 
 ':-'          Text
 '\n'          Text.Whitespace
 
 '|'           Text
 ' '           Text
-' '           Text
+' '           Text.Whitespace
 '*Row 1*'     Generic.Strong
-'\n'          Text
+'\n'          Text.Whitespace
 
 ':'           Text
 ' '           Text
@@ -1227,9 +1227,9 @@
 
 '|'           Text
 ' '           Text
-' '           Text
+' '           Text.Whitespace
 '*Row 2*'     Generic.Strong
-'\n'          Text
+'\n'          Text.Whitespace
 
 ':'           Text
 ' '           Text
@@ -1561,7 +1561,7 @@
 '#'           Generic.Heading
 ' SEE ALSO\n' Text
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*scdoc*'     Generic.Strong
 '('           Text

--- a/tests/examplefiles/smalltalk/Object.st.output
+++ b/tests/examplefiles/smalltalk/Object.st.output
@@ -79,7 +79,7 @@
 '\n'          Text
 
 'beep:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'soundName'   Name.Variable
 '\n\t'        Text
 '"Make the given sound, unless the making of sound is disabled in Preferences."' Comment
@@ -117,7 +117,7 @@
 '\n'          Text
 
 'contentsGetz:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'x'           Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -143,7 +143,7 @@
 '\n'          Text
 
 'deprecatedExplanation:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n     '     Text
 '"This method is OBSOLETE.  Use #deprecated: instead."' Comment
@@ -196,11 +196,11 @@
 '\n'          Text
 
 'deprecated:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' '           Text
 'explanation:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t '      Text
 '"This method is OBSOLETE.  Use #deprecated:block: instead."' Comment
@@ -263,7 +263,7 @@
 '\n'          Text
 
 'doIfNotNil:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -293,11 +293,11 @@
 '\n'          Text
 
 'ifKindOf:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aClass'      Name.Variable
 ' '           Text
 'thenDo:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -337,7 +337,7 @@
 '\n'          Text
 
 'playSoundNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'soundName'   Name.Variable
 '\n\t'        Text
 '"Deprecated.\n\tPlay the sound with the given name."' Comment
@@ -469,7 +469,7 @@
 '\n'          Text
 
 'contentType' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '"Janko Mivsek, apr98"' Comment
@@ -489,7 +489,7 @@
 '\n'          Text
 
 'deepSearchOfClass:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aClassName'  Name.Variable
 '\n\t'        Text
 '"finf all objects of that class down in object hierarchy"' Comment
@@ -778,7 +778,7 @@
 '\n'          Text
 
 'forLanguage:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aLanguageCodeSymbol' Name.Variable
 '\n\t'        Text
 '"for multilingual support: returns an apropriate instance of itself for that language. \n\tLangage is defined by ISO 639 2-letter language code, see \n\thttp://en.wikipedia.org/wiki/List_of_ISO_639-1_codes"' Comment
@@ -888,7 +888,7 @@
 '\n'          Text
 
 'printWebAppNotFoundFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSession'    Name.Variable
 ' \n\t'       Text
 '|'           Operator
@@ -931,7 +931,7 @@
 '\n'          Text
 
 'printWebPageFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSession'    Name.Variable
 ' \n\t'       Text
 '"find appropriate web application to represent self as web page"' Comment
@@ -984,7 +984,7 @@
 '\n'          Text
 
 'sendOver:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 ' \n\t'       Text
 '"from Wiki rendering"' Comment
@@ -1005,7 +1005,7 @@
 '\n'          Text
 
 'webAppFor:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSession'    Name.Variable
 '\n\t'        Text
 '|'           Operator
@@ -1120,7 +1120,7 @@
 '\n'          Text
 
 'binding:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Set the dynamic binding for the receiver, if anObject is nil, then \n\tremove the receiver\'s dynamic binding (if any)"' Comment
@@ -1205,7 +1205,7 @@
 '\n'          Text
 
 'asHtmlDocumentForRequest:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aNetworkRequest' Name.Variable
 '\n\n\t'      Text
 'self'        Name.Builtin.Pseudo
@@ -1234,7 +1234,7 @@
 '\n'          Text
 
 'asHttpResponseTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anHttpRequest' Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -1262,7 +1262,7 @@
 '\n'          Text
 
 'isComancheModule' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -1278,7 +1278,7 @@
 '\n'          Text
 
 'mimeType'    Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -1315,22 +1315,22 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'exclusive:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValueHolder' Name.Variable
 '\n \n\t'     Text
 'self'        Name.Builtin.Pseudo
@@ -1369,27 +1369,27 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArg'       Name.Variable
 '\n'          Text
 
 'exclusive:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValueHolder' Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -1438,27 +1438,27 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArgArray'  Name.Variable
 '\n'          Text
 
 'exclusive:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValueHolder' Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -1501,17 +1501,17 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'sendOnce:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -1544,22 +1544,22 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'sendOnce:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArg'       Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -1602,22 +1602,22 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'sendOnce:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArgArray'  Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -1741,7 +1741,7 @@
 '\n'          Text
 
 'exploreWithLabel:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'label'       Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -1803,7 +1803,7 @@
 '\n'          Text
 
 'askFor:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' \n\n    '   Text
 '"returns true or false"' Comment
@@ -1836,11 +1836,11 @@
 '\n'          Text
 
 'askFor:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' '           Text
 'ifAbsent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\n   '     Text
 '"enables a default value to be specified in order to be tolerant of potentially missing methods\n\t\n\te.g.\n\t(myPoint askFor: #originOffset) ifAbsent: [ 0@0 ].\n\t"' Comment
@@ -1974,7 +1974,7 @@
 '\n'          Text
 
 'readUsing:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aDescription' Name.Variable
 '\n\t'        Text
 '"Dispatch the read-access to the receiver using the accessor of aDescription."' Comment
@@ -1999,11 +1999,11 @@
 '\n'          Text
 
 'write:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 ' '           Text
 'using:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'aDescription' Name.Variable
 '\n\t'        Text
 '"Dispatch the write-access to the receiver of anObject using the accessor of aDescription."' Comment
@@ -2101,7 +2101,7 @@
 '\n'          Text
 
 'ifNull:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -2118,7 +2118,7 @@
 '\n'          Text
 
 'isNull'      Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -2135,7 +2135,7 @@
 '\n'          Text
 
 'orNull'      Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -2387,7 +2387,7 @@
 '\n'          Text
 
 'accept:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVisitor'    Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -2404,7 +2404,7 @@
 '\n'          Text
 
 'acceptDecorated:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVisitor'    Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -2423,7 +2423,7 @@
 '\n'          Text
 
 'isRio'       Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -2460,7 +2460,7 @@
 '\n'          Text
 
 'asFunction:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCollection' Name.Variable
 '\n\t'        Text
 '^'           Operator
@@ -2520,7 +2520,7 @@
 '\n'          Text
 
 'javascriptOn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -2560,7 +2560,7 @@
 '\n'          Text
 
 'deprecatedApi:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 'WADeprecatedApi' Name.Class
@@ -2696,7 +2696,7 @@
 '\n'          Text
 
 'labelForSelector:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 '\n\t'        Text
 '^'           Operator
@@ -2715,7 +2715,7 @@
 '\n'          Text
 
 'renderOn:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aRenderer'   Name.Variable
 '\n\t'        Text
 '"Override this method to customize how objects (not components) are rendered when passed as an argument to #render:. The default is the return value of #displayString.\n\tJust remember that you can not use #callback:, #on:of:, or #call:"' Comment
@@ -2736,7 +2736,7 @@
 '\n'          Text
 
 'restoreFromSnapshot:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -2772,7 +2772,7 @@
 '\n'          Text
 
 'validationError:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'message'     Name.Variable
 '\n\t'        Text
 '^'           Operator
@@ -2792,7 +2792,7 @@
 '\n'          Text
 
 'encodeOn:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aDocument'   Name.Variable
 '\n\t'        Text
 'aDocument'   Name.Variable
@@ -2866,7 +2866,7 @@
 '\n'          Text
 
 'systemNavigation' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -2955,11 +2955,11 @@
 '\n'          Text
 
 'addInstanceVarNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aName'       Name.Variable
 ' '           Text
 'withValue:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValue'      Name.Variable
 '\n\t'        Text
 '"Add an instance variable named aName and give it value aValue"' Comment
@@ -2999,7 +2999,7 @@
 '\n'          Text
 
 'at:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' \n\t'       Text
 '"Primitive. Assumes receiver is indexable. Answer the value of an \n\tindexable element in the receiver. Fail if the argument index is not an \n\tInteger or is out of bounds. Essential. See Object documentation \n\twhatIsAPrimitive."' Comment
@@ -3077,11 +3077,11 @@
 '\n'          Text
 
 'at:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' '           Text
 'modify:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '"Replace the element of the collection with itself transformed by the block"' Comment
@@ -3120,11 +3120,11 @@
 '\n'          Text
 
 'at:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' '           Text
 'put:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' \n\t'       Text
 '"Primitive. Assumes receiver is indexable. Store the argument value in \n\tthe indexable element of the receiver indicated by index. Fail if the \n\tindex is not an Integer or is out of bounds. Or fail if the value is not of \n\tthe right type for this kind of collection. Answer the value that was \n\tstored. Essential. See Object documentation whatIsAPrimitive."' Comment
@@ -3238,11 +3238,11 @@
 '\n'          Text
 
 'basicAddInstanceVarNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aName'       Name.Variable
 ' '           Text
 'withValue:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValue'      Name.Variable
 '\n\t'        Text
 '"Add an instance variable named aName and give it value aValue"' Comment
@@ -3282,7 +3282,7 @@
 '\n'          Text
 
 'basicAt:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' \n\t'       Text
 '"Primitive. Assumes receiver is indexable. Answer the value of an \n\tindexable element in the receiver. Fail if the argument index is not an \n\tInteger or is out of bounds. Essential. Do not override in a subclass. See \n\tObject documentation whatIsAPrimitive."' Comment
@@ -3342,11 +3342,11 @@
 '\n'          Text
 
 'basicAt:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' '           Text
 'put:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' \n\t'       Text
 '"Primitive. Assumes receiver is indexable. Store the second argument \n\tvalue in the indexable element of the receiver indicated by index. Fail \n\tif the index is not an Integer or is out of bounds. Or fail if the value is \n\tnot of the right type for this kind of collection. Answer the value that \n\twas stored. Essential. Do not override in a subclass. See Object \n\tdocumentation whatIsAPrimitive."' Comment
@@ -3466,7 +3466,7 @@
 '\n'          Text
 
 'bindWithTemp:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '^'           Operator
@@ -3491,11 +3491,11 @@
 '\n'          Text
 
 'ifNil:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'nilBlock'    Name.Variable
 ' '           Text
 'ifNotNilDo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' \n\t'       Text
 '"Evaluate aBlock with the receiver as its argument."' Comment
@@ -3520,7 +3520,7 @@
 '\n'          Text
 
 'ifNotNilDo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '"Evaluate the given block with the receiver as its argument."' Comment
@@ -3545,11 +3545,11 @@
 '\n'          Text
 
 'ifNotNilDo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' '           Text
 'ifNil:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'nilBlock'    Name.Variable
 '\n\t'        Text
 '"Evaluate aBlock with the receiver as its argument."' Comment
@@ -3574,7 +3574,7 @@
 '\n'          Text
 
 'in:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '"Evaluate the given block with the receiver as its argument."' Comment
@@ -3620,7 +3620,7 @@
 '\n'          Text
 
 'readFromString:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '"Create an object based on the contents of aString."' Comment
@@ -3701,7 +3701,7 @@
 '\n'          Text
 
 '->'          Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Answer an Association between self and anObject"' Comment
@@ -3729,7 +3729,7 @@
 '\n'          Text
 
 'bindingOf:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '^'           Operator
@@ -3765,7 +3765,7 @@
 '\n'          Text
 
 'caseOf:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlockAssociationCollection' Name.Variable
 '\n\t'        Text
 '"The elements of aBlockAssociationCollection are associations between blocks.\n\t Answer the evaluated value of the first association in aBlockAssociationCollection\n\t whose evaluated key equals the receiver.  If no match is found, report an error."' Comment
@@ -3811,11 +3811,11 @@
 '\n'          Text
 
 'caseOf:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlockAssociationCollection' Name.Variable
 ' '           Text
 'otherwise:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '"The elements of aBlockAssociationCollection are associations between blocks.\n\t Answer the evaluated value of the first association in aBlockAssociationCollection\n\t whose evaluated key equals the receiver.  If no match is found, answer the result\n\t of evaluating aBlock."' Comment
@@ -3908,7 +3908,7 @@
 '\n'          Text
 
 'inheritsFromAnyIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aList'       Name.Variable
 '\n\t'        Text
 '"Answer whether the receiver inherits from any class represented by any element in the list.  The elements of the list can be classes, class name symbols, or strings representing possible class names.  This allows speculative membership tests to be made even when some of the classes may not be known to the current image, and even when their names are not interned symbols."' Comment
@@ -4007,7 +4007,7 @@
 '\n'          Text
 
 'isKindOf:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aClass'      Name.Variable
 ' \n\t'       Text
 '"Answer whether the class, aClass, is a superclass or class of the receiver."' Comment
@@ -4050,11 +4050,11 @@
 '\n'          Text
 
 'isKindOf:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aClass'      Name.Variable
 ' '           Text
 'orOf:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anotherClass' Name.Variable
 '\n\t'        Text
 '"Answer whether either of the classes, aClass or anotherClass,, is a superclass or class of the receiver.  A convenience; could be somewhat optimized"' Comment
@@ -4089,7 +4089,7 @@
 '\n'          Text
 
 'isMemberOf:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aClass'      Name.Variable
 ' \n\t'       Text
 '"Answer whether the receiver is an instance of the class, aClass."' Comment
@@ -4113,7 +4113,7 @@
 '\n'          Text
 
 'respondsTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' \n\t'       Text
 '"Answer whether the method dictionary of the receiver\'s class contains \n\taSymbol as a message selector."' Comment
@@ -4156,7 +4156,7 @@
 '\n'          Text
 
 'closeTo:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Answer whether the receiver and the argument represent the same\n\tobject. If = is redefined in any subclass, consider also redefining the\n\tmessage hash."' Comment
@@ -4227,7 +4227,7 @@
 '\n'          Text
 
 'hashMappedBy:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'map'         Name.Variable
 '\n\t'        Text
 '"Answer what my hash would be if oops changed according to map."' Comment
@@ -4249,7 +4249,7 @@
 '\n'          Text
 
 'identityHashMappedBy:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'map'         Name.Variable
 '\n\t'        Text
 '"Answer what my hash would be if oops changed according to map."' Comment
@@ -4298,7 +4298,7 @@
 '\n'          Text
 
 'literalEqual:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'other'       Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -4333,9 +4333,9 @@
 '\n'          Text
 
 '='           Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
-' '           Text
+' '           Text.Whitespace
 '\n\t'        Text
 '"Answer whether the receiver and the argument represent the same \n\tobject. If = is redefined in any subclass, consider also redefining the \n\tmessage hash."' Comment
 '\n\n\t'      Text
@@ -4356,9 +4356,9 @@
 '\n'          Text
 
 '~='          Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
-' '           Text
+' '           Text.Whitespace
 '\n\t'        Text
 '"Answer whether the receiver and the argument do not represent the \n\tsame object."' Comment
 '\n\n\t'      Text
@@ -4383,11 +4383,11 @@
 '\n'          Text
 
 'adaptToFloat:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'rcvr'        Name.Variable
 ' '           Text
 'andSend:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 '\n\t'        Text
 '"If no method has been provided for adapting an object to a Float,\n\tthen it may be adequate to simply adapt it to a number."' Comment
@@ -4414,11 +4414,11 @@
 '\n'          Text
 
 'adaptToFraction:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'rcvr'        Name.Variable
 ' '           Text
 'andSend:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 '\n\t'        Text
 '"If no method has been provided for adapting an object to a Fraction,\n\tthen it may be adequate to simply adapt it to a number."' Comment
@@ -4445,11 +4445,11 @@
 '\n'          Text
 
 'adaptToInteger:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'rcvr'        Name.Variable
 ' '           Text
 'andSend:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 '\n\t'        Text
 '"If no method has been provided for adapting an object to a Integer,\n\tthen it may be adequate to simply adapt it to a number."' Comment
@@ -4476,7 +4476,7 @@
 '\n'          Text
 
 'asActionSequence' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -4496,7 +4496,7 @@
 '\n'          Text
 
 'asActionSequenceTrappingErrors' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -4608,7 +4608,7 @@
 '\n'          Text
 
 'as:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSimilarClass' Name.Variable
 '\n\t'        Text
 '"Create an object of class aSimilarClass that has similar contents to the receiver."' Comment
@@ -4631,7 +4631,7 @@
 '\n'          Text
 
 'complexContents' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -4670,7 +4670,7 @@
 '\n'          Text
 
 'mustBeBooleanIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'context'     Name.Variable
 '\n\t'        Text
 '"context is the where the non-boolean error occurred. Rewind context to before jump then raise error."' Comment
@@ -4746,7 +4746,7 @@
 '\n'          Text
 
 'withoutListWrapper' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -4762,7 +4762,7 @@
 '\n'          Text
 
 'clone'       Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '<'           Text
@@ -4804,7 +4804,7 @@
 '\n'          Text
 
 'copyAddedStateFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anotherObject' Name.Variable
 '\n\t'        Text
 '"Copy over the values of instance variables added by the receiver\'s class from anotherObject to the receiver.  These will be remapped in mapUniClasses, if needed."' Comment
@@ -4864,7 +4864,7 @@
 '\n'          Text
 
 'copyFrom:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anotherObject' Name.Variable
 '\n\t'        Text
 '"Copy to myself all instance variables I have in common with anotherObject.  This is dangerous because it ignores an object\'s control over its own inst vars.  "' Comment
@@ -5036,7 +5036,7 @@
 '\n'          Text
 
 'copySameFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'otherObject' Name.Variable
 '\n\t'        Text
 '"Copy to myself all instance variables named the same in otherObject.\n\tThis ignores otherObject\'s control over its own inst vars."' Comment
@@ -5875,7 +5875,7 @@
 '\n'          Text
 
 'veryDeepCopyUsing:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'copier'      Name.Variable
 '\n\t'        Text
 '"Do a complete tree copy using a dictionary.  An object in the tree twice is only copied once.  All references to the object in the copy of the tree will point to the new copy.\n\tSame as veryDeepCopy except copier (with dictionary) is supplied.\n\t** do not delete this method, even if it has no callers **"' Comment
@@ -6022,7 +6022,7 @@
 '\n'          Text
 
 'veryDeepCopyWith:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'deepCopier'  Name.Variable
 '\n\t'        Text
 '"Copy me and the entire tree of objects I point to.  An object in the tree twice is copied once, and both references point to him.  deepCopier holds a dictionary of objects we have seen.  Some classes refuse to be copied.  Some classes are picky about which fields get deep copied."' Comment
@@ -6570,7 +6570,7 @@
 '\n'          Text
 
 'veryDeepFixupWith:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'deepCopier'  Name.Variable
 '\n\t'        Text
 '"I have no fields and no superclass.  Catch the super call."' Comment
@@ -6587,7 +6587,7 @@
 '\n'          Text
 
 'veryDeepInner:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'deepCopier'  Name.Variable
 '\n\t'        Text
 '"No special treatment for inst vars of my superclasses.  Override when some need to be weakly copied.  Object>>veryDeepCopyWith: will veryDeepCopy any inst var whose class does not actually define veryDeepInner:"' Comment
@@ -6678,7 +6678,7 @@
 '\n'          Text
 
 'haltIf:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'condition'   Name.Variable
 '\n\t'        Text
 '"This is the typical message to use for inserting breakpoints during \n\tdebugging.  Param can be a block or expression, halt if true.\n\tIf the Block has one arg, the receiver is bound to that.\n \tIf the condition is a selector, we look up in the callchain. Halt if\n      any method\'s selector equals selector."' Comment
@@ -6976,7 +6976,7 @@
 '\n'          Text
 
 'doExpiredHaltCount:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -7030,7 +7030,7 @@
 '\n'          Text
 
 'haltOnCount:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'int'         Name.Variable
 ' \n\t'       Text
 'self'        Name.Builtin.Pseudo
@@ -7160,7 +7160,7 @@
 '\n'          Text
 
 'haltOnce:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"Halt unless we have already done it once."' Comment
@@ -7196,11 +7196,11 @@
 '\n'          Text
 
 'halt:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' '           Text
 'onCount:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'int'         Name.Variable
 ' \n\t'       Text
 'self'        Name.Builtin.Pseudo
@@ -7295,7 +7295,7 @@
 '\n'          Text
 
 'inspectOnCount:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'int'         Name.Variable
 ' \n\t'       Text
 'self'        Name.Builtin.Pseudo
@@ -7400,7 +7400,7 @@
 '\n'          Text
 
 'inspectUntilCount:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'int'         Name.Variable
 ' \n\t'       Text
 'self'        Name.Builtin.Pseudo
@@ -7511,7 +7511,7 @@
 '\n'          Text
 
 'setHaltCountTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'int'         Name.Variable
 '\n\t'        Text
 'Smalltalk'   Name.Class
@@ -7588,7 +7588,7 @@
 '\n'          Text
 
 'addDependent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Make the given object one of the receiver\'s dependents."' Comment
@@ -7737,11 +7737,11 @@
 '\n'          Text
 
 'evaluate:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'actionBlock' Name.Variable
 ' '           Text
 'wheneverChangeIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aspectBlock' Name.Variable
 '\n\t'        Text
 '|'           Operator
@@ -7872,7 +7872,7 @@
 '\n'          Text
 
 'myDependents:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCollectionOrNil' Name.Variable
 '\n\t'        Text
 '"Private. Set (or remove) the receiver\'s dependents list."' Comment
@@ -7935,7 +7935,7 @@
 '\n'          Text
 
 'removeDependent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Remove the given object as one of the receiver\'s dependents."' Comment
@@ -7999,15 +7999,15 @@
 '\n'          Text
 
 'acceptDroppingMorph:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'transferMorph' Name.Variable
 ' '           Text
 'event:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'evt'         Name.Variable
 ' '           Text
 'inMorph:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'dstListMorph' Name.Variable
 ' \n\t\n\t'   Text
 '^'           Operator
@@ -8024,11 +8024,11 @@
 '\n'          Text
 
 'dragAnimationFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'item'        Name.Variable
 ' '           Text
 'transferMorph:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'transferMorph' Name.Variable
 ' \n\t'       Text
 '"Default do nothing"' Comment
@@ -8043,11 +8043,11 @@
 '\n'          Text
 
 'dragPassengerFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'item'        Name.Variable
 ' '           Text
 'inMorph:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'dragSource'  Name.Variable
 ' \n\t'       Text
 '^'           Operator
@@ -8077,7 +8077,7 @@
 '\n'          Text
 
 'dragTransferTypeForMorph:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'dragSource'  Name.Variable
 ' \n\t'       Text
 '^'           Operator
@@ -8093,15 +8093,15 @@
 '\n'          Text
 
 'wantsDroppedMorph:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMorph'      Name.Variable
 ' '           Text
 'event:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEvent'     Name.Variable
 ' '           Text
 'inMorph:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'destinationLM' Name.Variable
 ' \n\t'       Text
 '^'           Operator
@@ -8117,7 +8117,7 @@
 '\n'          Text
 
 'assert:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\t'        Text
 '"Throw an assertion error if aBlock does not evaluates to true."' Comment
@@ -8146,11 +8146,11 @@
 '\n'          Text
 
 'assert:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' '           Text
 'descriptionBlock:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'descriptionBlock' Name.Variable
 '\n\t'        Text
 '"Throw an assertion error if aBlock does not evaluate to true."' Comment
@@ -8184,11 +8184,11 @@
 '\n'          Text
 
 'assert:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' '           Text
 'description:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '"Throw an assertion error if aBlock does not evaluates to true."' Comment
@@ -8218,7 +8218,7 @@
 '\n'          Text
 
 'backwardCompatibilityOnly:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExplanationString' Name.Variable
 '\n\t'        Text
 '"Warn that the sending method has been deprecated. Methods that are tagt with #backwardCompatibility:\n\t are kept for compatibility."' Comment
@@ -8276,7 +8276,7 @@
 '\n'          Text
 
 'confirm:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'queryString' Name.Variable
 '\n\t'        Text
 '"Put up a yes/no menu with caption queryString. Answer true if the \n\tresponse is yes, false if no. This is a modal question--the user must \n\trespond yes or no."' Comment
@@ -8303,11 +8303,11 @@
 '\n'          Text
 
 'confirm:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' '           Text
 'orCancel:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'cancelBlock' Name.Variable
 '\n\t'        Text
 '"Put up a yes/no/cancel menu with caption aString. Answer true if  \n\tthe response is yes, false if no. If cancel is chosen, evaluate  \n\tcancelBlock. This is a modal question--the user must respond yes or no."' Comment
@@ -8336,7 +8336,7 @@
 '\n'          Text
 
 'deprecated:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExplanationString' Name.Variable
 '\n\t'        Text
 '"Warn that the sending method has been deprecated."' Comment
@@ -8375,11 +8375,11 @@
 '\n'          Text
 
 'deprecated:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExplanationString' Name.Variable
 ' '           Text
 'block:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 ' \n\t '      Text
 '"Warn that the sender has been deprecated.  Answer the value of aBlock on resumption.  (Note that #deprecated: is usually the preferred method.)"' Comment
@@ -8428,7 +8428,7 @@
 '\n'          Text
 
 'doesNotUnderstand:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessage'    Name.Variable
 ' \n\t '      Text
 '"Handle the fact that there was an attempt to send the given message to the receiver but the receiver does not understand this message (typically sent from the machine when a message is sent to the receiver and no method is defined for that selector)."' Comment
@@ -8473,7 +8473,7 @@
 '\n'          Text
 
 'dpsTrace:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'reportObject' Name.Variable
 '  \n\t'      Text
 'Transcript'  Name.Class
@@ -8517,11 +8517,11 @@
 '\n'          Text
 
 'dpsTrace:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'reportObject' Name.Variable
 ' '           Text
 'levels:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'anInt'       Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -8551,15 +8551,15 @@
 '\n'          Text
 
 'dpsTrace:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'reportObject' Name.Variable
 ' '           Text
 'levels:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'anInt'       Name.Variable
 ' '           Text
 'withContext:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'currentContext' Name.Variable
 '\n\t'        Text
 '|'           Operator
@@ -8828,7 +8828,7 @@
 '\n'          Text
 
 'error:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"Throw a generic Error exception."' Comment
@@ -8886,7 +8886,7 @@
 '\n'          Text
 
 'halt:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"This is the typical message to use for inserting breakpoints during \n\tdebugging. It creates and schedules a Notifier with the argument, \n\taString, as the label."' Comment
@@ -8909,7 +8909,7 @@
 '\n'          Text
 
 'handles:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'exception'   Name.Variable
 '\n\t'        Text
 '"This method exists in case a non exception class is the first arg in an on:do: (for instance using a exception class that is not loaded). We prefer this to raising an error during error handling itself. Also, semantically it makes sense that the exception handler is not active if its exception class is not loaded"' Comment
@@ -8928,7 +8928,7 @@
 '\n'          Text
 
 'notifyWithLabel:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"Create and schedule a Notifier with aString as the window label as well as the contents of the window, in  order to request confirmation before a process can proceed."' Comment
@@ -8959,7 +8959,7 @@
 '\n'          Text
 
 'notify:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"Create and schedule a Notifier with the argument as the message in \n\torder to request confirmation before a process can proceed."' Comment
@@ -8982,11 +8982,11 @@
 '\n'          Text
 
 'notify:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' '           Text
 'at:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'location'    Name.Variable
 '\n\t'        Text
 '"Create and schedule a Notifier with the argument as the message in \n\torder to request confirmation before a process can proceed. Subclasses can\n\toverride this and insert an error message at location within aString."' Comment
@@ -9128,7 +9128,7 @@
 '\n'          Text
 
 'value'       Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -9144,7 +9144,7 @@
 '\n'          Text
 
 'valueWithArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSequenceOfArguments' Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -9160,11 +9160,11 @@
 '\n'          Text
 
 'actionsWithReceiver:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 ' '           Text
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -9204,15 +9204,15 @@
 '\n'          Text
 
 'renameActionsWithReceiver:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 ' '           Text
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 ' '           Text
 'toEvent:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'newEvent'    Name.Variable
 '\n\n\t'      Text
 '|'           Operator
@@ -9339,7 +9339,7 @@
 '\n'          Text
 
 'actionForEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n    '      Text
 '"Answer the action to be evaluated when <anEventSelector> has been triggered."' Comment
@@ -9395,12 +9395,12 @@
 '\n'          Text
 
 'actionForEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'ifAbsent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExceptionBlock' Name.Variable
 '\n    '      Text
 '"Answer the action to be evaluated when <anEventSelector> has been triggered."' Comment
@@ -9458,7 +9458,7 @@
 '\n'          Text
 
 'actionMap'   Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -9478,7 +9478,7 @@
 '\n'          Text
 
 'actionSequenceForEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 '^'           Operator
@@ -9515,7 +9515,7 @@
 '\n'          Text
 
 'actionsDo:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\n\t'      Text
 'self'        Name.Builtin.Pseudo
@@ -9536,7 +9536,7 @@
 '\n'          Text
 
 'createActionMap' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -9554,7 +9554,7 @@
 '\n'          Text
 
 'hasActionForEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n    '      Text
 '"Answer true if there is an action associated with anEventSelector"' Comment
@@ -9580,12 +9580,12 @@
 '\n'          Text
 
 'setActionSequence:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'actionSequence' Name.Variable
 '\n'          Text
 
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 '|'           Operator
@@ -9645,7 +9645,7 @@
 '\n'          Text
 
 'updateableActionMap' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -9665,11 +9665,11 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 ' '           Text
 'evaluate:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anAction'    Name.Variable
 ' \n\n\t'     Text
 '|'           Operator
@@ -9730,17 +9730,17 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -9773,22 +9773,22 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArgArray'  Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -9825,22 +9825,22 @@
 '\n'          Text
 
 'when:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'send:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMessageSelector' Name.Variable
 '\n'          Text
 
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArg'       Name.Variable
 '\n \n    '   Text
 'self'        Name.Builtin.Pseudo
@@ -9883,7 +9883,7 @@
 '\n'          Text
 
 'releaseActionMap' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 'EventManager' Name.Class
@@ -9902,7 +9902,7 @@
 '\n'          Text
 
 'removeActionsForEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 '|'           Operator
@@ -9954,7 +9954,7 @@
 '\n'          Text
 
 'removeActionsSatisfying:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aBlock'      Name.Variable
 '\n\n\t'      Text
 'self'        Name.Builtin.Pseudo
@@ -9993,12 +9993,12 @@
 '\n'          Text
 
 'removeActionsSatisfying:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aOneArgBlock' Name.Variable
 ' \n'         Text
 
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 'self'        Name.Builtin.Pseudo
@@ -10044,7 +10044,7 @@
 '\n'          Text
 
 'removeActionsWithReceiver:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\n\t'      Text
 'self'        Name.Builtin.Pseudo
@@ -10096,12 +10096,12 @@
 '\n'          Text
 
 'removeActionsWithReceiver:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 'self'        Name.Builtin.Pseudo
@@ -10137,12 +10137,12 @@
 '\n'          Text
 
 'removeAction:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anAction'    Name.Variable
 '\n'          Text
 
 'forEvent:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\n    '    Text
 'self'        Name.Builtin.Pseudo
@@ -10176,7 +10176,7 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n\t'        Text
 '"Evaluate all actions registered for <anEventSelector>. Return the value of the last registered action."' Comment
@@ -10202,12 +10202,12 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'ifNotHandled:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExceptionBlock' Name.Variable
 '\n\t'        Text
 '"Evaluate all actions registered for <anEventSelector>. Return the value of the last registered action."' Comment
@@ -10244,12 +10244,12 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArgumentList' Name.Variable
 '\n\n    '    Text
 '^'           Operator
@@ -10275,17 +10275,17 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArgumentList' Name.Variable
 '\n'          Text
 
 'ifNotHandled:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExceptionBlock' Name.Variable
 '\n\n    '    Text
 '^'           Operator
@@ -10320,12 +10320,12 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\n    '    Text
 '^'           Operator
@@ -10355,17 +10355,17 @@
 '\n'          Text
 
 'triggerEvent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEventSelector' Name.Variable
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n'          Text
 
 'ifNotHandled:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anExceptionBlock' Name.Variable
 '\n\n    '    Text
 '^'           Operator
@@ -10664,11 +10664,11 @@
 '\n'          Text
 
 'retryWithGC:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'execBlock'   Name.Variable
 ' '           Text
 'until:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'testBlock'   Name.Variable
 '\n\t'        Text
 '"Retry execBlock as long as testBlock returns false. Do an incremental GC after the first try, a full GC after the second try."' Comment
@@ -10751,15 +10751,15 @@
 '\n'          Text
 
 'toFinalizeSend:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSelector'   Name.Variable
 ' '           Text
 'to:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'aFinalizer'  Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aResourceHandle' Name.Variable
 '\n\t'        Text
 '"When I am finalized (e.g., garbage collected) close the associated resource handle by sending aSelector to the appropriate finalizer (the guy who knows how to get rid of the resource).\n\tWARNING: Neither the finalizer nor the resource handle are allowed to reference me. If they do, then I will NEVER be garbage collected. Since this cannot be validated here, it is up to the client to make sure this invariant is not broken."' Comment
@@ -10858,7 +10858,7 @@
 '\n'          Text
 
 'isThisEverCalled:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'msg'         Name.Variable
 '\n\t'        Text
 '"Send this message, with some useful printable argument, from methods or branches of methods which you believe are never reached.  2/5/96 sw"' Comment
@@ -10884,7 +10884,7 @@
 '\n'          Text
 
 'logEntry'    Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 'Transcript'  Name.Class
@@ -10916,7 +10916,7 @@
 '\n'          Text
 
 'logExecution' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 'Transcript'  Name.Class
@@ -10948,7 +10948,7 @@
 '\n'          Text
 
 'logExit'     Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 'Transcript'  Name.Class
@@ -10980,15 +10980,15 @@
 '\n'          Text
 
 'addModelYellowButtonMenuItemsTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCustomMenu' Name.Variable
 ' '           Text
 'forMorph:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMorph'      Name.Variable
 ' '           Text
 'hand:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aHandMorph'  Name.Variable
 ' \n\t'       Text
 '"The receiver serves as the model for aMorph; a menu is being constructed for the morph, and here the receiver is able to add its own items"' Comment
@@ -11125,7 +11125,7 @@
 '\n'          Text
 
 'codeStrippedOut:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'messageString' Name.Variable
 '\n\t'        Text
 '"When a method is stripped out for external release, it is replaced by a method that calls this"' Comment
@@ -11505,7 +11505,7 @@
 '\n'          Text
 
 'scriptPerformer' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -11543,7 +11543,7 @@
 '\n'          Text
 
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver with no args"' Comment
@@ -11575,7 +11575,7 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' \n\t'       Text
 '"Send the unary selector, aSymbol, to the receiver.\n\tFail if the number of arguments expected by the selector is not zero.\n\tPrimitive. Optional. See Object documentation whatIsAPrimitive."' Comment
@@ -11613,11 +11613,11 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' '           Text
 'orSendTo:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'otherTarget' Name.Variable
 '\n\t'        Text
 '"If I wish to intercept and handle selector myself, do it; else send it to otherTarget"' Comment
@@ -11662,11 +11662,11 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' '           Text
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'argArray'    Name.Variable
 ' \n\t'       Text
 '"Send the selector, aSymbol, to the receiver with arguments in argArray.\n\tFail if the number of arguments expected by the selector \n\tdoes not match the size of argArray.\n\tPrimitive. Optional. See Object documentation whatIsAPrimitive."' Comment
@@ -11704,15 +11704,15 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' '           Text
 'withArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'argArray'    Name.Variable
 ' '           Text
 'inSuperclass:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'lookupClass' Name.Variable
 '\n\t'        Text
 '"NOTE:  This is just like perform:withArguments:, except that\n\tthe message lookup process begins, not with the receivers\'s class,\n\tbut with the supplied superclass instead.  It will fail if lookupClass\n\tcannot be found among the receiver\'s superclasses.\n\tPrimitive. Essential. See Object documentation whatIsAPrimitive."' Comment
@@ -11815,11 +11815,11 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'selector'    Name.Variable
 ' '           Text
 'withEnoughArguments:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anArray'     Name.Variable
 '\n\t'        Text
 '"Send the selector, aSymbol, to the receiver with arguments in argArray.\n\tOnly use enough arguments for the arity of the selector; supply nils for missing ones."' Comment
@@ -11927,11 +11927,11 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 ' \n\t'       Text
 '"Send the selector, aSymbol, to the receiver with anObject as its argument.\n\tFail if the number of arguments expected by the selector is not one.\n\tPrimitive. Optional. See Object documentation whatIsAPrimitive."' Comment
@@ -11969,15 +11969,15 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'firstObject' Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'secondObject' Name.Variable
 ' \n\t'       Text
 '"Send the selector, aSymbol, to the receiver with the given arguments.\n\tFail if the number of arguments expected by the selector is not two.\n\tPrimitive. Optional. See Object documentation whatIsAPrimitive."' Comment
@@ -12019,19 +12019,19 @@
 '\n'          Text
 
 'perform:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'firstObject' Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'secondObject' Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'thirdObject' Name.Variable
 ' \n\t'       Text
 '"Send the selector, aSymbol, to the receiver with the given arguments.\n\tFail if the number of arguments expected by the selector is not three.\n\tPrimitive. Optional. See Object documentation whatIsAPrimitive."' Comment
@@ -12077,11 +12077,11 @@
 '\n'          Text
 
 'withArgs:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'argArray'    Name.Variable
 ' '           Text
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver and args in argArray"' Comment
@@ -12153,11 +12153,11 @@
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg1'        Name.Variable
 ' '           Text
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver and arg1"' Comment
@@ -12190,15 +12190,15 @@
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg1'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg2'        Name.Variable
 ' '           Text
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver and arg1 & arg2"' Comment
@@ -12234,19 +12234,19 @@
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg1'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg2'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg3'        Name.Variable
 ' '           Text
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver and arg1, arg2, & arg3"' Comment
@@ -12285,23 +12285,23 @@
 '\n'          Text
 
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg1'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg2'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg3'        Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'arg4'        Name.Variable
 ' '           Text
 'executeMethod:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'compiledMethod' Name.Variable
 '\n\t'        Text
 '"Execute compiledMethod against the receiver and arg1, arg2, arg3, & arg4"' Comment
@@ -12343,7 +12343,7 @@
 '\n'          Text
 
 'comeFullyUpOnReload:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'smartRefStream' Name.Variable
 '\n\t'        Text
 '"Normally this read-in object is exactly what we want to store. 7/26/96 tk"' Comment
@@ -12362,11 +12362,11 @@
 '\n'          Text
 
 'convertToCurrentVersion:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'varDict'     Name.Variable
 ' '           Text
 'refStream:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'smartRefStrm' Name.Variable
 '\n\n\t'      Text
 '"subclasses should implement if they wish to convert old instances to modern ones"' Comment
@@ -12381,11 +12381,11 @@
 '\n'          Text
 
 'fixUponLoad:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aProject'    Name.Variable
 ' '           Text
 'seg:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'anImageSegment' Name.Variable
 '\n\t'        Text
 '"change the object due to conventions that have changed on\nthe project level.  (sent to all objects in the incoming project).\nSpecific classes should reimplement this."' Comment
@@ -12400,7 +12400,7 @@
 '\n'          Text
 
 'indexIfCompact' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -12418,7 +12418,7 @@
 '\n'          Text
 
 'objectForDataStream:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'refStrm'     Name.Variable
 '\n    '      Text
 '"Return an object to store on an external data stream."' Comment
@@ -12437,11 +12437,11 @@
 '\n'          Text
 
 'readDataFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aDataStream' Name.Variable
 ' '           Text
 'size:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'varsOnDisk'  Name.Variable
 '\n\t'        Text
 '"Fill in the fields of self based on the contents of aDataStream.  Return self.\n\t Read in the instance-variables written by Object>>storeDataOn:.\n\t NOTE: This method must send beginReference: before reading any objects from aDataStream that might reference it.\n\t Allow aDataStream to have fewer inst vars.  See SmartRefStream."' Comment
@@ -12694,7 +12694,7 @@
 '\n'          Text
 
 'storeDataOn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aDataStream' Name.Variable
 '\n\t'        Text
 '"Store myself on a DataStream.  Answer self.  This is a low-level DataStream/ReferenceStream method. See also objectToStoreOnDataStream.  NOTE: This method must send \'aDataStream beginInstance:size:\' and then (nextPut:/nextPutWeak:) its subobjects.  readDataFrom:size: reads back what we write here."' Comment
@@ -12928,7 +12928,7 @@
 '\n'          Text
 
 'longPrintOn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 '\n\t'        Text
 '"Append to the argument, aStream, the names and values of all \n\tof the receiver\'s instance variables."' Comment
@@ -12992,15 +12992,15 @@
 '\n'          Text
 
 'longPrintOn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 ' '           Text
 'limitedTo:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'sizeLimit'   Name.Variable
 ' '           Text
 'indent:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'indent'      Name.Variable
 '\n\t'        Text
 '"Append to the argument, aStream, the names and values of all of the receiver\'s instance variables.  Limit is the length limit for each inst var."' Comment
@@ -13161,7 +13161,7 @@
 '\n'          Text
 
 'longPrintStringLimitedTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aLimitValue' Name.Variable
 '\n\t'        Text
 '"Answer a String whose characters are a description of the receiver."' Comment
@@ -13237,7 +13237,7 @@
 '\n'          Text
 
 'nominallyUnsent:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSelectorSymbol' Name.Variable
 '\n\t'        Text
 '"From within the body of a method which is not formally sent within the system, but which you intend to have remain in the system (for potential manual invocation, or for documentation, or perhaps because it\'s sent by commented-out-code that you anticipate uncommenting out someday, send this message, with the selector itself as the argument.\n\nThis will serve two purposes:\n\n\t(1)  The method will not be returned by searches for unsent selectors (because it, in a manner of speaking, sends itself).\n\t(2)\tYou can locate all such methods by browsing senders of #nominallyUnsent:"' Comment
@@ -13268,7 +13268,7 @@
 '\n'          Text
 
 'printOn:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 '\n\t'        Text
 '"Append to the argument, aStream, a sequence of characters that  \n\tidentifies the receiver."' Comment
@@ -13348,7 +13348,7 @@
 '\n'          Text
 
 'printStringLimitedTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'limit'       Name.Variable
 '\n\t'        Text
 '"Answer a String whose characters are a description of the receiver.\n\tIf you want to print without a character limit, use fullPrintString."' Comment
@@ -13472,7 +13472,7 @@
 '\n'          Text
 
 'storeOn:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStream'     Name.Variable
 ' \n\t'       Text
 '"Append to the argument aStream a sequence of characters that is an \n\texpression whose evaluation creates an object similar to the receiver."' Comment
@@ -13729,7 +13729,7 @@
 '\n'          Text
 
 'adaptedToWorld:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWorld'      Name.Variable
 '\n\t'        Text
 '"If I refer to a world or a hand, return the corresponding items in the new world."' Comment
@@ -13747,7 +13747,7 @@
 '\n'          Text
 
 'defaultFloatPrecisionFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aGetSelector' Name.Variable
 '\n\t'        Text
 '"Answer a number indicating the default float precision to be used in a numeric readout for which the receiver is the model."' Comment
@@ -13766,7 +13766,7 @@
 '\n'          Text
 
 'evaluateUnloggedForSelf:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCodeString' Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -13794,15 +13794,15 @@
 '\n'          Text
 
 'methodInterfacesForCategory:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCategorySymbol' Name.Variable
 ' '           Text
 'inVocabulary:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 ' '           Text
 'limitClass:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aLimitClass' Name.Variable
 '\n\t'        Text
 '"Return a list of methodInterfaces for the receiver in the given category, given a vocabulary.  aCategorySymbol is the inherent category symbol, not necessarily the wording as expressed in the vocabulary."' Comment
@@ -13914,7 +13914,7 @@
 '\n'          Text
 
 'methodInterfacesForInstanceVariablesCategoryIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 '\n\t'        Text
 '"Return a collection of methodInterfaces for the instance-variables category.  The vocabulary parameter, at present anyway, is not used.  And for non-players, the method is at present vacuous in any case"' Comment
@@ -13935,7 +13935,7 @@
 '\n'          Text
 
 'methodInterfacesForScriptsCategoryIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 '\n\t'        Text
 '"Answer a list of method interfaces for the category #scripts, as seen in a viewer or other tool.  The vocabulary argument is not presently used.  Also, at present, only Players really do anyting interesting here."' Comment
@@ -13956,7 +13956,7 @@
 '\n'          Text
 
 'selfWrittenAsIll' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -13972,7 +13972,7 @@
 '\n'          Text
 
 'selfWrittenAsIm' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -13988,7 +13988,7 @@
 '\n'          Text
 
 'selfWrittenAsMe' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -14004,7 +14004,7 @@
 '\n'          Text
 
 'selfWrittenAsMy' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -14020,7 +14020,7 @@
 '\n'          Text
 
 'selfWrittenAsThis' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -14036,7 +14036,7 @@
 '\n'          Text
 
 'universalTilesForGetterOf:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMethodInterface' Name.Variable
 '\n\t'        Text
 '"Return universal tiles for a getter on the given method interface."' Comment
@@ -14245,7 +14245,7 @@
 '\n'          Text
 
 'universalTilesForInterface:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMethodInterface' Name.Variable
 '\n\t'        Text
 '"Return universal tiles for the given method interface.  Record who self is."' Comment
@@ -14437,7 +14437,7 @@
 '\n'          Text
 
 'becomeForward:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'otherObject' Name.Variable
 ' \n\t'       Text
 '"Primitive. All variables in the entire system that used to point\n\tto the receiver now point to the argument.\n\tFails if either argument is a SmallInteger."' Comment
@@ -14470,11 +14470,11 @@
 '\n'          Text
 
 'becomeForward:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'otherObject' Name.Variable
 ' '           Text
 'copyHash:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'copyHash'    Name.Variable
 '\n\t'        Text
 '"Primitive. All variables in the entire system that used to point to the receiver now point to the argument.\n\tIf copyHash is true, the argument\'s identity hash bits will be set to those of the receiver.\n\tFails if either argument is a SmallInteger."' Comment
@@ -14551,7 +14551,7 @@
 '\n'          Text
 
 'instVarAt:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' \n\t'       Text
 '"Primitive. Answer a fixed variable in an object. The numbering of the \n\tvariables corresponds to the named instance variables. Fail if the index \n\tis not an Integer or is not the index of a fixed variable. Essential. See \n\tObject documentation whatIsAPrimitive."' Comment
@@ -14589,11 +14589,11 @@
 '\n'          Text
 
 'instVarAt:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'anInteger'   Name.Variable
 ' '           Text
 'put:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 ' \n\t'       Text
 '"Primitive. Store a value into a fixed variable in the receiver. The \n\tnumbering of the variables corresponds to the named instance variables. \n\tFail if the index is not an Integer or is not the index of a fixed variable. \n\tAnswer the value stored as the result. Using this message violates the \n\tprinciple that each object has sovereign control over the storing of \n\tvalues into its instance variables. Essential. See Object documentation \n\twhatIsAPrimitive."' Comment
@@ -14634,7 +14634,7 @@
 '\n'          Text
 
 'instVarNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '"Return the value of the instance variable in me with that name.  Slow and unclean, but very useful. "' Comment
@@ -14671,11 +14671,11 @@
 '\n'          Text
 
 'instVarNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' '           Text
 'put:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'aValue'      Name.Variable
 '\n\t'        Text
 '"Store into the value of the instance variable in me of that name.  Slow and unclean, but very useful. "' Comment
@@ -14737,7 +14737,7 @@
 '\n'          Text
 
 'primitiveChangeClassTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Primitive. Change the class of the receiver into the class of the argument given that the format of the receiver matches the format of the argument\'s class. Fail if receiver or argument are SmallIntegers, or the receiver is an instance of a compact class and the argument isn\'t, or when the argument\'s class is compact and the receiver isn\'t, or when the format of the receiver is different from the format of the argument\'s class, or when the arguments class is fixed and the receiver\'s size differs from the size that an instance of the argument\'s class should have.\n\tNote: The primitive will fail in most cases that you think might work. This is mostly because of a) the difference between compact and non-compact classes, and b) because of differences in the format. As an example, \'(Array new: 3) primitiveChangeClassTo: Morph basicNew\' would fail for three of the reasons mentioned above. Array is compact, Morph is not (failure #1). Array is variable and Morph is fixed (different format - failure #2). Morph is a fixed-field-only object and the array is too short (failure #3).\n\tThe facility is really provided for certain, very specific applications (mostly related to classes changing shape) and not for casual use."' Comment
@@ -14761,7 +14761,7 @@
 '\n'          Text
 
 'rootStubInImageSegment:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'imageSegment' Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -14888,7 +14888,7 @@
 '\n'          Text
 
 'hasLiteralSuchThat:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'testBlock'   Name.Variable
 '\n\t'        Text
 '"This is the end of the imbedded structure path so return false."' Comment
@@ -14907,7 +14907,7 @@
 '\n'          Text
 
 'hasLiteralThorough:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'literal'     Name.Variable
 '\n\t'        Text
 '"Answer true if literal is identical to any literal in this array, even if imbedded in further structures.  This is the end of the imbedded structure path so return false."' Comment
@@ -14951,7 +14951,7 @@
 '\n'          Text
 
 'haveFullProtocolBrowsedShowingSelector:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSelector'   Name.Variable
 '\n\t'        Text
 '"Open up a Lexicon on the receiver, having it open up showing aSelector, which may be nil"' Comment
@@ -15043,7 +15043,7 @@
 '\n'          Text
 
 'isBlock'     Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15060,7 +15060,7 @@
 '\n'          Text
 
 'isBlockClosure' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15077,7 +15077,7 @@
 '\n'          Text
 
 'isCharacter' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15146,7 +15146,7 @@
 '\n'          Text
 
 'isCompiledMethod' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15244,7 +15244,7 @@
 '\n'          Text
 
 'isHeap'      Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15278,7 +15278,7 @@
 '\n'          Text
 
 'isInterval'  Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15325,7 +15325,7 @@
 '\n'          Text
 
 'isMorph'     Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -15853,7 +15853,7 @@
 '\n'          Text
 
 'renameInternal:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'newName'     Name.Variable
 ' \n\t'       Text
 '"Change the internal name (because of a conflict) but leave the external name unchanged.  Change Player class name, but do not change the names that appear in tiles.  Any object that might be pointed to in the References dictionary might get this message sent to it upon reload"' Comment
@@ -15874,7 +15874,7 @@
 '\n'          Text
 
 'renameTo:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'newName'     Name.Variable
 '\n\t'        Text
 '"If the receiver has an inherent idea about its own name, it should take action here.  Any object that might be pointed to in the References dictionary might get this message sent to it upon reload"' Comment
@@ -15906,11 +15906,11 @@
 '\n'          Text
 
 'stepAt:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'millisecondClockValue' Name.Variable
 ' '           Text
 'in:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWindow'     Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -15931,7 +15931,7 @@
 '\n'          Text
 
 'stepIn:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWindow'     Name.Variable
 '\n\n\t'      Text
 '^'           Operator
@@ -15950,7 +15950,7 @@
 '\n'          Text
 
 'stepTime'    Name.Function
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 '\n\t'        Text
 '^'           Operator
 ' '           Text
@@ -15968,7 +15968,7 @@
 '\n'          Text
 
 'stepTimeIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSystemWindow' Name.Variable
 '\n\t\n\t'    Text
 '^'           Operator
@@ -16038,7 +16038,7 @@
 '\n'          Text
 
 'wantsStepsIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSystemWindow' Name.Variable
 '\n\t\n\t'    Text
 '^'           Operator
@@ -16057,7 +16057,7 @@
 '\n'          Text
 
 'iconOrThumbnailOfSize:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aNumberOrPoint' Name.Variable
 ' \n\t'       Text
 '"Answer an appropiate form to represent the receiver"' Comment
@@ -16076,7 +16076,7 @@
 '\n'          Text
 
 'inline:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'inlineFlag'  Name.Variable
 '\n\t'        Text
 '"For translation only; noop when running in Smalltalk."' Comment
@@ -16091,11 +16091,11 @@
 '\n'          Text
 
 'var:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'varSymbol'   Name.Variable
 ' '           Text
 'declareC:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'declString'  Name.Variable
 '\n\t'        Text
 '"For translation only; noop when running in Smalltalk."' Comment
@@ -16230,7 +16230,7 @@
 '\n'          Text
 
 'redoFromCapturedState:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'st'          Name.Variable
 ' \n\t'       Text
 '"May be overridden in subclasses.  See also capturedState"' Comment
@@ -16255,19 +16255,19 @@
 '\n'          Text
 
 'refineRedoTarget:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'target'      Name.Variable
 ' '           Text
 'selector:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' '           Text
 'arguments:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'arguments'   Name.Variable
 ' '           Text
 'in:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'refineBlock' Name.Variable
 ' \n\t'       Text
 '"Any object can override this method to refine its redo specification"' Comment
@@ -16298,19 +16298,19 @@
 '\n'          Text
 
 'refineUndoTarget:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'target'      Name.Variable
 ' '           Text
 'selector:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 ' '           Text
 'arguments:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'arguments'   Name.Variable
 ' '           Text
 'in:'         Name.Function
-' '           Text
+' '           Text.Whitespace
 'refineBlock' Name.Variable
 ' \n\t'       Text
 '"Any object can override this method to refine its undo specification"' Comment
@@ -16341,7 +16341,7 @@
 '\n'          Text
 
 'rememberCommand:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCommand'    Name.Variable
 '\n\t'        Text
 '"Remember the given command for undo"' Comment
@@ -16381,11 +16381,11 @@
 '\n'          Text
 
 'rememberUndoableAction:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'actionBlock' Name.Variable
 ' '           Text
 'named:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'caption'     Name.Variable
 '\n\t'        Text
 '|'           Operator
@@ -16469,7 +16469,7 @@
 '\n'          Text
 
 'undoFromCapturedState:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'st'          Name.Variable
 ' \n\t'       Text
 '"May be overridden in subclasses.  See also capturedState"' Comment
@@ -16511,7 +16511,7 @@
 '\n'          Text
 
 'changed:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aParameter'  Name.Variable
 ' \n\t'       Text
 '"Receiver changed. The change is denoted by the argument aParameter. \n\tUsually the argument is a Symbol that is part of the dependent\'s change \n\tprotocol. Inform all of the dependents."' Comment
@@ -16545,11 +16545,11 @@
 '\n'          Text
 
 'changed:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'anAspect'    Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Receiver changed. The change is denoted by the argument anAspect. \n\tUsually the argument is a Symbol that is part of the dependent\'s change \n\tprotocol. Inform all of the dependents. Also pass anObject for additional information."' Comment
@@ -16604,11 +16604,11 @@
 '\n'          Text
 
 'noteSelectionIndex:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anInteger'   Name.Variable
 ' '           Text
 'for:'        Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSymbol'     Name.Variable
 '\n\t'        Text
 '"backstop"'  Comment
@@ -16640,7 +16640,7 @@
 '\n'          Text
 
 'updateListsAndCodeIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWindow'     Name.Variable
 '\n\t'        Text
 'self'        Name.Builtin.Pseudo
@@ -16683,7 +16683,7 @@
 '\n'          Text
 
 'update:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aParameter'  Name.Variable
 ' \n\t'       Text
 '"Receive a change notice from an object of whom the receiver is a \n\tdependent. The default behavior is to do nothing; a subclass might want \n\tto change itself in some way."' Comment
@@ -16702,11 +16702,11 @@
 '\n'          Text
 
 'update:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'anAspect'    Name.Variable
 ' '           Text
 'with:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'anObject'    Name.Variable
 '\n\t'        Text
 '"Receive a change notice from an object of whom the receiver is a \n\tdependent. The default behavior is to call update:,\n\twhich by default does nothing; a subclass might want \n\tto change itself in some way."' Comment
@@ -16744,7 +16744,7 @@
 '\n'          Text
 
 'addModelItemsToWindowMenu:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMenu'       Name.Variable
 '\n\t'        Text
 '"aMenu is being constructed to be presented to the user in response to the user\'s pressing on the menu widget in the title bar of a morphic window.  Here, the model is given the opportunity to add any model-specific items to the menu, whose default target is the SystemWindow itself."' Comment
@@ -16759,15 +16759,15 @@
 '\n'          Text
 
 'addModelMenuItemsTo:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCustomMenu' Name.Variable
 ' '           Text
 'forMorph:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMorph'      Name.Variable
 ' '           Text
 'hand:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'aHandMorph'  Name.Variable
 ' \n\t'       Text
 '"The receiver serves as the model for aMorph; a menu is being constructed for the morph, and here the receiver is able to add its own items"' Comment
@@ -16847,7 +16847,7 @@
 '\n'          Text
 
 'eToyStreamedRepresentationNotifying:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWidget'     Name.Variable
 '\n\n\t'      Text
 '|'           Operator
@@ -17006,7 +17006,7 @@
 '\n'          Text
 
 'hasContentsInExplorer' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '^'           Operator
@@ -17044,7 +17044,7 @@
 '\n'          Text
 
 'inform:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '"Display a message for the user to read and then dismiss. 6/9/96 sw"' Comment
@@ -17094,7 +17094,7 @@
 '\n'          Text
 
 'inspectWithLabel:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aLabel'      Name.Variable
 '\n\t'        Text
 '"Create and schedule an Inspector in which the user can examine the receiver\'s variables."' Comment
@@ -17120,7 +17120,7 @@
 '\n'          Text
 
 'launchPartVia:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSelector'   Name.Variable
 '\n\t'        Text
 '"Obtain a morph by sending aSelector to self, and attach it to the morphic hand.  This provides a general protocol for parts bins"' Comment
@@ -17165,11 +17165,11 @@
 '\n'          Text
 
 'launchPartVia:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSelector'   Name.Variable
 ' '           Text
 'label:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 '\n\t'        Text
 '"Obtain a morph by sending aSelector to self, and attach it to the morphic hand.  This provides a general protocol for parts bins"' Comment
@@ -17278,7 +17278,7 @@
 '\n'          Text
 
 'modelWakeUpIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aWindow'     Name.Variable
 '\n\t'        Text
 '"A window with me as model is being entered or expanded.  Default response is no-op"' Comment
@@ -17297,7 +17297,7 @@
 '\n'          Text
 
 'mouseUpBalk:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'evt'         Name.Variable
 '\n\t'        Text
 '"A button I own got a mouseDown, but the user moved out before letting up.  Certain kinds of objects (so-called \'radio buttons\', for example, and other structures that must always have some selection, e.g. PaintBoxMorph) wish to take special action in this case; this default does nothing."' Comment
@@ -17362,7 +17362,7 @@
 '\n'          Text
 
 'windowReqNewLabel:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'labelString' Name.Variable
 '\n\t'        Text
 '"My window\'s title has been edited.\n\tReturn true if this is OK, and override for further behavior."' Comment
@@ -17487,7 +17487,7 @@
 '\n'          Text
 
 'categoriesForViewer:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 '\n\t'        Text
 '"Answer a list of categories to offer in the given viewer"' Comment
@@ -17524,11 +17524,11 @@
 '\n'          Text
 
 'categoriesForVocabulary:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 ' '           Text
 'limitClass:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aLimitClass' Name.Variable
 '\n\t'        Text
 '"Answer a list of categories of methods for the receiver when using the given vocabulary, given that one considers only methods that are implemented not further away than aLimitClass"' Comment
@@ -17752,7 +17752,7 @@
 '\n'          Text
 
 'defaultLimitClassForVocabulary:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 '\n\t'        Text
 '"Answer the class to use, by default, as the limit class on a protocol browser or viewer opened up on the receiver, within the purview of the Vocabulary provided"' Comment
@@ -17836,11 +17836,11 @@
 '\n'          Text
 
 'elementTypeFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aStringOrSymbol' Name.Variable
 ' '           Text
 'vocabulary:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aVocabulary' Name.Variable
 '\n\t'        Text
 '"Answer a symbol characterizing what kind of element aStringOrSymbol represents.  Realistically, at present, this always just returns #systemScript; a prototyped but not-incorporated architecture supported use of a leading colon to characterize an inst var of a system class, and for the moment we still see its remnant here."' Comment
@@ -17925,11 +17925,11 @@
 '\n'          Text
 
 'infoFor:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'anElement'   Name.Variable
 ' '           Text
 'inViewer:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 '\n\t'        Text
 '"The user made a gesture asking for info/menu relating to me.  Some of the messages dispatched here are not yet available in this image"' Comment
@@ -18263,7 +18263,7 @@
 '\n'          Text
 
 'initialTypeForSlotNamed:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aName'       Name.Variable
 '\n\t'        Text
 '"Answer the initial type to be ascribed to the given instance variable"' Comment
@@ -18298,11 +18298,11 @@
 '\n'          Text
 
 'methodInterfacesInPresentationOrderFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'interfaceList' Name.Variable
 ' '           Text
 'forCategory:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCategory'   Name.Variable
 ' \n\t'       Text
 '"Answer the interface list sorted in desired presentation order, using a \n\tstatic master-ordering list, q.v. The category parameter allows an \n\tescape in case one wants to apply different order strategies in different \n\tcategories, but for now a single master-priority-ordering is used -- see \n\tthe comment in method EToyVocabulary.masterOrderingOfPhraseSymbols"' Comment
@@ -18482,7 +18482,7 @@
 '\n'          Text
 
 'newScriptorAround:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aPhraseTileMorph' Name.Variable
 '\n\t'        Text
 '"Sprout a scriptor around aPhraseTileMorph, thus making a new script.  This is where generalized scriptors will be threaded in"' Comment
@@ -18501,11 +18501,11 @@
 '\n'          Text
 
 'offerViewerMenuForEvt:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'anEvent'     Name.Variable
 ' '           Text
 'morph:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'aMorph'      Name.Variable
 '\n\t'        Text
 '"Offer the viewer\'s primary menu to the user.  aMorph is some morph within the viewer itself, the one within which a mousedown triggered the need for this menu, and it is used only to retrieve the Viewer itself"' Comment
@@ -18536,11 +18536,11 @@
 '\n'          Text
 
 'offerViewerMenuFor:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 ' '           Text
 'event:'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'evt'         Name.Variable
 '\n\t'        Text
 '"Offer the primary Viewer menu to the user.  Copied up from Player code, but most of the functions suggested here don\'t work for non-Player objects, many aren\'t even defined, some relate to exploratory sw work not yet reflected in the current corpus.  We are early in the life cycle of this method..."' Comment
@@ -18870,7 +18870,7 @@
 '\n'          Text
 
 'renameScript:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'oldSelector' Name.Variable
 '\n\t'        Text
 '"prompt the user for a new selector and apply it.  Presently only works for players"' Comment
@@ -18889,11 +18889,11 @@
 '\n'          Text
 
 'tilePhrasesForCategory:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aCategorySymbol' Name.Variable
 ' '           Text
 'inViewer:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 '\n\t'        Text
 '"Return a collection of phrases for the category."' Comment
@@ -18962,11 +18962,11 @@
 '\n'          Text
 
 'tilePhrasesForMethodInterfaces:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'methodInterfaceList' Name.Variable
 ' '           Text
 'inViewer:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 '\n\t'        Text
 '"Return a collection of ViewerLine objects corresponding to the method-interface list provided.   The resulting list will be in the same order as the incoming list, but may be smaller if the viewer\'s vocbulary suppresses some of the methods, or if, in classic tiles mode, the selector requires more arguments than can be handled."' Comment
@@ -19134,11 +19134,11 @@
 '\n'          Text
 
 'tilePhrasesForSelectorList:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aList'       Name.Variable
 ' '           Text
 'inViewer:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'aViewer'     Name.Variable
 '\n\t'        Text
 '"Particular to the search facility in viewers.  Answer a list, in appropriate order, of ViewerLine objects to put into the viewer."' Comment
@@ -19239,11 +19239,11 @@
 '\n'          Text
 
 'uniqueInstanceVariableNameLike:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' '           Text
 'excluding:'  Name.Function
-' '           Text
+' '           Text.Whitespace
 'takenNames'  Name.Variable
 '\n\t'        Text
 '"Answer a nice instance-variable name to be added to the receiver which resembles aString, making sure it does not coincide with any element in takenNames"' Comment
@@ -19574,7 +19574,7 @@
 '\n'          Text
 
 'uniqueNameForReferenceFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'proposedName' Name.Variable
 '\n\t'        Text
 '"Answer a satisfactory symbol, similar to the proposedName but obeying the rules, to represent the receiver"' Comment
@@ -19800,7 +19800,7 @@
 '\n'          Text
 
 'usableMethodInterfacesIn:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aListOfMethodInterfaces' Name.Variable
 '\n\t'        Text
 '"Filter aList, returning a subset list of apt phrases"' Comment
@@ -19821,7 +19821,7 @@
 '\n'          Text
 
 'couldOpenInMorphic' Name.Function
-'\n'          Text
+'\n'          Text.Whitespace
 
 '\n        '  Text
 '"is there an obvious morphic world in which to open a new morph?"' Comment
@@ -19920,7 +19920,7 @@
 '\n'          Text
 
 'errorSubscriptBounds:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'index'       Name.Variable
 ' \n\t'       Text
 '"Create an error notification that an improper integer was used as an index."' Comment
@@ -19947,7 +19947,7 @@
 '\n'          Text
 
 'primitiveError:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aString'     Name.Variable
 ' \n\t'       Text
 '"This method is called when the error handling results in a recursion in \n\tcalling on error: or halt or halt:."' Comment
@@ -20147,11 +20147,11 @@
 '\n'          Text
 
 'storeAt:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'offset'      Name.Variable
 ' '           Text
 'inTempFrame:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aContext'    Name.Variable
 '\n\t'        Text
 '"This message had to get sent to an expression already on the stack\n\tas a Block argument being accessed by the debugger.\n\tJust re-route it to the temp frame."' Comment
@@ -20431,7 +20431,7 @@
 '\n'          Text
 
 'fileReaderServicesForDirectory:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aFileDirectory' Name.Variable
 '\n\t'        Text
 '"Backstop"'  Comment
@@ -20450,11 +20450,11 @@
 '\n'          Text
 
 'fileReaderServicesForFile:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'fullName'    Name.Variable
 ' '           Text
 'suffix:'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'suffix'      Name.Variable
 '\n\t'        Text
 '"Backstop"'  Comment
@@ -20640,11 +20640,11 @@
 '\n'          Text
 
 'instanceOfUniqueClassWithInstVarString:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'instVarString' Name.Variable
 ' '           Text
 'andClassInstVarString:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'classInstVarString' Name.Variable
 '\n\t'        Text
 '"Create a unique class for the receiver, and answer an instance of it"' Comment
@@ -20690,7 +20690,7 @@
 '\n'          Text
 
 'newFrom:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSimilarObject' Name.Variable
 '\n\t'        Text
 '"Create an object that has similar contents to aSimilarObject.\n\tIf the classes have any instance varaibles with the same names, copy them across.\n\tIf this is bad for a class, override this method."' Comment
@@ -20738,11 +20738,11 @@
 '\n'          Text
 
 'newUniqueClassInstVars:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'instVarString' Name.Variable
 ' '           Text
 'classInstVars:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'classInstVarString' Name.Variable
 '\n\t'        Text
 '"Create a unique class for the receiver"' Comment
@@ -20864,7 +20864,7 @@
 '\n'          Text
 
 'readCarefullyFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'textStringOrStream' Name.Variable
 '\n\t'        Text
 '"Create an object based on the contents of textStringOrStream.  Return an error instead of putting up a SyntaxError window."' Comment
@@ -20956,7 +20956,7 @@
 '\n'          Text
 
 'readFrom:'   Name.Function
-' '           Text
+' '           Text.Whitespace
 'textStringOrStream' Name.Variable
 '\n\t'        Text
 '"Create an object based on the contents of textStringOrStream."' Comment
@@ -21034,15 +21034,15 @@
 '\n'          Text
 
 'createFrom:' Name.Function
-' '           Text
+' '           Text.Whitespace
 'aSmartRefStream' Name.Variable
 ' '           Text
 'size:'       Name.Function
-' '           Text
+' '           Text.Whitespace
 'varsOnDisk'  Name.Variable
 ' '           Text
 'version:'    Name.Function
-' '           Text
+' '           Text.Whitespace
 'instVarList' Name.Variable
 '\n\t'        Text
 '"Create an instance of me so objects on the disk can be read in.  Tricky part is computing the size if variable.  Inst vars will be filled in later.  "' Comment

--- a/tests/examplefiles/smarty/smarty_example.html.output
+++ b/tests/examplefiles/smarty/smarty_example.html.output
@@ -36,7 +36,7 @@
 '\n<!-- ENTRIES START -->\n    ' Other
 '{'           Comment.Preproc
 'serendipity_hookPlugin' Name.Function
-' '           Text
+' '           Text.Whitespace
 'hook'        Name.Attribute
 '='           Operator
 '"entries_header"' Literal.String.Double
@@ -48,7 +48,7 @@
 '\n\n    '    Other
 '{'           Comment.Preproc
 'foreach'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'from'        Name.Attribute
 '='           Operator
 '$entries'    Name.Variable
@@ -60,7 +60,7 @@
 '\n    <div class="serendipity_Entry_Date">\n        ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$dategroup.is_sticky' Name.Variable
 '}'           Comment.Preproc
 '\n        <h3 class="serendipity_date">' Other
@@ -87,7 +87,7 @@
 '\n\n        ' Other
 '{'           Comment.Preproc
 'foreach'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'from'        Name.Attribute
 '='           Operator
 '$dategroup.entries' Name.Variable
@@ -114,7 +114,7 @@
 ' '           Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.is_entry_owner' Name.Variable
 '}'           Comment.Preproc
 'serendipity_entry_author_self' Other
@@ -124,13 +124,13 @@
 '">\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.categories' Name.Variable
 '}'           Comment.Preproc
 '\n            <span class="serendipity_entryIcon">\n            ' Other
 '{'           Comment.Preproc
 'foreach'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'from'        Name.Attribute
 '='           Operator
 '$entry.categories' Name.Variable
@@ -142,7 +142,7 @@
 '\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$category.category_icon' Name.Variable
 '}'           Comment.Preproc
 '\n                    <a href="' Other
@@ -192,7 +192,7 @@
 '\n            </div>\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.is_extended' Name.Variable
 '}'           Comment.Preproc
 '\n            <div class="serendipity_entry_extended"><a id="extended"></a>' Other
@@ -206,7 +206,7 @@
 '\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.has_extended' Name.Variable
 ' '           Text
 'and'         Name.Attribute
@@ -253,7 +253,7 @@
 '</a>\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.categories' Name.Variable
 '}'           Comment.Preproc
 '\n                   ' Other
@@ -263,7 +263,7 @@
 ' '           Other
 '{'           Comment.Preproc
 'foreach'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'from'        Name.Attribute
 '='           Operator
 '$entry.categories' Name.Variable
@@ -290,7 +290,7 @@
 '</a>'        Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 'not'         Name.Attribute
 ' '           Text
 '$smarty.foreach.categories.last' Name.Variable
@@ -309,13 +309,13 @@
 '\n\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.has_comments' Name.Variable
 '}'           Comment.Preproc
 '\n                    ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$use_popups' Name.Variable
 '}'           Comment.Preproc
 '\n                        | <a href="' Other
@@ -357,13 +357,13 @@
 '\n\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.has_trackbacks' Name.Variable
 '}'           Comment.Preproc
 '\n                    ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$use_popups' Name.Variable
 '}'           Comment.Preproc
 '\n                        | <a href="' Other
@@ -405,7 +405,7 @@
 '\n\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.is_entry_owner' Name.Variable
 ' '           Text
 'and'         Name.Attribute
@@ -453,7 +453,7 @@
 '\n\n        ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$is_single_entry' Name.Variable
 ' '           Text
 'and'         Name.Attribute
@@ -471,7 +471,7 @@
 '\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$CONST.DATA_UNSUBSCRIBED' Name.Variable
 '}'           Comment.Preproc
 '\n                <br /><div class="serendipity_center serendipity_msg_notice">' Other
@@ -490,7 +490,7 @@
 '\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$CONST.DATA_TRACKBACK_DELETED' Name.Variable
 '}'           Comment.Preproc
 '\n                <br /><div class="serendipity_center serendipity_msg_notice">' Other
@@ -509,7 +509,7 @@
 '\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$CONST.DATA_TRACKBACK_APPROVED' Name.Variable
 '}'           Comment.Preproc
 '\n                <br /><div class="serendipity_center serendipity_msg_notice">' Other
@@ -528,7 +528,7 @@
 '\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$CONST.DATA_COMMENT_DELETED' Name.Variable
 '}'           Comment.Preproc
 '\n                <br /><div class="serendipity_center serendipity_msg_notice">' Other
@@ -547,7 +547,7 @@
 '\n\n            ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$CONST.DATA_COMMENT_APPROVED' Name.Variable
 '}'           Comment.Preproc
 '\n                <br /><div class="serendipity_center serendipity_msg_notice">' Other
@@ -570,7 +570,7 @@
 '\n\n        ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$is_single_entry' Name.Variable
 ' '           Text
 'and'         Name.Attribute
@@ -610,7 +610,7 @@
 '</a>\n                    </div>\n                    <br />\n                        ' Other
 '{'           Comment.Preproc
 'serendipity_printTrackbacks' Name.Function
-' '           Text
+' '           Text.Whitespace
 'entry'       Name.Attribute
 '='           Operator
 '$entry.id'   Name.Variable
@@ -626,7 +626,7 @@
 '\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.viewmode' Name.Variable
 ' '           Text
 'eq'          Name.Attribute
@@ -668,7 +668,7 @@
 '\n                </div>\n                <br />\n                    ' Other
 '{'           Comment.Preproc
 'serendipity_printComments' Name.Function
-' '           Text
+' '           Text.Whitespace
 'entry'       Name.Attribute
 '='           Operator
 '$entry.id'   Name.Variable
@@ -680,13 +680,13 @@
 '\n\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.is_entry_owner' Name.Variable
 '}'           Comment.Preproc
 '\n                    ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$entry.allow_comments' Name.Variable
 '}'           Comment.Preproc
 '\n                    <div class="serendipity_center">(<a href="' Other
@@ -720,7 +720,7 @@
 '\n                <a id="feedback"></a>\n\n                ' Other
 '{'           Comment.Preproc
 'foreach'     Name.Function
-' '           Text
+' '           Text.Whitespace
 'from'        Name.Attribute
 '='           Operator
 '$comments_messagestack' Name.Variable
@@ -740,7 +740,7 @@
 '\n\n                ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$is_comment_added' Name.Variable
 '}'           Comment.Preproc
 '\n\n                <br />\n                <div class="serendipity_center serendipity_msg_notice">' Other
@@ -750,7 +750,7 @@
 '</div>\n\n                ' Other
 '{'           Comment.Preproc
 'elseif'      Name.Function
-' '           Text
+' '           Text.Whitespace
 '$is_comment_moderate' Name.Variable
 '}'           Comment.Preproc
 '\n\n                <br />\n                <div class="serendipity_center serendipity_msg_notice">' Other
@@ -764,7 +764,7 @@
 '</div>\n\n                ' Other
 '{'           Comment.Preproc
 'elseif'      Name.Function
-' '           Text
+' '           Text.Whitespace
 'not'         Name.Attribute
 ' '           Text
 '$entry.allow_comments' Name.Variable
@@ -808,7 +808,7 @@
 '\n    '      Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 'not'         Name.Attribute
 ' '           Text
 '$plugin_clean_page' Name.Variable
@@ -829,19 +829,19 @@
 
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_info' Name.Variable
 '}'           Comment.Preproc
 '\n    <div class="serendipity_pageFooter">\n    ' Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_info' Name.Variable
 '}'           Comment.Preproc
 '\n        '  Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_prev_page' Name.Variable
 '}'           Comment.Preproc
 '\n        <span class="previous"><a href="' Other
@@ -871,7 +871,7 @@
 '\n\n    '    Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_info' Name.Variable
 '}'           Comment.Preproc
 '\n        <span class="entries_info">(' Other
@@ -885,13 +885,13 @@
 '\n\n    '    Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_info' Name.Variable
 '}'           Comment.Preproc
 '\n        '  Other
 '{'           Comment.Preproc
 'if'          Name.Function
-' '           Text
+' '           Text.Whitespace
 '$footer_next_page' Name.Variable
 '}'           Comment.Preproc
 '\n        <span class="next"><a href="' Other
@@ -925,7 +925,7 @@
 '\n    '      Other
 '{'           Comment.Preproc
 'serendipity_hookPlugin' Name.Function
-' '           Text
+' '           Text.Whitespace
 'hook'        Name.Attribute
 '='           Operator
 '"entries_footer"' Literal.String.Double

--- a/tests/examplefiles/sml/example.sml.output
+++ b/tests/examplefiles/sml/example.sml.output
@@ -9,7 +9,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'a'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '12'          Literal.Number.Integer
@@ -158,7 +158,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '('           Punctuation
@@ -212,7 +212,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '('           Punctuation
@@ -234,7 +234,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'z'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '#2'          Name.Label
@@ -390,7 +390,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '{'           Punctuation
@@ -424,7 +424,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'z'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '#\n            2' Name.Label
@@ -434,7 +434,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 '||'          Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '12'          Literal.Number.Integer
@@ -465,7 +465,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '('           Punctuation
@@ -547,7 +547,7 @@
 'int'         Name.Class
 ' '           Text
 'and'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'E2'          Name.Class
 '\n  '        Text
 'fun'         Name.Class
@@ -576,7 +576,7 @@
 "'a"          Name.Decorator
 ' '           Text
 'id'          Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'fn'          Keyword.Reserved
@@ -818,7 +818,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 '!%&$#+-/:<=>?@\\~`^|*' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '3'           Literal.Number.Integer
@@ -892,7 +892,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'foo'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '!%&$#+-/:<=>?@\\~`^|*' Name
@@ -946,7 +946,7 @@
 ''            Text
 'val'         Keyword.Reserved
 '$$$'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'fn'          Keyword.Reserved
@@ -1173,7 +1173,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'w'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '{'           Punctuation
@@ -1220,7 +1220,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'z'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '#4'          Name.Label
@@ -1231,7 +1231,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'z'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '# ##='       Name.Label
@@ -1418,7 +1418,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '4'           Literal.Number.Integer
@@ -1427,7 +1427,7 @@
 'and'         Keyword.Reserved
 ' '           Text
 'y'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '5'           Literal.Number.Integer
@@ -1521,7 +1521,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'ref'         Name
@@ -1900,7 +1900,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'c'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '#"'          Literal.String.Char
@@ -1911,7 +1911,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'st'          Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '"'           Literal.String.Double

--- a/tests/examplefiles/sml/intsyn.fun.output
+++ b/tests/examplefiles/sml/intsyn.fun.output
@@ -365,7 +365,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Decl'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -4780,7 +4780,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Ordinary'    Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -4809,7 +4809,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Clause'      Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -5255,7 +5255,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'r'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'ref'         Name
@@ -7035,7 +7035,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'maxCid'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Global'      Name.Namespace
@@ -7045,7 +7045,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'dummyEntry'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'ConDec'      Name
@@ -7076,7 +7076,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'sgnArray'    Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Array'       Name.Namespace
@@ -7103,7 +7103,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'nextCid'     Name.Variable
-'  '          Text
+'  '          Text.Whitespace
 '='           Punctuation
 ' '           Text
 'ref'         Name
@@ -7114,7 +7114,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'maxMid'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Global'      Name.Namespace
@@ -7124,7 +7124,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'sgnStructArray' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Array'       Name.Namespace
@@ -7158,7 +7158,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'nextMid'     Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'ref'         Name
@@ -7636,7 +7636,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'cid'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '!'           Name
@@ -7869,7 +7869,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'mid'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 '!'           Name
@@ -8080,7 +8080,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'newConDec'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'case'        Keyword.Reserved
@@ -8585,7 +8585,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'id'          Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Shift'       Name
@@ -8673,7 +8673,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'shift'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Shift'       Name
@@ -8770,7 +8770,7 @@
 'val'         Keyword.Reserved
 ' '           Text
 'invShift'    Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Punctuation
 ' '           Text
 'Dot'         Name

--- a/tests/examplefiles/sml/intsyn.sig.output
+++ b/tests/examplefiles/sml/intsyn.sig.output
@@ -756,7 +756,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Maybe'       Name.Class
 '                               ' Text
 '(*'          Comment.Multiline
@@ -791,7 +791,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Meta'        Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -913,7 +913,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Type'        Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -1023,7 +1023,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Pi'          Name.Class
 '    '        Text
 'of'          Keyword.Reserved
@@ -1072,7 +1072,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Root'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1115,7 +1115,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Redex'       Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -1158,7 +1158,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Lam'         Name.Class
 '   '         Text
 'of'          Keyword.Reserved
@@ -1201,7 +1201,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'EVar'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1266,7 +1266,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'EClo'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1309,7 +1309,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'AVar'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1352,7 +1352,7 @@
 '*)'          Comment.Multiline
 '\n\n  '      Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'FgnExp'      Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -1395,7 +1395,7 @@
 '*)'          Comment.Multiline
 '\n\n  '      Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'NVar'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1641,7 +1641,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Const'       Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -1680,7 +1680,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Proj'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1723,7 +1723,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Skonst'      Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -1762,7 +1762,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Def'         Name.Class
 '   '         Text
 'of'          Keyword.Reserved
@@ -1801,7 +1801,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'NSDef'       Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -1840,7 +1840,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'FVar'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -1887,7 +1887,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'FgnConst'    Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2000,7 +2000,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'App'         Name.Class
 '   '         Text
 'of'          Keyword.Reserved
@@ -2043,7 +2043,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'SClo'        Name.Class
 '  '          Text
 'of'          Keyword.Reserved
@@ -2160,7 +2160,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Dot'         Name.Class
 '   '         Text
 'of'          Keyword.Reserved
@@ -2277,7 +2277,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Exp'         Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2316,7 +2316,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Axp'         Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2355,7 +2355,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Block'       Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2394,7 +2394,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Undef'       Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -2509,7 +2509,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'BDec'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2560,7 +2560,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'ADec'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2605,7 +2605,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'NDec'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2689,7 +2689,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'LVar'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -2746,7 +2746,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Inst'        Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3207,7 +3207,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Eqn'         Name.Class
 '      '      Text
 'of'          Keyword.Reserved
@@ -3256,7 +3256,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'FgnCnstr'    Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3369,7 +3369,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Constraint'  Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3430,7 +3430,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Foreign'     Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3571,7 +3571,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Fail'        Name.Class
 '\n\n  '      Text
 'and'         Keyword.Reserved
@@ -3644,7 +3644,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Delay'       Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3869,7 +3869,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'ConDef'      Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -3996,7 +3996,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'AbbrevDef'   Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -4088,7 +4088,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'BlockDec'    Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -4145,7 +4145,7 @@
 'list'        Name
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'BlockDef'    Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -4196,7 +4196,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'SkoDec'      Name.Class
 ' '           Text
 'of'          Keyword.Reserved
@@ -4544,7 +4544,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Ordinary'    Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline
@@ -4573,7 +4573,7 @@
 '*)'          Comment.Multiline
 '\n  '        Text
 '|'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'Clause'      Name.Class
 '\t\t\t\t'    Text
 '(*'          Comment.Multiline

--- a/tests/examplefiles/sql+jinja/example.sql.output
+++ b/tests/examplefiles/sql+jinja/example.sql.output
@@ -79,14 +79,14 @@
 '%}'          Comment.Preproc
 ','           Punctuation
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '-'           Text
 '%}'          Comment.Preproc
 '\n  '        Text.Whitespace
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc

--- a/tests/examplefiles/stan/example.stan.output
+++ b/tests/examplefiles/stan/example.stan.output
@@ -8,7 +8,7 @@
 '\n'          Text
 
 'functions'   Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 'void'        Keyword.Type
@@ -79,7 +79,7 @@
 '\n'          Text
 
 'data'        Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 '// valid name' Comment.Single
@@ -258,7 +258,7 @@
 '\n'          Text
 
 'transformed data' Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 'real'        Keyword.Type
@@ -380,7 +380,7 @@
 '\n'          Text
 
 'parameters'  Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 'real'        Keyword.Type
@@ -398,7 +398,7 @@
 '\n'          Text
 
 'transformed parameters' Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text
 
@@ -406,7 +406,7 @@
 '\n'          Text
 
 'model'       Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 '// ~, <- are operators,' Comment.Single
@@ -757,7 +757,7 @@
 '\n'          Text
 
 'generated quantities' Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n  '        Text
 'real'        Keyword.Type

--- a/tests/examplefiles/swift/test.swift.output
+++ b/tests/examplefiles/swift/test.swift.output
@@ -185,7 +185,7 @@
 '\n'          Text
 
 'extension'   Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'SKNode'      Name.Builtin.Pseudo
 ' '           Text
 '{'           Punctuation
@@ -193,7 +193,7 @@
 
 '    '        Text
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'func'        Name.Class
 ' '           Text
 'unarchiveFromFile' Name
@@ -215,7 +215,7 @@
 
 '        \n        ' Text
 'let'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'path'        Name.Variable
 ' '           Text
 '='           Punctuation
@@ -242,7 +242,7 @@
 
 '        \n        ' Text
 'var'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'sceneData'   Name.Variable
 ' '           Text
 '='           Punctuation
@@ -270,7 +270,7 @@
 
 '        '    Text
 'var'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'archiver'    Name.Variable
 ' '           Text
 '='           Punctuation
@@ -307,7 +307,7 @@
 
 '        '    Text
 'let'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'scene'       Name.Variable
 ' '           Text
 '='           Punctuation
@@ -348,7 +348,7 @@
 '\n'          Text
 
 'class'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'GameViewController' Name.Class
 ':'           Punctuation
 ' '           Text
@@ -363,7 +363,7 @@
 'override'    Keyword.Reserved
 ' '           Text
 'func'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'viewDidLoad' Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -385,7 +385,7 @@
 'if'          Keyword
 ' '           Text
 'let'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'scene'       Name.Variable
 ' '           Text
 '='           Punctuation
@@ -433,7 +433,7 @@
 
 '            ' Text
 'let'         Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'skView'      Name.Variable
 ' '           Text
 '='           Punctuation
@@ -646,7 +646,7 @@
 'override'    Keyword.Reserved
 ' '           Text
 'func'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'shouldAutorotate' Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -674,7 +674,7 @@
 'override'    Keyword.Reserved
 ' '           Text
 'func'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'supportedInterfaceOrientations' Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -758,7 +758,7 @@
 'override'    Keyword.Reserved
 ' '           Text
 'func'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'didReceiveMemoryWarning' Name.Function
 '('           Punctuation
 ')'           Punctuation

--- a/tests/examplefiles/tap/example.tap.output
+++ b/tests/examplefiles/tap/example.tap.output
@@ -8,7 +8,7 @@
 'A plan only supports directives so this text is wrong.\n' Generic.Error
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ' '           Text
 'A'           Text
@@ -27,7 +27,7 @@
 '\n'          Text
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'But'         Text
 ' '           Text
 'a'           Text
@@ -60,7 +60,7 @@
 '\n'          Text
 
 'not ok'      Generic.Error
-' '           Text
+' '           Text.Whitespace
 '3'           Literal.Number.Integer
 ' '           Text
 'This'        Text
@@ -85,7 +85,7 @@
 '\n'          Text
 
 'not ok'      Generic.Error
-' '           Text
+' '           Text.Whitespace
 '4'           Literal.Number.Integer
 ' '           Text
 'There'       Text
@@ -116,7 +116,7 @@
 '\n'          Comment
 
 'not ok'      Generic.Error
-' '           Text
+' '           Text.Whitespace
 '5'           Literal.Number.Integer
 ' '           Text
 '#'           Comment
@@ -148,7 +148,7 @@
 '\n'          Comment
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '6'           Literal.Number.Integer
 ' '           Text
 '-'           Text
@@ -175,7 +175,7 @@
 '\n'          Text
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '7'           Literal.Number.Integer
 ' '           Text
 'A'           Text
@@ -194,7 +194,7 @@
 '\n'          Comment
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '8'           Literal.Number.Integer
 ' '           Text
 'Tests'       Text
@@ -227,7 +227,7 @@
 '\n'          Comment
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '9'           Literal.Number.Integer
 ' '           Text
 'The'         Text
@@ -289,7 +289,7 @@
 '\n'          Text
 
 'not ok'      Generic.Error
-' '           Text
+' '           Text.Whitespace
 '10'          Literal.Number.Integer
 ' '           Text
 'Having'      Text
@@ -324,7 +324,7 @@
 '\n'          Text
 
 'not ok'      Generic.Error
-' '           Text
+' '           Text.Whitespace
 '11'          Literal.Number.Integer
 ' '           Text
 'Having'      Text
@@ -359,7 +359,7 @@
 '\n'          Text
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '12'          Literal.Number.Integer
 ' '           Text
 'Here'        Text
@@ -388,7 +388,7 @@
 '\n'          Text
 
 'ok'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '15'          Literal.Number.Integer
 ' '           Text
 'Only'        Text

--- a/tests/examplefiles/tcsh/test.tcsh.output
+++ b/tests/examplefiles/tcsh/test.tcsh.output
@@ -1657,7 +1657,7 @@
 '\n\n    '    Text
 'set '        Name.Builtin
 'folders'     Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Operator
@@ -1668,7 +1668,7 @@
 '\n    '      Text
 'set '        Name.Builtin
 'mha'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '('           Operator
@@ -2267,7 +2267,7 @@
 '\n    '      Text
 'set '        Name.Builtin
 '_elispdir'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '/usr/lib/emacs/19.34/lisp' Text
@@ -2276,7 +2276,7 @@
 '\n    '      Text
 'set '        Name.Builtin
 '_maildir'    Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '/var/spool/mail' Text
@@ -2285,7 +2285,7 @@
 '\n    '      Text
 'set '        Name.Builtin
 '_ypdir'      Name.Variable
-'  '          Text
+'  '          Text.Whitespace
 '='           Operator
 ' '           Text
 '/var/yp'     Text
@@ -2294,7 +2294,7 @@
 '\n    '      Text
 'set '        Name.Builtin
 '_domain'     Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text
 '"`dnsdomainname`"' Literal.String.Double

--- a/tests/examplefiles/thingsdb/test.ti.output
+++ b/tests/examplefiles/thingsdb/test.ti.output
@@ -48,7 +48,7 @@
 '\n'          Text.Whitespace
 
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '0'           Literal.Number.Integer
@@ -284,7 +284,7 @@
 '\n'          Text.Whitespace
 
 '.iris'       Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -313,7 +313,7 @@
 '\n'          Text.Whitespace
 
 '.arr'        Name.Attribute
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '['           Punctuation
@@ -331,7 +331,7 @@
 '\n'          Text.Whitespace
 
 'cato'        Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -341,7 +341,7 @@
 '\n'          Text.Whitespace
 
 'x'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -367,7 +367,7 @@
 '\n'          Text.Whitespace
 
 'a'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 '='           Operator
 ' '           Text.Whitespace
@@ -387,12 +387,12 @@
 '\n'          Text.Whitespace
 
 'bool'        Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '('           Punctuation
 'a'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 '='           Operator
 ' '           Text.Whitespace
@@ -403,7 +403,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'a'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
 '='           Operator
 ' '           Text.Whitespace

--- a/tests/examplefiles/tid/TiddlyWiki5.tid.output
+++ b/tests/examplefiles/tid/TiddlyWiki5.tid.output
@@ -181,10 +181,10 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*'           Keyword
-' '           Text
+' '           Text.Whitespace
 '<code>'      Name.Tag
 '&#96;'       Literal.String.Regex
 'backticks'   Text
@@ -197,7 +197,7 @@
 '\n'          Text.Whitespace
 
 '**'          Keyword
-' '           Text
+' '           Text.Whitespace
 'Alternatively' Text
 ','           Text
 ' '           Text
@@ -220,13 +220,13 @@
 '</code>'     Name.Tag
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 '*'           Keyword
-' '           Text
+' '           Text.Whitespace
 "`''bold''`"  Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 "''bold text''" Generic.Strong
 '\n'          Text.Whitespace
 
@@ -234,7 +234,7 @@
 '`//italic//`' Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 '//italic text//' Generic.Emph
 ' '           Text
 '('           Text
@@ -245,11 +245,11 @@
 '\n'          Text.Whitespace
 
 '*#'          Keyword
-' '           Text
+' '           Text.Whitespace
 '`__underscore__`' Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 '__underscored text__' Generic.Strong
 '\n'          Text.Whitespace
 
@@ -261,14 +261,14 @@
 ':'           Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '#'           Keyword
-' '           Text
+' '           Text.Whitespace
 '`^^superscript^^`' Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 '^^superscripted^^' Generic.Emph
 ' '           Text
 'text'        Text
@@ -281,11 +281,11 @@
 '\n'          Text.Whitespace
 
 '#'           Keyword
-' '           Text
+' '           Text.Whitespace
 '`,,subscript,,`' Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 ',,subscripted,,' Generic.Emph
 ' '           Text
 'text'        Text
@@ -298,11 +298,11 @@
 '\n'          Text.Whitespace
 
 '#*'          Keyword
-' '           Text
+' '           Text.Whitespace
 '`~~strikethrough~~`' Literal.String.Backtick
 ' '           Text
 'for'         Text
-' '           Text
+' '           Text.Whitespace
 '~~strikethrough~~' Generic.Deleted
 ' '           Text
 'text'        Text

--- a/tests/examplefiles/todotxt/example.todotxt.output
+++ b/tests/examplefiles/todotxt/example.todotxt.output
@@ -10,7 +10,7 @@
 '\n'          Text
 
 '(A)'         Generic.Heading
-' '           Text
+' '           Text.Whitespace
 '2014-01-08'  Generic.Subheading
 ' '           Text
 'Schedule'    Text
@@ -95,7 +95,7 @@
 
 'x '          Operator
 '2014-01-10'  Generic.Subheading
-' '           Operator
+' '           Text.Whitespace
 '2014-01-07'  Generic.Subheading
 ' '           Operator
 'Download'    Operator

--- a/tests/examplefiles/trac-wiki/moin_SyntaxReference.txt.output
+++ b/tests/examplefiles/trac-wiki/moin_SyntaxReference.txt.output
@@ -125,25 +125,25 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 "''"          Comment
 'emphasized (italics)' Text
 "''"          Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 "'''"         Comment
 'boldface'    Text
 "'''"         Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 "'''"         Comment
 "''"          Comment
 'bold italics' Text
@@ -151,66 +151,66 @@
 "''"          Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 'monospace`'  Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '{{{'         Name.Builtin
 'source code' Comment.Preproc
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '__'          Comment
 'underline'   Text
 '__'          Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 ',,'          Comment
 'sub'         Text
 ',,'          Comment
 'script'      Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '^'           Comment
 'super'       Text
 '^'           Comment
 'script'      Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '~'           Text
 '-smaller-'   Text
 '~'           Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '~'           Text
 '+larger+'    Text
 '~'           Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '--(strike through)--' Text
 '\n'          Text
 
@@ -240,78 +240,78 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'FrontPage'   Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '["FrontPage"' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'HelpOnEditing/SubPages' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '/SubPage'    Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '../SiblingPage' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[:FrontPage:named' Keyword
 ' link'       Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[#anchorname' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[#anchorname' Keyword
 ' description' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[wiki:Self:PageName#anchorname' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[wiki:Self:PageName#anchorname' Keyword
 ' description' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'attachment:filename.txt' Text
 '\n'          Text
 
@@ -328,86 +328,86 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'http://moinmoin.wikiwikiweb.de/' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[http://moinmoin.wikiwikiweb.de/' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[http://moinmoin.wikiwikiweb.de/' Keyword
 ' MoinMoin Wiki' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[http://moinmoin.wikiwikiweb.de/wiki/moinmoin.png' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'http://moinmoin.wikiwikiweb.de/wiki/moinmoin.png' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[http://moinmoin.wikiwikiweb.de/wiki/moinmoin.png' Keyword
 ' moinmoin.png' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'MeatBall:InterWiki' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'wiki:MeatBall/InterWiki' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[wiki:MeatBall/InterWiki' Keyword
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[wiki:MeatBall/InterWiki' Keyword
 ' InterWiki page on MeatBall' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '[file://///servername/share/full/path/to/file/filename%20with%20spaces.txt' Keyword
 ' link to file filename with spaces.txt' Literal.String
 ']'           Keyword
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'user@example.com' Text
 '\n'          Text
 
@@ -424,46 +424,46 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Wiki'        Text
 "'''"         Comment
 "'''"         Comment
 'Name'        Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'Wiki``Name'  Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '!'           Keyword
 'WikiName'    Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'WikiName'    Text
 "'''"         Comment
 "'''"         Comment
 's'           Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'WikiName``s' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 'http://www.example.com`' Text
 '\n'          Text
@@ -513,59 +513,59 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 1'      Text
 '\n'          Text
 
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 2 (preceding white space)' Text
 '\n'          Text
 
-'  '          Text
+'  '          Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 2.1'    Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 2.1.1'  Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 3'      Text
 '\n'          Text
 
-'  '          Text
+'  '          Text.Whitespace
 '.'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 3.1 (bulletless)' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '.'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 4 (bulletless)' Text
 '\n'          Text
 
-'  '          Text
+'  '          Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 4.1'    Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 '.'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 4.1.1 (bulletless)' Text
 '\n'          Text
 
@@ -612,27 +612,27 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 'I.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 1'      Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 'i.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 1.1'    Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 'i.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 1.2'    Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 'I.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item 2'      Text
 '\n'          Text
 
@@ -649,27 +649,27 @@
 '}}}'         Name.Builtin
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 'A.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item A'      Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 'a.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item A. a)'  Text
 '\n'          Text
 
-'   '         Text
+'   '         Text.Whitespace
 'a.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item A. b)'  Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 'A.'          Name.Builtin
-' '           Text
+' '           Text.Whitespace
 'item B'      Text
 '\n'          Text
 
@@ -974,45 +974,45 @@
 "''"          Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '[[Anchor(anchorname)]]' Keyword
 '`'           Comment
 ' inserts a link anchor `anchorname`' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '[[BR]]'      Keyword
 '`'           Comment
 ' inserts a hard line break' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '[[FootNote(Note)]]' Keyword
 '`'           Comment
 ' inserts a footnote saying `Note`' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '[[Include(HelpOnMacros/Include)]]' Keyword
 '`'           Comment
 ' inserts the contents of the page `HelpOnMacros/Include` inline' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '[[MailTo(user AT example DOT com)]]' Keyword
 '`'           Comment
@@ -1034,16 +1034,16 @@
 "''"          Comment
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '@``SIG``@` inserts your login name and timestamp of modification' Text
 '\n'          Text
 
-' '           Text
+' '           Text.Whitespace
 '*'           Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '`'           Comment
 '@``TIME``@` inserts date and time of modification' Text
 '\n'          Text

--- a/tests/examplefiles/twig/twig_test.output
+++ b/tests/examplefiles/twig/twig_test.output
@@ -1,7 +1,7 @@
 'From the Twig test suite, https://github.com/fabpot/Twig, available under BSD license.\n\n--TEST--\nException for an unclosed tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -9,7 +9,7 @@
 '%}'          Comment.Preproc
 '\n     '     Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -17,7 +17,7 @@
 '%}'          Comment.Preproc
 '\n\n\n\n\n         ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -29,21 +29,21 @@
 '%}'          Comment.Preproc
 '\n\n\n\n         ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n\n\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--EXCEPTION--\nTwig_Error_Syntax: Unexpected tag name "endblock" (expecting closing tag for the "if" tag defined near line 4) in "index.twig" at line 16\n--TEST--\nException for an undefined trait\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'foo'"       Literal.String.Single
@@ -60,7 +60,7 @@
 '\n--TEMPLATE(foo)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -69,7 +69,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -266,7 +266,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'a'           Name.Variable
@@ -416,7 +416,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'a'           Name.Variable
@@ -429,7 +429,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'b'           Name.Variable
@@ -442,7 +442,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'ary'         Name.Variable
@@ -793,7 +793,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -951,7 +951,7 @@
 '8'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'divisible'   Name.Function
 ' '           Text
 'by'          Name.Variable
@@ -971,9 +971,9 @@
 '8'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'divisible'   Name.Function
 ' '           Text
 'by'          Name.Variable
@@ -993,7 +993,7 @@
 '8'           Literal.Number
 ' '           Text
 'is'          Keyword
-'    '        Text
+'    '        Text.Whitespace
 'divisible'   Name.Function
 '   '         Text
 'by'          Name.Variable
@@ -1014,9 +1014,9 @@
 '8'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-'\n   '       Text
+'\n   '       Text.Whitespace
 'divisible'   Name.Function
 '\n   '       Text
 'by'          Name.Variable
@@ -1033,7 +1033,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nOK\nOK\nOK\nOK\n--TEST--\nTwig supports the .. operator\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -1051,14 +1051,14 @@
 '}}'          Comment.Preproc
 ' '           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'letter'      Name.Variable
@@ -1077,14 +1077,14 @@
 '}}'          Comment.Preproc
 ' '           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'letter'      Name.Variable
@@ -1107,14 +1107,14 @@
 '}}'          Comment.Preproc
 ' '           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -1139,14 +1139,14 @@
 '}}'          Comment.Preproc
 ' '           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -1176,7 +1176,7 @@
 '}}'          Comment.Preproc
 ' '           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1626,7 +1626,7 @@
 "\n--DATA--\nreturn array('foo' => 'bar', 'items' => array('foo' => new TwigTestFoo(), 'bar' => 'foo'))\n--CONFIG--\nreturn array('strict_variables' => false)\n--EXPECT--\nfoo\nfoo\nbar\n\nbar_a-43\nbar_bar\nfoo\nis\nin\nnot\n--TEST--\nTwig allows to use named operators as variable names\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'match'       Name.Variable
@@ -1646,7 +1646,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1667,7 +1667,7 @@
 "\n--DATA--\nreturn array('matches' => array(1, 2, 3), 'in' => 'in', 'is' => 'is')\n--EXPECT--\n1\n2\n3\nin\nis\n--TEST--\nTwig parses postfix expressions\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -1680,7 +1680,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -1690,7 +1690,7 @@
 '%}'          Comment.Preproc
 'foo'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -1760,7 +1760,7 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -1780,9 +1780,9 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -1802,7 +1802,7 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -1822,9 +1822,9 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -1844,7 +1844,7 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-'   '         Text
+'   '         Text.Whitespace
 'same'        Name.Function
 '    '        Text
 'as'          Name.Variable
@@ -1865,9 +1865,9 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-'\n    '      Text
+'\n    '      Text.Whitespace
 'same'        Name.Function
 '\n    '      Text
 'as'          Name.Variable
@@ -2490,7 +2490,7 @@
 '\n--DATA--\nreturn array(\'number1\' => -5.5, \'number2\' => -5, \'number3\' => -0, \'number4\' => 0, \'number5\' => 5, \'number6\' => 5.5)\n--EXPECT--\n5.5\n5\n0\n0\n5\n5.5\n5.5\n5\n0\n0\n5\n5.5\n--TEST--\n"batch" filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'row'         Name.Variable
@@ -2507,7 +2507,7 @@
 '%}'          Comment.Preproc
 '\n  <div class=row>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'column'      Name.Variable
@@ -2525,21 +2525,21 @@
 '}}'          Comment.Preproc
 '</div>\n  '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  </div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\', \'c\', \'d\', \'e\', \'f\', \'g\', \'h\', \'i\', \'j\'))\n--EXPECT--\n<div class=row>\n      <div class=item>a</div>\n      <div class=item>b</div>\n      <div class=item>c</div>\n      <div class=item>d</div>\n    </div>\n  <div class=row>\n      <div class=item>e</div>\n      <div class=item>f</div>\n      <div class=item>g</div>\n      <div class=item>h</div>\n    </div>\n  <div class=row>\n      <div class=item>i</div>\n      <div class=item>j</div>\n    </div>\n--TEST--\n"batch" filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'row'         Name.Variable
@@ -2556,7 +2556,7 @@
 '%}'          Comment.Preproc
 '\n  <div class=row>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'column'      Name.Variable
@@ -2574,21 +2574,21 @@
 '}}'          Comment.Preproc
 '</div>\n  '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  </div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\', \'c\', \'d\', \'e\', \'f\', \'g\', \'h\', \'i\', \'j\'))\n--EXPECT--\n<div class=row>\n      <div class=item>a</div>\n      <div class=item>b</div>\n      <div class=item>c</div>\n    </div>\n  <div class=row>\n      <div class=item>d</div>\n      <div class=item>e</div>\n      <div class=item>f</div>\n    </div>\n  <div class=row>\n      <div class=item>g</div>\n      <div class=item>h</div>\n      <div class=item>i</div>\n    </div>\n  <div class=row>\n      <div class=item>j</div>\n    </div>\n--TEST--\n"batch" filter\n--TEMPLATE--\n<table>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'row'         Name.Variable
@@ -2608,7 +2608,7 @@
 '%}'          Comment.Preproc
 '\n  <tr>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'column'      Name.Variable
@@ -2626,21 +2626,21 @@
 '}}'          Comment.Preproc
 '</td>\n  '   Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  </tr>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n</table>\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\', \'c\', \'d\', \'e\', \'f\', \'g\', \'h\', \'i\', \'j\'))\n--EXPECT--\n<table>\n  <tr>\n      <td>a</td>\n      <td>b</td>\n      <td>c</td>\n    </tr>\n  <tr>\n      <td>d</td>\n      <td>e</td>\n      <td>f</td>\n    </tr>\n  <tr>\n      <td>g</td>\n      <td>h</td>\n      <td>i</td>\n    </tr>\n  <tr>\n      <td>j</td>\n      <td></td>\n      <td></td>\n    </tr>\n</table>\n--TEST--\n"batch" filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'row'         Name.Variable
@@ -2660,7 +2660,7 @@
 '%}'          Comment.Preproc
 '\n  <div class=row>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'column'      Name.Variable
@@ -2678,21 +2678,21 @@
 '}}'          Comment.Preproc
 '</div>\n  '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  </div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\', \'c\', \'d\', \'e\', \'f\', \'g\', \'h\', \'i\', \'j\', \'k\', \'l\'))\n--EXPECT--\n<div class=row>\n      <div class=item>a</div>\n      <div class=item>b</div>\n      <div class=item>c</div>\n    </div>\n  <div class=row>\n      <div class=item>d</div>\n      <div class=item>e</div>\n      <div class=item>f</div>\n    </div>\n  <div class=row>\n      <div class=item>g</div>\n      <div class=item>h</div>\n      <div class=item>i</div>\n    </div>\n  <div class=row>\n      <div class=item>j</div>\n      <div class=item>k</div>\n      <div class=item>l</div>\n    </div>\n--TEST--\n"batch" filter\n--TEMPLATE--\n<table>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'row'         Name.Variable
@@ -2712,7 +2712,7 @@
 '%}'          Comment.Preproc
 '\n  <tr>\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'column'      Name.Variable
@@ -2730,14 +2730,14 @@
 '}}'          Comment.Preproc
 '</td>\n  '   Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  </tr>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -3382,7 +3382,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3412,7 +3412,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3442,7 +3442,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3472,7 +3472,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3502,7 +3502,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3533,7 +3533,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3566,7 +3566,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3597,7 +3597,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3628,7 +3628,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3659,7 +3659,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3690,7 +3690,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3723,7 +3723,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3754,7 +3754,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3784,7 +3784,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3814,7 +3814,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3844,7 +3844,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3874,7 +3874,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3940,7 +3940,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -3971,7 +3971,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4004,7 +4004,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4038,7 +4038,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4071,7 +4071,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4105,7 +4105,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4138,7 +4138,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4170,7 +4170,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4206,7 +4206,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4238,7 +4238,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4270,7 +4270,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4302,7 +4302,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'same'        Name.Function
 ' '           Text
 'as'          Name.Variable
@@ -4458,7 +4458,7 @@
 '\n--DATA--\nreturn array(\'arr\' => new ArrayObject(array(1, 2, 3, 4)))\n--EXPECT--\n1\n1\n1\n1\nÄ\n--TEST--\n"escape" filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -4467,7 +4467,7 @@
 '\n    foo<br />\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endset'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -4499,7 +4499,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'true'        Keyword.Pseudo
@@ -4514,7 +4514,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -6174,7 +6174,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -6199,7 +6199,7 @@
 ')'           Operator
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -6214,7 +6214,7 @@
 '\n--DATA--\nreturn array(\'obj\' => new TwigTestFoo(), \'method\' => \'foo\', \'array\' => array(\'foo\' => \'bar\'), \'item\' => \'foo\', \'nonmethod\' => \'xxx\', \'arguments\' => array(\'a\', \'b\'))\n--EXPECT--\nfoo\nbar\nbar_a-b\nbar_a-b\nok\nko\n--TEST--\n"block" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 "'base.twig'" Literal.String.Single
@@ -6223,7 +6223,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -6231,14 +6231,14 @@
 '%}'          Comment.Preproc
 'BAR'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -6253,14 +6253,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -6268,7 +6268,7 @@
 '%}'          Comment.Preproc
 'BAR_BASE'    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -6310,7 +6310,7 @@
 '\n--DATA--\nreturn array(\'expect\' => DATE_W3C, \'object\' => new ArrayObject(array(\'hi\')));\n--EXPECT--\ntrue\n2\n--TEST--\n"cycle" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -6349,7 +6349,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -6603,7 +6603,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo/bar\na/b/bar\n--TEST--\n"include" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'tmp'         Name.Variable
@@ -6751,7 +6751,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\n--TEST--\n"include" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -6760,7 +6760,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -6777,14 +6777,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -6802,7 +6802,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -6959,7 +6959,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'k'           Name.Variable
@@ -6979,7 +6979,7 @@
 '}}'          Comment.Preproc
 ','           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7207,7 +7207,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\n1,3,5,7,9\n--TEST--\n"block" function recursively called in a parent template\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"ordered_menu.twig"' Literal.String.Double
@@ -7216,7 +7216,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'label'       Name.Variable
@@ -7232,21 +7232,21 @@
 '}}'          Comment.Preproc
 '"'           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'list'        Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'class'       Name.Variable
@@ -7264,14 +7264,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(ordered_menu.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"menu.twig"' Literal.String.Double
@@ -7280,14 +7280,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'list'        Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'class'       Name.Variable
@@ -7319,14 +7319,14 @@
 '}}'          Comment.Preproc
 '</ol>'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(menu.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -7335,7 +7335,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'list'        Name.Variable
@@ -7352,21 +7352,21 @@
 '}}'          Comment.Preproc
 '</ul>'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'children'    Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'currentItem' Name.Variable
@@ -7377,7 +7377,7 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -7396,12 +7396,12 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -7412,14 +7412,14 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'item'        Name.Variable
@@ -7427,15 +7427,15 @@
 '%}'          Comment.Preproc
 '<li>'        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'item'        Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'iterable'    Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -7448,7 +7448,7 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7461,20 +7461,20 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '</li>'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'label'       Name.Variable
@@ -7494,7 +7494,7 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7535,7 +7535,7 @@
 '<br />\n\nBAR\n--TEST--\n"template_from_string" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 'template_from_string' Name.Variable
@@ -7547,7 +7547,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 'template_from_string' Name.Variable
@@ -7559,7 +7559,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 'template_from_string' Name.Variable
@@ -7571,14 +7571,14 @@
 '\n--TEMPLATE(parent.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7591,7 +7591,7 @@
 '")\n--EXPECT--\nHello Fabien\nHello Fabien\nHello Fabien\n--TEST--\nmacro\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7604,7 +7604,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'test'        Name.Variable
@@ -7666,7 +7666,7 @@
 '\n--DATA--\nreturn array();\n--EXPECT--\nfoobar\nbarfoo\n--TEST--\nmacro\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7679,7 +7679,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -7697,14 +7697,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -7715,7 +7715,7 @@
 '\n    <br />\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7736,7 +7736,7 @@
 '\n--DATA--\nreturn array();\n--EXPECT--\n<br />\n--TEST--\nmacro\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7749,7 +7749,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'test'        Name.Variable
@@ -7785,7 +7785,7 @@
 "\n--DATA--\nreturn array('this' => 'foo');\n--EXPECT--\nfoo\n--TEST--\nmacro\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7798,7 +7798,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7811,7 +7811,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'test'        Name.Variable
@@ -7903,7 +7903,7 @@
 '\n--DATA--\nreturn array();\n--EXPECT--\na<br />b<br />\na<br />b<br />\n1<br />c<br />\n1<br />c<br />\n--TEST--\nmacro with a filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -7916,7 +7916,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'test'        Name.Variable
@@ -7926,22 +7926,22 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'escape'      Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 'foo<br />'   Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -7976,9 +7976,9 @@
 '.region'     Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'null'        Name.Function
 ' '           Text
 '?'           Operator
@@ -8029,7 +8029,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'image'       Name.Variable
@@ -8049,7 +8049,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8066,7 +8066,7 @@
 '\n--DATA--\nreturn array(\'hash\' => array(\'2e2\' => \'works\'))\n--EXPECT--\nworks\n--TEST--\n"autoescape" tag applies escaping on its children\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8080,14 +8080,14 @@
 '<br />\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8103,14 +8103,14 @@
 '<br />\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8126,14 +8126,14 @@
 '<br />\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'true'        Keyword.Pseudo
@@ -8149,14 +8149,14 @@
 '<br />\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8172,14 +8172,14 @@
 '<br />\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'<br />\')\n--EXPECT--\n&lt;br /&gt;<br />\n&lt;br /&gt;<br />\n<br /><br />\n&lt;br /&gt;<br />\n<br /><br />\n--TEST--\n"autoescape" tag applies escaping on embedded blocks\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8187,7 +8187,7 @@
 '%}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -8201,21 +8201,21 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'<br />\')\n--EXPECT--\n&lt;br /&gt;\n--TEST--\n"autoescape" tag does not double-escape\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8233,14 +8233,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'<br />\')\n--EXPECT--\n&lt;br /&gt;\n--TEST--\n"autoescape" tag applies escaping after calling functions\n--TEMPLATE--\n\nautoescape false\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8267,14 +8267,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n\nautoescape 'html'\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8353,14 +8353,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\nautoescape js\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'js'"        Literal.String.Single
@@ -8378,14 +8378,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n\nautoescape false\n\nsafe_br\n<br />\n\nunsafe_br\n<br />\n\n\nautoescape \'html\'\n\nsafe_br\n<br />\n\nunsafe_br\n&lt;br /&gt;\n\nunsafe_br()|raw\n<br />\n\nsafe_br()|escape\n&lt;br /&gt;\n\nsafe_br()|raw\n<br />\n\nunsafe_br()|escape\n&lt;br /&gt;\n\n\nautoescape js\n\nsafe_br\n\\x3Cbr\\x20\\x2F\\x3E\n--TEST--\n"autoescape" tag does not apply escaping on literals\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8508,7 +8508,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8522,7 +8522,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8536,7 +8536,7 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8550,7 +8550,7 @@
 '}}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8564,7 +8564,7 @@
 '}}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8576,7 +8576,7 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8589,7 +8589,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -8603,7 +8603,7 @@
 '\n--DATA--\nreturn array(\'var\' => \'<br />\')\n--EXPECT--\n&lt;br /&gt;\n  &lt;br /&gt;\n      <br />\n          &lt;br /&gt;\n        <br />\n    &lt;br /&gt;\n&lt;br /&gt;\n--TEST--\n"autoescape" tag applies escaping to object method calls\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8637,14 +8637,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--EXPECT--\nFabien&lt;br /&gt;\nfabien&lt;br /&gt;\nFabien&lt;br /&gt;\n--TEST--\n"autoescape" tag does not escape when raw is used as a filter\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8662,14 +8662,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'<br />\')\n--EXPECT--\n<br />\n--TEST--\n"autoescape" tag accepts an escaping strategy\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'true'        Keyword.Pseudo
@@ -8683,14 +8683,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'true'        Keyword.Pseudo
@@ -8704,14 +8704,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'js'"        Literal.String.Single
@@ -8723,14 +8723,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8742,14 +8742,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'<br />"\')\n--EXPECT--\n\\x3Cbr\\x20\\x2F\\x3E\\x22\n&lt;br /&gt;&quot;\n\\x3Cbr\\x20\\x2F\\x3E\\x22\n&lt;br /&gt;&quot;\n--TEST--\nescape types\n--TEMPLATE--\n\n1. autoescape \'html\' |escape(\'js\')\n\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8769,14 +8769,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n\n2. autoescape 'html' |escape('js')\n\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8796,14 +8796,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n\n3. autoescape 'js' |escape('js')\n\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'js'"        Literal.String.Single
@@ -8823,14 +8823,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n4. no escape\n\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8845,14 +8845,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n\n5. |escape('js')|escape('html')\n\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 'false'       Keyword.Pseudo
@@ -8877,14 +8877,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n\n6. autoescape 'html' |escape('js')|escape('html')\n\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8909,14 +8909,14 @@
 '&quot;)"></a>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n--DATA--\nreturn array(\'msg\' => "<>\\n\'\\"")\n--EXPECT--\n\n1. autoescape \'html\' |escape(\'js\')\n\n<a onclick="alert(&quot;\\x3C\\x3E\\x0A\\x27\\x22&quot;)"></a>\n\n2. autoescape \'html\' |escape(\'js\')\n\n<a onclick="alert(&quot;\\x3C\\x3E\\x0A\\x27\\x22&quot;)"></a>\n\n3. autoescape \'js\' |escape(\'js\')\n\n<a onclick="alert(&quot;\\x3C\\x3E\\x0A\\x27\\x22&quot;)"></a>\n\n4. no escape\n\n<a onclick="alert(&quot;<>\n\'"&quot;)"></a>\n\n5. |escape(\'js\')|escape(\'html\')\n\n<a onclick="alert(&quot;\\x3C\\x3E\\x0A\\x27\\x22&quot;)"></a>\n\n6. autoescape \'html\' |escape(\'js\')|escape(\'html\')\n\n<a onclick="alert(&quot;\\x3C\\x3E\\x0A\\x27\\x22&quot;)"></a>\n\n--TEST--\n"autoescape" tag do not applies escaping on filter arguments\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -8991,14 +8991,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => "<Fabien>\\nTwig", \'sep\' => \'<br />\')\n--EXPECT--\n&lt;Fabien&gt;<br />\nTwig\n&lt;Fabien&gt;&lt;br /&gt;\nTwig\n&lt;Fabien&gt;<br />\nTwig\n&lt;Fabien&gt;<br />\nTwig\n&lt;Fabien&gt;&lt;br /&gt;\nTwig\n--TEST--\n"autoescape" tag applies escaping after calling filters\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -9125,14 +9125,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => "<Fabien>\\nTwig")\n--EXPECT--\n\n(escape_and_nl2br is an escaper filter)\n\n1. Don\'t escape escaper filter output\n( var is escaped by |escape_and_nl2br, line-breaks are added, \n  the output is not escaped )\n&lt;Fabien&gt;<br />\nTwig\n\n2. Don\'t escape escaper filter output\n( var is escaped by |escape_and_nl2br, line-breaks are added, \n  the output is not escaped, |raw is redundant )\n&lt;Fabien&gt;<br />\nTwig\n\n3. Explicit escape\n( var is escaped by |escape_and_nl2br, line-breaks are added,\n  the output is explicitly escaped by |escape )\n&amp;lt;Fabien&amp;gt;&lt;br /&gt;\nTwig\n\n4. Escape non-escaper filter output\n( var is upper-cased by |upper,\n  the output is auto-escaped )\n&lt;FABIEN&gt;\nTWIG\n\n5. Escape if last filter is not an escaper\n( var is escaped by |escape_and_nl2br, line-breaks are added,\n  the output is upper-cased by |upper,\n  the output is auto-escaped as |upper is not an escaper )\n&amp;LT;FABIEN&amp;GT;&lt;BR /&gt;\nTWIG\n\n6. Don\'t escape escaper filter output\n( var is upper cased by upper,\n  the output is escaped by |escape_and_nl2br, line-breaks are added,\n  the output is not escaped as |escape_and_nl2br is an escaper )\n&lt;FABIEN&gt;<br />\nTWIG\n\n7. Escape if last filter is not an escaper\n( the output of |format is "<b>" ~ var ~ "</b>",\n  the output is auto-escaped )\n&lt;b&gt;&lt;Fabien&gt;\nTwig&lt;/b&gt;\n\n8. Escape if last filter is not an escaper\n( the output of |format is "<b>" ~ var ~ "</b>",\n  |raw is redundant,\n  the output is auto-escaped )\n&lt;b&gt;&lt;Fabien&gt;\nTwig&lt;/b&gt;\n\n9. Don\'t escape escaper filter output\n( the output of |format is "<b>" ~ var ~ "</b>",\n  the output is not escaped due to |raw filter at the end )\n<b><Fabien>\nTwig</b>\n\n10. Don\'t escape escaper filter output\n( the output of |format is "<b>" ~ var ~ "</b>",\n  the output is not escaped due to |raw filter at the end,\n  the |raw filter on var is redundant )\n<b><Fabien>\nTwig</b>\n--TEST--\n"autoescape" tag applies escaping after calling filters, and before calling pre_escape filters\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -9205,14 +9205,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => "<Fabien>\\nTwig")\n--EXPECT--\n\n(nl2br is pre_escaped for "html" and declared safe for "html")\n\n1. Pre-escape and don\'t post-escape\n( var|escape|nl2br )\n&lt;Fabien&gt;<br />\nTwig\n\n2. Don\'t double-pre-escape\n( var|escape|nl2br )\n&lt;Fabien&gt;<br />\nTwig\n\n3. Don\'t escape safe values\n( var|raw|nl2br )\n<Fabien><br />\nTwig\n\n4. Don\'t escape safe values\n( var|escape|nl2br|nl2br )\n&lt;Fabien&gt;<br /><br />\nTwig\n\n5. Re-escape values that are escaped for an other contexts\n( var|escape_something|escape|nl2br )\n&lt;FABIEN&gt;<br />\nTWIG\n\n6. Still escape when using filters not declared safe\n( var|escape|nl2br|upper|escape )\n&amp;LT;FABIEN&amp;GT;&lt;BR /&gt;\nTWIG\n\n--TEST--\n"autoescape" tag handles filters preserving the safety\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'autoescape'  Keyword
 ' '           Text
 "'html'"      Literal.String.Single
@@ -9275,7 +9275,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endautoescape' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -9284,7 +9284,7 @@
 '\'FABIEN\': \'FABPOT\'})|escape )\n&amp;LT;FABPOT&amp;GT;\nTWIG\n\n--TEST--\n"block" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'title1'      Name.Variable
@@ -9292,14 +9292,14 @@
 '%}'          Comment.Preproc
 'FOO'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'title2'      Name.Variable
@@ -9312,21 +9312,21 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => \'bar\')\n--EXPECT--\nFOObar\n--TEST--\n"block" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -9334,7 +9334,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -9342,21 +9342,21 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXCEPTION--\nTwig_Error_Syntax: The block \'content\' has already been defined line 2 in "index.twig" at line 3\n--TEST--\n"§" special chars in a block name\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 '§'           Name.Variable
@@ -9365,7 +9365,7 @@
 '\n§\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '§'           Name.Variable
@@ -9374,7 +9374,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\n§\n--TEST--\n"embed" tag\n--TEMPLATE--\nFOO\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9382,7 +9382,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9398,21 +9398,21 @@
 '}}'          Comment.Preproc
 '\n        block1extended\n    ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\nBAR\n--TEMPLATE(foo.twig)--\nA\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9421,14 +9421,14 @@
 '\n    block1\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nB\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9437,14 +9437,14 @@
 '\n    block2\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nC\n--DATA--\nreturn array()\n--EXPECT--\nFOO\n\nA\n            block1\n\n        block1extended\n    B\n    block2\nC\nBAR\n--TEST--\n"embed" tag\n--TEMPLATE(index.twig)--\nFOO\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9452,7 +9452,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9466,35 +9466,35 @@
 '}}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nBAR\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXCEPTION--\nTwig_Error_Runtime: Variable "nothing" does not exist in "index.twig" at line 5\n--TEST--\n"embed" tag\n--TEMPLATE--\nFOO\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9502,7 +9502,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9518,21 +9518,21 @@
 '}}'          Comment.Preproc
 '\n        block1extended\n    ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9540,7 +9540,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9556,21 +9556,21 @@
 '}}'          Comment.Preproc
 '\n        block1extended\n    ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\nBAR\n--TEMPLATE(foo.twig)--\nA\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9579,14 +9579,14 @@
 '\n    block1\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nB\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9595,14 +9595,14 @@
 '\n    block2\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nC\n--DATA--\nreturn array()\n--EXPECT--\nFOO\n\nA\n            block1\n\n        block1extended\n    B\n    block2\nC\n\nA\n            block1\n\n        block1extended\n    B\n    block2\nC\nBAR\n--TEST--\n"embed" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9610,7 +9610,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9626,7 +9626,7 @@
 '}}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9634,7 +9634,7 @@
 '%}'          Comment.Preproc
 '\n            ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9650,33 +9650,33 @@
 '}}'          Comment.Preproc
 '\n                block1extended\n            ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n    '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\nA\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9685,14 +9685,14 @@
 '\n    block1\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nB\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9701,14 +9701,14 @@
 '\n    block2\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nC\n--DATA--\nreturn array()\n--EXPECT--\nA\n            block1\n\n        \nA\n                    block1\n\n                block1extended\n            B\n    block2\nC\n    B\n    block2\nC\n--TEST--\n"embed" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -9717,7 +9717,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9734,14 +9734,14 @@
 '\n    blockc1baseextended\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9757,7 +9757,7 @@
 '}}'          Comment.Preproc
 '\n\n    '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'embed'       Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -9765,7 +9765,7 @@
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9781,27 +9781,27 @@
 '}}'          Comment.Preproc
 '\n            block1extended\n        ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endembed'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\nA\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9810,14 +9810,14 @@
 '\n    blockc1base\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9826,14 +9826,14 @@
 '\n    blockc2base\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nB\n--TEMPLATE(foo.twig)--\nA\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c1'          Name.Variable
@@ -9842,14 +9842,14 @@
 '\n    block1\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nB\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'c2'          Name.Variable
@@ -9858,16 +9858,16 @@
 '\n    block2\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nC\n--DATA--\nreturn array()\n--EXPECT--\nA\n        blockc1base\n\n    blockc1baseextended\n        blockc2base\n\n\n    \nA\n                block1\n\n            block1extended\n        B\n    block2\nCB--TEST--\n"filter" tag applies a filter on its children\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'upper'       Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -9880,16 +9880,16 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'var\')\n--EXPECT--\nSOME TEXT WITH A VAR\n--TEST--\n"filter" tag applies a filter on its children\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'json_encode' Name.Function
 '|'           Operator
 'raw'         Name.Function
@@ -9897,16 +9897,16 @@
 '%}'          Comment.Preproc
 'test'        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n"test"\n--TEST--\n"filter" tags accept multiple chained filters\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lower'       Name.Function
 '|'           Operator
 'title'       Name.Function
@@ -9921,16 +9921,16 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'VAR\')\n--EXPECT--\n    Var\n--TEST--\n"filter" tags can be nested at will\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'lower'       Name.Function
 '|'           Operator
 'title'       Name.Function
@@ -9944,9 +9944,9 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'upper'       Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -9958,7 +9958,7 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -9971,23 +9971,23 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'var\' => \'var\')\n--EXPECT--\n  Var\n      Var\n    Var\n--TEST--\n"filter" tag applies the filter on "for" tags\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'upper'       Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10007,30 +10007,30 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\nA\nB\n--TEST--\n"filter" tag applies the filter on "if" tags\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'filter'      Keyword
-' '           Text
+' '           Text.Whitespace
 'upper'       Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'items'       Name.Variable
@@ -10051,28 +10051,28 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'items'       Name.Variable
 '.3'          Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 '\nFOO\n'     Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -10087,28 +10087,28 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'items'       Name.Variable
 '.3'          Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 '\nFOO\n'     Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'elseif'      Keyword
 ' '           Text
 'items'       Name.Variable
@@ -10126,21 +10126,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfilter'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\nA, B\n\nB\n\nA\n--TEST--\n"for" tag takes a condition\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -10155,7 +10155,7 @@
 'i'           Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'odd'         Name.Function
 ' '           Text
 '-'           Text
@@ -10182,14 +10182,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => array(\'bar\' => \'X\'))\n--CONFIG--\nreturn array(\'strict_variables\' => false)\n--EXPECT--\n1.1X\n2.3X\n3.5X\n--TEST--\n"for" tag keeps the context safe\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10201,7 +10201,7 @@
 '%}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10219,7 +10219,7 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -10232,14 +10232,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\n      * a\n      * b\n    * a\n      * a\n      * b\n    * b\n--TEST--\n"for" tag can use an "else" clause\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10258,21 +10258,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  no item\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\n  * a\n  * b\n--DATA--\nreturn array(\'items\' => array())\n--EXPECT--\n  no item\n--DATA--\nreturn array()\n--CONFIG--\nreturn array(\'strict_variables\' => false)\n--EXPECT--\n  no item\n--TEST--\n"for" tag does not reset inner variables\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -10285,7 +10285,7 @@
 '%}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'j'           Name.Variable
@@ -10301,7 +10301,7 @@
 'k'           Name.Variable
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'k'           Name.Variable
@@ -10324,21 +10324,21 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'k\' => 0)\n--EXPECT--\n      0 1\n      1 1\n      2 1\n        3 2\n      4 2\n      5 2\n--TEST--\n"for" tag can iterate over keys and values\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10366,14 +10366,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\n  * 0/a\n  * 1/b\n--TEST--\n"for" tag can iterate over keys\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10394,14 +10394,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\n  * 0\n  * 1\n--TEST--\n"for" tag adds a loop variable to the context locally\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10414,35 +10414,35 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'loop'        Name.Builtin
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
 'WORKS'       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array())\n--EXPECT--\nWORKS\n--TEST--\n"for" tag adds a loop variable to the context\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10504,14 +10504,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXPECT--\n  * 1/0\n  * 2/1\n  * 1//2\n\n  * 2/1\n  * 1/0\n  * /1/2\n--TEST--\n"for" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -10536,14 +10536,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXCEPTION--\nTwig_Error_Syntax: The "loop" variable cannot be used in a looping condition in "index.twig" at line 2\n--TEST--\n"for" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -10574,14 +10574,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'))\n--EXCEPTION--\nTwig_Error_Syntax: The "loop.last" variable is not defined when looping with a condition in "index.twig" at line 3\n--TEST--\n"for" tag can use an "else" clause\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10593,7 +10593,7 @@
 '%}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10611,7 +10611,7 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -10623,28 +10623,28 @@
 '}}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  no item1\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\', \'b\'), \'items1\' => array())\n--EXPECT--\nno a\n        no b\n--TEST--\n"for" tag iterates over iterable and countable objects\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10712,14 +10712,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10747,14 +10747,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10775,7 +10775,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -10797,7 +10797,7 @@
 ' return count($this->values); }\n}\nreturn array(\'items\' => new ItemsIteratorCountable())\n--EXPECT--\n  * bar\n  * 1/0\n  * 2/1\n  * 1//2\n\n  * foo\n  * 2/1\n  * 1/0\n  * /1/2\n\n\n  * foo/bar\n  * bar/foo\n\n  * foo\n  * bar\n--TEST--\n"for" tag iterates over iterable objects\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -10837,14 +10837,14 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10872,14 +10872,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10900,7 +10900,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -10920,7 +10920,7 @@
 ' return false !== current($this->values); }\n}\nreturn array(\'items\' => new ItemsIterator())\n--EXPECT--\n  * bar\n  * 1/0\n  * 1\n\n  * foo\n  * 2/1\n  * \n\n\n  * foo/bar\n  * bar/foo\n\n  * foo\n  * bar\n--TEST--\n"for" tags can be nested\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -10949,7 +10949,7 @@
 '):\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'value'       Name.Variable
@@ -10975,21 +10975,21 @@
 ')\n'         Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'items\' => array(\'a\' => array(\'a1\', \'a2\', \'a3\'), \'b\' => array(\'b1\')))\n--EXPECT--\n* a (2):\n  * a1 (3)\n  * a2 (3)\n  * a3 (3)\n* b (2):\n  * b1 (1)\n--TEST--\n"for" tag iterates over item values\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'item'        Name.Variable
@@ -11008,14 +11008,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n--DATA--\nreturn array('items' => array('a', 'b'))\n--EXPECT--\n  * a\n  * b\n--TEST--\nglobal variables\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"included.twig"' Literal.String.Double
@@ -11024,7 +11024,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 '"included.twig"' Literal.String.Double
@@ -11046,7 +11046,7 @@
 '\n--TEMPLATE(included.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -11057,20 +11057,20 @@
 '\ncalled foobar\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array();\n--EXPECT--\ncalled foobar\n--TEST--\n"if" creates a condition\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'a'           Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -11083,13 +11083,13 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'elseif'      Keyword
 ' '           Text
 'b'           Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -11102,21 +11102,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  NOTHING\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'a\' => \'a\')\n--EXPECT--\n  a\n--DATA--\nreturn array(\'b\' => \'b\')\n--EXPECT--\n  b\n--DATA--\nreturn array()\n--EXPECT--\n  NOTHING\n--TEST--\n"if" takes an expression as a test\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'a'           Name.Variable
@@ -11129,7 +11129,7 @@
 '\n  A1\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'elseif'      Keyword
 ' '           Text
 'a'           Name.Variable
@@ -11143,21 +11143,21 @@
 '\n  A2\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n  A3\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'a\' => 1)\n--EXPECT--\n  A1\n--DATA--\nreturn array(\'a\' => 12)\n--EXPECT--\n  A2\n--DATA--\nreturn array(\'a\' => 7)\n--EXPECT--\n  A3\n--TEST--\n"include" tag\n--TEMPLATE--\nFOO\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11166,7 +11166,7 @@
 '\n\nBAR\n--TEMPLATE(foo.twig)--\nFOOBAR\n--DATA--\nreturn array()\n--EXPECT--\nFOO\n\nFOOBAR\nBAR\n--TEST--\n"include" tag allows expressions for the template to include\n--TEMPLATE--\nFOO\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -11175,7 +11175,7 @@
 '\n\nBAR\n--TEMPLATE(foo.twig)--\nFOOBAR\n--DATA--\nreturn array(\'foo\' => \'foo.twig\')\n--EXPECT--\nFOO\n\nFOOBAR\nBAR\n--TEST--\n"include" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '['           Operator
@@ -11193,7 +11193,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11206,7 +11206,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11224,7 +11224,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11244,7 +11244,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\n--TEST--\n"include" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -11253,7 +11253,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11270,14 +11270,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11285,7 +11285,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11294,14 +11294,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array();\n--EXCEPTION--\nTwig_Error_Loader: Template "foo.twig" is not defined in "base.twig" at line 3.\n--TEST--\n"include" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11310,7 +11310,7 @@
 '\n--DATA--\nreturn array();\n--EXCEPTION--\nTwig_Error_Loader: Template "foo.twig" is not defined in "index.twig" at line 2.\n--TEST--\n"include" tag accept variables and only\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11319,7 +11319,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11330,7 +11330,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11348,7 +11348,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11368,7 +11368,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'k'           Name.Variable
@@ -11388,14 +11388,14 @@
 '}}'          Comment.Preproc
 ','           Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => \'bar\')\n--EXPECT--\nfoo,global,_parent,\nglobal,_parent,\nfoo,global,foo1,_parent,\nfoo1,global,_parent,\n--TEST--\n"include" tag accepts Twig_Template instance\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -11404,7 +11404,7 @@
 ' FOO\n--TEMPLATE(foo.twig)--\nBAR\n--DATA--\nreturn array(\'foo\' => $twig->loadTemplate(\'foo.twig\'))\n--EXPECT--\nBAR FOO\n--TEST--\n"include" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '['           Operator
@@ -11418,7 +11418,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '['           Operator
@@ -11432,7 +11432,7 @@
 '\n--TEMPLATE(foo.twig)--\nfoo\n--DATA--\nreturn array()\n--EXPECT--\nfoo\nfoo\n--TEST--\n"include" tag accept variables\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11450,7 +11450,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11470,7 +11470,7 @@
 '\n--DATA--\nreturn array(\'vars\' => array(\'foo\' => \'bar\'))\n--EXPECT--\nbar\nbar\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11479,7 +11479,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11488,28 +11488,28 @@
 '\nFOO\n'     Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nFOO\n--TEST--\nblock_expr2\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base2.twig"' Literal.String.Double
@@ -11518,7 +11518,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'element'     Name.Variable
@@ -11538,14 +11538,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base2.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -11554,14 +11554,14 @@
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'spaceless'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'element'     Name.Variable
@@ -11577,7 +11577,7 @@
 '.children'   Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -11607,7 +11607,7 @@
 '}}'          Comment.Preproc
 '\n            ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -11628,14 +11628,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endspaceless' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 "\n--DATA--\nreturn array(\n    'item' => array(\n        'children' => array(\n            null,\n            null,\n        )\n    )\n)\n--EXPECT--\nElement:<div>Element:<div></div>Element:<div></div></div>\n--TEST--\nblock_expr\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -11644,7 +11644,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'element'     Name.Variable
@@ -11664,21 +11664,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'spaceless'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'element'     Name.Variable
@@ -11694,7 +11694,7 @@
 '.children'   Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '%}'          Comment.Preproc
@@ -11724,7 +11724,7 @@
 '}}'          Comment.Preproc
 '\n            ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -11745,14 +11745,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endspaceless' Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\n    \'item\' => array(\n        \'children\' => array(\n            null,\n            null,\n        )\n    )\n)\n--EXPECT--\nElement:<div>Element:<div></div>Element:<div></div></div>\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 'standalone'  Name.Variable
@@ -11769,7 +11769,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11784,14 +11784,14 @@
 '}}'          Comment.Preproc
 'FOO'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11799,14 +11799,14 @@
 '%}'          Comment.Preproc
 'FOO'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(bar.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11814,14 +11814,14 @@
 '%}'          Comment.Preproc
 'BAR'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => \'foo.twig\', \'standalone\' => true)\n--EXPECT--\nFOOFOO\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -11830,7 +11830,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11839,28 +11839,28 @@
 '\nFOO\n'     Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => \'foo.twig\')\n--EXPECT--\nFOO\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -11869,7 +11869,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11877,14 +11877,14 @@
 '%}'          Comment.Preproc
 'FOO'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nFOO\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '['           Operator
@@ -11898,7 +11898,7 @@
 '\n--TEMPLATE(bar.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11907,21 +11907,21 @@
 '\nfoo\n'     Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"layout.twig"' Literal.String.Double
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11936,21 +11936,21 @@
 '}}'          Comment.Preproc
 'index '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(layout.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11965,14 +11965,14 @@
 '}}'          Comment.Preproc
 'layout '     Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -11980,14 +11980,14 @@
 '%}'          Comment.Preproc
 'base '       Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nbase layout index\n--TEST--\n"block" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12012,14 +12012,14 @@
 '\n    ENDCONTENT\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n--DATA--\nreturn array()\n--EXPECT--\nCONTENTSUBCONTENTENDCONTENT\n--TEST--\n"block" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -12028,7 +12028,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12036,7 +12036,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'subcontent'  Name.Variable
@@ -12044,7 +12044,7 @@
 '%}'          Comment.Preproc
 '\n        '  Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'subsubcontent' Name.Variable
@@ -12052,27 +12052,27 @@
 '%}'          Comment.Preproc
 '\n            SUBSUBCONTENT\n        ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12080,7 +12080,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'subcontent'  Name.Variable
@@ -12088,21 +12088,21 @@
 '%}'          Comment.Preproc
 '\n        SUBCONTENT\n    ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nSUBSUBCONTENT\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"layout.twig"' Literal.String.Double
@@ -12111,7 +12111,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'inside'      Name.Variable
@@ -12119,7 +12119,7 @@
 '%}'          Comment.Preproc
 'INSIDE'      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'inside'      Name.Variable
@@ -12128,7 +12128,7 @@
 '\n--TEMPLATE(layout.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -12137,7 +12137,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'body'        Name.Variable
@@ -12145,7 +12145,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'inside'      Name.Variable
@@ -12156,7 +12156,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'body'        Name.Variable
@@ -12165,7 +12165,7 @@
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'body'        Name.Variable
@@ -12176,7 +12176,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nINSIDE\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -12193,7 +12193,7 @@
 '\n--TEMPLATE(foo.twig)--\nFOO\n--TEMPLATE(bar.twig)--\nBAR\n--DATA--\nreturn array(\'foo\' => true)\n--EXPECT--\nFOO\n--DATA--\nreturn array(\'foo\' => false)\n--EXPECT--\nBAR\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12201,7 +12201,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -12210,14 +12210,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--EXCEPTION--\nTwig_Error_Syntax: Cannot extend from a block in "index.twig" at line 3\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -12226,28 +12226,28 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"included.twig"' Literal.String.Double
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'footer'      Name.Variable
@@ -12255,14 +12255,14 @@
 '%}'          Comment.Preproc
 'Footer'      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(included.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"base.twig"' Literal.String.Double
@@ -12271,7 +12271,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12279,14 +12279,14 @@
 '%}'          Comment.Preproc
 'Included Content' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(base.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12294,14 +12294,14 @@
 '%}'          Comment.Preproc
 'Default Content' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'footer'      Name.Variable
@@ -12309,14 +12309,14 @@
 '%}'          Comment.Preproc
 'Default Footer' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nIncluded Content\nDefault Footer\nFooter\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -12325,7 +12325,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12333,7 +12333,7 @@
 '%}'          Comment.Preproc
 '\n  '        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'inside'      Name.Variable
@@ -12341,7 +12341,7 @@
 '%}'          Comment.Preproc
 '\n    INSIDE OVERRIDDEN\n  ' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -12356,14 +12356,14 @@
 '\n  AFTER\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12372,14 +12372,14 @@
 '\n  BAR\n'   Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n\nINSIDE OVERRIDDEN\n  \n  BEFORE\n    BAR\n\n  AFTER\n--TEST--\n"extends" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -12388,7 +12388,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12410,14 +12410,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12425,14 +12425,14 @@
 '%}'          Comment.Preproc
 'BAR'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nBARFOOBAR\n--TEST--\n"parent" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'foo.twig'"  Literal.String.Single
@@ -12441,7 +12441,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12458,14 +12458,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12473,14 +12473,14 @@
 '%}'          Comment.Preproc
 'BAR'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nBAR\n--TEST--\n"parent" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12497,14 +12497,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--EXCEPTION--\nTwig_Error_Syntax: Calling "parent" on a template that does not extend nor "use" another template is forbidden in "index.twig" at line 3\n--TEST--\n"extends" tag accepts Twig_Template instance\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -12513,7 +12513,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12531,14 +12531,14 @@
 'FOO\n'       Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12546,14 +12546,14 @@
 '%}'          Comment.Preproc
 'BAR'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array(\'foo\' => $twig->loadTemplate(\'foo.twig\'))\n--EXPECT--\nBARFOO\n--TEST--\n"parent" function\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'extends'     Keyword
 ' '           Text
 '"parent.twig"' Literal.String.Double
@@ -12562,7 +12562,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"use1.twig"' Literal.String.Double
@@ -12571,7 +12571,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"use2.twig"' Literal.String.Double
@@ -12580,7 +12580,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_parent' Name.Variable
@@ -12597,14 +12597,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use1' Name.Variable
@@ -12621,14 +12621,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use2' Name.Variable
@@ -12645,14 +12645,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12679,14 +12679,14 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(parent.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_parent' Name.Variable
@@ -12697,7 +12697,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use1' Name.Variable
@@ -12708,7 +12708,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use2' Name.Variable
@@ -12719,7 +12719,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -12730,7 +12730,7 @@
 '\n--TEMPLATE(use1.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use1' Name.Variable
@@ -12741,7 +12741,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use2' Name.Variable
@@ -12752,7 +12752,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use1_only' Name.Variable
@@ -12763,7 +12763,7 @@
 '\n--TEMPLATE(use2.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use2' Name.Variable
@@ -12774,7 +12774,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content_use2_only' Name.Variable
@@ -12785,7 +12785,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\n    content_parent\n    content_use1\n    content_use2\n    content_use1_only\n    content_use2_only\n--TEST--\n"macro" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -12829,7 +12829,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'input'       Name.Variable
@@ -12892,14 +12892,14 @@
 '">\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n  <input type="text" name="username" value="" size="20">\n\n  <input type="password" name="password" value="" size="1">\n--TEST--\n"macro" tag supports name for endmacro\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -12932,7 +12932,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -12942,14 +12942,14 @@
 '%}'          Comment.Preproc
 'foo'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -12959,7 +12959,7 @@
 '%}'          Comment.Preproc
 'bar'         Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -12968,7 +12968,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\nbar\n\n--TEST--\n"macro" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 "'forms.twig'" Literal.String.Single
@@ -13012,7 +13012,7 @@
 '\n--TEMPLATE(forms.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'input'       Name.Variable
@@ -13075,14 +13075,14 @@
 '">\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n  <input type="text" name="username" value="" size="20">\n\n  <input type="password" name="password" value="" size="1">\n--TEST--\n"macro" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 "'forms.twig'" Literal.String.Single
@@ -13095,7 +13095,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 "'forms.twig'" Literal.String.Single
@@ -13145,7 +13145,7 @@
 '\n--TEMPLATE(forms.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13161,14 +13161,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -13184,14 +13184,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoofoo\nfoofoo\nbarfoo\n--TEST--\n"macro" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword
 ' '           Text
 "'forms.twig'" Literal.String.Single
@@ -13223,7 +13223,7 @@
 '\n--TEMPLATE(forms.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13248,14 +13248,14 @@
 ' '           Text
 '}}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\nfooglobal\nfooglobal\n--TEST--\n"macro" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'import'      Keyword
 ' '           Text
 '_self'       Name.Variable
@@ -13299,7 +13299,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'macro'       Keyword
 ' '           Text
 'input'       Name.Variable
@@ -13362,23 +13362,23 @@
 '">\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endmacro'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n  <input type="text" name="username" value="" size="20">\n\n  <input type="password" name="password" value="" size="1">\n--TEST--\n"raw" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'raw'         Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n{{ foo }}\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endraw'      Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n' Other
 
@@ -13390,16 +13390,16 @@
 '\n--TEST--\n"raw" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'raw'         Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n{{ foo }}\n{% endverbatim %}\n--DATA--\nreturn array()\n--EXCEPTION--\nTwig_Error_Syntax: Unexpected end of file: Unclosed "raw" block in "index.twig" at line 2\n--TEST--\n"raw" tag\n--TEMPLATE--\n1***\n\n{%- raw %}\n    {{ \'bla\' }}\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endraw'      Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n1***\n2***\n\n' Other
 
@@ -13411,9 +13411,9 @@
 "\n    {{ 'bla' }}\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endraw'      Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n2***\n3***\n\n' Other
 
@@ -13425,7 +13425,7 @@
 "\n    {{ 'bla' }}\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endraw'      Keyword
 ' -'          Text
 '%}'          Comment.Preproc
@@ -13441,7 +13441,7 @@
 '{%'          Comment.Preproc
 '- '          Text
 'endraw'      Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n4***\n5***\n\n' Other
 
@@ -13526,7 +13526,7 @@
 '%}'          Comment.Preproc
 '\n\n    '    Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 '1'           Literal.Number
@@ -13542,7 +13542,7 @@
 '%}'          Comment.Preproc
 '\n    '      Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -13613,21 +13613,21 @@
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'include'     Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endsandbox'  Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(foo.twig)--\nfoo\n--DATA--\nreturn array()\n--EXPECT--\nfoo\nfoo\nfoo\nfoo\n--TEST--\n"set" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13640,7 +13640,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -13667,7 +13667,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13698,21 +13698,21 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\nfoo&lt;br /&gt;\n\n\nfoobar\n--TEST--\n"set" tag block empty capture\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
 ' '           Text
 '%}'          Comment.Preproc
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endset'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13720,14 +13720,14 @@
 '%}'          Comment.Preproc
 'FAIL'        Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n--TEST--\n"set" tag block capture\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13735,7 +13735,7 @@
 '%}'          Comment.Preproc
 'f<br />o<br />o' Other
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endset'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -13749,7 +13749,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nf<br />o<br />o\n--TEST--\n"set" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'set'         Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -13790,14 +13790,14 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoobar\nbarfoo\n--TEST--\n"spaceless" tag removes whites between HTML tags\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'spaceless'   Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n    <div>   <div>   foo   </div>   </div>\n\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endspaceless' Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -13839,7 +13839,7 @@
 '\n\nTrim on control tag:\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -13872,7 +13872,7 @@
 '\n\n\nTrim on output tag:\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'i'           Name.Variable
@@ -13899,7 +13899,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -13909,7 +13909,7 @@
 '\n       \nAfter the comment.\n\nTrim leading space:\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'leading'     Name.Variable
@@ -13925,7 +13925,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -13955,7 +13955,7 @@
 '\n\n\nTrim trailing space:\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'trailing'    Name.Variable
@@ -13972,7 +13972,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '-'           Text
@@ -14006,7 +14006,7 @@
 '\n\nend\n--DATA--\nreturn array(\'leading\' => \'leading space\', \'trailing\' => \'trailing space\', \'both\' => \'both\')\n--EXPECT--\n15\n18\n\nTrim on control tag:\n123456789\n\nTrim on output tag:\n123456789\n\nTrim comments:After the comment.\n\nTrim leading space:\nleading space\nleading space\n\nTrim trailing space:\ntrailing spaceCombined:<ul>\n\t<li>both</li>\n</ul>end\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"blocks.twig"' Literal.String.Double
@@ -14033,7 +14033,7 @@
 '\n--TEMPLATE(blocks.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14044,7 +14044,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"blocks.twig"' Literal.String.Double
@@ -14063,7 +14063,7 @@
 '\n--TEMPLATE(blocks.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14074,7 +14074,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -14083,7 +14083,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"bar.twig"'  Literal.String.Double
@@ -14092,7 +14092,7 @@
 '\n--TEMPLATE(bar.twig)--\n--DATA--\nreturn array()\n--EXPECT--\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -14131,7 +14131,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"bar.twig"'  Literal.String.Double
@@ -14140,7 +14140,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14151,7 +14151,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14162,7 +14162,7 @@
 '\n--TEMPLATE(bar.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14173,7 +14173,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14184,7 +14184,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nfoo\nfoo\nbar\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"ancestor.twig"' Literal.String.Double
@@ -14193,7 +14193,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"parent.twig"' Literal.String.Double
@@ -14212,7 +14212,7 @@
 '\n--TEMPLATE(parent.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'sub_container' Name.Variable
@@ -14221,14 +14221,14 @@
 '\n    <div class="overriden_sub_container">overriden sub_container</div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(ancestor.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'container'   Name.Variable
@@ -14246,14 +14246,14 @@
 '</div>\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'sub_container' Name.Variable
@@ -14262,14 +14262,14 @@
 '\n    <div class="sub_container">sub_container</div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n<div class="container">    <div class="overriden_sub_container">overriden sub_container</div>\n</div>\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"parent.twig"' Literal.String.Double
@@ -14288,7 +14288,7 @@
 '\n--TEMPLATE(parent.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"ancestor.twig"' Literal.String.Double
@@ -14297,7 +14297,7 @@
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'sub_container' Name.Variable
@@ -14306,14 +14306,14 @@
 '\n    <div class="overriden_sub_container">overriden sub_container</div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--TEMPLATE(ancestor.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'container'   Name.Variable
@@ -14331,14 +14331,14 @@
 '</div>\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n\n'        Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'sub_container' Name.Variable
@@ -14347,14 +14347,14 @@
 '\n    <div class="sub_container">sub_container</div>\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n<div class="container">    <div class="overriden_sub_container">overriden sub_container</div>\n</div>\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -14371,7 +14371,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"bar.twig"'  Literal.String.Double
@@ -14420,7 +14420,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14431,7 +14431,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14442,7 +14442,7 @@
 '\n--TEMPLATE(bar.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14453,7 +14453,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14464,7 +14464,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nbar\nfoo\nbar\nfoo\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"foo.twig"'  Literal.String.Double
@@ -14473,7 +14473,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 '"bar.twig"'  Literal.String.Double
@@ -14512,7 +14512,7 @@
 '\n--TEMPLATE(foo.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14523,7 +14523,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14534,7 +14534,7 @@
 '\n--TEMPLATE(bar.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'content'     Name.Variable
@@ -14545,7 +14545,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14556,7 +14556,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nbar\nfoo\nbar\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file2.html.twig'" Literal.String.Single
@@ -14564,7 +14564,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14583,7 +14583,7 @@
 '\n    Content of block (second override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14592,7 +14592,7 @@
 '\n--TEMPLATE(file2.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file1.html.twig'" Literal.String.Single
@@ -14601,7 +14601,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14620,7 +14620,7 @@
 '\n    Content of block (first override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14629,7 +14629,7 @@
 '\n--TEMPLATE(file1.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14639,7 +14639,7 @@
 '\n    Content of block\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14648,7 +14648,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nContent of block\nContent of block (first override)\nContent of block (second override)\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file2.html.twig'" Literal.String.Single
@@ -14657,7 +14657,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file1.html.twig'" Literal.String.Single
@@ -14670,7 +14670,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14689,7 +14689,7 @@
 '\n    Content of foo (second override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14698,7 +14698,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14717,7 +14717,7 @@
 '\n    Content of bar (second override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14726,7 +14726,7 @@
 '\n--TEMPLATE(file2.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file1.html.twig'" Literal.String.Single
@@ -14735,7 +14735,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14754,7 +14754,7 @@
 '\n    Content of foo (first override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14763,7 +14763,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14782,7 +14782,7 @@
 '\n    Content of bar (first override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14791,7 +14791,7 @@
 '\n--TEMPLATE(file1.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14801,7 +14801,7 @@
 '\n    Content of foo\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foo'         Name.Variable
@@ -14810,7 +14810,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14820,7 +14820,7 @@
 '\n    Content of bar\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -14829,7 +14829,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nContent of foo\nContent of foo (first override)\nContent of foo (second override)\nContent of bar\nContent of bar (second override)\n--TEST--\n"use" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file2.html.twig'" Literal.String.Single
@@ -14846,7 +14846,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14866,7 +14866,7 @@
 '\n    Content of block (second override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14875,7 +14875,7 @@
 '\n--TEMPLATE(file2.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'use'         Keyword
 ' '           Text
 "'file1.html.twig'" Literal.String.Single
@@ -14892,7 +14892,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14912,7 +14912,7 @@
 '\n    Content of block (first override)\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14921,7 +14921,7 @@
 '\n--TEMPLATE(file1.html.twig)--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'block'       Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14931,7 +14931,7 @@
 '\n    Content of block\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endblock'    Keyword
 ' '           Text
 'foobar'      Name.Variable
@@ -14940,16 +14940,16 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nContent of block\nContent of block (first override)\nContent of block (second override)\n--TEST--\n"verbatim" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'verbatim'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n{{ foo }}\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endverbatim' Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n--DATA--\nreturn array()\n--EXPECT--\n' Other
 
@@ -14961,16 +14961,16 @@
 '\n--TEST--\n"verbatim" tag\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'verbatim'    Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n{{ foo }}\n{% endraw %}\n--DATA--\nreturn array()\n--EXCEPTION--\nTwig_Error_Syntax: Unexpected end of file: Unclosed "verbatim" block in "index.twig" at line 2\n--TEST--\n"verbatim" tag\n--TEMPLATE--\n1***\n\n{%- verbatim %}\n    {{ \'bla\' }}\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endverbatim' Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n1***\n2***\n\n' Other
 
@@ -14982,9 +14982,9 @@
 "\n    {{ 'bla' }}\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endverbatim' Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n2***\n3***\n\n' Other
 
@@ -14996,7 +14996,7 @@
 "\n    {{ 'bla' }}\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endverbatim' Keyword
 ' -'          Text
 '%}'          Comment.Preproc
@@ -15012,7 +15012,7 @@
 '{%'          Comment.Preproc
 '- '          Text
 'endverbatim' Keyword
-' '           Text
+' '           Text.Whitespace
 '%}'          Comment.Preproc
 '\n\n4***\n5***\n\n' Other
 
@@ -15061,7 +15061,7 @@
 '5***\n--TEST--\narray index test\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'key'         Name.Variable
@@ -15084,7 +15084,7 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -15095,7 +15095,7 @@
 '8'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'constant'    Name.Function
 '('           Operator
 "'E_NOTICE'"  Literal.String.Single
@@ -15117,7 +15117,7 @@
 "'bar'"       Literal.String.Single
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'constant'    Name.Function
 '('           Operator
 "'TwigTestFoo::BAR_NAME'" Literal.String.Single
@@ -15139,7 +15139,7 @@
 'value'       Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'constant'    Name.Function
 '('           Operator
 "'TwigTestFoo::BAR_NAME'" Literal.String.Single
@@ -15161,7 +15161,7 @@
 '2'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'constant'    Name.Function
 '('           Operator
 "'ARRAY_AS_PROPS'" Literal.String.Single
@@ -15186,7 +15186,7 @@
 'definedVar'  Name.Variable
 '                     ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15205,9 +15205,9 @@
 'definedVar'  Name.Variable
 '                     ' Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15226,7 +15226,7 @@
 'undefinedVar' Name.Variable
 '                   ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15245,9 +15245,9 @@
 'undefinedVar' Name.Variable
 '                   ' Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15266,7 +15266,7 @@
 'zeroVar'     Name.Variable
 '                        ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15285,7 +15285,7 @@
 'nullVar'     Name.Variable
 '                        ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15305,7 +15305,7 @@
 '.definedVar' Name.Variable
 '              ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15327,7 +15327,7 @@
 ']'           Operator
 '           ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15347,9 +15347,9 @@
 '.definedVar' Name.Variable
 '              ' Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15369,7 +15369,7 @@
 '.undefinedVar' Name.Variable
 '            ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15391,7 +15391,7 @@
 ']'           Operator
 '         '   Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15411,9 +15411,9 @@
 '.undefinedVar' Name.Variable
 '            ' Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15433,7 +15433,7 @@
 '.zeroVar'    Name.Variable
 '                 ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15453,7 +15453,7 @@
 '.nullVar'    Name.Variable
 '                 ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15474,7 +15474,7 @@
 '.0'          Literal.Number
 '          '  Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15499,7 +15499,7 @@
 ']'           Operator
 '      '      Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15519,7 +15519,7 @@
 '.foo'        Name.Variable
 '                     ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15539,7 +15539,7 @@
 '.undefinedMethod' Name.Variable
 '         '   Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15561,7 +15561,7 @@
 ')'           Operator
 '                ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15584,7 +15584,7 @@
 ')'           Operator
 '             ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15606,7 +15606,7 @@
 ')'           Operator
 '       '     Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15629,7 +15629,7 @@
 ')'           Operator
 '    '        Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15650,7 +15650,7 @@
 '.foo'        Name.Variable
 '                ' Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15671,7 +15671,7 @@
 '.undefinedMethod' Name.Variable
 '    '        Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15692,7 +15692,7 @@
 '.self'       Name.Variable
 '    '        Text
 'is'          Keyword
-'     '       Text
+'     '       Text.Whitespace
 'defined'     Name.Function
 ' '           Text
 '?'           Operator
@@ -15711,7 +15711,7 @@
 'foo'         Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15730,7 +15730,7 @@
 'bar'         Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15749,7 +15749,7 @@
 'foobar'      Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15768,7 +15768,7 @@
 'array'       Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15787,7 +15787,7 @@
 'zero'        Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15806,7 +15806,7 @@
 'string'      Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15825,7 +15825,7 @@
 'countable_empty' Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15844,7 +15844,7 @@
 'countable_not_empty' Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15863,7 +15863,7 @@
 'markup_empty' Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15882,7 +15882,7 @@
 'markup_not_empty' Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'empty'       Name.Function
 ' '           Text
 '?'           Operator
@@ -15908,7 +15908,7 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'even'        Name.Function
 ' '           Text
 '?'           Operator
@@ -15927,7 +15927,7 @@
 '2'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'even'        Name.Function
 ' '           Text
 '?'           Operator
@@ -15946,9 +15946,9 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'even'        Name.Function
 ' '           Text
 '?'           Operator
@@ -15967,9 +15967,9 @@
 '2'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'not'         Keyword
-' '           Text
+' '           Text.Whitespace
 'even'        Name.Function
 ' '           Text
 '?'           Operator
@@ -15984,7 +15984,7 @@
 '\n--DATA--\nreturn array()\n--EXPECT--\nok\nok\nok\nok\n--TEST--\nTwig supports the in operator\n--TEMPLATE--\n' Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -15997,14 +15997,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'not'         Keyword
@@ -16021,21 +16021,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'bar'         Name.Variable
@@ -16050,21 +16050,21 @@
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'else'        Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "'a'"         Literal.String.Single
@@ -16077,14 +16077,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "'c'"         Literal.String.Single
@@ -16099,14 +16099,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "''"          Literal.String.Single
@@ -16121,14 +16121,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "''"          Literal.String.Single
@@ -16141,14 +16141,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "'0'"         Literal.String.Single
@@ -16163,14 +16163,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "'a'"         Literal.String.Single
@@ -16185,14 +16185,14 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
 '\n'          Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 "'0'"         Literal.String.Single
@@ -16205,7 +16205,7 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -16546,7 +16546,7 @@
 "\n--DATA--\nreturn array('bar' => 'bar', 'foo' => array('bar' => 'bar'), 'dir_name' => dirname(__FILE__), 'dir_object' => new SplFileInfo(dirname(__FILE__)))\n--EXPECT--\nTRUE\nTRUE\nTRUE\nTRUE\nTRUE\nTRUE\nTRUE\nTRUE\nTRUE\nFALSE\nFALSE\nFALSE\nFALSE\nFALSE\nTRUE\nFALSE\nFALSE\nFALSE\nFALSE\nFALSE\nFALSE\nTRUE\nFALSE\nFALSE\n--TEST--\nTwig supports the in operator when using objects\n--TEMPLATE--\n" Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'if'          Keyword
 ' '           Text
 'object'      Name.Variable
@@ -16559,7 +16559,7 @@
 '\nTRUE\n'    Other
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endif'       Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -16570,7 +16570,7 @@
 'foo'         Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'iterable'    Name.Function
 ' '           Text
 '?'           Operator
@@ -16589,7 +16589,7 @@
 'traversable' Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'iterable'    Name.Function
 ' '           Text
 '?'           Operator
@@ -16608,7 +16608,7 @@
 'obj'         Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'iterable'    Name.Function
 ' '           Text
 '?'           Operator
@@ -16627,7 +16627,7 @@
 'val'         Name.Variable
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'iterable'    Name.Function
 ' '           Text
 '?'           Operator
@@ -16646,7 +16646,7 @@
 '1'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'odd'         Name.Function
 ' '           Text
 '?'           Operator
@@ -16665,7 +16665,7 @@
 '2'           Literal.Number
 ' '           Text
 'is'          Keyword
-' '           Text
+' '           Text.Whitespace
 'odd'         Name.Function
 ' '           Text
 '?'           Operator

--- a/tests/examplefiles/typoscript/typoscript_example.output
+++ b/tests/examplefiles/typoscript/typoscript_example.output
@@ -3292,7 +3292,7 @@
 '='           Operator
 ' '           Text
 'uploads/pics/' Literal.String
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 '\n\t'        Text
 '# Single image rendering' Comment
@@ -6837,7 +6837,7 @@
 '='           Operator
 ' '           Text
 'uploads/media/' Literal.String
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 '\t'          Text
 '20'          Literal.Number.Integer
@@ -9463,7 +9463,7 @@
 '='           Operator
 ' '           Text
 'uploads/pics/' Literal.String
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 '\t\t\t'      Text
 'import'      Text
@@ -9724,7 +9724,7 @@
 '='           Operator
 ' '           Text
 'uploads/pics/' Literal.String
-'\n'          Literal.String
+'\n'          Text.Whitespace
 
 '\t\t'        Text
 'import'      Text
@@ -11603,7 +11603,7 @@
 'tx_cssstyledcontent' Text
 '.'           Punctuation
 '_CSS_DEFAULT_STYLE' Name.Class
-' '           Text
+' '           Text.Whitespace
 '('           Literal.String.Symbol
 '\n\t'        Text
 '/* Captions */' Comment

--- a/tests/examplefiles/vim/vimrc.output
+++ b/tests/examplefiles/vim/vimrc.output
@@ -5,7 +5,7 @@
 
 ':'           Punctuation
 'py'          Keyword
-' '           Text
+' '           Text.Whitespace
 'print'       Name.Builtin
 ' '           Text
 '"'           Literal.String.Double
@@ -16,7 +16,7 @@
 ':'           Punctuation
 ':'           Text
 'pyt'         Keyword
-' '           Text
+' '           Text.Whitespace
 'print'       Name.Builtin
 ' '           Text
 "'"           Literal.String.Single
@@ -26,7 +26,7 @@
 
 '  '          Text
 'pyth'        Keyword
-'\t'          Text
+'\t'          Text.Whitespace
 'print'       Name.Builtin
 ' '           Text
 "'''"         Literal.String.Single
@@ -38,7 +38,7 @@
 ':'           Text
 ' '           Text
 'pytho'       Keyword
-' '           Text
+' '           Text.Whitespace
 'print'       Name.Builtin
 ' '           Text
 '"'           Literal.String.Double
@@ -47,7 +47,7 @@
 '\n'          Text.Whitespace
 
 'python'      Keyword
-' '           Text
+' '           Text.Whitespace
 'print'       Name.Builtin
 ' '           Text
 '"""'         Literal.String.Double
@@ -77,7 +77,7 @@
 '\n'          Text
 
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'MyFunc'      Name.Function
 '('           Punctuation
 'str'         Name.Builtin
@@ -85,7 +85,7 @@
 ':'           Punctuation
 '\n'          Text
 
-'  '          Text
+'  '          Text.Whitespace
 '""" My Function """' Literal.String.Doc
 '\n'          Text
 

--- a/tests/examplefiles/whiley/example.whiley.output
+++ b/tests/examplefiles/whiley/example.whiley.output
@@ -29,9 +29,9 @@
 '\n'          Text
 
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'string'      Name
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword.Namespace
 ' '           Text
 'whiley'      Name
@@ -42,9 +42,9 @@
 '\n'          Text
 
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'char'        Name
-' '           Text
+' '           Text.Whitespace
 'from'        Keyword.Namespace
 ' '           Text
 'whiley'      Name
@@ -64,36 +64,36 @@
 '\n\n'        Text
 
 'constant'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ADD'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '0'           Literal.Number.Integer
 '\n'          Text
 
 'constant'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'SUB'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '1'           Literal.Number.Integer
 '\n'          Text
 
 'constant'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'MUL'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '2'           Literal.Number.Integer
 '\n'          Text
 
 'constant'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'DIV'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '3'           Literal.Number.Integer
@@ -103,9 +103,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'BOp'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
@@ -135,9 +135,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'BinOp'       Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -163,9 +163,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Var'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -181,9 +181,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'ListAccess'  Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -205,9 +205,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Expr'        Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 'int'         Keyword.Type
@@ -245,9 +245,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Value'       Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 'int'         Keyword.Type
@@ -263,9 +263,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Print'       Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -278,9 +278,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Set'         Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -298,9 +298,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Stmt'        Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 'Print'       Name
@@ -320,9 +320,9 @@
 '\n\n'        Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'RuntimeError' Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -335,9 +335,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'Environment' Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '['           Punctuation
@@ -813,9 +813,9 @@
 '\n\n'        Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'State'       Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation
@@ -833,9 +833,9 @@
 '\n'          Text
 
 'type'        Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'SyntaxError' Name
-' '           Text
+' '           Text.Whitespace
 'is'          Keyword.Reserved
 ' '           Text
 '{'           Punctuation

--- a/tests/examplefiles/xorg.conf/xorg.conf.output
+++ b/tests/examplefiles/xorg.conf/xorg.conf.output
@@ -1,13 +1,13 @@
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"Files"'     Literal.String.Escape
 '\n\t'        Text
 'ModulePath'  Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"/usr/lib64/opengl/nvidia/extensions"' Name.Constant
 '\n\t'        Text
 'ModulePath'  Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"/usr/lib64/xorg/modules"' Name.Constant
 '\n'          Text
 
@@ -15,15 +15,15 @@
 '\n\n'        Text
 
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"ServerLayout"' Literal.String.Escape
 '\n\t'        Text
 'Identifier'  Name.Builtin
-'     '       Text
+'     '       Text.Whitespace
 '"XFree86 Configured"' Name.Constant
 '\n\t'        Text
 'Screen'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"Screen"'    Name.Constant
 '\n'          Text
 
@@ -31,11 +31,11 @@
 '\n\n'        Text
 
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"ServerFlags"' Literal.String.Escape
 '\n\t'        Text
 'Option'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"AutoAddDevices" "false"' Name.Constant
 '\n'          Text
 
@@ -43,37 +43,37 @@
 '\n\n'        Text
 
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"Screen"'    Literal.String.Escape
 '\n        '  Text
 'Identifier'  Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"Screen"'    Name.Constant
 '\n\t'        Text
 'Device'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"Card0"'     Name.Constant
 '\n\t'        Text
 'DefaultDepth' Name.Builtin
-'    '        Text
+'    '        Text.Whitespace
 '24'          Name.Constant
 '\n\t'        Text
 'SubSection'  Literal.String.Escape
-'     '       Text
+'     '       Text.Whitespace
 '"Display"'   Literal.String.Escape
 '\n\t\t'      Text
 'Depth'       Name.Builtin
-'       '     Text
+'       '     Text.Whitespace
 '24'          Name.Constant
 '\n\t'        Text
 'EndSubSection' Literal.String.Escape
 '\n        '  Text
 'Option'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"UseEDIDDpi" "False"' Name.Constant
 '\n        '  Text
 'Option'      Name.Builtin
-' '           Text
+' '           Text.Whitespace
 '"DPI" "96 x 96"' Name.Constant
 '\n'          Text
 
@@ -81,19 +81,19 @@
 '\n\n'        Text
 
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"Device"'    Literal.String.Escape
 '\n    '      Text
 'Identifier'  Name.Builtin
-'  '          Text
+'  '          Text.Whitespace
 '"Card0"'     Name.Constant
 '\n    '      Text
 'Driver'      Name.Builtin
-'      '      Text
+'      '      Text.Whitespace
 '"nvidia"'    Name.Constant
 '\n    '      Text
 'VendorName'  Name.Builtin
-'  '          Text
+'  '          Text.Whitespace
 '"NVIDIA Corporation" ' Name.Constant
 '# inline comment' Comment
 '\n    '      Text
@@ -126,7 +126,7 @@
 '\n\n'        Text
 
 'Section'     Literal.String.Escape
-' '           Text
+' '           Text.Whitespace
 '"Extensions"' Literal.String.Escape
 '\n'          Text
 

--- a/tests/examplefiles/xquery/test-3.0.xq.output
+++ b/tests/examplefiles/xquery/test-3.0.xq.output
@@ -1,5 +1,5 @@
 'xquery'      Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'version'     Keyword.Pseudo
 ' '           Text.Whitespace
 '"3.0"'       Literal.String.Double
@@ -7,7 +7,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'namespace'   Keyword.Declaration
 ' '           Text.Whitespace
 'other'       Name.Namespace
@@ -19,9 +19,9 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'local:straight-var1' Name
 ' '           Text.Whitespace
@@ -32,12 +32,12 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Decorator
 'private'     Name.Decorator
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'local:private-var' Name
 ' '           Text.Whitespace
@@ -48,12 +48,12 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Decorator
 'public'      Name.Decorator
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'local:public-var' Name
 ' '           Text.Whitespace
@@ -64,18 +64,18 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Decorator
 'other:annotation' Name.Decorator
 '('           Punctuation
 "'param1'"    Literal.String.Single
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '"param2"'    Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'local:some-var' Name
 ' '           Text.Whitespace
@@ -86,9 +86,9 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'local:straight-var2' Name
 ' '           Text.Whitespace
@@ -104,7 +104,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:word-count' Name.Function
@@ -120,7 +120,7 @@
 ')'           Punctuation
 '*'           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:integer'  Keyword.Type
@@ -152,7 +152,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:add'   Name.Function
@@ -181,7 +181,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:dispatch' Name.Function
@@ -196,7 +196,7 @@
 '('           Punctuation
 ')'           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'item'        Keyword
@@ -337,7 +337,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:noise' Name.Function
@@ -349,7 +349,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'duck'        Name
 ' '           Text.Whitespace
@@ -368,14 +368,14 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'switch'      Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 '$'           Name.Variable
 'animal'      Name
 ')'           Punctuation
 '\n\t\t\t'    Text.Whitespace
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 '"Cow"'       Literal.String.Double
 ' '           Text.Whitespace
 'return'      Keyword
@@ -383,7 +383,7 @@
 '"Moo"'       Literal.String.Double
 '\n\t\t\t'    Text.Whitespace
 'case'        Keyword
-' '           Text
+' '           Text.Whitespace
 "'Cat'"       Literal.String.Single
 ' '           Text.Whitespace
 'return'      Keyword
@@ -417,7 +417,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:a-to-z' Name.Function
@@ -427,7 +427,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'data'        Name
 ' '           Text.Whitespace
@@ -526,7 +526,7 @@
 '{'           Punctuation
 '\n\t\t\t'    Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'item'        Name
 ' '           Text.Whitespace
@@ -600,7 +600,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:plays-by-character' Name.Function
@@ -610,7 +610,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'plays'       Name
 ' '           Text.Whitespace
@@ -1036,7 +1036,7 @@
 'return'      Keyword
 '\n\n\t\t'    Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'play'        Name
 ' '           Text.Whitespace
@@ -1048,7 +1048,7 @@
 'play'        Name.Tag
 '\n\t\t'      Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'title'       Name
 ' '           Text.Whitespace
@@ -1060,7 +1060,7 @@
 'title'       Name.Tag
 '\n\t\t'      Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'character'   Name
 ' '           Text.Whitespace
@@ -1132,37 +1132,37 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 '%'           Name.Decorator
 'other:a'     Name.Decorator
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 '%'           Name.Decorator
 'private'     Name.Decorator
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 '%'           Name.Decorator
 'other:b'     Name.Decorator
 '('           Punctuation
 "'1'"         Literal.String.Single
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 '%'           Name.Decorator
 'other:c'     Name.Decorator
 '('           Punctuation
 '"1"'         Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '"2"'         Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '"3"'         Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '"4"'         Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'function'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'local:very-annotated' Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -1170,7 +1170,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'thing'       Name
 ' '           Text.Whitespace
@@ -1189,12 +1189,12 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '%'           Name.Decorator
 'public'      Name.Decorator
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'local:slightly-annotated' Name.Function
 '('           Punctuation
 ')'           Punctuation
@@ -1202,7 +1202,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'nothing'     Name
 ' '           Text.Whitespace
@@ -1222,7 +1222,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:ordered' Name.Function
@@ -1232,7 +1232,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'hit'         Name
 ' '           Text.Whitespace
@@ -1256,7 +1256,7 @@
 ']'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'score'       Name
 ' '           Text.Whitespace
@@ -1329,7 +1329,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:concat-expr' Name.Function
@@ -1341,7 +1341,7 @@
 '{'           Punctuation
 '\n\n\t'      Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'concatenated' Name
 ' '           Text.Whitespace
@@ -1371,7 +1371,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:human-units' Name.Function
@@ -1383,7 +1383,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'unit'        Name
 ' '           Text.Whitespace
@@ -1499,7 +1499,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:merge-simple' Name.Function
@@ -1521,7 +1521,7 @@
 'xs:string'   Keyword.Type
 '+'           Operator
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
@@ -1549,7 +1549,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:apply' Name.Function
@@ -1582,7 +1582,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:apply-all' Name.Function
@@ -1619,7 +1619,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:apply-all-long' Name.Function
@@ -1633,7 +1633,7 @@
 '('           Punctuation
 'xs:string'   Keyword.Type
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
@@ -1667,7 +1667,7 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:merge' Name.Function
@@ -1710,7 +1710,7 @@
 'xs:string'   Keyword.Type
 '+'           Operator
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
@@ -1735,7 +1735,7 @@
 '\n\n'        Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'to-upper'    Name
 ' '           Text.Whitespace
@@ -1747,7 +1747,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'to-upper-long' Name
 ' '           Text.Whitespace
@@ -1757,7 +1757,7 @@
 '('           Punctuation
 'xs:string'   Keyword.Type
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type

--- a/tests/examplefiles/xquery/test-exist-update.xq.output
+++ b/tests/examplefiles/xquery/test-exist-update.xq.output
@@ -1,5 +1,5 @@
 'xquery'      Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'version'     Keyword.Pseudo
 ' '           Text.Whitespace
 '"3.0"'       Literal.String.Double
@@ -7,7 +7,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:add-log-message' Name.Function
@@ -19,7 +19,7 @@
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'empty-sequence' Name.Tag
@@ -32,7 +32,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'logfile-collection' Name
 ' '           Text.Whitespace
@@ -41,7 +41,7 @@
 '"/db/apps/exist101/log"' Literal.String.Double
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'logfile-name' Name
 ' '           Text.Whitespace
@@ -50,7 +50,7 @@
 '"exist101-log.xml"' Literal.String.Double
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'logfile-full' Name
 ' '           Text.Whitespace
@@ -70,7 +70,7 @@
 ')'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'logfile-created' Name
 ' '           Text.Whitespace
@@ -109,7 +109,7 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 '\n\t\t\t'    Text.Whitespace
 '<'           Name.Tag
@@ -149,7 +149,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:insert-attributes' Name.Function
@@ -159,7 +159,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'elm'         Name
 ' '           Text.Whitespace
@@ -184,7 +184,7 @@
 '('           Punctuation
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '<'           Name.Tag
@@ -198,11 +198,11 @@
 ','           Punctuation
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'x'           Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -225,11 +225,11 @@
 ','           Punctuation
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'a'           Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -258,7 +258,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:insert-elem' Name.Function
@@ -268,7 +268,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'elm'         Name
 ' '           Text.Whitespace
@@ -291,7 +291,7 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '<'           Name.Tag
@@ -321,7 +321,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:insert-elem2' Name.Function
@@ -331,7 +331,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'elm'         Name
 ' '           Text.Whitespace
@@ -352,7 +352,7 @@
 '*'           Name.Tag
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'new-element' Name
 ' '           Text.Whitespace
@@ -384,7 +384,7 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable
@@ -401,7 +401,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:insert-single' Name.Function
@@ -411,7 +411,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '<'           Name.Tag
@@ -457,7 +457,7 @@
 '\n\n\n'      Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:trim-insert' Name.Function
@@ -467,7 +467,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'document'    Name
 ' '           Text.Whitespace
@@ -479,7 +479,7 @@
 ')'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'newentry'    Name
 ' '           Text.Whitespace
@@ -516,7 +516,7 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'delete'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable
@@ -554,7 +554,7 @@
 'then'        Keyword
 '\n\t\t\t'    Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable
@@ -575,7 +575,7 @@
 'else'        Keyword
 '\n\t\t\t'    Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable
@@ -594,7 +594,7 @@
 '\n\n\n'      Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:attempt-document-node-insert' Name.Function
@@ -610,7 +610,7 @@
 ':)'          Comment
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'document'    Name
 ' '           Text.Whitespace
@@ -636,7 +636,7 @@
 'return'      Keyword
 '\n\t\t'      Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '<'           Name.Tag
@@ -656,7 +656,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'local:attempt-attr-update-with-node' Name.Function
@@ -666,7 +666,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'replace'     Keyword
 ' '           Text.Whitespace
 'doc'         Name.Function
@@ -705,7 +705,7 @@
 '\n\n\n'      Text.Whitespace
 
 '(#'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'exist:batch-transaction' Name.Variable
 ' '           Literal
 '#)'          Punctuation
@@ -713,7 +713,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'delete'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable
@@ -734,7 +734,7 @@
 ','           Punctuation
 '\n\t'        Text.Whitespace
 'update'      Keyword
-' '           Text
+' '           Text.Whitespace
 'insert'      Keyword
 ' '           Text.Whitespace
 '$'           Name.Variable

--- a/tests/examplefiles/xquery/test.xqy.output
+++ b/tests/examplefiles/xquery/test.xqy.output
@@ -9,7 +9,7 @@
 '\n'          Text.Whitespace
 
 'xquery'      Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'version'     Keyword.Pseudo
 ' '           Text.Whitespace
 '"1.0"'       Literal.String.Double
@@ -17,7 +17,7 @@
 '\n\n'        Text.Whitespace
 
 'module'      Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'namespace'   Keyword.Declaration
 ' '           Text.Whitespace
 'xqueryexample' Name.Namespace
@@ -27,7 +27,7 @@
 '\n'          Text.Whitespace
 
 'import'      Keyword.Pseudo
-' '           Text
+' '           Text.Whitespace
 'module'      Keyword.Pseudo
 ' '           Text.Whitespace
 'namespace'   Keyword
@@ -39,13 +39,13 @@
 '"http://example.com/ns/imported"' Literal.String.Double
 ' '           Text.Whitespace
 'at'          Keyword
-' '           Text
+' '           Text.Whitespace
 '"no/such/file.xqy"' Literal.String.Double
 ';'           Punctuation
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'namespace'   Keyword.Declaration
 ' '           Text.Whitespace
 'sess'        Name.Namespace
@@ -57,9 +57,9 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'amazing'     Name
 ' '           Text.Whitespace
@@ -70,9 +70,9 @@
 '\n'          Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'variable'    Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'SESSIONS'    Name
 ' '           Text.Whitespace
@@ -94,7 +94,7 @@
 '\n\n'        Text.Whitespace
 
 'declare'     Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'option'      Keyword.Declaration
 ' '           Text.Whitespace
 'sess:clear'  Name.Variable
@@ -104,7 +104,7 @@
 '\n\n'        Text.Whitespace
 
 'define'      Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'function'    Keyword.Declaration
 ' '           Text.Whitespace
 'whatsit'     Name.Function
@@ -116,7 +116,7 @@
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'as'          Keyword
 ' '           Text.Whitespace
 'xs:string'   Keyword.Type
@@ -124,7 +124,7 @@
 '{'           Punctuation
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'var1'        Name
 ' '           Text.Whitespace
@@ -133,7 +133,7 @@
 '1'           Literal.Number.Integer
 '\n\t'        Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'var2'        Name
 ' '           Text.Whitespace
@@ -164,7 +164,7 @@
 ')'           Punctuation
 '\n\n\t'      Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'let'         Name
 ' '           Text.Whitespace
@@ -190,13 +190,13 @@
 ':)'          Comment
 ' '           Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'element'     Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t'    Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'attribute'   Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -207,7 +207,7 @@
 ','           Punctuation
 '\n\t\t\t\t'  Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'test'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -218,7 +218,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'foo'         Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -268,7 +268,7 @@
 '\n\n'        Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'bride'       Name
 ' '           Text.Whitespace
@@ -278,7 +278,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'test'        Name
 ' '           Text.Whitespace
@@ -305,7 +305,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'test'        Name
 ' '           Text.Whitespace
@@ -332,7 +332,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'test'        Name
 ' '           Text.Whitespace
@@ -357,7 +357,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'test'        Name
 ' '           Text.Whitespace
@@ -380,7 +380,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'test'        Name
 ' '           Text.Whitespace
@@ -397,7 +397,7 @@
 '\n\n'        Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'noop'        Name
 ' '           Text.Whitespace
@@ -414,7 +414,7 @@
 '\n'          Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'noop'        Name
 ' '           Text.Whitespace
@@ -431,14 +431,14 @@
 '\n\n'        Text.Whitespace
 
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'noop'        Name
 ' '           Text.Whitespace
 ':='          Operator
 '\n\t'        Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'version'     Name
 ' '           Text.Whitespace
@@ -455,7 +455,7 @@
 'version'     Name.Tag
 '\n\t\t'      Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'row'         Name
 ' '           Text.Whitespace
@@ -695,13 +695,13 @@
 ':)'          Comment
 '\n\t\t\t\t'  Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'div'         Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'id'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -712,7 +712,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'class'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -723,7 +723,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'h1'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -734,7 +734,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'p'           Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -746,13 +746,13 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'a'           Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'href'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -782,7 +782,7 @@
 '{'           Punctuation
 '\n\t\t\t\t'  Text.Whitespace
 'for'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'i'           Name
 ' '           Text.Whitespace
@@ -792,7 +792,7 @@
 'sessions'    Name
 '\n\t\t\t\t'  Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'id'          Name
 ' '           Text.Whitespace
@@ -805,7 +805,7 @@
 ')'           Punctuation
 '\n\t\t\t\t'  Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'uri'         Name
 ' '           Text.Whitespace
@@ -822,7 +822,7 @@
 ':)'          Comment
 '\n\t\t\t\t'  Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'conflicting' Name
 ' '           Text.Whitespace
@@ -838,7 +838,7 @@
 ')'           Punctuation
 '\n\t\t\t\t'  Text.Whitespace
 'let'         Keyword
-' '           Text
+' '           Text.Whitespace
 '$'           Name.Variable
 'name'        Name
 ' '           Text.Whitespace
@@ -864,13 +864,13 @@
 'return'      Keyword
 ' '           Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'tr'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'td'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -882,7 +882,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'td'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -899,7 +899,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'td'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -916,7 +916,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'td'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -933,13 +933,13 @@
 ','           Punctuation
 '\n\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'td'          Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t' Text.Whitespace
 'if'          Keyword
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'empty'       Name.Function
 '('           Punctuation
@@ -1001,13 +1001,13 @@
 ':)'          Comment
 '\n\t\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'input'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1018,7 +1018,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1040,7 +1040,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'onclick'     Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1061,7 +1061,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1106,13 +1106,13 @@
 ':)'          Comment
 '\n\t\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'input'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1123,7 +1123,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1134,7 +1134,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'onclick'     Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1155,7 +1155,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1191,13 +1191,13 @@
 ':)'          Comment
 '\n\t\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'input'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1208,7 +1208,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1219,7 +1219,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'onclick'     Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1240,7 +1240,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1276,13 +1276,13 @@
 ':)'          Comment
 '\n\t\t\t\t\t\t' Text.Whitespace
 'element'     Keyword
-' '           Text
+' '           Text.Whitespace
 'input'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'type'        Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1293,7 +1293,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1304,7 +1304,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'onclick'     Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -1325,7 +1325,7 @@
 ','           Punctuation
 '\n\t\t\t\t\t\t\t' Text.Whitespace
 'attribute'   Keyword
-' '           Text
+' '           Text.Whitespace
 'value'       Name.Variable
 ' '           Text.Whitespace
 '{'           Punctuation

--- a/tests/examplefiles/yaml+jinja/example.sls.output
+++ b/tests/examplefiles/yaml+jinja/example.sls.output
@@ -9,7 +9,7 @@
 '\n\n'        Text.Whitespace
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'mnt'         Name.Variable
@@ -128,7 +128,7 @@
 '\n'          Text.Whitespace
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc
@@ -312,7 +312,7 @@
 '\n'          Text.Whitespace
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'for'         Keyword
 ' '           Text
 'mnt'         Name.Variable
@@ -367,7 +367,7 @@
 '\n'          Text.Whitespace
 
 '{%'          Comment.Preproc
-' '           Text
+' '           Text.Whitespace
 'endfor'      Keyword
 ' '           Text
 '%}'          Comment.Preproc

--- a/tests/snippets/http/test_application_calendar_xml.txt
+++ b/tests/snippets/http/test_application_calendar_xml.txt
@@ -6,13 +6,13 @@ Content-Type: application/calendar+xml
 
 ---tokens---
 'GET'         Name.Function
-' '           Text
+' '           Text.Whitespace
 '/'           Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.0'         Literal.Number
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Content-Type' Name.Attribute
 ''            Text

--- a/tests/snippets/http/test_application_xml.txt
+++ b/tests/snippets/http/test_application_xml.txt
@@ -6,13 +6,13 @@ Content-Type: application/xml
 
 ---tokens---
 'GET'         Name.Function
-' '           Text
+' '           Text.Whitespace
 '/'           Name.Namespace
-' '           Text
+' '           Text.Whitespace
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.0'         Literal.Number
-'\n'          Text
+'\n'          Text.Whitespace
 
 'Content-Type' Name.Attribute
 ''            Text

--- a/tests/snippets/http/test_http_status_line.txt
+++ b/tests/snippets/http/test_http_status_line.txt
@@ -5,8 +5,8 @@ HTTP/1.1 200 OK
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.1'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 '200'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 'OK'          Name.Exception
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/snippets/http/test_http_status_line_without_reason_phrase.txt
+++ b/tests/snippets/http/test_http_status_line_without_reason_phrase.txt
@@ -5,6 +5,6 @@ HTTP/1.1 200
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.1'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 '200'         Literal.Number
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/snippets/http/test_http_status_line_without_reason_phrase_rfc_7230.txt
+++ b/tests/snippets/http/test_http_status_line_without_reason_phrase_rfc_7230.txt
@@ -5,7 +5,7 @@ HTTP/1.1 200
 'HTTP'        Keyword.Reserved
 '/'           Operator
 '1.1'         Literal.Number
-' '           Text
+' '           Text.Whitespace
 '200'         Literal.Number
-' '           Text
-'\n'          Text
+' '           Text.Whitespace
+'\n'          Text.Whitespace

--- a/tests/snippets/julia/test_keywords.txt
+++ b/tests/snippets/julia/test_keywords.txt
@@ -15,14 +15,14 @@ mutable     struct MutableType end
 'mutable'     Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'MutableType' Keyword.Type
 ' '           Text.Whitespace
 'end'         Keyword
 '\n'          Text.Whitespace
 
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'ImmutableType' Keyword.Type
 ' '           Text.Whitespace
 'end'         Keyword
@@ -31,7 +31,7 @@ mutable     struct MutableType end
 'abstract'    Keyword
 ' '           Text.Whitespace
 'type'        Keyword
-' '           Text
+' '           Text.Whitespace
 'AbstractMyType' Keyword.Type
 ' '           Text.Whitespace
 'end'         Keyword
@@ -40,7 +40,7 @@ mutable     struct MutableType end
 'primitive'   Keyword
 ' '           Text.Whitespace
 'type'        Keyword
-' '           Text
+' '           Text.Whitespace
 'MyPrimitive' Keyword.Type
 ' '           Text.Whitespace
 '32'          Literal.Number.Integer
@@ -74,7 +74,7 @@ mutable     struct MutableType end
 'abstract'    Keyword
 '    '        Text.Whitespace
 'type'        Keyword
-' '           Text
+' '           Text.Whitespace
 'AbstractMyType' Keyword.Type
 ' '           Text.Whitespace
 'end'         Keyword
@@ -83,7 +83,7 @@ mutable     struct MutableType end
 'primitive'   Keyword
 ' \t'         Text.Whitespace
 'type'        Keyword
-' '           Text
+' '           Text.Whitespace
 'MyPrimitive' Keyword.Type
 ' '           Text.Whitespace
 '32'          Literal.Number.Integer
@@ -94,7 +94,7 @@ mutable     struct MutableType end
 'mutable'     Keyword
 '     '       Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'MutableType' Keyword.Type
 ' '           Text.Whitespace
 'end'         Keyword

--- a/tests/snippets/md/test_code_block_with_language.txt
+++ b/tests/snippets/md/test_code_block_with_language.txt
@@ -9,7 +9,7 @@ import this
 '\n'          Text
 
 'import'      Keyword.Namespace
-' '           Text
+' '           Text.Whitespace
 'this'        Name.Namespace
 '\n'          Text
 

--- a/tests/snippets/md/test_inline_code.txt
+++ b/tests/snippets/md/test_inline_code.txt
@@ -9,13 +9,13 @@ code (`in brackets`)
 
 ---tokens---
 'code:'       Text
-' '           Text
+' '           Text.Whitespace
 '`code`'      Literal.String.Backtick
 '\n'          Text.Whitespace
 
 '\n'          Text.Whitespace
 
-' '           Text
+' '           Text.Whitespace
 '`**code**`'  Literal.String.Backtick
 '\n'          Text.Whitespace
 

--- a/tests/snippets/md/test_inline_code_in_list.txt
+++ b/tests/snippets/md/test_inline_code_in_list.txt
@@ -21,6 +21,6 @@
 '\n'          Text.Whitespace
 
 '1.'          Keyword
-' '           Text
+' '           Text.Whitespace
 '`code`'      Literal.String.Backtick
 '\n'          Text.Whitespace

--- a/tests/snippets/md/test_invalid_bold.txt
+++ b/tests/snippets/md/test_invalid_bold.txt
@@ -20,12 +20,12 @@ _no bold_
 'bold**'      Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*no bold*'   Generic.Emph
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '_no bold_'   Generic.Emph
 '\n'          Text.Whitespace

--- a/tests/snippets/md/test_invalid_italics.txt
+++ b/tests/snippets/md/test_invalid_italics.txt
@@ -20,12 +20,12 @@ __no italics__
 'italics*'    Text
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '**no italics**' Generic.Strong
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '__no italics__' Generic.Strong
 '\n'          Text.Whitespace

--- a/tests/snippets/md/test_italics_and_bold.txt
+++ b/tests/snippets/md/test_italics_and_bold.txt
@@ -7,15 +7,15 @@
 '**bold**'    Generic.Strong
 ' '           Text
 'and'         Text
-' '           Text
+' '           Text.Whitespace
 '*italics*'   Generic.Emph
 '\n'          Text.Whitespace
 
-'\n'          Text
+'\n'          Text.Whitespace
 
 '*italics*'   Generic.Emph
 ' '           Text
 'and'         Text
-' '           Text
+' '           Text.Whitespace
 '**bold**'    Generic.Strong
 '\n'          Text.Whitespace

--- a/tests/snippets/praat/test_broken_unquoted_string.txt
+++ b/tests/snippets/praat/test_broken_unquoted_string.txt
@@ -6,7 +6,7 @@ printline string
 'printline'   Keyword
 ' '           Text.Whitespace
 'string'      Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '...'         Punctuation
 ' '           Text.Whitespace

--- a/tests/snippets/python2/test_cls_builtin.txt
+++ b/tests/snippets/python2/test_cls_builtin.txt
@@ -8,7 +8,7 @@ class TestClass():
 
 ---tokens---
 'class'       Keyword
-' '           Text
+' '           Text.Whitespace
 'TestClass'   Name.Class
 '('           Punctuation
 ')'           Punctuation
@@ -21,7 +21,7 @@ class TestClass():
 
 '    '        Text
 'def'         Keyword
-' '           Text
+' '           Text.Whitespace
 'hello'       Name.Function
 '('           Punctuation
 'cls'         Name.Builtin.Pseudo

--- a/tests/snippets/smarty/test_nested_curly.txt
+++ b/tests/snippets/smarty/test_nested_curly.txt
@@ -4,7 +4,7 @@
 ---tokens---
 '{'           Comment.Preproc
 'templateFunction' Name.Function
-' '           Text
+' '           Text.Whitespace
 'param'       Name.Attribute
 '='           Operator
 '{'           Comment.Preproc

--- a/tests/test_html_lexer.py
+++ b/tests/test_html_lexer.py
@@ -55,7 +55,7 @@ def test_long_unclosed_javascript_fragment(lexer_html):
     tokens_intro = [
         (Token.Punctuation, '<'),
         (Token.Name.Tag, 'script'),
-        (Token.Text, ' '),
+        (Token.Text.Whitespace, ' '),
         (Token.Name.Attribute, 'type'),
         (Token.Operator, '='),
         (Token.Literal.String, '"text/javascript"'),

--- a/tests/test_irc_formatter.py
+++ b/tests/test_irc_formatter.py
@@ -22,9 +22,9 @@ def test_correct_output():
     assert '\x0302lambda\x03 x: \x0302123\x03\n' == houtfile.getvalue()
 
 def test_linecount_output():
-    hfmt = IRCFormatter(linenos = True)
+    hfmt = IRCFormatter(linenos=True)
     houtfile = StringIO()
     hfmt.format(newlinetokensource, houtfile)
 
-    expected_out = '0001: \x0302from\x03 \\\n0002: \\\n0003:     \x1d\x0310os\x03\x1d \x0302import\x03  path\n0004: '
+    expected_out = '0001: \x0302from\x03 \\\n0002: \\\n0003:     \x1d\x0310os\x03\x1d\x0315 \x03\x0302import\x03  path\n0004: '
     assert expected_out == houtfile.getvalue()

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -60,7 +60,7 @@ def test_atx_heading(lexer):
     for fragment in fragments:
         tokens = [
             (Generic.Heading, fragment),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -95,7 +95,7 @@ def test_atx_subheading(lexer):
     for fragment in fragments:
         tokens = [
             (Generic.Subheading, fragment),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -126,9 +126,9 @@ def test_setext_heading(lexer):
     for fragment in fragments:
         tokens = [
             (Generic.Heading, fragment.split('\n')[0]),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
             (Generic.Heading, fragment.split('\n')[1]),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 
@@ -159,9 +159,9 @@ def test_setext_subheading(lexer):
     for fragment in fragments:
         tokens = [
             (Generic.Subheading, fragment.split('\n')[0]),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
             (Generic.Subheading, fragment.split('\n')[1]),
-            (Token.Text, '\n'),
+            (Token.Text.Whitespace, '\n'),
         ]
         assert list(lexer.get_tokens(fragment)) == tokens
 

--- a/tests/test_perllexer.py
+++ b/tests/test_perllexer.py
@@ -10,7 +10,7 @@ import time
 
 import pytest
 
-from pygments.token import Keyword, Name, String, Text
+from pygments.token import Keyword, Name, String, Whitespace, Text
 from pygments.lexers.perl import PerlLexer
 
 
@@ -161,21 +161,21 @@ def test_substitution_with_parenthesis(lexer):
 # Namespaces/modules
 
 def test_package_statement(lexer):
-    assert_tokens(lexer, ['package', ' ', 'Foo'], [Keyword, Text, Name.Namespace])
-    assert_tokens(lexer, ['package', '  ', 'Foo::Bar'], [Keyword, Text, Name.Namespace])
+    assert_tokens(lexer, ['package', ' ', 'Foo'], [Keyword, Whitespace, Name.Namespace])
+    assert_tokens(lexer, ['package', '  ', 'Foo::Bar'], [Keyword, Whitespace, Name.Namespace])
 
 
 def test_use_statement(lexer):
-    assert_tokens(lexer, ['use', ' ', 'Foo'], [Keyword, Text, Name.Namespace])
-    assert_tokens(lexer, ['use', '  ', 'Foo::Bar'], [Keyword, Text, Name.Namespace])
+    assert_tokens(lexer, ['use', ' ', 'Foo'], [Keyword, Whitespace, Name.Namespace])
+    assert_tokens(lexer, ['use', '  ', 'Foo::Bar'], [Keyword, Whitespace, Name.Namespace])
 
 
 def test_no_statement(lexer):
-    assert_tokens(lexer, ['no', ' ', 'Foo'], [Keyword, Text, Name.Namespace])
-    assert_tokens(lexer, ['no', '  ', 'Foo::Bar'], [Keyword, Text, Name.Namespace])
+    assert_tokens(lexer, ['no', ' ', 'Foo'], [Keyword, Whitespace, Name.Namespace])
+    assert_tokens(lexer, ['no', '  ', 'Foo::Bar'], [Keyword, Whitespace, Name.Namespace])
 
 
 def test_require_statement(lexer):
-    assert_tokens(lexer, ['require', ' ', 'Foo'], [Keyword, Text, Name.Namespace])
-    assert_tokens(lexer, ['require', '  ', 'Foo::Bar'], [Keyword, Text, Name.Namespace])
+    assert_tokens(lexer, ['require', ' ', 'Foo'], [Keyword, Whitespace, Name.Namespace])
+    assert_tokens(lexer, ['require', '  ', 'Foo::Bar'], [Keyword, Whitespace, Name.Namespace])
     assert_tokens(lexer, ['require', ' ', '"Foo/Bar.pm"'], [Keyword, Text, String])


### PR DESCRIPTION
This solves tricky cases like Praat for example using `'([\w.]+)(:|\s*\()'` as a regex with bygroups, and there's no easy way to find out which path is taken there. By handling it in bygroups, we can "post-process" those matches. This has a performance cost of course, and I'd prefer a better way to handle this so I'm open for ideas.

Another downside is that this overwrites token types like `Literal.String`, because I don't know at replacement time if the original action was `Text` (which seems most common) or something else like `Punctuation`. As a result, I can't recommend merging this, but I'd like to start the discussion how to approach this :)