### PR TITLE
Resolve `pygments/formatters/html.py`'s `HtmlFormatter.format_unencoded` calling a function with missing arguments

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -980,7 +980,7 @@ class HtmlFormatter(Formatter):
                 source = self._wrap_lineanchors(source)
             if self.linespans:
                 source = self._wrap_linespans(source)
-            source = self.wrap(source)
+            source = self.wrap(source, outfile)
             if self.linenos == 1:
                 source = self._wrap_tablelinenos(source)
             source = self._wrap_div(source)


### PR DESCRIPTION
Error, grrr

Updated file in question, `pygments/formatters/html.py`, has a function used by some tool that I use programatically named `format_unencoded` inside class `HtmlFormatter`. I don't know how it works, but it throws the following error:

```
TypeError: Markdown._color_with_pygments.<locals>.HtmlCodeFormatter.wrap() missing 1 required positional argument: 'outfile'
```

Little digging up, and by modifying said file's line 983 from

```py
            source = self.wrap(source)
```
to
```py
            source = self.wrap(source, outfile)
```
fixes the error. Thus, this pull request.

---

If I have not been touching python for about 2 years now, I would have still called myself a newbie and apologize heavily for being a newbie. But it seems like a persisting me-issue, so apologies for being a massive dum-dum. But please approve PR, cuz its bugging me.