### PR TITLE
Fix various documentation references.

### DIFF
--- a/doc/docs/api.rst
+++ b/doc/docs/api.rst
@@ -1,6 +1,3 @@
-.. -*- mode: rst -*-
-
-=====================
 The full Pygments API
 =====================
 
@@ -70,7 +67,7 @@ Functions from :mod:`pygments.lexers`:
     the input, because this method is equivalent to running eval on the input file.
     The lexer is given the `options` at its instantiation.
 
-    :exc:`ClassNotFound` is raised if there are any errors loading the Lexer
+    :exc:`pygments.util.ClassNotFound` is raised if there are any errors loading the Lexer
 
     .. versionadded:: 2.2
 
@@ -145,7 +142,7 @@ Functions from :mod:`pygments.formatters`:
     careful with the input, because this method is equivalent to running eval
     on the input file. The formatter is given the `options` at its instantiation.
 
-    :exc:`ClassNotFound` is raised if there are any errors loading the Formatter
+    :exc:`pygments.util.ClassNotFound` is raised if there are any errors loading the Formatter
 
     .. versionadded:: 2.2
 
@@ -256,6 +253,12 @@ The base lexer class from which all lexers are derived is:
 
         A list of MIME types for content that can be lexed with this
         lexer.
+
+There are several base class derived from ``Lexer`` you can use to build your lexer from:
+
+.. autoclass:: pygments.lexer.DelegatingLexer
+.. autoclass:: pygments.lexer.RegexLexer
+.. autoclass:: pygments.lexer.ExtendedRegexLexer
 
 
 .. module:: pygments.formatter

--- a/doc/docs/cmdline.rst
+++ b/doc/docs/cmdline.rst
@@ -96,7 +96,7 @@ the "colorful" style prepending a ".syntax" selector to all style rules.
 
 For an explanation what ``-a`` means for :doc:`a particular formatter
 <formatters>`, look for the `arg` argument for the formatter's
-:meth:`.get_style_defs()` method.
+:meth:`.get_style_defs() <pygments.formatter.Formatter.get_style_defs()>` method.
 
 
 Getting lexer names

--- a/doc/docs/lexerdevelopment.rst
+++ b/doc/docs/lexerdevelopment.rst
@@ -24,7 +24,7 @@ RegexLexer
 ==========
 
 The lexer base class used by almost all of Pygments' lexers is the
-:class:`RegexLexer`.  This class allows you to define lexing rules in terms of
+:class:`RegexLexer <pygments.lexer.RegexLexer>`.  This class allows you to define lexing rules in terms of
 *regular expressions* for different *states*.
 
 States are groups of regular expressions that are matched against the input
@@ -131,7 +131,7 @@ If you only want to use your lexer with the Pygments API, you can import and
 instantiate the lexer yourself, then pass it to :func:`pygments.highlight`.
 
 Use the ``-f`` flag to select a different output format than terminal
-escape sequences. The :class:`pygments.formatters.html.HtmlFormatter` helps
+escape sequences. The :class:`.HtmlFormatter` helps
 you with debugging your lexer. You can use the ``debug_token_types`` option
 to display the token types assigned to each part of your input file:
 

--- a/doc/docs/quickstart.rst
+++ b/doc/docs/quickstart.rst
@@ -58,7 +58,7 @@ can be produced by:
 
     print(HtmlFormatter().get_style_defs('.highlight'))
 
-The argument to :func:`get_style_defs` is used as an additional CSS selector:
+The argument to :meth:`get_style_defs() <pygments.formatter.Formatter.get_style_defs()>` is used as an additional CSS selector:
 the output may look like this:
 
 .. sourcecode:: css
@@ -71,7 +71,7 @@ the output may look like this:
 Options
 =======
 
-The :func:`highlight()` function supports a fourth argument called *outfile*, it
+The :func:`highlight() <pygments.highlight>` function supports a fourth argument called *outfile*, it
 must be a file object if given. The formatted output will then be written to
 this file instead of being returned as a string.
 
@@ -153,8 +153,8 @@ or some template tags), use these functions:
     >>> guess_lexer_for_filename('test.py', 'print "Hello World!"')
     <pygments.lexers.PythonLexer>
 
-:func:`.guess_lexer()` passes the given content to the lexer classes'
-:meth:`analyse_text()` method and returns the one for which it returns the
+:func:`.guess_lexer() <pygments.lexers.guess_lexer>` passes the given content to the lexer classes'
+:meth:`analyse_text() <pygments.lexer.Lexer.analyse_text>` method and returns the one for which it returns the
 highest number.
 
 All lexers have two different filename pattern lists: the primary and the

--- a/doc/docs/styles.rst
+++ b/doc/docs/styles.rst
@@ -79,7 +79,7 @@ Terminal Styles
 
 Custom styles used with the 256-color terminal formatter can also map colors to
 use the 8 default ANSI colors.  To do so, use ``ansigreen``, ``ansibrightred`` or
-any other colors defined in :attr:`pygments.style.ansicolors`.  Foreground ANSI
+any other colors defined in :data:`pygments.style.ansicolors`.  Foreground ANSI
 colors will be mapped to the corresponding `escape codes 30 to 37
 <https://en.wikipedia.org/wiki/ANSI_escape_code#Colors>`_ thus respecting any
 custom color mapping and themes provided by many terminal emulators.  Light


### PR DESCRIPTION
Address some of the issues in #2312.

This is still missing a few more references:
* pygments.util.ClassNotFound has no documentation to link to
* `pygments.styles.STYLE_MAP` and `pygments.styles.ansicolors` need to be documented
* References to `__init__` and `fnmatch` from generated code are not fixed