### PR TITLE
Updates C and C++ lexers

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -107,7 +107,8 @@ class CFamilyLexer(RegexLexer):
             (words(('int8', 'int16', 'int32', 'int64', 'wchar_t'), prefix=r'__',
                     suffix=r'\b'), Keyword.Reserved),
             (words(('bool', 'int', 'long', 'float', 'short', 'double', 'char',
-                    'unsigned', 'signed', 'void'), suffix=r'\b'), Keyword.Type)
+                    'unsigned', 'signed', 'void', '_BitInt',
+                    '__int128'), suffix=r'\b'), Keyword.Type)
         ],
         'keywords': [
             (r'(struct|union)(\s+)', bygroups(Keyword, Whitespace), 'classname'),

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -380,7 +380,7 @@ class CppLexer(CFamilyLexer):
                 'catch', 'const_cast', 'delete', 'dynamic_cast', 'explicit',
                 'export', 'friend', 'mutable', 'new', 'operator',
                 'private', 'protected', 'public', 'reinterpret_cast', 'class',
-                'restrict', 'static_cast', 'template', 'this', 'throw', 'throws',
+                '__restrict', 'static_cast', 'template', 'this', 'throw', 'throws',
                 'try', 'typeid', 'using', 'virtual', 'constexpr', 'nullptr', 'concept',
                 'decltype', 'noexcept', 'override', 'final', 'constinit', 'consteval',
                 'co_await', 'co_return', 'co_yield', 'requires', 'import', 'module',

--- a/tests/snippets/c/builtin_types.txt
+++ b/tests/snippets/c/builtin_types.txt
@@ -1,0 +1,13 @@
+---input---
+__int128
+_BitInt(2)
+
+---tokens---
+'__int128'    Keyword.Type
+'\n'          Text.Whitespace
+
+'_BitInt'     Keyword.Type
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/cpp/extension-keywords.txt
+++ b/tests/snippets/cpp/extension-keywords.txt
@@ -1,0 +1,6 @@
+---input---
+__restrict
+
+---tokens---
+'__restrict'  Keyword
+'\n'          Text.Whitespace

--- a/tests/snippets/cpp/extension-keywords.txt
+++ b/tests/snippets/cpp/extension-keywords.txt
@@ -1,6 +1,0 @@
----input---
-__restrict
-
----tokens---
-'__restrict'  Keyword
-'\n'          Text.Whitespace

--- a/tests/snippets/cpp/extension_keywords.txt
+++ b/tests/snippets/cpp/extension_keywords.txt
@@ -1,0 +1,17 @@
+---input---
+__restrict
+__int128
+_BitInt(2)
+
+---tokens---
+'__restrict'  Keyword
+'\n'          Text.Whitespace
+
+'__int128'    Keyword.Type
+'\n'          Text.Whitespace
+
+'_BitInt'     Keyword.Type
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
* `restrict` isn't a C++ keyword, but `__restrict` is recognised by Clang, GCC, and MSVC as a language extension.
* `_BitInt` is a new C type and an extended integral type for C++.
* `__int128` is an extended integral type on both Clang and GCC.