### PR TITLE
Markdown: add comment parsing to lexer

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -540,13 +540,17 @@ class MarkdownLexer(RegexLexer):
     tokens = {
         'root': [
             # heading with '#' prefix (atx-style)
-            (r'(^#[^#].+)(\n)', bygroups(Generic.Heading, Text)),
+            (r'(^#[^#].+?)(<!--.*?-->)?(\n)',
+             bygroups(Generic.Heading, Comment, Text)),
             # subheading with '#' prefix (atx-style)
-            (r'(^#{2,6}[^#].+)(\n)', bygroups(Generic.Subheading, Text)),
+            (r'(^#{2,6}[^#].+?)(<!--.*?-->)?(\n)',
+             bygroups(Generic.Subheading, Comment, Text)),
             # heading with '=' underlines (Setext-style)
-            (r'^(.+)(\n)(=+)(\n)', bygroups(Generic.Heading, Text, Generic.Heading, Text)),
+            (r'^(.+?)(<!--.*?-->)?(\n)(=+)(<!--.*?-->)?(\n)',
+             bygroups(Generic.Heading, Comment, Text, Generic.Heading, Comment, Text)),
             # subheading with '-' underlines (Setext-style)
-            (r'^(.+)(\n)(-+)(\n)', bygroups(Generic.Subheading, Text, Generic.Subheading, Text)),
+            (r'^(.+?)(<!--.*?-->)?(\n)(-+)(<!--.*?-->)?(\n)',
+             bygroups(Generic.Subheading, Comment, Text, Generic.Subheading, Comment, Text)),
             # task list
             (r'^(\s*)([*-] )(\[[ xX]\])( .+\n)',
             bygroups(Whitespace, Keyword, Keyword, using(this, state='inline'))),
@@ -594,6 +598,9 @@ class MarkdownLexer(RegexLexer):
              bygroups(Text, Name.Tag, Text, Text, Name.Label, Text)),
             (r'^(\s*\[)([^]]*)(\]:\s*)(.+)',
              bygroups(Text, Name.Label, Text, Name.Attribute)),
+            # comments (can span multiple lines)
+            (r'(<!--[\s\S]*?-->)',
+             bygroups(Comment)),
 
             # general text, must come last!
             (r'[^\\\s]+', Text),

--- a/tests/test_markdown_lexer.py
+++ b/tests/test_markdown_lexer.py
@@ -7,7 +7,7 @@
 """
 
 import pytest
-from pygments.token import Generic, Token, String
+from pygments.token import Generic, Token, String, Comment
 
 from pygments.lexers.markup import MarkdownLexer
 
@@ -176,3 +176,33 @@ def test_invalid_code_block(lexer):
     for fragment in fragments:
         for token, _ in lexer.get_tokens(fragment):
             assert token != String.Backtick
+
+
+def test_comment(lexer):
+    fragments = (
+        '<!-- test -->',
+        '<!--test-->',
+        'Some paragraph <!--test-->',
+        '1. Some list item <!--test-->',
+        '# Some heading <!--test-->',
+        '# Some heading <!--- (1) --->',
+        '### Some heading <!--test-->',
+        'Some heading\n=============<!--test-->',
+        'Some heading\n-------------<!--test-->',
+    )
+    heading_equal = 'Heading <!--test-->\n====='
+    heading_hyphen = 'Heading <!--test-->\n-----'
+    paragraph_comment = 'Paragraph <!--test--> interrupted.'
+    paragraph_newline_comment = 'Paragraph <!--test\n--> interrupted.'
+
+    # for each fragment, assert second to last token is a comment
+    for fragment in fragments:
+        assert list(lexer.get_tokens(fragment))[-2][0] == Comment
+
+    # assert second token is a comment for heading examples
+    assert list(lexer.get_tokens(heading_equal))[1][0] == Comment
+    assert list(lexer.get_tokens(heading_hyphen))[1][0] == Comment
+
+    # assert third token is a comment for paragraph examples
+    assert list(lexer.get_tokens(paragraph_comment))[2][0] == Comment
+    assert list(lexer.get_tokens(paragraph_newline_comment))[2][0] == Comment


### PR DESCRIPTION
Prior to this commit, comments were not included in the Markdown lexer. This patch adds comments to the Markdown lexer output. Now comments such as`<!-- comment -->` will be highlighted as comments appropriately. This includes multi-line comments.

The regex strings for Markdown headings have been altered to allow for comments at the end of heading lines.

Fixes #2273 