### PR TITLE
CI: Use Ubuntu 20.04 for Python 3.6 testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.6"
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.6"
       max-parallel: 4
 
     steps:


### PR DESCRIPTION
Some recent GitHub action runs have started to fail, like

https://github.com/Jean-Abou-Samra/pygments/actions/runs/3642986206/jobs/6150712048

(others don't fail because they pick up Python 3.6 in a cache).

The problem is that GitHub upgraded the ubuntu-latest images to refer to Ubuntu 22.04, and setup-python doesn't provide Python 3.6 on 22.04, so use 20.04 for Python 3.6.