### PR TITLE
Fix GLSL and HLSL preprocessor directive start

### DIFF
--- a/pygments/lexers/graphics.py
+++ b/pygments/lexers/graphics.py
@@ -30,7 +30,7 @@ class GLShaderLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'^#(?:.*\\\n)*.*$', Comment.Preproc),
+            (r'#(?:.*\\\n)*.*$', Comment.Preproc),
             (r'//.*$', Comment.Single),
             (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
             (r'\+|-|~|!=?|\*|/|%|<<|>>|<=?|>=?|==?|&&?|\^|\|\|?',
@@ -161,7 +161,7 @@ class HLSLShaderLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'^#(?:.*\\\n)*.*$', Comment.Preproc),
+            (r'#(?:.*\\\n)*.*$', Comment.Preproc),
             (r'//.*$', Comment.Single),
             (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
             (r'\+|-|~|!=?|\*|/|%|<<|>>|<=?|>=?|==?|&&?|\^|\|\|?',

--- a/tests/examplefiles/glsl/glsl.frag
+++ b/tests/examplefiles/glsl/glsl.frag
@@ -1,5 +1,11 @@
 /* Fragment shader */
 
+// Macro inside a single-line comment: #define COMMENT_MACRO 1
+
+/* Macro inside a block comment: #define COMMENT_MACRO 2 */
+
+    # define INDENTED_MACRO 5.0
+
 #define SINGLELINE_MACRO 10.0
 
 #define MULTILINE_MACRO(a, b) vec2( \

--- a/tests/examplefiles/glsl/glsl.frag.output
+++ b/tests/examplefiles/glsl/glsl.frag.output
@@ -1,6 +1,14 @@
 '/* Fragment shader */' Comment.Multiline
 '\n\n'        Text.Whitespace
 
+'// Macro inside a single-line comment: #define COMMENT_MACRO 1' Comment.Single
+'\n\n'        Text.Whitespace
+
+'/* Macro inside a block comment: #define COMMENT_MACRO 2 */' Comment.Multiline
+'\n\n    '    Text.Whitespace
+'# define INDENTED_MACRO 5.0' Comment.Preproc
+'\n\n'        Text.Whitespace
+
 '#define SINGLELINE_MACRO 10.0' Comment.Preproc
 '\n\n'        Text.Whitespace
 

--- a/tests/examplefiles/glsl/glsl.vert
+++ b/tests/examplefiles/glsl/glsl.vert
@@ -1,5 +1,11 @@
 /* Vertex shader */
 
+// Macro inside a single-line comment: #define COMMENT_MACRO 1
+
+/* Macro inside a block comment: #define COMMENT_MACRO 2 */
+
+    # define INDENTED_MACRO 5.0
+
 #define SINGLELINE_MACRO 10.0
 
 #define MULTILINE_MACRO(a, b) vec2( \

--- a/tests/examplefiles/glsl/glsl.vert.output
+++ b/tests/examplefiles/glsl/glsl.vert.output
@@ -1,6 +1,14 @@
 '/* Vertex shader */' Comment.Multiline
 '\n\n'        Text.Whitespace
 
+'// Macro inside a single-line comment: #define COMMENT_MACRO 1' Comment.Single
+'\n\n'        Text.Whitespace
+
+'/* Macro inside a block comment: #define COMMENT_MACRO 2 */' Comment.Multiline
+'\n\n    '    Text.Whitespace
+'# define INDENTED_MACRO 5.0' Comment.Preproc
+'\n\n'        Text.Whitespace
+
 '#define SINGLELINE_MACRO 10.0' Comment.Preproc
 '\n\n'        Text.Whitespace
 

--- a/tests/examplefiles/hlsl/example.hlsl
+++ b/tests/examplefiles/hlsl/example.hlsl
@@ -1,5 +1,11 @@
 // A few random snippets of HLSL shader code I gathered...
 
+// Macro inside a single-line comment: #define COMMENT_MACRO 1
+
+/* Macro inside a block comment: #define COMMENT_MACRO 2 */
+
+	# define INDENTED_MACRO 5.0
+
 #define SINGLELINE_MACRO 10.0
 
 #define MULTILINE_MACRO(a, b) float2( \

--- a/tests/examplefiles/hlsl/example.hlsl.output
+++ b/tests/examplefiles/hlsl/example.hlsl.output
@@ -1,6 +1,14 @@
 '// A few random snippets of HLSL shader code I gathered...' Comment.Single
 '\n\n'        Text.Whitespace
 
+'// Macro inside a single-line comment: #define COMMENT_MACRO 1' Comment.Single
+'\n\n'        Text.Whitespace
+
+'/* Macro inside a block comment: #define COMMENT_MACRO 2 */' Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'# define INDENTED_MACRO 5.0' Comment.Preproc
+'\n\n'        Text.Whitespace
+
 '#define SINGLELINE_MACRO 10.0' Comment.Preproc
 '\n\n'        Text.Whitespace
 


### PR DESCRIPTION
Currently, both shader language lexers require that when parsing preprocessor directives `#` is the first character on a line. This PR loosens the restriction as these should all be valid directives:

``` glsl
#define NORMAL 1
#    define VALUE 10
    #define MORE 20
    #    define ANOTHER 30
```

This also allows putting line numbers, non-breaking spaces etc. in certain code snippets:

``` glsl
10. #ifdef VALUE
11. ...
12. #endif
```
