### PR TITLE
add support for lexing attributes in Chapel

### DIFF
--- a/pygments/lexers/chapel.py
+++ b/pygments/lexers/chapel.py
@@ -135,6 +135,6 @@ class ChapelLexer(RegexLexer):
             (r'[^()]*', Name.Other, '#pop'),
         ],
         'attributename': [
-            (r'([a-zA-Z_][.\w$]*)', Name.Decorator, '#pop'),
+            (r'[a-zA-Z_][.\w$]*', Name.Decorator, '#pop'),
         ],
     }


### PR DESCRIPTION
This PR adds support for language changes in Chapel. 

Chapel 1.30 includes support for attributes. The lexer was not able to process them without some adjustments.

