### PR TITLE
Add support for more declarations and access modifiers in Carbon lexer

### DIFF
--- a/pygments/lexers/carbon.py
+++ b/pygments/lexers/carbon.py
@@ -41,12 +41,13 @@ class CarbonLexer(RegexLexer):
             # Declaration
             (r'(package|import|api|namespace|library)\b', Keyword.Namespace),
             (r'(abstract|alias|fn|class|interface|let|var|virtual|external|'
-             r'base|addr|extends)\b', Keyword.Declaration),
+             r'base|addr|extends|choice)\b', Keyword.Declaration),
             # Keywords
             (words(('as', 'or', 'not', 'and', 'break', 'continue', 'case',
                     'default', 'if', 'else', 'destructor', 'for', 'forall',
-                    'while', 'where', 'then', 'in', 'is', 'return',
-                    'returned'), suffix=r'\b'), Keyword),
+                    'while', 'where', 'then', 'in', 'is', 'return', 'returned',
+                    'friend', 'partial', 'private', 'protected', 'observe',
+                    'override', 'Self'), suffix=r'\b'), Keyword),
             (r'(self)\b', Keyword.Pseudo),
             (r'(true|false)\b', Keyword.Constant),
             (r'(auto|bool|string|i8|i16|i32|i64|u8|u16|u32|u64|'

--- a/tests/examplefiles/carbon/declarations.carbon
+++ b/tests/examplefiles/carbon/declarations.carbon
@@ -1,0 +1,30 @@
+package ExplorerTest api;
+
+choice MyOptionalElement(ZZ:! type, YY:! type) {
+  None(YY),
+  Element(ZZ)
+}
+
+abstract class C {
+  var a: i32;
+}
+
+base class B {
+  var value_b: i32;
+}
+
+interface Vector {
+  fn Zero() -> Self;
+  fn Add[self: Self](b: Self) -> Self;
+  fn Scale[self: Self](v: i32) -> Self;
+}
+
+class Pal {
+  private var x: i32;
+  protected var y: i32;
+  friend Buddy;
+}
+
+abstract class MyAbstractClass {
+  protected fn Create() -> partial Self { }
+}

--- a/tests/examplefiles/carbon/declarations.carbon.output
+++ b/tests/examplefiles/carbon/declarations.carbon.output
@@ -1,0 +1,248 @@
+'package'     Keyword.Namespace
+' '           Text.Whitespace
+'ExplorerTest' Name.Other
+' '           Text.Whitespace
+'api'         Keyword.Namespace
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'choice'      Keyword.Declaration
+' '           Text.Whitespace
+'MyOptionalElement' Name.Other
+'('           Punctuation
+'ZZ'          Name.Other
+':'           Punctuation
+'!'           Punctuation
+' '           Text.Whitespace
+'type'        Name.Other
+','           Punctuation
+' '           Text.Whitespace
+'YY'          Name.Other
+':'           Punctuation
+'!'           Punctuation
+' '           Text.Whitespace
+'type'        Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'None'        Name.Other
+'('           Punctuation
+'YY'          Name.Other
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'Element'     Name.Other
+'('           Punctuation
+'ZZ'          Name.Other
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'abstract'    Keyword.Declaration
+' '           Text.Whitespace
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'C'           Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'var'         Keyword.Declaration
+' '           Text.Whitespace
+'a'           Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'i32'         Keyword.Type
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'base'        Keyword.Declaration
+' '           Text.Whitespace
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'B'           Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'var'         Keyword.Declaration
+' '           Text.Whitespace
+'value_b'     Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'i32'         Keyword.Type
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'interface'   Keyword.Declaration
+' '           Text.Whitespace
+'Vector'      Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fn'          Keyword.Declaration
+' '           Text.Whitespace
+'Zero'        Name.Other
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fn'          Keyword.Declaration
+' '           Text.Whitespace
+'Add'         Name.Other
+'['           Punctuation
+'self'        Keyword.Pseudo
+':'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+']'           Punctuation
+'('           Punctuation
+'b'           Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'fn'          Keyword.Declaration
+' '           Text.Whitespace
+'Scale'       Name.Other
+'['           Punctuation
+'self'        Keyword.Pseudo
+':'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+']'           Punctuation
+'('           Punctuation
+'v'           Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'i32'         Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Punctuation
+' '           Text.Whitespace
+'Self'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'Pal'         Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'private'     Keyword
+' '           Text.Whitespace
+'var'         Keyword.Declaration
+' '           Text.Whitespace
+'x'           Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'i32'         Keyword.Type
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'protected'   Keyword
+' '           Text.Whitespace
+'var'         Keyword.Declaration
+' '           Text.Whitespace
+'y'           Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'i32'         Keyword.Type
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'friend'      Keyword
+' '           Text.Whitespace
+'Buddy'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'abstract'    Keyword.Declaration
+' '           Text.Whitespace
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'MyAbstractClass' Name.Other
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'protected'   Keyword
+' '           Text.Whitespace
+'fn'          Keyword.Declaration
+' '           Text.Whitespace
+'Create'      Name.Other
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Punctuation
+' '           Text.Whitespace
+'partial'     Keyword
+' '           Text.Whitespace
+'Self'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Add support for more declarations and access modifiers in the Carbon lexer

Source:
https://github.com/carbon-language/carbon-lang/blob/trunk/docs/design/classes.md
https://github.com/carbon-language/carbon-lang/blob/trunk/toolchain/lexer/token_kind.def