### PR TITLE
Add support for normal diff syntax

### DIFF
--- a/pygments/lexers/diff.py
+++ b/pygments/lexers/diff.py
@@ -10,42 +10,45 @@
 
 import re
 
-from pygments.lexer import RegexLexer, include, bygroups
-from pygments.token import Text, Comment, Operator, Keyword, Name, Generic, \
-    Literal, Whitespace
+from pygments.lexer import RegexLexer, bygroups, include
+from pygments.token import (Comment, Generic, Keyword, Literal, Name, Operator,
+                            Text, Whitespace)
 
-__all__ = ['DiffLexer', 'DarcsPatchLexer', 'WDiffLexer']
+__all__ = ["DiffLexer", "DarcsPatchLexer", "WDiffLexer"]
 
 
 class DiffLexer(RegexLexer):
     """
-    Lexer for unified or context-style diffs or patches.
+    Lexer for normal, unified, or context-style diffs or patches.
     """
 
-    name = 'Diff'
-    aliases = ['diff', 'udiff']
-    filenames = ['*.diff', '*.patch']
-    mimetypes = ['text/x-diff', 'text/x-patch']
+    name = "Diff"
+    aliases = ["diff", "udiff"]
+    filenames = ["*.diff", "*.patch"]
+    mimetypes = ["text/x-diff", "text/x-patch"]
 
     tokens = {
-        'root': [
-            (r'( )(.*)(\n)', bygroups(Whitespace, Text, Whitespace)),
-            (r'(\+.*)(\n)', bygroups(Generic.Inserted, Whitespace)),
-            (r'(-.*)(\n)', bygroups(Generic.Deleted, Whitespace)),
-            (r'(!.*)(\n)', bygroups(Generic.Strong, Whitespace)),
-            (r'(@.*)(\n)', bygroups(Generic.Subheading, Whitespace)),
-            (r'((?:[Ii]ndex|diff).*)(\n)', bygroups(Generic.Heading, Whitespace)),
-            (r'(=.*)(\n)', bygroups(Generic.Heading, Whitespace)),
-            (r'(.*)(\n)', Whitespace),
+        "root": [
+            (r"( )(.*)(\n)", bygroups(Whitespace, Text, Whitespace)),
+            (r"(!.*|---)(\n)", bygroups(Generic.Strong, Whitespace)),
+            (r"((?:< |-).*)(\n)", bygroups(Generic.Deleted, Whitespace)),
+            (r"((?:> |\+).*)(\n)", bygroups(Generic.Inserted, Whitespace)),
+            (
+                r"(@.*|\d(?:,\d+)?(?:a|c|d)\d+(?:,\d+)?)(\n)",
+                bygroups(Generic.Subheading, Whitespace),
+            ),
+            (r"((?:[Ii]ndex|diff).*)(\n)", bygroups(Generic.Heading, Whitespace)),
+            (r"(=.*)(\n)", bygroups(Generic.Heading, Whitespace)),
+            (r"(.*)(\n)", bygroups(Text, Whitespace)),
         ]
     }
 
     def analyse_text(text):
-        if text[:7] == 'Index: ':
+        if text[:7] == "Index: ":
             return True
-        if text[:5] == 'diff ':
+        if text[:5] == "diff ":
             return True
-        if text[:4] == '--- ':
+        if text[:4] == "--- ":
             return 0.9
 
 
@@ -58,51 +61,82 @@ class DarcsPatchLexer(RegexLexer):
     .. versionadded:: 0.10
     """
 
-    name = 'Darcs Patch'
-    aliases = ['dpatch']
-    filenames = ['*.dpatch', '*.darcspatch']
+    name = "Darcs Patch"
+    aliases = ["dpatch"]
+    filenames = ["*.dpatch", "*.darcspatch"]
 
-    DPATCH_KEYWORDS = ('hunk', 'addfile', 'adddir', 'rmfile', 'rmdir', 'move',
-                       'replace')
+    DPATCH_KEYWORDS = (
+        "hunk",
+        "addfile",
+        "adddir",
+        "rmfile",
+        "rmdir",
+        "move",
+        "replace",
+    )
 
     tokens = {
-        'root': [
-            (r'<', Operator),
-            (r'>', Operator),
-            (r'\{', Operator),
-            (r'\}', Operator),
-            (r'(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)(\])',
-             bygroups(Operator, Keyword, Name, Whitespace, Name, Operator,
-                      Literal.Date, Whitespace, Operator)),
-            (r'(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)',
-             bygroups(Operator, Keyword, Name, Whitespace, Name, Operator,
-                      Literal.Date, Whitespace), 'comment'),
-            (r'New patches:', Generic.Heading),
-            (r'Context:', Generic.Heading),
-            (r'Patch bundle hash:', Generic.Heading),
-            (r'(\s*)(%s)(.*)(\n)' % '|'.join(DPATCH_KEYWORDS),
-                bygroups(Whitespace, Keyword, Text, Whitespace)),
-            (r'\+', Generic.Inserted, "insert"),
-            (r'-', Generic.Deleted, "delete"),
-            (r'(.*)(\n)', bygroups(Text, Whitespace)),
+        "root": [
+            (r"<", Operator),
+            (r">", Operator),
+            (r"\{", Operator),
+            (r"\}", Operator),
+            (
+                r"(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)(\])",
+                bygroups(
+                    Operator,
+                    Keyword,
+                    Name,
+                    Whitespace,
+                    Name,
+                    Operator,
+                    Literal.Date,
+                    Whitespace,
+                    Operator,
+                ),
+            ),
+            (
+                r"(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)",
+                bygroups(
+                    Operator,
+                    Keyword,
+                    Name,
+                    Whitespace,
+                    Name,
+                    Operator,
+                    Literal.Date,
+                    Whitespace,
+                ),
+                "comment",
+            ),
+            (r"New patches:", Generic.Heading),
+            (r"Context:", Generic.Heading),
+            (r"Patch bundle hash:", Generic.Heading),
+            (
+                r"(\s*)(%s)(.*)(\n)" % "|".join(DPATCH_KEYWORDS),
+                bygroups(Whitespace, Keyword, Text, Whitespace),
+            ),
+            (r"\+", Generic.Inserted, "insert"),
+            (r"-", Generic.Deleted, "delete"),
+            (r"(.*)(\n)", bygroups(Text, Whitespace)),
         ],
-        'comment': [
-            (r'[^\]].*\n', Comment),
-            (r'\]', Operator, "#pop"),
+        "comment": [
+            (r"[^\]].*\n", Comment),
+            (r"\]", Operator, "#pop"),
         ],
-        'specialText': [            # darcs add [_CODE_] special operators for clarity
-            (r'\n', Whitespace, "#pop"),  # line-based
-            (r'\[_[^_]*_]', Operator),
+        "specialText": [  # darcs add [_CODE_] special operators for clarity
+            (r"\n", Whitespace, "#pop"),  # line-based
+            (r"\[_[^_]*_]", Operator),
         ],
-        'insert': [
-            include('specialText'),
-            (r'\[', Generic.Inserted),
-            (r'[^\n\[]+', Generic.Inserted),
+        "insert": [
+            include("specialText"),
+            (r"\[", Generic.Inserted),
+            (r"[^\n\[]+", Generic.Inserted),
         ],
-        'delete': [
-            include('specialText'),
-            (r'\[', Generic.Deleted),
-            (r'[^\n\[]+', Generic.Deleted),
+        "delete": [
+            include("specialText"),
+            (r"\[", Generic.Deleted),
+            (r"[^\n\[]+", Generic.Deleted),
         ],
     }
 
@@ -120,10 +154,10 @@ class WDiffLexer(RegexLexer):
     .. versionadded:: 2.2
     """
 
-    name = 'WDiff'
-    url = 'https://www.gnu.org/software/wdiff/'
-    aliases = ['wdiff']
-    filenames = ['*.wdiff']
+    name = "WDiff"
+    url = "https://www.gnu.org/software/wdiff/"
+    aliases = ["wdiff"]
+    filenames = ["*.wdiff"]
     mimetypes = []
 
     flags = re.MULTILINE | re.DOTALL
@@ -136,30 +170,28 @@ class WDiffLexer(RegexLexer):
     ins_cl = r"\+\}"
     del_op = r"\[\-"
     del_cl = r"\-\]"
-    normal = r'[^{}[\]+-]+'  # for performance
+    normal = r"[^{}[\]+-]+"  # for performance
     tokens = {
-        'root': [
-            (ins_op, Generic.Inserted, 'inserted'),
-            (del_op, Generic.Deleted, 'deleted'),
+        "root": [
+            (ins_op, Generic.Inserted, "inserted"),
+            (del_op, Generic.Deleted, "deleted"),
             (normal, Text),
-            (r'.', Text),
+            (r".", Text),
         ],
-        'inserted': [
-            (ins_op, Generic.Inserted, '#push'),
-            (del_op, Generic.Inserted, '#push'),
-            (del_cl, Generic.Inserted, '#pop'),
-
-            (ins_cl, Generic.Inserted, '#pop'),
+        "inserted": [
+            (ins_op, Generic.Inserted, "#push"),
+            (del_op, Generic.Inserted, "#push"),
+            (del_cl, Generic.Inserted, "#pop"),
+            (ins_cl, Generic.Inserted, "#pop"),
             (normal, Generic.Inserted),
-            (r'.', Generic.Inserted),
+            (r".", Generic.Inserted),
         ],
-        'deleted': [
-            (del_op, Generic.Deleted, '#push'),
-            (ins_op, Generic.Deleted, '#push'),
-            (ins_cl, Generic.Deleted, '#pop'),
-
-            (del_cl, Generic.Deleted, '#pop'),
+        "deleted": [
+            (del_op, Generic.Deleted, "#push"),
+            (ins_op, Generic.Deleted, "#push"),
+            (ins_cl, Generic.Deleted, "#pop"),
+            (del_cl, Generic.Deleted, "#pop"),
             (normal, Generic.Deleted),
-            (r'.', Generic.Deleted),
+            (r".", Generic.Deleted),
         ],
     }

--- a/pygments/lexers/diff.py
+++ b/pygments/lexers/diff.py
@@ -10,45 +10,45 @@
 
 import re
 
-from pygments.lexer import RegexLexer, bygroups, include
-from pygments.token import (Comment, Generic, Keyword, Literal, Name, Operator,
-                            Text, Whitespace)
+from pygments.lexer import RegexLexer, include, bygroups
+from pygments.token import Text, Comment, Operator, Keyword, Name, Generic, \
+    Literal, Whitespace
 
-__all__ = ["DiffLexer", "DarcsPatchLexer", "WDiffLexer"]
+__all__ = ['DiffLexer', 'DarcsPatchLexer', 'WDiffLexer']
 
 
 class DiffLexer(RegexLexer):
     """
-    Lexer for normal, unified, or context-style diffs or patches.
+    Lexer for unified or context-style diffs or patches.
     """
 
-    name = "Diff"
-    aliases = ["diff", "udiff"]
-    filenames = ["*.diff", "*.patch"]
-    mimetypes = ["text/x-diff", "text/x-patch"]
+    name = 'Diff'
+    aliases = ['diff', 'udiff']
+    filenames = ['*.diff', '*.patch']
+    mimetypes = ['text/x-diff', 'text/x-patch']
 
     tokens = {
-        "root": [
-            (r"( )(.*)(\n)", bygroups(Whitespace, Text, Whitespace)),
-            (r"(!.*|---)(\n)", bygroups(Generic.Strong, Whitespace)),
-            (r"((?:< |-).*)(\n)", bygroups(Generic.Deleted, Whitespace)),
-            (r"((?:> |\+).*)(\n)", bygroups(Generic.Inserted, Whitespace)),
+        'root': [
+            (r'( )(.*)(\n)', bygroups(Whitespace, Text, Whitespace)),
+            (r'(!.*|---)(\n)', bygroups(Generic.Strong, Whitespace)),
+            (r'((?:< |-).*)(\n)', bygroups(Generic.Deleted, Whitespace)),
+            (r'((?:> |\+).*)(\n)', bygroups(Generic.Inserted, Whitespace)),
             (
-                r"(@.*|\d(?:,\d+)?(?:a|c|d)\d+(?:,\d+)?)(\n)",
+                r'(@.*|\d(?:,\d+)?(?:a|c|d)\d+(?:,\d+)?)(\n)',
                 bygroups(Generic.Subheading, Whitespace),
             ),
-            (r"((?:[Ii]ndex|diff).*)(\n)", bygroups(Generic.Heading, Whitespace)),
-            (r"(=.*)(\n)", bygroups(Generic.Heading, Whitespace)),
-            (r"(.*)(\n)", bygroups(Text, Whitespace)),
+            (r'((?:[Ii]ndex|diff).*)(\n)', bygroups(Generic.Heading, Whitespace)),
+            (r'(=.*)(\n)', bygroups(Generic.Heading, Whitespace)),
+            (r'(.*)(\n)', bygroups(Text, Whitespace)),
         ]
     }
 
     def analyse_text(text):
-        if text[:7] == "Index: ":
+        if text[:7] == 'Index: ':
             return True
-        if text[:5] == "diff ":
+        if text[:5] == 'diff ':
             return True
-        if text[:4] == "--- ":
+        if text[:4] == '--- ':
             return 0.9
 
 
@@ -61,82 +61,51 @@ class DarcsPatchLexer(RegexLexer):
     .. versionadded:: 0.10
     """
 
-    name = "Darcs Patch"
-    aliases = ["dpatch"]
-    filenames = ["*.dpatch", "*.darcspatch"]
+    name = 'Darcs Patch'
+    aliases = ['dpatch']
+    filenames = ['*.dpatch', '*.darcspatch']
 
-    DPATCH_KEYWORDS = (
-        "hunk",
-        "addfile",
-        "adddir",
-        "rmfile",
-        "rmdir",
-        "move",
-        "replace",
-    )
+    DPATCH_KEYWORDS = ('hunk', 'addfile', 'adddir', 'rmfile', 'rmdir', 'move',
+                       'replace')
 
     tokens = {
-        "root": [
-            (r"<", Operator),
-            (r">", Operator),
-            (r"\{", Operator),
-            (r"\}", Operator),
-            (
-                r"(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)(\])",
-                bygroups(
-                    Operator,
-                    Keyword,
-                    Name,
-                    Whitespace,
-                    Name,
-                    Operator,
-                    Literal.Date,
-                    Whitespace,
-                    Operator,
-                ),
-            ),
-            (
-                r"(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)",
-                bygroups(
-                    Operator,
-                    Keyword,
-                    Name,
-                    Whitespace,
-                    Name,
-                    Operator,
-                    Literal.Date,
-                    Whitespace,
-                ),
-                "comment",
-            ),
-            (r"New patches:", Generic.Heading),
-            (r"Context:", Generic.Heading),
-            (r"Patch bundle hash:", Generic.Heading),
-            (
-                r"(\s*)(%s)(.*)(\n)" % "|".join(DPATCH_KEYWORDS),
-                bygroups(Whitespace, Keyword, Text, Whitespace),
-            ),
-            (r"\+", Generic.Inserted, "insert"),
-            (r"-", Generic.Deleted, "delete"),
-            (r"(.*)(\n)", bygroups(Text, Whitespace)),
+        'root': [
+            (r'<', Operator),
+            (r'>', Operator),
+            (r'\{', Operator),
+            (r'\}', Operator),
+            (r'(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)(\])',
+             bygroups(Operator, Keyword, Name, Whitespace, Name, Operator,
+                      Literal.Date, Whitespace, Operator)),
+            (r'(\[)((?:TAG )?)(.*)(\n)(.*)(\*\*)(\d+)(\s?)',
+             bygroups(Operator, Keyword, Name, Whitespace, Name, Operator,
+                      Literal.Date, Whitespace), 'comment'),
+            (r'New patches:', Generic.Heading),
+            (r'Context:', Generic.Heading),
+            (r'Patch bundle hash:', Generic.Heading),
+            (r'(\s*)(%s)(.*)(\n)' % '|'.join(DPATCH_KEYWORDS),
+                bygroups(Whitespace, Keyword, Text, Whitespace)),
+            (r'\+', Generic.Inserted, "insert"),
+            (r'-', Generic.Deleted, "delete"),
+            (r'(.*)(\n)', bygroups(Text, Whitespace)),
         ],
-        "comment": [
-            (r"[^\]].*\n", Comment),
-            (r"\]", Operator, "#pop"),
+        'comment': [
+            (r'[^\]].*\n', Comment),
+            (r'\]', Operator, "#pop"),
         ],
-        "specialText": [  # darcs add [_CODE_] special operators for clarity
-            (r"\n", Whitespace, "#pop"),  # line-based
-            (r"\[_[^_]*_]", Operator),
+        'specialText': [            # darcs add [_CODE_] special operators for clarity
+            (r'\n', Whitespace, "#pop"),  # line-based
+            (r'\[_[^_]*_]', Operator),
         ],
-        "insert": [
-            include("specialText"),
-            (r"\[", Generic.Inserted),
-            (r"[^\n\[]+", Generic.Inserted),
+        'insert': [
+            include('specialText'),
+            (r'\[', Generic.Inserted),
+            (r'[^\n\[]+', Generic.Inserted),
         ],
-        "delete": [
-            include("specialText"),
-            (r"\[", Generic.Deleted),
-            (r"[^\n\[]+", Generic.Deleted),
+        'delete': [
+            include('specialText'),
+            (r'\[', Generic.Deleted),
+            (r'[^\n\[]+', Generic.Deleted),
         ],
     }
 
@@ -154,10 +123,10 @@ class WDiffLexer(RegexLexer):
     .. versionadded:: 2.2
     """
 
-    name = "WDiff"
-    url = "https://www.gnu.org/software/wdiff/"
-    aliases = ["wdiff"]
-    filenames = ["*.wdiff"]
+    name = 'WDiff'
+    url = 'https://www.gnu.org/software/wdiff/'
+    aliases = ['wdiff']
+    filenames = ['*.wdiff']
     mimetypes = []
 
     flags = re.MULTILINE | re.DOTALL
@@ -170,28 +139,30 @@ class WDiffLexer(RegexLexer):
     ins_cl = r"\+\}"
     del_op = r"\[\-"
     del_cl = r"\-\]"
-    normal = r"[^{}[\]+-]+"  # for performance
+    normal = r'[^{}[\]+-]+'  # for performance
     tokens = {
-        "root": [
-            (ins_op, Generic.Inserted, "inserted"),
-            (del_op, Generic.Deleted, "deleted"),
+        'root': [
+            (ins_op, Generic.Inserted, 'inserted'),
+            (del_op, Generic.Deleted, 'deleted'),
             (normal, Text),
-            (r".", Text),
+            (r'.', Text),
         ],
-        "inserted": [
-            (ins_op, Generic.Inserted, "#push"),
-            (del_op, Generic.Inserted, "#push"),
-            (del_cl, Generic.Inserted, "#pop"),
-            (ins_cl, Generic.Inserted, "#pop"),
+        'inserted': [
+            (ins_op, Generic.Inserted, '#push'),
+            (del_op, Generic.Inserted, '#push'),
+            (del_cl, Generic.Inserted, '#pop'),
+
+            (ins_cl, Generic.Inserted, '#pop'),
             (normal, Generic.Inserted),
-            (r".", Generic.Inserted),
+            (r'.', Generic.Inserted),
         ],
-        "deleted": [
-            (del_op, Generic.Deleted, "#push"),
-            (ins_op, Generic.Deleted, "#push"),
-            (ins_cl, Generic.Deleted, "#pop"),
-            (del_cl, Generic.Deleted, "#pop"),
+        'deleted': [
+            (del_op, Generic.Deleted, '#push'),
+            (ins_op, Generic.Deleted, '#push'),
+            (ins_cl, Generic.Deleted, '#pop'),
+
+            (del_cl, Generic.Deleted, '#pop'),
             (normal, Generic.Deleted),
-            (r".", Generic.Deleted),
+            (r'.', Generic.Deleted),
         ],
     }

--- a/tests/snippets/diff/normal.txt
+++ b/tests/snippets/diff/normal.txt
@@ -1,0 +1,38 @@
+---input---
+1,2d0
+< A
+< A
+4c2
+< C
+---
+> F
+5a4
+> E
+
+---tokens---
+'1,2d0'       Generic.Subheading
+'\n'          Text.Whitespace
+
+'< A'         Generic.Deleted
+'\n'          Text.Whitespace
+
+'< A'         Generic.Deleted
+'\n'          Text.Whitespace
+
+'4c2'         Generic.Subheading
+'\n'          Text.Whitespace
+
+'< C'         Generic.Deleted
+'\n'          Text.Whitespace
+
+'---'         Generic.Strong
+'\n'          Text.Whitespace
+
+'> F'         Generic.Inserted
+'\n'          Text.Whitespace
+
+'5a4'         Generic.Subheading
+'\n'          Text.Whitespace
+
+'> E'         Generic.Inserted
+'\n'          Text.Whitespace

--- a/tests/snippets/diff/unified.txt
+++ b/tests/snippets/diff/unified.txt
@@ -1,0 +1,44 @@
+---input---
+--- old.txt	2023-01-17 21:02:15.449417575 -0700
++++ new.txt	2023-01-17 21:02:12.489441682 -0700
+@@ -1,5 +1,4 @@
+-A
+-A
+ B
+-C
++F
+ D
++E
+
+---tokens---
+'--- old.txt\t2023-01-17 21:02:15.449417575 -0700' Generic.Deleted
+'\n'          Text.Whitespace
+
+'+++ new.txt\t2023-01-17 21:02:12.489441682 -0700' Generic.Inserted
+'\n'          Text.Whitespace
+
+'@@ -1,5 +1,4 @@' Generic.Subheading
+'\n'          Text.Whitespace
+
+'-A'          Generic.Deleted
+'\n'          Text.Whitespace
+
+'-A'          Generic.Deleted
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+'B'           Text
+'\n'          Text.Whitespace
+
+'-C'          Generic.Deleted
+'\n'          Text.Whitespace
+
+'+F'          Generic.Inserted
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+'D'           Text
+'\n'          Text.Whitespace
+
+'+E'          Generic.Inserted
+'\n'          Text.Whitespace


### PR DESCRIPTION
There was already support for unified diff syntax, so this adds support for normal diff syntax as well. Test file was generated with the following

`old.txt`

```text
A
A
B
C
D
```

`new.txt`

```text
B
F
D
E
```

```bash
$ diff old.txt new.txt
```

```diff
1,2d0
< A
< A
4c2
< C
---
> F
5a4
> E
```