### PR TITLE
adds hcl alias for terraform syntax

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -607,8 +607,8 @@ class TerraformLexer(ExtendedRegexLexer):
 
     name = 'Terraform'
     url = 'https://www.terraform.io/'
-    aliases = ['terraform', 'tf']
-    filenames = ['*.tf']
+    aliases = ['terraform', 'tf', 'hcl']
+    filenames = ['*.tf', '*.hcl']
     mimetypes = ['application/x-tf', 'application/x-terraform']
 
     classes = ('backend', 'data', 'module', 'output', 'provider',


### PR DESCRIPTION
This PR adds `hcl` as an option for highlighting HCL syntax as Hashicorp uses HCL for more than just Terraform, like Nomad.

ie. 

`````
  ```hcl
     non-terraform hcl goes here
  ```
`````