### PR TITLE
Python console: do not require output that looks like a traceback to be valid

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,9 +3,12 @@ Pygments changelog
 
 Pull request numbers before 2.4.2 are not linked as they refer to the now defunct Bitbucket project.
 
-Version 2.16.0
+Version 2.15.1
 --------------
 (unreleased)
+
+- Fix Python console traceback lexing being too strict (#2407)
+
 
 Version 2.15.0
 --------------
@@ -67,6 +70,7 @@ Version 2.15.0
 - The top-level ``Makefile`` has been removed. Instead, all shortcuts
   for developing are now defined and run through tox.  The ``doc`` folder
   still contains a ``Makefile`` as an alternative to ``tox -e doc``.
+
 
 Version 2.14.0
 --------------

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -763,7 +763,8 @@ class PythonTracebackLexer(RegexLexer):
             (r'^([^:]+)(: )(.+)(\n)',
              bygroups(Generic.Error, Text, Name, Whitespace), '#pop'),
             (r'^([a-zA-Z_][\w.]*)(:?\n)',
-             bygroups(Generic.Error, Whitespace), '#pop')
+             bygroups(Generic.Error, Whitespace), '#pop'),
+            default('#pop'),
         ],
         'markers': [
             # Either `PEP 657 <https://www.python.org/dev/peps/pep-0657/>`

--- a/tests/snippets/pycon/multiple_tb.txt
+++ b/tests/snippets/pycon/multiple_tb.txt
@@ -1,0 +1,108 @@
+---input---
+>>> from multiprocessing import Pool
+>>> p = Pool(5)
+>>> def f(x):
+...     return x*x
+...
+>>> with p:
+...     p.map(f, [1,2,3])
+Process PoolWorker-1:
+Process PoolWorker-2:
+Process PoolWorker-3:
+Traceback (most recent call last):
+Traceback (most recent call last):
+Traceback (most recent call last):
+AttributeError: Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>
+AttributeError: Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>
+AttributeError: Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>
+
+---tokens---
+'>>> '        Generic.Prompt
+'from'        Keyword.Namespace
+' '           Text
+'multiprocessing' Name.Namespace
+' '           Text
+'import'      Keyword.Namespace
+' '           Text
+'Pool'        Name
+'\n'          Text.Whitespace
+
+'>>> '        Generic.Prompt
+'p'           Name
+' '           Text
+'='           Operator
+' '           Text
+'Pool'        Name
+'('           Punctuation
+'5'           Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'>>> '        Generic.Prompt
+'def'         Keyword
+' '           Text
+'f'           Name.Function
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'... '        Generic.Prompt
+'    '        Text
+'return'      Keyword
+' '           Text
+'x'           Name
+'*'           Operator
+'x'           Name
+'\n'          Text.Whitespace
+
+'...'         Generic.Prompt
+'\n'          Text.Whitespace
+
+'>>> '        Generic.Prompt
+'with'        Keyword
+' '           Text
+'p'           Name
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'... '        Generic.Prompt
+'    '        Text
+'p'           Name
+'.'           Operator
+'map'         Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+' '           Text
+'['           Punctuation
+'1'           Literal.Number.Integer
+','           Punctuation
+'2'           Literal.Number.Integer
+','           Punctuation
+'3'           Literal.Number.Integer
+']'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Process PoolWorker-1:\n' Generic.Output
+
+'Process PoolWorker-2:\n' Generic.Output
+
+'Process PoolWorker-3:\n' Generic.Output
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'AttributeError' Generic.Error
+': '          Text
+"Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>" Name
+'\n'          Text.Whitespace
+
+"AttributeError: Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>\n" Generic.Output
+
+"AttributeError: Can't get attribute 'f' on <module '__main__' (<class '_frozen_importlib.BuiltinImporter'>)>\n" Generic.Output


### PR DESCRIPTION
which causes Error to be flagged with output that just happens to look like a traceback

Fixes #2407