### PR TITLE
styles gallery: Make docstring in example follow PEP 257

### DIFF
--- a/doc/examples/example.py
+++ b/doc/examples/example.py
@@ -4,7 +4,7 @@ from typing import Iterator
 class Math:
     @staticmethod
     def fib(n: int) -> Iterator[int]:
-        """ Fibonacci series up to n """
+        """Fibonacci series up to n."""
         a, b = 0, 1
         while a < n:
             yield a


### PR DESCRIPTION
The example is displayed multiple times at https://pygments.org/styles/. Code displayed on the Pygments website should follow best practices, such as https://peps.python.org/pep-0257/.