### PR TITLE
Improve number regex and add lexer guess for carbon syntax

### DIFF
--- a/pygments/lexers/carbon.py
+++ b/pygments/lexers/carbon.py
@@ -53,10 +53,11 @@ class CarbonLexer(RegexLexer):
             (r'(auto|bool|string|i8|i16|i32|i64|u8|u16|u32|u64|'
              r'f8|f16|f32|f64)\b', Keyword.Type),
             # numeric literals
-            (r'[0-9]*[.][0-9]+', Number.Double),
-            (r'0b[01]+[sl]?', Number.Bin),
-            (r'0o[0-7]+[sl]?', Number.Oct),
-            (r'[0-9]+', Number.Integer),
+            (r'[0-9]*[.][0-9]+?', Number.Double),
+            (r'0b[01]+?', Number.Bin),
+            (r'0o[0-7]+?', Number.Oct),
+            (r'0x[0-9a-fA-F]+?', Number.Hex),
+            (r'[0-9]+?', Number.Integer),
             # string literal
             (r'"(\\.|[^"\\])*"', String),
             # char literal
@@ -69,3 +70,27 @@ class CarbonLexer(RegexLexer):
             (r'[^\W\d]\w*', Name.Other),
         ]
     }
+
+    def analyse_text(text):
+        result = 0
+        if 'forall' in text:
+            result += 0.1
+        if 'type' in text:
+            result += 0.1
+        if 'Self' in text:
+            result += 0.1
+        if 'observe' in text:
+            result += 0.1
+        if 'package' in text:
+            result += 0.1
+        if 'library' in text:
+            result += 0.1
+        if 'choice' in text:
+            result += 0.1
+        if 'addr' in text:
+            result += 0.1
+        if 'constraint' in text:
+            result += 0.1
+        if 'impl' in text:
+            result += 0.1
+        return result

--- a/tests/test_guess.py
+++ b/tests/test_guess.py
@@ -169,6 +169,22 @@ def test_guess_c_lexer():
     lexer = guess_lexer(code)
     assert lexer.__class__.__name__ == 'CLexer'
 
+def test_guess_carbon_lexer():
+    code = '''
+    package Sorting api;
+
+    abstract class C {
+      var a: i32;
+    }
+
+    base class B {
+      var value_b: i32;
+    }
+
+    impl JustX as X {}
+    '''
+    lexer = guess_lexer(code)
+    assert lexer.__class__.__name__ == 'CarbonLexer'
 
 def test_cbmbasicv2_analyse_text():
     text = "10 PRINT \"PART 1\""


### PR DESCRIPTION
- Improve number regex and add hex support
- Add lexer guess for carbon syntax

Source for hex:
#https://github.com/carbon-language/carbon-lang/blob/trunk/toolchain/lexer/numeric_literal_test.cpp