### PR TITLE
bash/tcsh: move "break" to keywords

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -55,9 +55,9 @@ class BashLexer(RegexLexer):
         ],
         'basic': [
             (r'\b(if|fi|else|while|in|do|done|for|then|return|function|case|'
-             r'select|continue|until|esac|elif)(\s*)\b',
+             r'select|break|continue|until|esac|elif)(\s*)\b',
              bygroups(Keyword, Whitespace)),
-            (r'\b(alias|bg|bind|break|builtin|caller|cd|command|compgen|'
+            (r'\b(alias|bg|bind|builtin|caller|cd|command|compgen|'
              r'complete|declare|dirs|disown|echo|enable|eval|exec|exit|'
              r'export|false|fc|fg|getopts|hash|help|history|jobs|kill|let|'
              r'local|logout|popd|printf|pushd|pwd|read|readonly|set|shift|'
@@ -591,9 +591,9 @@ class TcshLexer(RegexLexer):
         ],
         'basic': [
             (r'\b(if|endif|else|while|then|foreach|case|default|'
-             r'continue|goto|breaksw|end|switch|endsw)\s*\b',
+             r'break|continue|goto|breaksw|end|switch|endsw)\s*\b',
              Keyword),
-            (r'\b(alias|alloc|bg|bindkey|break|builtins|bye|caller|cd|chdir|'
+            (r'\b(alias|alloc|bg|bindkey|builtins|bye|caller|cd|chdir|'
              r'complete|dirs|echo|echotc|eval|exec|exit|fg|filetest|getxvers|'
              r'glob|getspath|hashstat|history|hup|inlib|jobs|kill|'
              r'limit|log|login|logout|ls-F|migrate|newgrp|nice|nohup|notify|'

--- a/tests/examplefiles/bash/ltmain.sh.output
+++ b/tests/examplefiles/bash/ltmain.sh.output
@@ -1774,7 +1774,7 @@
 '='           Operator
 'CC'          Text
 '\n\t      '  Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 ' '           Text.Whitespace
 ';'           Punctuation
 ';'           Punctuation
@@ -1988,7 +1988,7 @@
 '='           Operator
 '$z'          Name.Variable
 '\n\t      '  Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 '\n\t      '  Text.Whitespace
 ';'           Punctuation
 ';'           Punctuation
@@ -3656,7 +3656,7 @@
 '$arg'        Name.Variable
 '"'           Literal.String.Double
 '\n    '      Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 '\n    '      Text.Whitespace
 ';'           Punctuation
 ';'           Punctuation
@@ -3895,7 +3895,7 @@
 '='           Operator
 'compile'     Text
 '\n\t   '     Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 '\n\t   '     Text.Whitespace
 ';'           Punctuation
 ';'           Punctuation
@@ -6989,7 +6989,7 @@
 '='           Operator
 'yes'         Text
 '\n\t'        Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 '\n\t'        Text.Whitespace
 ';'           Punctuation
 ';'           Punctuation
@@ -12680,7 +12680,7 @@
 '\n\t\t'      Text.Whitespace
 'fi'          Keyword
 '\n\t\t'      Text.Whitespace
-'break'       Name.Builtin
+'break'       Keyword
 ' '           Text.Whitespace
 '2'           Literal.Number
 '\n\t      '  Text.Whitespace


### PR DESCRIPTION
Fixes #2374