### PR TITLE
Native: fix contrast ratio to meet WCAG AA guidelines

### DIFF
--- a/pygments/styles/native.py
+++ b/pygments/styles/native.py
@@ -27,7 +27,7 @@ class NativeStyle(Style):
         Whitespace:         '#666666',
 
         Comment:            'italic #ababab',
-        Comment.Preproc:    'noitalic bold #cd2828',
+        Comment.Preproc:    'noitalic bold #ff3a3a',
         Comment.Special:    'noitalic bold #e50808 bg:#520000',
 
         Keyword:            'bold #6ebf26',

--- a/tests/contrast/min_contrasts.json
+++ b/tests/contrast/min_contrasts.json
@@ -13,7 +13,7 @@
   "pastie": 2.5,
   "borland": 2.3,
   "trac": 2.3,
-  "native": 3.0,
+  "native": 3.1,
   "fruity": 1.6,
   "bw": 21.0,
   "vim": 1.3,


### PR DESCRIPTION
# Before

The red `#define _Py_SHARED_SHIFT 2` shown [here](https://peps.python.org/pep-0703/#biased-reference-counting), with `class="cp"` is `#cd2828`:

![image](https://user-images.githubusercontent.com/1324225/214524944-28122192-ec24-40e0-ab01-6b2325d1a3df.png)

Has a contrast ratio of 3.04 which doesn't meet the WCAG AA minimum of 4.5:

![image](https://user-images.githubusercontent.com/1324225/214525207-3d3c1c89-b42c-4ee0-a25f-372ec9988f77.png)

![image](https://user-images.githubusercontent.com/1324225/214525378-864f7082-73d3-447d-8086-e7d7cba16c91.png)

And is flagged by Lighthouse:

![image](https://user-images.githubusercontent.com/1324225/214526202-3245abf7-f110-41fc-bb89-9261ec029f90.png)

# After

Using Google's suggestion of `#ff3a3a` increases it to 4.59:

![image](https://user-images.githubusercontent.com/1324225/214526526-de9fc8aa-39b8-4e4d-830c-f19eb70a2469.png)

![image](https://user-images.githubusercontent.com/1324225/214525568-9a0cd7fa-1cb6-4778-8077-2f5256d4eddf.png)

(For comparison, the AAA suggestion of `#ff8888` is a bit pale, so let's go for AA.)

<details>
<summary>AAA</summary>

![image](https://user-images.githubusercontent.com/1324225/214525721-d2b1a27e-7fe9-46c7-9d0d-bfed378544ae.png)

</details>


