### PR TITLE
Add `linenostart` support to Terminal formatter

### DIFF
--- a/pygments/formatters/terminal.py
+++ b/pygments/formatters/terminal.py
@@ -12,7 +12,7 @@ from pygments.formatter import Formatter
 from pygments.token import Keyword, Name, Comment, String, Error, \
     Number, Operator, Generic, Token, Whitespace
 from pygments.console import ansiformat
-from pygments.util import get_choice_opt
+from pygments.util import get_choice_opt, get_int_opt
 
 
 __all__ = ['TerminalFormatter']
@@ -75,6 +75,10 @@ class TerminalFormatter(Formatter):
     `linenos`
         Set to ``True`` to have line numbers on the terminal output as well
         (default: ``False`` = no line numbers).
+
+    `linenostart`
+        The line number for the first line (default: ``1``).
+
     """
     name = 'Terminal'
     aliases = ['terminal', 'console']
@@ -86,14 +90,17 @@ class TerminalFormatter(Formatter):
                                      ['light', 'dark'], 'light') == 'dark'
         self.colorscheme = options.get('colorscheme', None) or TERMINAL_COLORS
         self.linenos = options.get('linenos', False)
-        self._lineno = 0
+        self.linenostart = abs(get_int_opt(options, "linenostart", 1))
+        self._lineno = self.linenostart
 
     def format(self, tokensource, outfile):
         return Formatter.format(self, tokensource, outfile)
 
     def _write_lineno(self, outfile):
+        outfile.write(
+            "%s%04d: " % (self._lineno > self.linenostart and "\n" or "", self._lineno)
+        )
         self._lineno += 1
-        outfile.write("%s%04d: " % (self._lineno != 1 and '\n' or '', self._lineno))
 
     def _get_color(self, ttype):
         # self.colorscheme is a dict containing usually generic types, so we

--- a/tests/test_terminal_formatter.py
+++ b/tests/test_terminal_formatter.py
@@ -9,6 +9,8 @@
 import re
 from io import StringIO
 
+import pytest
+
 from pygments.lexers.sql import PlPgsqlLexer
 from pygments.formatters import TerminalFormatter, Terminal256Formatter, \
     HtmlFormatter, LatexFormatter
@@ -53,6 +55,24 @@ def test_reasonable_output_lineno():
 
     for a, b in zip(DEMO_TEXT.splitlines(), plain.splitlines()):
         assert a in b
+
+
+@pytest.mark.parametrize("linenostart", [-1, 0, 1, 2, 3])
+def test_reasonable_output_linenostart(linenostart):
+    out = StringIO()
+    TerminalFormatter(linenos=True, linenostart=linenostart).format(DEMO_TOKENS, out)
+    plain = strip_ansi(out.getvalue())
+    assert DEMO_TEXT.count("\n") + 1 == plain.count("\n")
+    print(repr(plain))
+
+    linenostart = abs(linenostart)
+
+    for i, (demo_line, plain_line) in enumerate(
+        zip(DEMO_TEXT.splitlines(), plain.splitlines())
+    ):
+        line_no, source = plain_line.split(": ", 1)
+        assert source == demo_line
+        assert int(line_no) == i + linenostart
 
 
 class MyStyle(Style):


### PR DESCRIPTION
Implementation is very similar to existing ones in Html/Latex formatters and addresses the problem in https://github.com/Bachmann1234/diff_cover/issues/283