### PR TITLE
Stop the HTML formatter from emitting empty whitespace spans.

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -878,14 +878,12 @@ class HtmlFormatter(Formatter):
             # for all but the last line
             for part in parts[:-1]:
                 if line:
-                    if lspan != cspan:
-                        # If part is empty (i.e. it was a newline), just close
-                        if part:
-                            line.extend(((lspan and '</span>'), cspan, part,
-                                        (cspan and '</span>'), lsep))
-                        else:
-                            line.extend(((lspan and '</span>'), lsep))
-                    else:  # both are the same
+                    # Also check for part being non-empty, so we avoid creating
+                    # empty <span> tags
+                    if lspan != cspan and part:
+                        line.extend(((lspan and '</span>'), cspan, part,
+                                     (cspan and '</span>'), lsep))
+                    else:  # both are the same, or the current part was empty
                         line.extend((part, (lspan and '</span>'), lsep))
                     yield 1, ''.join(line)
                     line = []

--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -879,8 +879,12 @@ class HtmlFormatter(Formatter):
             for part in parts[:-1]:
                 if line:
                     if lspan != cspan:
-                        line.extend(((lspan and '</span>'), cspan, part,
-                                     (cspan and '</span>'), lsep))
+                        # If part is empty (i.e. it was a newline), just close
+                        if part:
+                            line.extend(((lspan and '</span>'), cspan, part,
+                                        (cspan and '</span>'), lsep))
+                        else:
+                            line.extend(((lspan and '</span>'), lsep))
                     else:  # both are the same
                         line.extend((part, (lspan and '</span>'), lsep))
                     yield 1, ''.join(line)

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos">3</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos">3</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos">3</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos">3</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos">1</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">3</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos">3</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos">1</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">3</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos">3</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos special">3</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special">3</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos special">3</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos">1</span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special">3</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos">1</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos special">3</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special">3</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_1_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos">1</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos special">3</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos">1</span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special">3</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos"> 9</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos"> 9</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos"> 9</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos"> 9</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos special"> 9</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos special"> 9</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special"> 9</span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos special"> 9</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_1_start_8_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos special"> 9</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special"> 9</span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos"> </span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos"> </span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos"> </span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos"> </span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> </span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos"> </span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos"> </span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> </span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos"> </span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos"> </span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos special"> </span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special"> </span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-3"><span class="linenos special"> </span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-1"><span class="linenos"> </span></a><span class="c1"># a</span>
+<a href="#-2"><span class="linenos">2</span></a><span class="c1"># b</span>
+<a href="#-3"><span class="linenos special"> </span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> </span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos special"> </span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special"> </span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_1_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> </span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">2</span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos special"> </span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> </span><span class="c1"># a</span>
+<span class="linenos">2</span><span class="c1"># b</span>
+<span class="linenos special"> </span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos">  </span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos">  </span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">  </span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos">  </span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos special">  </span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span><span class="w"></span>
-<a href="#-9"><span class="linenos special">  </span></a><span class="c1"># b</span><span class="w"></span>
-<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><a href="#-8"><span class="linenos"> 8</span></a><span class="c1"># a</span>
+<a href="#-9"><span class="linenos special">  </span></a><span class="c1"># b</span>
+<a href="#-10"><span class="linenos">10</span></a><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos special">  </span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><span class="filename">testfilename</span><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_cls_step_2_start_8_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span><span class="w"></span>
-<span class="linenos special">  </span><span class="c1"># b</span><span class="w"></span>
-<span class="linenos">10</span><span class="c1"># c</span><span class="w"></span>
+<div class="highlight"><pre><span></span><span class="linenos"> 8</span><span class="c1"># a</span>
+<span class="linenos special">  </span><span class="c1"># b</span>
+<span class="linenos">10</span><span class="c1"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_1_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_1_start_8_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-1"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-2"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-3"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_1_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_0_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_anchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><a href="#-8"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span></a><span style="color: #3D7B7B; font-style: italic"># a</span>
+<a href="#-9"><span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span></a><span style="color: #3D7B7B; font-style: italic"># b</span>
+<a href="#-10"><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></a><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor_filename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><span class="filename">testfilename</span><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/inline_nocls_step_2_start_8_special_3_noanchor_nofilename.html
@@ -1,4 +1,4 @@
-<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<div class="highlight" style="background: #f8f8f8"><pre style="line-height: 125%;"><span></span><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span><span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span><span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-1">1</a></span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="normal"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-1">1</a></span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="normal"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
-<span class="normal">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
-<span class="normal">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-1">1</a></span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="special"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-1">1</a></span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="special"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
-<span class="special">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_1_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal">1</span>
 <span class="normal">2</span>
-<span class="special">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special">3</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="normal"><a href="#-9"> 9</a></span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="normal"><a href="#-9"> 9</a></span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="normal"> 9</span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="normal"> 9</span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="special"><a href="#-9"> 9</a></span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="special"><a href="#-9"> 9</a></span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="special"> 9</span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_1_start_8_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="special"> 9</span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal">2</span>
-<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal">2</span>
-<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal"><a href="#-2">2</a></span>
-<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal">2</span>
-<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_1_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> </span>
 <span class="normal">2</span>
-<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="special"> </span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="normal">  </span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="normal">  </span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="normal">  </span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="normal">  </span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="special">  </span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"><a href="#-8"> 8</a></span>
 <span class="special">  </span>
-<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="special">  </span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_cls_step_2_start_8_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span class="normal"> 8</span>
 <span class="special">  </span>
-<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span><span class="w"></span>
-<span class="c1"># b</span><span class="w"></span>
-<span class="c1"># c</span><span class="w"></span>
+<span class="normal">10</span></pre></div></td><td class="code"><div><pre><span></span><span class="c1"># a</span>
+<span class="c1"># b</span>
+<span class="c1"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-1">1</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-1">1</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-1">1</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-1">1</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-3">3</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_1_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">1</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">3</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-9"> 9</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-9"> 9</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 9</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-9"> 9</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"><a href="#-9"> 9</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_1_start_8_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> 9</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-2">2</a></span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_1_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> </span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">2</span>
-<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;"> </span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_0_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_anchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-8"> 8</a></span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"><a href="#-10">10</a></span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor_filename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor_filename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><th class="filename" colspan="2"><span class="filename">testfilename</span></th></tr><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>

--- a/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor_nofilename.html
+++ b/tests/html_linenos_expected_output/table_nocls_step_2_start_8_special_3_noanchor_nofilename.html
@@ -1,6 +1,6 @@
 <div class="highlight" style="background: #f8f8f8"><table class="highlighttable"><tr><td class="linenos"><div class="linenodiv"><pre><span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;"> 8</span>
 <span style="color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px;">  </span>
-<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># b</span><span style="color: #bbbbbb"></span>
-<span style="color: #3D7B7B; font-style: italic"># c</span><span style="color: #bbbbbb"></span>
+<span style="color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px;">10</span></pre></div></td><td class="code"><div><pre style="line-height: 125%;"><span></span><span style="color: #3D7B7B; font-style: italic"># a</span>
+<span style="color: #3D7B7B; font-style: italic"># b</span>
+<span style="color: #3D7B7B; font-style: italic"># c</span>
 </pre></div></td></tr></table></div>


### PR DESCRIPTION
This adds logic to handle the case where the split produced empty output, as creating a `<span class="w"></span>` is quite wasteful in that case (it just bloats the output. This doesn't fix all empty `<span>` instances, but at least removes a good chunk of them.