### PR TITLE
Declare support for Python 3.11, test 3.12-dev, drop EOL 3.6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,9 @@ name: Pygments
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,9 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-      max-parallel: 4
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,13 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-        exclude:
-          - os: ubuntu-latest
-            python-version: "3.6"
-        include:
-          - os: ubuntu-20.04
-            python-version: "3.6"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
       max-parallel: 4
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         exclude:
           - os: ubuntu-latest
             python-version: "3.6"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
     - name: Run make check
       run: make check
     - name: Fail if the basic checks failed
@@ -50,6 +52,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
     - name: Regenerate mapfiles
       run: make mapfiles
     - name: Fail if mapfiles changed
@@ -65,7 +69,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.x"
     - name: Check out regexlint
       run: git clone https://github.com/pygments/regexlint
     - name: Run regexlint

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  FORCE_COLOR: 1
+
 permissions: {}
 jobs:
   build:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.x"
     - name: Checkout Pygments
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Sphinx & WCAG contrast ratio
       run: pip install Sphinx wcag-contrast-ratio
     - name: Create Pyodide WASM package

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing :: Filters

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -39,7 +38,7 @@ project_urls =
 packages = find:
 zip_safe = false
 include_package_data = true
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 include =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310}, lint
+envlist = py{36, 37, 38, 39, 310, 311}, lint
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310, 311, 312}, lint
+envlist = py{37, 38, 39, 310, 311, 312}, lint
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36, 37, 38, 39, 310, 311}, lint
+envlist = py{36, 37, 38, 39, 310, 311, 312}, lint
 
 [testenv]
 deps =


### PR DESCRIPTION
	
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

Also test on Python 3.12-dev to be ready for the next version, drop support for EOL Python 3.6 (EOL since 2021), add colour to the CI logs for readability, and bump GitHub Actions.