### PR TITLE
Update uxntal lexer to reflect current runes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,6 +237,7 @@ Other contributors, listed alphabetically, are:
 * Erick Tryzelaar -- Felix lexer
 * Alexander Udalov -- Kotlin lexer improvements
 * Thomas Van Doren -- Chapel lexer
+* Dave Van Ee -- Uxntal lexer updates
 * Daniele Varrazzo -- PostgreSQL lexers
 * Abe Voelker -- OpenEdge ABL lexer
 * Pepijn de Vos -- HTML formatter CTags support

--- a/pygments/lexers/tal.py
+++ b/pygments/lexers/tal.py
@@ -54,19 +54,22 @@ class TalLexer(RegexLexer):
             (r'[][{}](?!\S)', Punctuation), # delimiters
             (r'#([0-9a-f]{2}){1,2}(?!\S)', Number.Hex), # integer
             (r'"\S+', String), # raw string
-            (r"'\S(?!\S)", String.Char), # raw char
             (r'([0-9a-f]{2}){1,2}(?!\S)', Literal), # raw integer
             (r'[|$][0-9a-f]{1,4}(?!\S)', Keyword.Declaration), # abs/rel pad
             (r'%\S+', Name.Decorator), # macro
             (r'@\S+', Name.Function), # label
             (r'&\S+', Name.Label), # sublabel
             (r'/\S+', Name.Tag), # spacer
-            (r'\.\S+', Name.Variable.Magic), # zero page addr
-            (r',\S+', Name.Variable.Instance), # rel addr
-            (r';\S+', Name.Variable.Global), # abs addr
-            (r':\S+', Literal), # raw addr
+            (r'\.\S+', Name.Variable.Magic), # literal zero page addr
+            (r',\S+', Name.Variable.Instance), # literal rel addr
+            (r';\S+', Name.Variable.Global), # literal abs addr
+            (r'-\S+', Literal), # raw zero page addr
+            (r'_\S+', Literal), # raw relative addr
+            (r'=\S+', Literal), # raw absolute addr
+            (r'!\S+', Name.Function), # immediate jump
+            (r'\?\S+', Name.Function), # conditional immediate jump
             (r'~\S+', Keyword.Namespace), # include
-            (r'\S+', Name),
+            (r'\S+', Name.Function), # macro invocation, immediate subroutine
         ]
     }
 

--- a/tests/examplefiles/tal/piano.tal
+++ b/tests/examplefiles/tal/piano.tal
@@ -1,536 +1,528 @@
-( piano )
+( Piano:
+	Play notes with the keyboard or the controller )
 
-%+  { ADD } %-   { SUB }  %*  { MUL } %/   { DIV }
-%<  { LTH } %>   { GTH }  %=  { EQU } %!   { NEQ }
-%++ { ADD2 } %-- { SUB2 } %** { MUL2 } %// { DIV2 }
-%<< { LTH2 } %>> { GTH2 } %== { EQU2 } %!! { NEQ2 }
-%!~ { NEQk NIP }
+|00 @System &vector $2 &wst $1 &rst $1 &pad $4 &r $2 &g $2 &b $2 &debug $1 &halt $1
+|10 @Console &vector $2 &read $1 &pad $5 &write $1 &error $1
+|20 @Screen &vector $2 &width $2 &height $2 &auto $1 &pad $1 &x $2 &y $2 &addr $2 &pixel $1 &sprite $1
+|30 @Audio0 &vector $2 &position $2 &output $1 &pad $3 &adsr $2 &length $2 &addr $2 &volume $1 &pitch $1
+|40 @Audio1 &vector $2 &position $2 &output $1 &pad $3 &adsr $2 &length $2 &addr $2 &volume $1 &pitch $1
+|80 @Controller &vector $2 &button $1 &key $1
+|90 @Mouse &vector $2 &x $2 &y $2 &state $1 &pad $3 &modx $2 &mody $2
 
 %HALT { #010f DEO }
 
-%RTN  { JMP2r }
-%TOS  { #00 SWP }
-%MOD  { DUP2 / * - }
-%GTS2 { #8000 ++ SWP2 #8000 ++ << }
-%2/   { #01 SFT }
-%2//  { #01 SFT2 }
-%4//  { #02 SFT2 }
-%8//  { #03 SFT2 }
-%8**  { #30 SFT2 }
-
-%AUTO-NONE   { #00 .Screen/auto DEO }
-%AUTO-X      { #01 .Screen/auto DEO }
-%AUTO-YADDR  { #06 .Screen/auto DEO }
-
-( devices )
-
-|00 @System     &vector $2 &wst      $1 &rst    $1 &pad    $4 &r      $2 &g      $2 &b      $2 &debug  $1 &halt $1
-|10 @Console    &vector $2 &read     $1 &pad    $5 &write  $1 &error  $1
-|20 @Screen     &vector $2 &width $2 &height $2 &auto $1 &pad $1 &x $2 &y $2 &addr $2 &pixel $1 &sprite $1
-|30 @Audio0     &vector $2 &position $2 &output $1 &pad    $3 &adsr   $2 &length $2 &addr   $2 &volume $1 &pitch $1
-|80 @Controller &vector $2 &button   $1 &key    $1
-|90 @Mouse      &vector $2 &x        $2 &y      $2 &state  $1 &pad    $3 &modx   $2 &mody   $2
-|a0 @File       &vector $2 &success  $2 &stat   $2 &delete $1 &append $1 &name   $2 &length $2 &read   $2 &write $2
-
-( variables )
-
 |0000
 
-@last-note   $1
-@octave      $1
-@pointer     
-	&x $2 &y $2
-@center      
-	&x $2 &y $2
-@adsr-view   
-	&x1 $2 &y1 $2 &x2 $2 &y2 $2
-@wave-view   
-	&x1 $2 &y1 $2 &x2 $2 &y2 $2
-@octave-view 
-	&x1 $2 &y1 $2 &x2 $2 &y2 $2
-
-( program )
+	@octave $1
+	@center &x $2 &y $2
+	@adsr-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
+	@wave-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
+	@octave-view &x1 $2 &y1 $2 &x2 $2 &y2 $2
 
 |0100 ( -> )
-	
-	( theme ) 
-	#0fe5 .System/r DEO2 
-	#0fc5 .System/g DEO2 
-	#0f25 .System/b DEO2
 
-	( vectors ) 
-	;on-frame   .Screen/vector DEO2
-	;on-control .Controller/vector DEO2
-	;on-mouse   .Mouse/vector DEO2
-	;on-message .Console/vector DEO2
-
+	( theme )
+	#0fe3 .System/r DEO2
+	#0fc3 .System/g DEO2
+	#0f23 .System/b DEO2
+	( resize )
+	#0180 .Screen/width DEO2
+	#00e0 .Screen/height DEO2
 	( find center )
-	.Screen/width DEI2 2// .center/x STZ2
-	.Screen/height DEI2 2// .center/y STZ2
-
-	( place octave )
-	.center/x LDZ2 #0080 -- .octave-view/x1 STZ2
-	.center/y LDZ2 #0008 ++ .octave-view/y1 STZ2
-	.octave-view/x1 LDZ2 #0050 ++ .octave-view/x2 STZ2
-	.octave-view/y1 LDZ2 #0018 ++ .octave-view/y2 STZ2
-
+	.Screen/width DEI2 #01 SFT2
+		DUP2 .center/x STZ2
+		#0080 SUB2
+		DUP2 .octave-view/x1 STZ2
+			#0050 ADD2 .octave-view/x2 STZ2
+	.Screen/height DEI2 #01 SFT2 #0010 ADD2
+		DUP2 .center/y STZ2
+		#0010 ADD2
+		DUP2 .octave-view/y1 STZ2
+			#0018 ADD2 .octave-view/y2 STZ2
 	( place adsr )
-	.center/x LDZ2 #0020 -- .adsr-view/x1 STZ2
-	.center/y LDZ2 #0008 ++ .adsr-view/y1 STZ2
-	.adsr-view/x1 LDZ2 #00a0 ++ .adsr-view/x2 STZ2
-	.adsr-view/y1 LDZ2 #0018 ++ .adsr-view/y2 STZ2
-
+	.center/x LDZ2 #0020 SUB2 .adsr-view/x1 STZ2
+	.center/y LDZ2 #0010 ADD2 .adsr-view/y1 STZ2
+	.adsr-view/x1 LDZ2 #00a0 ADD2 .adsr-view/x2 STZ2
+	.adsr-view/y1 LDZ2 #0018 ADD2 .adsr-view/y2 STZ2
 	( place waveform )
-	.center/x LDZ2 #0080 -- .wave-view/x1 STZ2
-	.center/y LDZ2 #0020 -- .wave-view/y1 STZ2
-	.wave-view/x1 LDZ2 #0100 ++ .wave-view/x2 STZ2
-	.wave-view/y1 LDZ2 #0020 ++ .wave-view/y2 STZ2
-
-	( default settings )
-	#ff .last-note STZ
-	#041c .Audio0/adsr DEO2
-	#dd .Audio0/volume DEO
+	.center/x LDZ2 #0080 SUB2 .wave-view/x1 STZ2
+	.center/y LDZ2 #0040 SUB2 .wave-view/y1 STZ2
+	.wave-view/x1 LDZ2 #0100 ADD2 .wave-view/x2 STZ2
+	.wave-view/y1 LDZ2 #0040 ADD2 .wave-view/y2 STZ2
+	( setup synth )
+	#041c set-env
+	#dd set-vol
 	;sin-pcm .Audio0/addr DEO2
-	#0100 .Audio0/length DEO2
-
-	( inital drawing ) 
-	;draw-octave JSR2
-	;draw-adsr JSR2
-	;draw-wave JSR2
+	;sin-pcm .Audio1/addr DEO2
+	#0100
+		DUP2 .Audio0/length DEO2
+		.Audio1/length DEO2
+	( inital drawing )
+	draw-octave
+	draw-adsr
+	draw-wave
+	( unlock )
+	;on-frame .Screen/vector DEO2
+	;on-control .Controller/vector DEO2
+	;on-mouse .Mouse/vector DEO2
+	;on-message .Console/vector DEO2
 
 BRK
 
-( this data exists to test literals
-  as well as multi-line ( and nested )
-  comments )
-@test-dat "this 20 "is 20 'a 20 "test 00
-@test-ptr :test-dat
+(
+@|vectors )
 
 @on-frame ( -> )
-	
-	.adsr-view/y2 LDZ2 #0020 -- .Screen/y DEO2
 
-	#10 #00 
+	.Mouse/state DEI ?&skip-sft
+	[ LIT2 00 &soft $1 ] EQUk ?&no-soft
+		soften
+		DUP #01 SUB ,&soft STR
+		&no-soft
+	POP2
+	&skip-sft
+
+	[ LIT &last $1 ] .Audio0/output DEI NEQk ?&changed
+		POP2 BRK
+		&changed
+	,&last STR POP
+
+	( redraw )
+	[ LIT2 00 -Screen/auto ] DEO
+	.adsr-view/y2 LDZ2 #0020 SUB2 .Screen/y DEO2
+	#1000
 	&loop
-		.adsr-view/x2 LDZ2 #003a -- .Screen/x DEO2
-		#10 OVR - .Audio0/output DEI #0f AND < .Screen/pixel DEO
-		.adsr-view/x2 LDZ2 #003a -- INC2 INC2 .Screen/x DEO2
-		#10 OVR - .Audio0/output DEI #04 SFT < .Screen/pixel DEO
-		.Screen/y DEI2 INC2 INC2 .Screen/y DEO2
-		INC GTHk ,&loop JCN
+		.adsr-view/x2 LDZ2 #003a SUB2 .Screen/x DEO2
+		#10 OVR SUB .Audio0/output DEI
+			DUP2 #0f AND LTH .Screen/pixel DEO
+		.Screen/x DEI2k INC2 INC2 ROT DEO2
+			#04 SFT LTH .Screen/pixel DEO
+		.Screen/y DEI2k INC2 INC2 ROT DEO2
+		INC GTHk ?&loop
 	POP2
 
 BRK
 
 @on-control ( -> )
 
-	( clear last cursor )
-	.pointer/x LDZ2 .Screen/x DEO2 
-	.pointer/y LDZ2 .Screen/y DEO2 
-	#40 .Screen/sprite DEO
-
 	.Controller/key DEI
-	[ LIT 'a ] !~ ,&no-c JCN
-		#30 .octave LDZ #0c * + ;play JSR2 &no-c
-	[ LIT 's ] !~ ,&no-d JCN
-		#32 .octave LDZ #0c * + ;play JSR2 &no-d
-	[ LIT 'd ] !~ ,&no-e JCN
-		#34 .octave LDZ #0c * + ;play JSR2 &no-e
-	[ LIT 'f ] !~ ,&no-f JCN
-		#35 .octave LDZ #0c * + ;play JSR2 &no-f
-	[ LIT 'g ] !~ ,&no-g JCN
-		#37 .octave LDZ #0c * + ;play JSR2 &no-g
-	[ LIT 'h ] !~ ,&no-a JCN
-		#39 .octave LDZ #0c * + ;play JSR2 &no-a
-	[ LIT 'j ] !~ ,&no-b JCN
-		#3b .octave LDZ #0c * + ;play JSR2 &no-b
-	[ LIT 'k ] !~ ,&no-c2 JCN
-		#3c .octave LDZ #0c * + ;play JSR2 &no-c2
-	[ #1b ] !~ ,&no-esc JCN HALT &no-esc
+	( octave )
+	[ LIT "a ] NEQk NIP ?&no-c #30 .octave LDZ #0c MUL ADD play &no-c
+	[ LIT "w ] NEQk NIP ?&no-c# #31 .octave LDZ #0c MUL ADD play &no-c#
+	[ LIT "s ] NEQk NIP ?&no-d #32 .octave LDZ #0c MUL ADD play &no-d
+	[ LIT "e ] NEQk NIP ?&no-d# #33 .octave LDZ #0c MUL ADD play &no-d#
+	[ LIT "d ] NEQk NIP ?&no-e #34 .octave LDZ #0c MUL ADD play &no-e
+	[ LIT "f ] NEQk NIP ?&no-f #35 .octave LDZ #0c MUL ADD play &no-f
+	[ LIT "t ] NEQk NIP ?&no-f# #36 .octave LDZ #0c MUL ADD play &no-f#
+	[ LIT "g ] NEQk NIP ?&no-g #37 .octave LDZ #0c MUL ADD play &no-g
+	[ LIT "y ] NEQk NIP ?&no-g# #38 .octave LDZ #0c MUL ADD play &no-g#
+	[ LIT "h ] NEQk NIP ?&no-a #39 .octave LDZ #0c MUL ADD play &no-a
+	[ LIT "u ] NEQk NIP ?&no-a# #3a .octave LDZ #0c MUL ADD play &no-a#
+	[ LIT "j ] NEQk NIP ?&no-b #3b .octave LDZ #0c MUL ADD play &no-b
+	[ LIT "k ] NEQk NIP ?&no-c2 #3c .octave LDZ #0c MUL ADD play &no-c2
+	( controls )
+	[ LIT "z ] NEQk NIP ?&no-dec .octave LDZk #01 SUB SWP STZ &no-dec
+	[ LIT "x ] NEQk NIP ?&no-inc .octave LDZk INC SWP STZ &no-inc
+	[ #1b ] NEQk NIP ?&no-esc HALT &no-esc
 	POP
 
 	( release )
 	#00 .Controller/key DEO
 
-	.Controller/button DEI 
-	DUP #11 ! ,&cu JCN #3c ;play JSR2 &cu
-	DUP #21 ! ,&cd JCN #3d ;play JSR2 &cd
-	DUP #41 ! ,&cl JCN #3e ;play JSR2 &cl
-	DUP #81 ! ,&cr JCN #3f ;play JSR2 &cr
-	DUP #12 ! ,&au JCN #40 ;play JSR2 &au
-	DUP #22 ! ,&ad JCN #41 ;play JSR2 &ad
-	DUP #42 ! ,&al JCN #42 ;play JSR2 &al
-	DUP #82 ! ,&ar JCN #43 ;play JSR2 &ar
-	DUP #14 ! ,&su JCN #44 ;play JSR2 &su
-	DUP #24 ! ,&sd JCN #45 ;play JSR2 &sd
-	DUP #44 ! ,&sl JCN #46 ;play JSR2 &sl
-	DUP #84 ! ,&sr JCN #47 ;play JSR2 &sr
-	DUP #40 ! ,&l JCN .Audio0/addr DEI2 #0010 -- .Audio0/addr DEO2 &l
-	DUP #80 ! ,&r JCN .Audio0/addr DEI2 #0010 ++ .Audio0/addr DEO2 &r
+	.Controller/button DEI
+	[ #11 ] NEQk NIP ?&cu #3c play &cu
+	[ #21 ] NEQk NIP ?&cd #3d play &cd
+	[ #41 ] NEQk NIP ?&cl #3e play &cl
+	[ #81 ] NEQk NIP ?&cr #3f play &cr
+	[ #12 ] NEQk NIP ?&au #40 play &au
+	[ #22 ] NEQk NIP ?&ad #41 play &ad
+	[ #42 ] NEQk NIP ?&al #42 play &al
+	[ #82 ] NEQk NIP ?&ar #43 play &ar
+	[ #14 ] NEQk NIP ?&su #44 play &su
+	[ #24 ] NEQk NIP ?&sd #45 play &sd
+	[ #44 ] NEQk NIP ?&sl #46 play &sl
+	[ #84 ] NEQk NIP ?&sr #47 play &sr
 	POP
 
-	;draw-octave JSR2
-	;draw-wave JSR2
+	draw-octave
 
 BRK
 
 @on-message ( -> )
-	
-	.Console/read DEI ;play JSR2
-	;draw-octave JSR2
+
+	.Console/read DEI play
+	draw-octave
 
 BRK
 
 @on-mouse ( -> )
 
-	;draw-cursor JSR2 
-	
-	.Mouse/state DEI #00 ! #01 JCN [ BRK ]
+	#00 .Mouse/state DEI NEQ #41 ADD ;cursor-icn update-cursor
 
-	.Mouse/x DEI2 .Mouse/y DEI2 .wave-view ;within-rect JSR2 
-		;on-touch-wave-view JCN2
-	.Mouse/x DEI2 .Mouse/y DEI2 .adsr-view ;within-rect JSR2 
-		;on-touch-adsr-view JCN2
-	.Mouse/x DEI2 .Mouse/y DEI2 .octave-view ;within-rect JSR2 
-		;on-touch-octave-view JCN2
+	.Mouse/state DEI ?on-mouse-touch
+
+BRK
+
+@on-mouse-touch ( -> )
+
+	.Mouse/x DEI2 .Mouse/y DEI2 .wave-view within-rect
+		?on-touch-wave-view
+	.Mouse/x DEI2 .Mouse/y DEI2 .adsr-view within-rect
+		?on-touch-knobs-view
+	.Mouse/x DEI2 .Mouse/y DEI2 .octave-view within-rect
+		?on-touch-octave-view
 
 BRK
 
 @on-touch-wave-view ( -> )
 
-	.Mouse/x DEI2 .wave-view/x1 LDZ2 -- .Audio0/length DEO2
-	;draw-wave JSR2
-	;draw-cursor JSR2 
+	.Mouse/state DEI #01 GTH ?&paint
+	.Mouse/x DEI2 .wave-view/x1 LDZ2 SUB2
+		( min ) #0010 GTH2k [ JMP SWP2 POP2 ] set-length
+
+BRK
+
+&paint ( -> )
+
+	.Mouse/y DEI2 .wave-view/y1 LDZ2 SUB2 #20 SFT2 NIP
+	.Mouse/x DEI2 .wave-view/x1 LDZ2 SUB2 ;sin-pcm ADD2 STA
+	draw-wave
+	#10 ;on-frame/soft STA
 
 BRK
 
 @on-touch-octave-view ( -> )
 
-	.Mouse/x DEI2 .octave-view/x1 LDZ2 -- 8// NIP #09 ! ,&no-mod JCN
-		.Mouse/y DEI2 .octave-view/y1 LDZ2 -- 8// NIP 
-		[ #00 ] !~ ,&no-incr JCN
-			.octave LDZ #03 = ,&no-incr JCN
+	.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 NIP #09 NEQ ?&no-mod
+		.Mouse/y DEI2 .octave-view/y1 LDZ2 SUB2 #03 SFT2 NIP
+		[ #00 ] NEQk NIP ?&no-incr
+			.octave LDZ #03 EQU ?&no-incr
 			.octave LDZ INC .octave STZ &no-incr
-		[ #02 ] !~ ,&no-decr JCN
-			.octave LDZ #ff = ,&no-decr JCN
-			.octave LDZ #01 - .octave STZ &no-decr
+		[ #02 ] NEQk NIP ?&no-decr
+			.octave LDZ #ff EQU ?&no-decr
+			.octave LDZ #01 SUB .octave STZ &no-decr
 		POP
 		( release ) #00 .Mouse/state DEO
-		;draw-octave JSR2
+		draw-octave
 		BRK
 	&no-mod
 
-	.Mouse/x DEI2 .octave-view/x1 LDZ2 -- 8// NIP #06 > ,&no-key JCN
-		.Mouse/x DEI2 .octave-view/x1 LDZ2 -- 8// ;notes ++ LDA .octave LDZ #0c * + ;play JSR2
+	.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 NIP #06 GTH ?&no-key
+		.Mouse/x DEI2 .octave-view/x1 LDZ2 SUB2 #03 SFT2 ;notes-lut ADD2 LDA .octave LDZ #0c MUL ADD play
 		( release ) #00 .Mouse/state DEO
-		;draw-octave JSR2
+		draw-octave
 	&no-key
-
-BRK 
-
-@on-touch-adsr-view ( -> )
-
-	.Mouse/x DEI2 .adsr-view/x1 LDZ2 -- 8// NIP #03 /
-	[ #00 ] !~ ,&no-a JCN
-		.Audio0/adsr DEI
-		#10 .Mouse/state DEI #10 = #e0 * + +
-		.Audio0/adsr DEO &no-a
-	[ #01 ] !~ ,&no-d JCN
-		.Audio0/adsr DEI
-		DUP #f0 AND STH #01 .Mouse/state DEI #10 = #0e * + + #0f AND STHr +
-		.Audio0/adsr DEO &no-d
-	[ #02 ] !~ ,&no-s JCN
-		.Audio0/adsr INC DEI
-		#10 .Mouse/state DEI #10 = #e0 * + +
-		.Audio0/adsr INC DEO &no-s
-	[ #03 ] !~ ,&no-r JCN
-		.Audio0/adsr INC DEI
-		DUP #f0 AND STH #01 .Mouse/state DEI #10 = #0e * + + #0f AND STHr +
-		.Audio0/adsr INC DEO &no-r
-	[ #05 ] !~ ,&no-left JCN
-		.Audio0/volume DEI 
-		#10 .Mouse/state DEI #10 = #e0 * + +
-		.Audio0/volume DEO &no-left
-	[ #06 ] !~ ,&no-right JCN
-		.Audio0/volume DEI
-		DUP #f0 AND STH #01 .Mouse/state DEI #10 = #0e * + + #0f AND STHr +
-		.Audio0/volume DEO &no-right
-	POP
-
-	( release ) #00 .Mouse/state DEO
-	;draw-adsr JSR2
-	;draw-cursor JSR2 
 
 BRK
 
+@on-touch-knobs-view ( -> )
+
+	.Mouse/x DEI2 .adsr-view/x1 LDZ2 SUB2 #03 SFT2 NIP #03 DIV
+	.Mouse/y DEI2 .adsr-view/y1 LDZ2 SUB2 NIP
+	OVR #04 LTH ?on-touch-adsr
+	OVR #04 GTH ?on-touch-vol
+	POP2
+
+BRK
+
+@on-touch-adsr ( knob value -> )
+
+	STH2
+	( mask ) #ffff #000f #03 OVRr STHr SUB #60 SFT SFT2 EOR2
+		.Audio0/adsr DEI2 AND2
+	( value ) #000f STHr OVR LTHk [ JMP SWP POP ] SUB
+	( shift ) #03 STHr SUB #60 SFT SFT2 ORA2
+	set-env
+
+BRK
+
+@on-touch-vol ( knob value -> )
+
+	SWP #03 SUB INC INC SWP STH2
+	( mask ) #0f OVRr STHr #60 SFT SFT
+		.Audio0/volume DEI AND
+	( value ) #0f STHr OVR LTHk [ JMP SWP POP ] SUB
+	( shift ) #01 STHr SUB #60 SFT SFT ORA
+	set-vol
+
+BRK
+
+(
+@|core )
+
 @play ( pitch -- )
-	
-	DUP #0c MOD .last-note STZ 
-	.Audio0/pitch DEO
 
-RTN
+	DUP #0c DIVk MUL SUB ;draw-octave/last STA
+	DUP .Audio0/pitch DEO
+		#0c SUB .Audio1/pitch DEO
 
-@draw-cursor ( -- )
-	
-	( clear last cursor )
-	;cursor .Screen/addr DEO2 
-	.pointer/x LDZ2 .Screen/x DEO2 
-	.pointer/y LDZ2 .Screen/y DEO2 
-	#40 .Screen/sprite DEO
-	( record pointer positions )
-	.Mouse/x DEI2 DUP2 .pointer/x STZ2 .Screen/x DEO2 
-	.Mouse/y DEI2 DUP2 .pointer/y STZ2 .Screen/y DEO2  
-	( colorize on state )
-	#41 [ .Mouse/state DEI #00 ! ] + .Screen/sprite DEO
+JMP2r
 
-RTN
+@set-length ( length* -- )
+
+	DUP2 .Audio0/length DEO2
+		.Audio1/length DEO2
+
+!draw-wave
+
+@set-vol ( vol -- )
+
+	DUP .Audio0/volume DEO
+		.Audio1/volume DEO
+
+!draw-adsr
+
+@set-env ( adsr* -- )
+
+	DUP2 .Audio0/adsr DEO2
+		.Audio1/adsr DEO2
+
+!draw-adsr
+
+@soften ( -- )
+
+	#0100 #0000
+	&l
+		DUP2 ;sin-pcm ADD2 get-average SWP2 STA POP
+		INC2 GTH2k ?&l
+	POP2 POP2
+	draw-wave
+
+JMP2r
+
+@get-average ( addr* -- addr* average* )
+
+	[ LIT2r 0000 ]
+	DUP2 #0001 SUB2 DUP2 #0002 ADD2 SWP2
+	&l
+		LDAk LITr 00 STH ADD2r
+		INC2 GTH2k ?&l
+	POP2 POP2
+	LDAk #00 SWP DUP2 DUP2 STH2r
+	#01 SFT2 ADD2 ADD2 ADD2 #02 SFT2
+
+JMP2r
+
+(
+@|drawing )
+
+@update-cursor ( color addr* -- )
+
+	[ LIT2 00 -Screen/auto ] DEO
+	#40 draw-cursor
+	.Mouse/x DEI2 ,draw-cursor/x STR2
+	.Mouse/y DEI2 ,draw-cursor/y STR2
+	.Screen/addr DEO2
+
+@draw-cursor ( color -- )
+
+	[ LIT2 &x $2 ] .Screen/x DEO2
+	[ LIT2 &y $2 ] .Screen/y DEO2
+	.Screen/sprite DEO
+
+JMP2r
 
 @draw-octave ( -- )
-	
-	.octave-view/x1 LDZ2 #0048 ++ .Screen/x DEO2
 
-	;arrow-icns .Screen/addr DEO2
+	( arrows )
+	[ LIT2 02 -Screen/auto ] DEO
+	.octave-view/x1 LDZ2 #0048 ADD2 .Screen/x DEO2
 	.octave-view/y1 LDZ2 .Screen/y DEO2
-	#01 .Screen/sprite DEO
-
-	;arrow-icns #0008 ++ .Screen/addr DEO2
-	.octave-view/y1 LDZ2 #0010 ++ .Screen/y DEO2
-	#01 .Screen/sprite DEO
-
-	;font-hex .octave LDZ #03 + #00 SWP 8** ++ .Screen/addr DEO2
-	.octave-view/y1 LDZ2 #0008 ++ .Screen/y DEO2
-	#03 .Screen/sprite DEO
-
+	;arrow-icns .Screen/addr DEO2
+	[ LIT2 01 -Screen/sprite ] DEO
+	;font-hex .octave LDZ #03 ADD #00 SWP #30 SFT2 ADD2 .Screen/addr DEO2
+	[ LIT2 02 -Screen/sprite ] DEO
+	;arrow-icns/down .Screen/addr DEO2
+	[ LIT2 01 -Screen/sprite ] DEO
+	( octave )
 	.octave-view/x1 LDZ2 .Screen/x DEO2
 	.octave-view/y1 LDZ2 .Screen/y DEO2
-	AUTO-YADDR
-	.last-note LDZ STH
-	;keys-left-icns STHkr #00 = INC ,draw-key JSR
-	;keys-middle-icns STHkr #02 = INC ,draw-key JSR
-	;keys-right-icns STHkr #04 = INC ,draw-key JSR
-	;keys-left-icns STHkr #05 = INC ,draw-key JSR
-	;keys-middle-icns STHkr #07 = INC ,draw-key JSR
-	;keys-middle-icns STHkr #09 = INC ,draw-key JSR
-	;keys-right-icns STHr #0b = INC ,draw-key JSR
-	AUTO-NONE
+	[ LIT2 06 -Screen/auto ] DEO
+	[ LITr &last ff ]
+	;keys-left-icns STHkr #00 EQU INC draw-key
+	;keys-middle-icns STHkr #02 EQU INC draw-key
+	;keys-right-icns STHkr #04 EQU INC draw-key
+	;keys-left-icns STHkr #05 EQU INC draw-key
+	;keys-middle-icns STHkr #07 EQU INC draw-key
+	;keys-middle-icns STHkr #09 EQU INC draw-key
+	;keys-right-icns STHr #0b EQU INC
 
-RTN
+( >> )
 
 @draw-key ( addr* color -- )
-		
+
 	STH
 	.Screen/addr DEO2
 	.Screen/y DEI2
 	STHr .Screen/sprite DEOk DEOk DEO
-	.Screen/x DEI2k #0008 ++ ROT DEO2
+	.Screen/x DEI2k #0008 ADD2 ROT DEO2
 	.Screen/y DEO2
 
-RTN
+JMP2r
 
 @draw-adsr ( -- )
-	
+
 	( adsr )
 	.adsr-view/x1 LDZ2 .adsr-view/y1 LDZ2
-		.Audio0/adsr DEI #04 SFT
-		;draw-knob JSR2
-	.adsr-view/x1 LDZ2 #0018 ++ .adsr-view/y1 LDZ2
-		.Audio0/adsr DEI #0f AND
-		;draw-knob JSR2
-	.adsr-view/x1 LDZ2 #0030 ++ .adsr-view/y1 LDZ2
-		.Audio0/adsr INC DEI #04 SFT
-		;draw-knob JSR2
-	.adsr-view/x1 LDZ2 #0048 ++ .adsr-view/y1 LDZ2
-		.Audio0/adsr INC DEI #0f AND
-		;draw-knob JSR2
+		.Audio0/adsr DEI #04 SFT draw-knob
+	.adsr-view/x1 LDZ2 #0018 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr DEI #0f AND draw-knob
+	.adsr-view/x1 LDZ2 #0030 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr INC DEI #04 SFT draw-knob
+	.adsr-view/x1 LDZ2 #0048 ADD2 .adsr-view/y1 LDZ2
+		.Audio0/adsr INC DEI #0f AND draw-knob
 	( volume )
-	.adsr-view/x2 LDZ2 #0028 -- .adsr-view/y1 LDZ2
-		.Audio0/volume DEI #04 SFT
-		;draw-knob JSR2
-	.adsr-view/x2 LDZ2 #0010 -- .adsr-view/y1 LDZ2
+	.adsr-view/x2 LDZ2 #0028 SUB2 .adsr-view/y1 LDZ2
+		.Audio0/volume DEI #04 SFT draw-knob
+	.adsr-view/x2 LDZ2 #0010 SUB2 .adsr-view/y1 LDZ2
 		.Audio0/volume DEI #0f AND
-		;draw-knob JSR2
 
-RTN
+!draw-knob
 
 @draw-wave ( -- )
-	
-	( clear )
-	.wave-view/x1 LDZ2
-	.wave-view/y1 LDZ2
-	.wave-view/x2 LDZ2 INC2
-	.wave-view/y2 LDZ2
-	#00 ;fill-rect JSR2
 
-	#01 ;draw-wave-length JSR2
-
+	( background )
 	.wave-view/x1 LDZ2 .Screen/x DEO2
-
+	.wave-view/y1 LDZ2 .Screen/y DEO2
+	;fill-icn .Screen/addr DEO2
+	[ LIT2 75 -Screen/auto ] DEO
+	#e0 &lbg
+		;dotted-icn .Screen/addr DEO2
+		[ LIT2 0c -Screen/sprite ] DEO
+		INC DUP ?&lbg
+	POP
+	.wave-view/x1 LDZ2 .Screen/x DEO2
 	( waveform )
-	#ff #00 
+	[ LIT2 01 -Screen/auto ] DEO
+	;sin-pcm/end ;sin-pcm
 	&loop
-		( dotted line )
-		DUP #01 AND ,&no-dot JCN 
-			.wave-view/y1 LDZ2 #0010 ++ .Screen/y DEO2
-			#03 .Screen/pixel DEO
-		&no-dot
-		#00 OVR .Audio0/addr DEI2 ++ LDA 
-		2/
-		TOS 4// .wave-view/y1 LDZ2 ++ .Screen/y DEO2
-		.Screen/x DEI2 INC2 .Screen/x DEO2
-		( draw ) DUP 
-			.Audio0/length DEI2 NIP > 
-			.Audio0/length DEI2 #0100 !! #0101 == DUP ADD INC .Screen/pixel DEO
-		INC GTHk ,&loop JCN
-	POP2
-
-	( range )
-	AUTO-X
-	.wave-view/x1 LDZ2 .Screen/x DEO2
-	.wave-view/y1 LDZ2 #0010 -- .Screen/y DEO2
-	.Audio0/addr DEI2 #02 ;draw-short JSR2
-	.wave-view/x2 LDZ2 #0020 -- .Screen/x DEO2
-	.Audio0/length DEI2 #02 ;draw-short JSR2
-	AUTO-NONE
-
-RTN
-
-@draw-wave-length ( color -- )
-	
-	STH
-	.wave-view/x1 LDZ2 .Audio0/length DEI2 ++ .Screen/x DEO2
-	.wave-view/y1 LDZ2 DUP2 #0020 ++ SWP2
-	&loop
-		DUP2 .Screen/y DEO2
-		( draw ) STHkr .Screen/pixel DEO
-		INC2 GTH2k ,&loop JCN
+		DUP2 ;sin-pcm SUB2 .Audio0/length DEI2 DIV2k MUL2 SUB2 ;sin-pcm ADD2 LDA
+		#00 SWP #02 SFT2 .wave-view/y1 LDZ2 ADD2 .Screen/y DEO2
+		( draw ) DUP2 ;sin-pcm SUB2 NIP .Audio0/length DEI2 NIP #01 SUB GTH INC .Screen/pixel DEO
+		INC2 GTH2k ?&loop
 	POP2 POP2
-	POPr
+	( length line )
+	.wave-view/x1 LDZ2 .Audio0/length DEI2 #0001 SUB2 ADD2 .Screen/x DEO2
+	.wave-view/y1 LDZ2 .Screen/y DEO2
+	;line-icn .Screen/addr DEO2
+	[ LIT2 71 -Screen/auto ] DEO
+	[ LIT2 05 -Screen/sprite ] DEO
+	( range )
+	[ LIT2 01 -Screen/auto ] DEO
+	.wave-view/x1 LDZ2 .Screen/x DEO2
+	.wave-view/y1 LDZ2 #0018 SUB2 .Screen/y DEO2
+	.Audio0/length DEI2
 
-RTN
+!draw-short
 
 @draw-knob ( x* y* value -- )
 
-	( load ) STH .Screen/y DEO2  .Screen/x DEO2
-	;knob-icns .Screen/addr DEO2 
-		( draw ) #01 .Screen/sprite DEO
-	.Screen/x DEI2 #0008 ++ .Screen/x DEO2 
-	;knob-icns #0008 ++ .Screen/addr DEO2 
-		( draw ) #01 .Screen/sprite DEO
-	.Screen/y DEI2 #0008 ++ .Screen/y DEO2 
-	;knob-icns #0018 ++ .Screen/addr DEO2 
-		( draw ) #01 .Screen/sprite DEO
-	.Screen/x DEI2 #0008 -- .Screen/x DEO2 
-	;knob-icns #0010 ++ .Screen/addr DEO2 
-		( draw ) #01 .Screen/sprite DEO
-	.Screen/x DEI2 #0004 ++ .Screen/x DEO2
-	.Screen/y DEI2 #0008 ++ .Screen/y DEO2
-	;font-hex #00 STHkr #30 SFT ++ .Screen/addr DEO2
-		( draw ) #01 .Screen/sprite DEO
-	.Screen/x DEI2 #0004 -- #00 #00 STHkr ;knob-offsetx ++ LDA ++ .Screen/x DEO2
-	.Screen/y DEI2 #0010 -- #00 #00 STHr ;knob-offsety ++ LDA ++ .Screen/y DEO2
-	;knob-icns #0020 ++ .Screen/addr DEO2
-		( draw ) #05 .Screen/sprite DEO
+	STH
+	OVR2 OVR2 .Screen/y DEO2 .Screen/x DEO2
+	( circle )
+	;knob-icns .Screen/addr DEO2
+	[ LIT2 16 -Screen/auto ] DEO
+	[ LIT2 01 -Screen/sprite ] DEOk DEO
+	( value )
+	#0010 ADD2 .Screen/y DEO2
+	#0004 ADD2 .Screen/x DEO2
+	;font-hex #00 STHkr #30 SFT ADD2 .Screen/addr DEO2
+	[ LIT2 00 -Screen/auto ] DEO
+	[ LIT2 01 -Screen/sprite ] DEO
+	( marker )
+	.Screen/x DEI2 #0004 SUB2 #0000 STHkr ;knob-offsetx ADD2 LDA ADD2 .Screen/x DEO2
+	.Screen/y DEI2 #0010 SUB2 #0000 STHr ;knob-offsety ADD2 LDA ADD2 .Screen/y DEO2
+	;knob-icns/index .Screen/addr DEO2
+	[ LIT2 05 -Screen/sprite ] DEO
 
-RTN
+JMP2r
 
-@draw-short ( short* color -- )
+@draw-short ( short* -- )
 
-	STH 
-	SWP STHkr ,draw-byte JSR 
-	STHr 
+	SWP draw-byte
 
-@draw-byte ( byte color -- )
+@draw-byte ( byte -- )
 
-	STH 
-	DUP #04 SFT STHkr ,draw-hex JSR #0f AND 
-	STHr 
+	DUP #04 SFT draw-hex #0f AND
 
-@draw-hex ( char color -- )
+@draw-hex ( char -- )
 
-	SWP TOS 8** ;font-hex ++ .Screen/addr DEO2
-	.Screen/sprite DEO
+	#00 SWP #30 SFT2 ;font-hex ADD2 .Screen/addr DEO2
+	[ LIT2 02 -Screen/sprite ] DEO
 
-RTN
-
-@fill-rect ( x1* y1* x2* y2* color -- )
-	
-	,&color STR
-	( x1 x2 y1 y2 ) ROT2
-	&ver
-		( save ) DUP2 .Screen/y DEO2
-		STH2 STH2 OVR2 OVR2 SWP2
-		&hor
-			( save ) DUP2 .Screen/x DEO2
-			( draw ) ,&color LDR .Screen/pixel DEO
-			( incr ) INC2
-			OVR2 OVR2 GTS2 ,&hor JCN
-		POP2 POP2 STH2r STH2r
-		( incr ) INC2
-		OVR2 OVR2 GTS2 ,&ver JCN
-	POP2 POP2 POP2 POP2
-
-RTN
-	&color $1
+JMP2r
 
 @within-rect ( x* y* rect -- flag )
-	
+
 	STH
-	( y < rect.y1 ) DUP2 STHkr #02 ADD LDZ2 LTH2 ,&skip JCN
-	( y > rect.y2 ) DUP2 STHkr #06 ADD LDZ2 GTH2 ,&skip JCN
+	( y < rect.y1 ) DUP2 STHkr INC INC LDZ2 LTH2 ?&skip
+	( y > rect.y2 ) DUP2 STHkr #06 ADD LDZ2 GTH2 ?&skip
 	SWP2
-	( x < rect.x1 ) DUP2 STHkr LDZ2 LTH2 ,&skip JCN
-	( x > rect.x2 ) DUP2 STHkr #04 ADD LDZ2 GTH2 ,&skip JCN
+	( x < rect.x1 ) DUP2 STHkr LDZ2 LTH2 ?&skip
+	( x > rect.x2 ) DUP2 STHkr #04 ADD LDZ2 GTH2 ?&skip
 	POP2 POP2 POPr
-	#01 
-RTN
+	#01
+JMP2r
 	&skip
 	POP2 POP2 POPr
 	#00
 
-RTN
+JMP2r
 
-@cursor 
-	80c0 e0f0 f8e0 1000 
+@phex ( short* -- ) SWP phex/b &b DUP #04 SFT phex/c &c #0f AND DUP #09 GTH #27 MUL ADD #30 ADD #18 DEO JMP2r
 
-@arrow-icns 
+(
+@|assets )
+
+@notes-lut [
+	30 32 34 35 37 39 3b 3c ]
+
+@dotted-icn [
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	aa00 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000
+	0000 0000 0000 0000 ]
+@line-icn [
+	8080 8080 8080 8080
+	]
+@fill-icn [
+	ffff ffff ffff ffff ]
+@cursor-icn [
+	80c0 e0f0 f8e0 1000 ]
+@arrow-icns [
 	0010 387c fe10 1000
-	0010 1010 fe7c 3810 
-
-@notes 
-	30 32 34 35
-	37 39 3b 3c
-
-@keys-left-icns 
+&down
+	0010 1010 fe7c 3810 ]
+@keys-left-icns [
 	7c7c 7c7c 7c7c 7c7c
 	7c7c 7c7c 7c7c 7e7f
-	7f7f 7f7f 7f7f 3e00 
-
-@keys-middle-icns 
+	7f7f 7f7f 7f7f 3e00 ]
+@keys-middle-icns [
 	1c1c 1c1c 1c1c 1c1c
 	1c1c 1c1c 1c1c 3e7f
-	7f7f 7f7f 7f7f 3e00 
-
-@keys-right-icns 
+	7f7f 7f7f 7f7f 3e00 ]
+@keys-right-icns [
 	1f1f 1f1f 1f1f 1f1f
 	1f1f 1f1f 1f1f 3f7f
-	7f7f 7f7f 7f7f 3e00 
-
-@knob-icns 
+	7f7f 7f7f 7f7f 3e00 ]
+@knob-icns [
 	0003 0c10 2020 4040
 	00c0 3008 0404 0202
 	4040 2020 100c 0300
 	0202 0404 0830 c000
-	0000 183c 3c18 0000 
-
-@knob-offsetx 
+	&index
+	0000 183c 3c18 0000 ]
+@knob-offsetx [
 	01 00 00 00 00 01 02 03
-	05 06 07 08 08 08 08 07 
-
-@knob-offsety 
+	05 06 07 08 08 08 08 07 ]
+@knob-offsety [
 	07 06 05 03 02 01 00 00
-	00 00 01 02 03 05 06 07 
-
-@font-hex ( 0-F )
+	00 00 01 02 03 05 06 07 ]
+@font-hex [
 	007c 8282 8282 827c 0030 1010 1010 1010
 	007c 8202 7c80 80fe 007c 8202 1c02 827c
 	000c 1424 4484 fe04 00fe 8080 7c02 827c
@@ -538,9 +530,10 @@ RTN
 	007c 8282 7c82 827c 007c 8282 7e02 827c
 	007c 8202 7e82 827e 00fc 8282 fc82 82fc
 	007c 8280 8080 827c 00fc 8282 8282 82fc
-	007c 8280 f080 827c 007c 8280 f080 8080 
+	007c 8280 f080 827c 007c 8280 f080 8080 ]
 
-@sin-pcm
+( pad ) [ 8080 8080 ]
+@sin-pcm [
 	8083 8689 8c8f 9295 989b 9ea1 a4a7 aaad
 	b0b3 b6b9 bbbe c1c3 c6c9 cbce d0d2 d5d7
 	d9db dee0 e2e4 e6e7 e9eb ecee f0f1 f2f4
@@ -556,4 +549,7 @@ RTN
 	0102 0202 0202 0303 0405 0506 0708 090a
 	0b0c 0e0f 1012 1415 1719 1a1c 1e20 2225
 	2729 2b2e 3032 3537 3a3d 3f42 4547 4a4d
-	5053 5659 5c5f 6265 686b 6e71 7477 7a7d
+	5053 5659 5c5f 6265 686b 6e71 7477 7a7d ]
+	&end
+( pad ) [ 8080 8080 ]
+

--- a/tests/examplefiles/tal/piano.tal.output
+++ b/tests/examplefiles/tal/piano.tal.output
@@ -1,349 +1,42 @@
 '('           Comment.Multiline
-' piano '     Comment.Multiline
-')'           Comment.Multiline
-'\n\n'        Text.Whitespace
-
-'%+'          Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'ADD'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%-'          Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'SUB'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'  '          Text.Whitespace
-'%*'          Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'MUL'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%/'          Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'DIV'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%<'          Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'LTH'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%>'          Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'GTH'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'  '          Text.Whitespace
-'%='          Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'EQU'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%!'          Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'NEQ'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%++'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'ADD2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%--'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'SUB2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%**'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'MUL2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%//'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'DIV2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%<<'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'LTH2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%>>'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'GTH2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%=='         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'EQU2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-' '           Text.Whitespace
-'%!!'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'NEQ2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%!~'         Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'NEQk'        Keyword.Reserved
-' '           Text.Whitespace
-'NIP'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n\n'        Text.Whitespace
-
-'%HALT'       Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#010f'       Literal.Number.Hex
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n\n'        Text.Whitespace
-
-'%RTN'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'JMP2r'       Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%TOS'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-'SWP'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%MOD'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
-' '           Text.Whitespace
-'/'           Name
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'-'           Name
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%GTS2'       Name.Decorator
-' '           Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#8000'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'SWP2'        Keyword.Reserved
-' '           Text.Whitespace
-'#8000'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'<<'          Name
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%2/'         Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'SFT'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%2//'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'SFT2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%4//'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#02'         Literal.Number.Hex
-' '           Text.Whitespace
-'SFT2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%8//'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#03'         Literal.Number.Hex
-' '           Text.Whitespace
-'SFT2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%8**'        Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#30'         Literal.Number.Hex
-' '           Text.Whitespace
-'SFT2'        Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n\n'        Text.Whitespace
-
-'%AUTO-NONE'  Name.Decorator
-'   '         Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/auto' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%AUTO-X'     Name.Decorator
-'      '      Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/auto' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n'          Text.Whitespace
-
-'%AUTO-YADDR' Name.Decorator
-'  '          Text.Whitespace
-'{'           Punctuation
-' '           Text.Whitespace
-'#06'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/auto' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'}'           Punctuation
-'\n\n'        Text.Whitespace
-
-'('           Comment.Multiline
-' devices '   Comment.Multiline
+' Piano:\n\tPlay notes with the keyboard or the controller ' Comment.Multiline
 ')'           Comment.Multiline
 '\n\n'        Text.Whitespace
 
 '|00'         Keyword.Declaration
 ' '           Text.Whitespace
 '@System'     Name.Function
-'     '       Text.Whitespace
+' '           Text.Whitespace
 '&vector'     Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&wst'        Name.Label
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&rst'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&pad'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$4'          Keyword.Declaration
 ' '           Text.Whitespace
 '&r'          Name.Label
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&g'          Name.Label
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&b'          Name.Label
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&debug'      Name.Label
-'  '          Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&halt'       Name.Label
@@ -354,32 +47,32 @@
 '|10'         Keyword.Declaration
 ' '           Text.Whitespace
 '@Console'    Name.Function
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '&vector'     Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&read'       Name.Label
-'     '       Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&pad'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$5'          Keyword.Declaration
 ' '           Text.Whitespace
 '&write'      Name.Label
-'  '          Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&error'      Name.Label
-'  '          Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 '\n'          Text.Whitespace
 
 '|20'         Keyword.Declaration
 ' '           Text.Whitespace
 '@Screen'     Name.Function
-'     '       Text.Whitespace
+' '           Text.Whitespace
 '&vector'     Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -424,7 +117,7 @@
 '|30'         Keyword.Declaration
 ' '           Text.Whitespace
 '@Audio0'     Name.Function
-'     '       Text.Whitespace
+' '           Text.Whitespace
 '&vector'     Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -438,11 +131,11 @@
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&pad'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$3'          Keyword.Declaration
 ' '           Text.Whitespace
 '&adsr'       Name.Label
-'   '         Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&length'     Name.Label
@@ -450,7 +143,48 @@
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&addr'       Name.Label
-'   '         Text.Whitespace
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+'&volume'     Name.Label
+' '           Text.Whitespace
+'$1'          Keyword.Declaration
+' '           Text.Whitespace
+'&pitch'      Name.Label
+' '           Text.Whitespace
+'$1'          Keyword.Declaration
+'\n'          Text.Whitespace
+
+'|40'         Keyword.Declaration
+' '           Text.Whitespace
+'@Audio1'     Name.Function
+' '           Text.Whitespace
+'&vector'     Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+'&position'   Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+'&output'     Name.Label
+' '           Text.Whitespace
+'$1'          Keyword.Declaration
+' '           Text.Whitespace
+'&pad'        Name.Label
+' '           Text.Whitespace
+'$3'          Keyword.Declaration
+' '           Text.Whitespace
+'&adsr'       Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+'&length'     Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+'&addr'       Name.Label
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&volume'     Name.Label
@@ -471,119 +205,66 @@
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&button'     Name.Label
-'   '         Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&key'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 '\n'          Text.Whitespace
 
 '|90'         Keyword.Declaration
 ' '           Text.Whitespace
 '@Mouse'      Name.Function
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '&vector'     Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&x'          Name.Label
-'        '    Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&y'          Name.Label
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&state'      Name.Label
-'  '          Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
 ' '           Text.Whitespace
 '&pad'        Name.Label
-'    '        Text.Whitespace
+' '           Text.Whitespace
 '$3'          Keyword.Declaration
 ' '           Text.Whitespace
 '&modx'       Name.Label
-'   '         Text.Whitespace
+' '           Text.Whitespace
 '$2'          Keyword.Declaration
 ' '           Text.Whitespace
 '&mody'       Name.Label
-'   '         Text.Whitespace
-'$2'          Keyword.Declaration
-'\n'          Text.Whitespace
-
-'|a0'         Keyword.Declaration
-' '           Text.Whitespace
-'@File'       Name.Function
-'       '     Text.Whitespace
-'&vector'     Name.Label
-' '           Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&success'    Name.Label
-'  '          Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&stat'       Name.Label
-'   '         Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&delete'     Name.Label
-' '           Text.Whitespace
-'$1'          Keyword.Declaration
-' '           Text.Whitespace
-'&append'     Name.Label
-' '           Text.Whitespace
-'$1'          Keyword.Declaration
-' '           Text.Whitespace
-'&name'       Name.Label
-'   '         Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&length'     Name.Label
-' '           Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&read'       Name.Label
-'   '         Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&write'      Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
 '\n\n'        Text.Whitespace
 
-'('           Comment.Multiline
-' variables ' Comment.Multiline
-')'           Comment.Multiline
+'%HALT'       Name.Decorator
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'#010f'       Literal.Number.Hex
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+' '           Text.Whitespace
+'}'           Punctuation
 '\n\n'        Text.Whitespace
 
 '|0000'       Keyword.Declaration
-'\n\n'        Text.Whitespace
-
-'@last-note'  Name.Function
-'   '         Text.Whitespace
-'$1'          Keyword.Declaration
-'\n'          Text.Whitespace
-
+'\n\n\t'      Text.Whitespace
 '@octave'     Name.Function
-'      '      Text.Whitespace
+' '           Text.Whitespace
 '$1'          Keyword.Declaration
-'\n'          Text.Whitespace
-
-'@pointer'    Name.Function
-'     \n\t'   Text.Whitespace
-'&x'          Name.Label
-' '           Text.Whitespace
-'$2'          Keyword.Declaration
-' '           Text.Whitespace
-'&y'          Name.Label
-' '           Text.Whitespace
-'$2'          Keyword.Declaration
-'\n'          Text.Whitespace
-
+'\n\t'        Text.Whitespace
 '@center'     Name.Function
-'      \n\t'  Text.Whitespace
+' '           Text.Whitespace
 '&x'          Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -591,10 +272,9 @@
 '&y'          Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
-'\n'          Text.Whitespace
-
+'\n\t'        Text.Whitespace
 '@adsr-view'  Name.Function
-'   \n\t'     Text.Whitespace
+' '           Text.Whitespace
 '&x1'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -610,10 +290,9 @@
 '&y2'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
-'\n'          Text.Whitespace
-
+'\n\t'        Text.Whitespace
 '@wave-view'  Name.Function
-'   \n\t'     Text.Whitespace
+' '           Text.Whitespace
 '&x1'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -629,10 +308,9 @@
 '&y2'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
-'\n'          Text.Whitespace
-
+'\n\t'        Text.Whitespace
 '@octave-view' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
 '&x1'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
@@ -648,11 +326,6 @@
 '&y2'         Name.Label
 ' '           Text.Whitespace
 '$2'          Keyword.Declaration
-'\n\n'        Text.Whitespace
-
-'('           Comment.Multiline
-' program '   Comment.Multiline
-')'           Comment.Multiline
 '\n\n'        Text.Whitespace
 
 '|0100'       Keyword.Declaration
@@ -660,57 +333,45 @@
 '('           Comment.Multiline
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 '('           Comment.Multiline
 ' theme '     Comment.Multiline
 ')'           Comment.Multiline
-' \n\t'       Text.Whitespace
-'#0fe5'       Literal.Number.Hex
+'\n\t'        Text.Whitespace
+'#0fe3'       Literal.Number.Hex
 ' '           Text.Whitespace
 '.System/r'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'#0fc5'       Literal.Number.Hex
+'\n\t'        Text.Whitespace
+'#0fc3'       Literal.Number.Hex
 ' '           Text.Whitespace
 '.System/g'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'#0f25'       Literal.Number.Hex
+'\n\t'        Text.Whitespace
+'#0f23'       Literal.Number.Hex
 ' '           Text.Whitespace
 '.System/b'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
 '('           Comment.Multiline
-' vectors '   Comment.Multiline
+' resize '    Comment.Multiline
 ')'           Comment.Multiline
-' \n\t'       Text.Whitespace
-';on-frame'   Name.Variable.Global
-'   '         Text.Whitespace
-'.Screen/vector' Name.Variable.Magic
+'\n\t'        Text.Whitespace
+'#0180'       Literal.Number.Hex
+' '           Text.Whitespace
+'.Screen/width' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-';on-control' Name.Variable.Global
+'#00e0'       Literal.Number.Hex
 ' '           Text.Whitespace
-'.Controller/vector' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-';on-mouse'   Name.Variable.Global
-'   '         Text.Whitespace
-'.Mouse/vector' Name.Variable.Magic
+'.Screen/height' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-';on-message' Name.Variable.Global
-' '           Text.Whitespace
-'.Console/vector' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
 '('           Comment.Multiline
 ' find center ' Comment.Multiline
 ')'           Comment.Multiline
@@ -719,9 +380,31 @@
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'2//'         Name
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.center/x'   Name.Variable.Magic
+' '           Text.Whitespace
+'STZ2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'#0080'       Literal.Number.Hex
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'.octave-view/x1' Name.Variable.Magic
+' '           Text.Whitespace
+'STZ2'        Keyword.Reserved
+'\n\t\t\t'    Text.Whitespace
+'#0050'       Literal.Number.Hex
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'.octave-view/x2' Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
@@ -729,64 +412,38 @@
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'2//'         Name
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'#0010'       Literal.Number.Hex
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.center/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-'('           Comment.Multiline
-' place octave ' Comment.Multiline
-')'           Comment.Multiline
-'\n\t'        Text.Whitespace
-'.center/x'   Name.Variable.Magic
+'\n\t\t'      Text.Whitespace
+'#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0080'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'.octave-view/x1' Name.Variable.Magic
-' '           Text.Whitespace
-'STZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.center/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.octave-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.octave-view/x1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0050'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.octave-view/x2' Name.Variable.Magic
-' '           Text.Whitespace
-'STZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.octave-view/y1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
+'\n\t\t\t'    Text.Whitespace
 '#0018'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.octave-view/y2' Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' place adsr ' Comment.Multiline
 ')'           Comment.Multiline
@@ -797,7 +454,7 @@
 ' '           Text.Whitespace
 '#0020'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -807,9 +464,9 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
+'#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -821,7 +478,7 @@
 ' '           Text.Whitespace
 '#00a0'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/x2' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -833,12 +490,12 @@
 ' '           Text.Whitespace
 '#0018'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y2' Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' place waveform ' Comment.Multiline
 ')'           Comment.Multiline
@@ -849,7 +506,7 @@
 ' '           Text.Whitespace
 '#0080'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.wave-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -859,9 +516,9 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0020'       Literal.Number.Hex
+'#0040'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.wave-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -873,7 +530,7 @@
 ' '           Text.Whitespace
 '#0100'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.wave-view/x2' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -883,35 +540,25 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0020'       Literal.Number.Hex
+'#0040'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.wave-view/y2' Name.Variable.Magic
 ' '           Text.Whitespace
 'STZ2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-'('           Comment.Multiline
-' default settings ' Comment.Multiline
-')'           Comment.Multiline
 '\n\t'        Text.Whitespace
-'#ff'         Literal.Number.Hex
-' '           Text.Whitespace
-'.last-note'  Name.Variable.Magic
-' '           Text.Whitespace
-'STZ'         Keyword.Reserved
+'('           Comment.Multiline
+' setup synth ' Comment.Multiline
+')'           Comment.Multiline
 '\n\t'        Text.Whitespace
 '#041c'       Literal.Number.Hex
 ' '           Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
+'set-env'     Name.Function
 '\n\t'        Text.Whitespace
 '#dd'         Literal.Number.Hex
 ' '           Text.Whitespace
-'.Audio0/volume' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
+'set-vol'     Name.Function
 '\n\t'        Text.Whitespace
 ';sin-pcm'    Name.Variable.Global
 ' '           Text.Whitespace
@@ -919,63 +566,69 @@
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
+';sin-pcm'    Name.Variable.Global
+' '           Text.Whitespace
+'.Audio1/addr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
 '#0100'       Literal.Number.Hex
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Audio0/length' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t\t'      Text.Whitespace
+'.Audio1/length' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' inital drawing ' Comment.Multiline
 ')'           Comment.Multiline
-' \n\t'       Text.Whitespace
-';draw-octave' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-';draw-adsr'  Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-octave' Name.Function
 '\n\t'        Text.Whitespace
-';draw-wave'  Name.Variable.Global
+'draw-adsr'   Name.Function
+'\n\t'        Text.Whitespace
+'draw-wave'   Name.Function
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' unlock '    Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+';on-frame'   Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'.Screen/vector' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+';on-control' Name.Variable.Global
+' '           Text.Whitespace
+'.Controller/vector' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+';on-mouse'   Name.Variable.Global
+' '           Text.Whitespace
+'.Mouse/vector' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+';on-message' Name.Variable.Global
+' '           Text.Whitespace
+'.Console/vector' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 '('           Comment.Multiline
-' this data exists to test literals\n  as well as multi-line ' Comment.Multiline
-'('           Comment.Multiline
-' and nested ' Comment.Multiline
+'\n@|vectors ' Comment.Multiline
 ')'           Comment.Multiline
-'\n  comments ' Comment.Multiline
-')'           Comment.Multiline
-'\n'          Text.Whitespace
-
-'@test-dat'   Name.Function
-' '           Text.Whitespace
-'"this'       Literal.String
-' '           Text.Whitespace
-'20'          Literal
-' '           Text.Whitespace
-'"is'         Literal.String
-' '           Text.Whitespace
-'20'          Literal
-' '           Text.Whitespace
-"'a"          Literal.String.Char
-' '           Text.Whitespace
-'20'          Literal
-' '           Text.Whitespace
-'"test'       Literal.String
-' '           Text.Whitespace
-'00'          Literal
-'\n'          Text.Whitespace
-
-'@test-ptr'   Name.Function
-' '           Text.Whitespace
-':test-dat'   Literal
 '\n\n'        Text.Whitespace
 
 '@on-frame'   Name.Function
@@ -983,23 +636,107 @@
 '('           Comment.Multiline
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
+'.Mouse/state' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI'         Keyword.Reserved
+' '           Text.Whitespace
+'?&skip-sft'  Name.Function
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'00'          Literal
+' '           Text.Whitespace
+'&soft'       Name.Label
+' '           Text.Whitespace
+'$1'          Keyword.Declaration
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'EQUk'        Keyword.Reserved
+' '           Text.Whitespace
+'?&no-soft'   Name.Function
+'\n\t\t'      Text.Whitespace
+'soften'      Name.Function
+'\n\t\t'      Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+',&soft'      Name.Variable.Instance
+' '           Text.Whitespace
+'STR'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'&no-soft'    Name.Label
+'\n\t'        Text.Whitespace
+'POP2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'&skip-sft'   Name.Label
+'\n\n\t'      Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'&last'       Name.Label
+' '           Text.Whitespace
+'$1'          Keyword.Declaration
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'.Audio0/output' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI'         Keyword.Reserved
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'?&changed'   Name.Function
+'\n\t\t'      Text.Whitespace
+'POP2'        Keyword.Reserved
+' '           Text.Whitespace
+'BRK'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'&changed'    Name.Label
+'\n\t'        Text.Whitespace
+',&last'      Name.Variable.Instance
+' '           Text.Whitespace
+'STR'         Keyword.Reserved
+' '           Text.Whitespace
+'POP'         Keyword.Reserved
+'\n\n\t'      Text.Whitespace
+'('           Comment.Multiline
+' redraw '    Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'00'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
 '.adsr-view/y2' Name.Variable.Magic
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
 '#0020'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' \n\t'       Text.Whitespace
+'\n\t'        Text.Whitespace
+'#1000'       Literal.Number.Hex
+'\n\t'        Text.Whitespace
 '&loop'       Name.Label
 '\n\t\t'      Text.Whitespace
 '.adsr-view/x2' Name.Variable.Magic
@@ -1008,7 +745,7 @@
 ' '           Text.Whitespace
 '#003a'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1018,53 +755,41 @@
 ' '           Text.Whitespace
 'OVR'         Keyword.Reserved
 ' '           Text.Whitespace
-'-'           Name
+'SUB'         Keyword.Reserved
 ' '           Text.Whitespace
 '.Audio0/output' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI'         Keyword.Reserved
+'\n\t\t\t'    Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
 '#0f'         Literal.Number.Hex
 ' '           Text.Whitespace
 'AND'         Keyword.Reserved
 ' '           Text.Whitespace
-'<'           Name
+'LTH'         Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/pixel' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t\t'      Text.Whitespace
-'.adsr-view/x2' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#003a'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
+'DEI2k'       Keyword.Reserved
+' '           Text.Whitespace
+'INC2'        Keyword.Reserved
+' '           Text.Whitespace
+'INC2'        Keyword.Reserved
+' '           Text.Whitespace
+'ROT'         Keyword.Reserved
+' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'OVR'         Keyword.Reserved
-' '           Text.Whitespace
-'-'           Name
-' '           Text.Whitespace
-'.Audio0/output' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
+'\n\t\t\t'    Text.Whitespace
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
 ' '           Text.Whitespace
-'<'           Name
+'LTH'         Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/pixel' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1072,13 +797,13 @@
 '\n\t\t'      Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
+'DEI2k'       Keyword.Reserved
 ' '           Text.Whitespace
 'INC2'        Keyword.Reserved
 ' '           Text.Whitespace
 'INC2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
+'ROT'         Keyword.Reserved
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t\t'      Text.Whitespace
@@ -1086,9 +811,7 @@
 ' '           Text.Whitespace
 'GTHk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&loop'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&loop'      Name.Function
 '\n\t'        Text.Whitespace
 'POP2'        Keyword.Reserved
 '\n\n'        Text.Whitespace
@@ -1102,50 +825,28 @@
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
-'('           Comment.Multiline
-' clear last cursor ' Comment.Multiline
-')'           Comment.Multiline
-'\n\t'        Text.Whitespace
-'.pointer/x'  Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'.pointer/y'  Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'#40'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-'\n\n\t'      Text.Whitespace
 '.Controller/key' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' octave '    Comment.Multiline
+')'           Comment.Multiline
 '\n\t'        Text.Whitespace
 '['           Punctuation
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'a"          Literal.String.Char
+'"a'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-c'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-c'      Name.Function
+' '           Text.Whitespace
 '#30'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1154,13 +855,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-c'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1168,16 +867,46 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'s"          Literal.String.Char
+'"w'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-d'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-c#'     Name.Function
+' '           Text.Whitespace
+'#31'         Literal.Number.Hex
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ'         Keyword.Reserved
+' '           Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'play'        Name.Function
+' '           Text.Whitespace
+'&no-c#'      Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"s'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-d'      Name.Function
+' '           Text.Whitespace
 '#32'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1186,13 +915,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-d'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1200,16 +927,46 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'d"          Literal.String.Char
+'"e'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-e'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-d#'     Name.Function
+' '           Text.Whitespace
+'#33'         Literal.Number.Hex
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ'         Keyword.Reserved
+' '           Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'play'        Name.Function
+' '           Text.Whitespace
+'&no-d#'      Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"d'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-e'      Name.Function
+' '           Text.Whitespace
 '#34'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1218,13 +975,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-e'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1232,16 +987,16 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'f"          Literal.String.Char
+'"f'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-f'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-f'      Name.Function
+' '           Text.Whitespace
 '#35'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1250,13 +1005,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-f'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1264,16 +1017,46 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'g"          Literal.String.Char
+'"t'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-g'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-f#'     Name.Function
+' '           Text.Whitespace
+'#36'         Literal.Number.Hex
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ'         Keyword.Reserved
+' '           Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'play'        Name.Function
+' '           Text.Whitespace
+'&no-f#'      Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"g'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-g'      Name.Function
+' '           Text.Whitespace
 '#37'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1282,13 +1065,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-g'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1296,16 +1077,46 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'h"          Literal.String.Char
+'"y'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-a'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-g#'     Name.Function
+' '           Text.Whitespace
+'#38'         Literal.Number.Hex
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ'         Keyword.Reserved
+' '           Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'play'        Name.Function
+' '           Text.Whitespace
+'&no-g#'      Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"h'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-a'      Name.Function
+' '           Text.Whitespace
 '#39'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1314,13 +1125,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-a'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1328,16 +1137,46 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'j"          Literal.String.Char
+'"u'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-b'      Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-a#'     Name.Function
+' '           Text.Whitespace
+'#3a'         Literal.Number.Hex
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ'         Keyword.Reserved
+' '           Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'play'        Name.Function
+' '           Text.Whitespace
+'&no-a#'      Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"j'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-b'      Name.Function
+' '           Text.Whitespace
 '#3b'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1346,13 +1185,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-b'       Name.Label
 '\n\t'        Text.Whitespace
@@ -1360,16 +1197,16 @@
 ' '           Text.Whitespace
 'LIT'         Keyword.Reserved
 ' '           Text.Whitespace
-"'k"          Literal.String.Char
+'"k'          Literal.String
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-c2'     Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
+'?&no-c2'     Name.Function
+' '           Text.Whitespace
 '#3c'         Literal.Number.Hex
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -1378,15 +1215,71 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&no-c2'      Name.Label
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' controls '  Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"z'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-dec'    Name.Function
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZk'        Keyword.Reserved
+' '           Text.Whitespace
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'STZ'         Keyword.Reserved
+' '           Text.Whitespace
+'&no-dec'     Name.Label
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT'         Keyword.Reserved
+' '           Text.Whitespace
+'"x'          Literal.String
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'NEQk'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&no-inc'    Name.Function
+' '           Text.Whitespace
+'.octave'     Name.Variable.Magic
+' '           Text.Whitespace
+'LDZk'        Keyword.Reserved
+' '           Text.Whitespace
+'INC'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'STZ'         Keyword.Reserved
+' '           Text.Whitespace
+'&no-inc'     Name.Label
 '\n\t'        Text.Whitespace
 '['           Punctuation
 ' '           Text.Whitespace
@@ -1394,13 +1287,13 @@
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-esc'    Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-esc'    Name.Function
 ' '           Text.Whitespace
-'HALT'        Name
+'HALT'        Name.Function
 ' '           Text.Whitespace
 '&no-esc'     Name.Label
 '\n\t'        Text.Whitespace
@@ -1419,280 +1312,226 @@
 '.Controller/button' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI'         Keyword.Reserved
-' \n\t'       Text.Whitespace
-'DUP'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
 ' '           Text.Whitespace
 '#11'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&cu'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&cu'        Name.Function
 ' '           Text.Whitespace
 '#3c'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&cu'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#21'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&cd'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&cd'        Name.Function
 ' '           Text.Whitespace
 '#3d'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&cd'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#41'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&cl'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&cl'        Name.Function
 ' '           Text.Whitespace
 '#3e'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&cl'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#81'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&cr'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&cr'        Name.Function
 ' '           Text.Whitespace
 '#3f'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&cr'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#12'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&au'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&au'        Name.Function
 ' '           Text.Whitespace
 '#40'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&au'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#22'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&ad'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&ad'        Name.Function
 ' '           Text.Whitespace
 '#41'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&ad'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#42'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&al'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&al'        Name.Function
 ' '           Text.Whitespace
 '#42'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&al'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#82'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&ar'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&ar'        Name.Function
 ' '           Text.Whitespace
 '#43'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&ar'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#14'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&su'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&su'        Name.Function
 ' '           Text.Whitespace
 '#44'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&su'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#24'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&sd'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&sd'        Name.Function
 ' '           Text.Whitespace
 '#45'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&sd'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#44'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&sl'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&sl'        Name.Function
 ' '           Text.Whitespace
 '#46'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&sl'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
+'['           Punctuation
 ' '           Text.Whitespace
 '#84'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+']'           Punctuation
 ' '           Text.Whitespace
-',&sr'        Name.Variable.Instance
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&sr'        Name.Function
 ' '           Text.Whitespace
 '#47'         Literal.Number.Hex
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 ' '           Text.Whitespace
 '&sr'         Name.Label
 '\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'#40'         Literal.Number.Hex
-' '           Text.Whitespace
-'!'           Name
-' '           Text.Whitespace
-',&l'         Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-' '           Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0010'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' '           Text.Whitespace
-'&l'          Name.Label
-'\n\t'        Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'#80'         Literal.Number.Hex
-' '           Text.Whitespace
-'!'           Name
-' '           Text.Whitespace
-',&r'         Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-' '           Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0010'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' '           Text.Whitespace
-'&r'          Name.Label
-'\n\t'        Text.Whitespace
 'POP'         Keyword.Reserved
 '\n\n\t'      Text.Whitespace
-';draw-octave' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-';draw-wave'  Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-octave' Name.Function
 '\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
@@ -1703,18 +1542,14 @@
 '('           Comment.Multiline
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 '.Console/read' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 '\n\t'        Text.Whitespace
-';draw-octave' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-octave' Name.Function
 '\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
@@ -1726,27 +1561,37 @@
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
-';draw-cursor' Name.Variable.Global
+'#00'         Literal.Number.Hex
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\t\n\t'   Text.Whitespace
 '.Mouse/state' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI'         Keyword.Reserved
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
+'NEQ'         Keyword.Reserved
 ' '           Text.Whitespace
-'!'           Name
+'#41'         Literal.Number.Hex
 ' '           Text.Whitespace
-'#01'         Literal.Number.Hex
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+';cursor-icn' Name.Variable.Global
 ' '           Text.Whitespace
-'['           Punctuation
+'update-cursor' Name.Function
+'\n\n\t'      Text.Whitespace
+'.Mouse/state' Name.Variable.Magic
 ' '           Text.Whitespace
+'DEI'         Keyword.Reserved
+' '           Text.Whitespace
+'?on-mouse-touch' Name.Function
+'\n\n'        Text.Whitespace
+
 'BRK'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'@on-mouse-touch' Name.Function
 ' '           Text.Whitespace
-']'           Punctuation
+'('           Comment.Multiline
+' -> '        Comment.Multiline
+')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1758,13 +1603,9 @@
 ' '           Text.Whitespace
 '.wave-view'  Name.Variable.Magic
 ' '           Text.Whitespace
-';within-rect' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-';on-touch-wave-view' Name.Variable.Global
-' '           Text.Whitespace
-'JCN2'        Keyword.Reserved
+'within-rect' Name.Function
+'\n\t\t'      Text.Whitespace
+'?on-touch-wave-view' Name.Function
 '\n\t'        Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1776,13 +1617,9 @@
 ' '           Text.Whitespace
 '.adsr-view'  Name.Variable.Magic
 ' '           Text.Whitespace
-';within-rect' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-';on-touch-adsr-view' Name.Variable.Global
-' '           Text.Whitespace
-'JCN2'        Keyword.Reserved
+'within-rect' Name.Function
+'\n\t\t'      Text.Whitespace
+'?on-touch-knobs-view' Name.Function
 '\n\t'        Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1794,13 +1631,9 @@
 ' '           Text.Whitespace
 '.octave-view' Name.Variable.Magic
 ' '           Text.Whitespace
-';within-rect' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-';on-touch-octave-view' Name.Variable.Global
-' '           Text.Whitespace
-'JCN2'        Keyword.Reserved
+'within-rect' Name.Function
+'\n\t\t'      Text.Whitespace
+'?on-touch-octave-view' Name.Function
 '\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
@@ -1812,6 +1645,16 @@
 ' -> '        Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
+'.Mouse/state' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI'         Keyword.Reserved
+' '           Text.Whitespace
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'GTH'         Keyword.Reserved
+' '           Text.Whitespace
+'?&paint'     Name.Function
+'\n\t'        Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
@@ -1820,20 +1663,78 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'('           Comment.Multiline
+' min '       Comment.Multiline
+')'           Comment.Multiline
 ' '           Text.Whitespace
-'.Audio0/length' Name.Variable.Magic
+'#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
+'GTH2k'       Keyword.Reserved
+' '           Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'JMP'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP2'        Keyword.Reserved
+' '           Text.Whitespace
+'POP2'        Keyword.Reserved
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'set-length'  Name.Function
+'\n\n'        Text.Whitespace
+
+'BRK'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'&paint'      Name.Label
+' '           Text.Whitespace
+'('           Comment.Multiline
+' -> '        Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'.Mouse/y'    Name.Variable.Magic
+' '           Text.Whitespace
+'DEI2'        Keyword.Reserved
+' '           Text.Whitespace
+'.wave-view/y1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'#20'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-';draw-wave'  Name.Variable.Global
+'.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'DEI2'        Keyword.Reserved
+' '           Text.Whitespace
+'.wave-view/x1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+';sin-pcm'    Name.Variable.Global
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'STA'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-';draw-cursor' Name.Variable.Global
+'draw-wave'   Name.Function
+'\n\t'        Text.Whitespace
+'#10'         Literal.Number.Hex
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\n'       Text.Whitespace
+';on-frame/soft' Name.Variable.Global
+' '           Text.Whitespace
+'STA'         Keyword.Reserved
+'\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
 '\n\n'        Text.Whitespace
@@ -1852,19 +1753,19 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'8//'         Name
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
 '#09'         Literal.Number.Hex
 ' '           Text.Whitespace
-'!'           Name
+'NEQ'         Keyword.Reserved
 ' '           Text.Whitespace
-',&no-mod'    Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-mod'    Name.Function
 '\n\t\t'      Text.Whitespace
 '.Mouse/y'    Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1874,23 +1775,25 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'8//'         Name
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 'NIP'         Keyword.Reserved
-' \n\t\t'     Text.Whitespace
+'\n\t\t'      Text.Whitespace
 '['           Punctuation
 ' '           Text.Whitespace
 '#00'         Literal.Number.Hex
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-incr'   Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-incr'   Name.Function
 '\n\t\t\t'    Text.Whitespace
 '.octave'     Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1898,11 +1801,9 @@
 ' '           Text.Whitespace
 '#03'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
-',&no-incr'   Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-incr'   Name.Function
 '\n\t\t\t'    Text.Whitespace
 '.octave'     Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1922,11 +1823,11 @@
 ' '           Text.Whitespace
 ']'           Punctuation
 ' '           Text.Whitespace
-'!~'          Name
+'NEQk'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-decr'   Name.Variable.Instance
+'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-decr'   Name.Function
 '\n\t\t\t'    Text.Whitespace
 '.octave'     Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1934,11 +1835,9 @@
 ' '           Text.Whitespace
 '#ff'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
-',&no-decr'   Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-decr'   Name.Function
 '\n\t\t\t'    Text.Whitespace
 '.octave'     Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1946,7 +1845,7 @@
 ' '           Text.Whitespace
 '#01'         Literal.Number.Hex
 ' '           Text.Whitespace
-'-'           Name
+'SUB'         Keyword.Reserved
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
 ' '           Text.Whitespace
@@ -1966,9 +1865,7 @@
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t\t'      Text.Whitespace
-';draw-octave' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-octave' Name.Function
 '\n\t\t'      Text.Whitespace
 'BRK'         Keyword.Reserved
 '\n\t'        Text.Whitespace
@@ -1982,19 +1879,19 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'8//'         Name
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
 '#06'         Literal.Number.Hex
 ' '           Text.Whitespace
-'>'           Name
+'GTH'         Keyword.Reserved
 ' '           Text.Whitespace
-',&no-key'    Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&no-key'    Name.Function
 '\n\t\t'      Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2004,13 +1901,15 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'8//'         Name
+'#03'         Literal.Number.Hex
 ' '           Text.Whitespace
-';notes'      Name.Variable.Global
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+';notes-lut'  Name.Variable.Global
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 'LDA'         Keyword.Reserved
 ' '           Text.Whitespace
@@ -2020,13 +1919,11 @@
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'*'           Name
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
-';play'       Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'play'        Name.Function
 '\n\t\t'      Text.Whitespace
 '('           Comment.Multiline
 ' release '   Comment.Multiline
@@ -2038,17 +1935,15 @@
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t\t'      Text.Whitespace
-';draw-octave' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-octave' Name.Function
 '\n\t'        Text.Whitespace
 '&no-key'     Name.Label
 '\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
-' \n\n'       Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'@on-touch-adsr-view' Name.Function
+'@on-touch-knobs-view' Name.Function
 ' '           Text.Whitespace
 '('           Comment.Multiline
 ' -> '        Comment.Multiline
@@ -2062,334 +1957,231 @@
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'8//'         Name
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
 '#03'         Literal.Number.Hex
 ' '           Text.Whitespace
-'/'           Name
+'DIV'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'['           Punctuation
+'.Mouse/y'    Name.Variable.Magic
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
+'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-']'           Punctuation
+'.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
-'!~'          Name
+'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-',&no-a'      Name.Variable.Instance
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#e0'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-a'       Name.Label
+'NIP'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'['           Punctuation
+'OVR'         Keyword.Reserved
 ' '           Text.Whitespace
-'#01'         Literal.Number.Hex
+'#04'         Literal.Number.Hex
 ' '           Text.Whitespace
-']'           Punctuation
+'LTH'         Keyword.Reserved
 ' '           Text.Whitespace
-'!~'          Name
-' '           Text.Whitespace
-',&no-d'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'#f0'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
-' '           Text.Whitespace
-'STH'         Keyword.Reserved
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#0e'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'#0f'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
-' '           Text.Whitespace
-'STHr'        Keyword.Reserved
-' '           Text.Whitespace
-'+'           Name
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-d'       Name.Label
+'?on-touch-adsr' Name.Function
 '\n\t'        Text.Whitespace
-'['           Punctuation
+'OVR'         Keyword.Reserved
 ' '           Text.Whitespace
-'#02'         Literal.Number.Hex
+'#04'         Literal.Number.Hex
 ' '           Text.Whitespace
-']'           Punctuation
+'GTH'         Keyword.Reserved
 ' '           Text.Whitespace
-'!~'          Name
-' '           Text.Whitespace
-',&no-s'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'INC'         Keyword.Reserved
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#e0'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'INC'         Keyword.Reserved
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-s'       Name.Label
+'?on-touch-vol' Name.Function
 '\n\t'        Text.Whitespace
-'['           Punctuation
+'POP2'        Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'BRK'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'@on-touch-adsr' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' knob value -> ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'STH2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' mask '      Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'#ffff'       Literal.Number.Hex
+' '           Text.Whitespace
+'#000f'       Literal.Number.Hex
 ' '           Text.Whitespace
 '#03'         Literal.Number.Hex
 ' '           Text.Whitespace
-']'           Punctuation
-' '           Text.Whitespace
-'!~'          Name
-' '           Text.Whitespace
-',&no-r'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/adsr' Name.Variable.Magic
-' '           Text.Whitespace
-'INC'         Keyword.Reserved
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'#f0'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
-' '           Text.Whitespace
-'STH'         Keyword.Reserved
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#0e'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'#0f'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
+'OVRr'        Keyword.Reserved
 ' '           Text.Whitespace
 'STHr'        Keyword.Reserved
 ' '           Text.Whitespace
-'+'           Name
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'#60'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'EOR2'        Keyword.Reserved
 '\n\t\t'      Text.Whitespace
 '.Audio0/adsr' Name.Variable.Magic
 ' '           Text.Whitespace
-'INC'         Keyword.Reserved
+'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-r'       Name.Label
+'AND2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'['           Punctuation
-' '           Text.Whitespace
-'#05'         Literal.Number.Hex
-' '           Text.Whitespace
-']'           Punctuation
-' '           Text.Whitespace
-'!~'          Name
-' '           Text.Whitespace
-',&no-left'   Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/volume' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#e0'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-'\n\t\t'      Text.Whitespace
-'.Audio0/volume' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-left'    Name.Label
-'\n\t'        Text.Whitespace
-'['           Punctuation
-' '           Text.Whitespace
-'#06'         Literal.Number.Hex
-' '           Text.Whitespace
-']'           Punctuation
-' '           Text.Whitespace
-'!~'          Name
-' '           Text.Whitespace
-',&no-right'  Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Audio0/volume' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'#f0'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
-' '           Text.Whitespace
-'STH'         Keyword.Reserved
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#10'         Literal.Number.Hex
-' '           Text.Whitespace
-'='           Name
-' '           Text.Whitespace
-'#0e'         Literal.Number.Hex
-' '           Text.Whitespace
-'*'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
-'#0f'         Literal.Number.Hex
-' '           Text.Whitespace
-'AND'         Keyword.Reserved
-' '           Text.Whitespace
-'STHr'        Keyword.Reserved
-' '           Text.Whitespace
-'+'           Name
-'\n\t\t'      Text.Whitespace
-'.Audio0/volume' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-' '           Text.Whitespace
-'&no-right'   Name.Label
-'\n\t'        Text.Whitespace
-'POP'         Keyword.Reserved
-'\n\n\t'      Text.Whitespace
 '('           Comment.Multiline
-' release '   Comment.Multiline
+' value '     Comment.Multiline
 ')'           Comment.Multiline
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
+'#000f'       Literal.Number.Hex
 ' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
+'STHr'        Keyword.Reserved
 ' '           Text.Whitespace
-'DEO'         Keyword.Reserved
+'OVR'         Keyword.Reserved
+' '           Text.Whitespace
+'LTHk'        Keyword.Reserved
+' '           Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'JMP'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'POP'         Keyword.Reserved
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-';draw-adsr'  Name.Variable.Global
+'('           Comment.Multiline
+' shift '     Comment.Multiline
+')'           Comment.Multiline
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'STHr'        Keyword.Reserved
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'#60'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'ORA2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-';draw-cursor' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-' \n\n'       Text.Whitespace
+'set-env'     Name.Function
+'\n\n'        Text.Whitespace
 
 'BRK'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'@on-touch-vol' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' knob value -> ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'#03'         Literal.Number.Hex
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'INC'         Keyword.Reserved
+' '           Text.Whitespace
+'INC'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'STH2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' mask '      Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'#0f'         Literal.Number.Hex
+' '           Text.Whitespace
+'OVRr'        Keyword.Reserved
+' '           Text.Whitespace
+'STHr'        Keyword.Reserved
+' '           Text.Whitespace
+'#60'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'.Audio0/volume' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI'         Keyword.Reserved
+' '           Text.Whitespace
+'AND'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' value '     Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'#0f'         Literal.Number.Hex
+' '           Text.Whitespace
+'STHr'        Keyword.Reserved
+' '           Text.Whitespace
+'OVR'         Keyword.Reserved
+' '           Text.Whitespace
+'LTHk'        Keyword.Reserved
+' '           Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'JMP'         Keyword.Reserved
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'POP'         Keyword.Reserved
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' shift '     Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'STHr'        Keyword.Reserved
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'#60'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'ORA'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'set-vol'     Name.Function
+'\n\n'        Text.Whitespace
+
+'BRK'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'('           Comment.Multiline
+'\n@|core '   Comment.Multiline
+')'           Comment.Multiline
 '\n\n'        Text.Whitespace
 
 '@play'       Name.Function
@@ -2397,121 +2189,309 @@
 '('           Comment.Multiline
 ' pitch -- '  Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 'DUP'         Keyword.Reserved
 ' '           Text.Whitespace
 '#0c'         Literal.Number.Hex
 ' '           Text.Whitespace
-'MOD'         Name
+'DIVk'        Keyword.Reserved
 ' '           Text.Whitespace
-'.last-note'  Name.Variable.Magic
+'MUL'         Keyword.Reserved
 ' '           Text.Whitespace
-'STZ'         Keyword.Reserved
-' \n\t'       Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+';draw-octave/last' Name.Variable.Global
+' '           Text.Whitespace
+'STA'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
 '.Audio0/pitch' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'#0c'         Literal.Number.Hex
+' '           Text.Whitespace
+'SUB'         Keyword.Reserved
+' '           Text.Whitespace
+'.Audio1/pitch' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'@draw-cursor' Name.Function
+'@set-length' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' length* -- ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Audio0/length' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'.Audio1/length' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'!draw-wave'  Name.Function
+'\n\n'        Text.Whitespace
+
+'@set-vol'    Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' vol -- '    Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
+'.Audio0/volume' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'.Audio1/volume' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'!draw-adsr'  Name.Function
+'\n\n'        Text.Whitespace
+
+'@set-env'    Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' adsr* -- '  Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Audio0/adsr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'.Audio1/adsr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'!draw-adsr'  Name.Function
+'\n\n'        Text.Whitespace
+
+'@soften'     Name.Function
 ' '           Text.Whitespace
 '('           Comment.Multiline
 ' -- '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
-'('           Comment.Multiline
-' clear last cursor ' Comment.Multiline
-')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'#0100'       Literal.Number.Hex
+' '           Text.Whitespace
+'#0000'       Literal.Number.Hex
 '\n\t'        Text.Whitespace
-';cursor'     Name.Variable.Global
+'&l'          Name.Label
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/addr' Name.Variable.Magic
+';sin-pcm'    Name.Variable.Global
 ' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'.pointer/x'  Name.Variable.Magic
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
+'get-average' Name.Function
 ' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
+'SWP2'        Keyword.Reserved
 ' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'.pointer/y'  Name.Variable.Magic
+'STA'         Keyword.Reserved
 ' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
+'POP'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'INC2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
+'GTH2k'       Keyword.Reserved
 ' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-'#40'         Literal.Number.Hex
+'?&l'         Name.Function
+'\n\t'        Text.Whitespace
+'POP2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'POP2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'draw-wave'   Name.Function
+'\n\n'        Text.Whitespace
+
+'JMP2r'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'@get-average' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' addr* -- addr* average* ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2r'       Keyword.Reserved
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n\t'        Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'#0001'       Literal.Number.Hex
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'#0002'       Literal.Number.Hex
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'SWP2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'&l'          Name.Label
+'\n\t\t'      Text.Whitespace
+'LDAk'        Keyword.Reserved
+' '           Text.Whitespace
+'LITr'        Keyword.Reserved
+' '           Text.Whitespace
+'00'          Literal
+' '           Text.Whitespace
+'STH'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD2r'       Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'INC2'        Keyword.Reserved
+' '           Text.Whitespace
+'GTH2k'       Keyword.Reserved
+' '           Text.Whitespace
+'?&l'         Name.Function
+'\n\t'        Text.Whitespace
+'POP2'        Keyword.Reserved
+' '           Text.Whitespace
+'POP2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'LDAk'        Keyword.Reserved
+' '           Text.Whitespace
+'#00'         Literal.Number.Hex
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+'STH2r'       Keyword.Reserved
+'\n\t'        Text.Whitespace
+'#01'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'#02'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'JMP2r'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'('           Comment.Multiline
+'\n@|drawing ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'@update-cursor' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' color addr* -- ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'00'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'('           Comment.Multiline
-' record pointer positions ' Comment.Multiline
-')'           Comment.Multiline
+'#40'         Literal.Number.Hex
+' '           Text.Whitespace
+'draw-cursor' Name.Function
 '\n\t'        Text.Whitespace
 '.Mouse/x'    Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
+',draw-cursor/x' Name.Variable.Instance
 ' '           Text.Whitespace
-'.pointer/x'  Name.Variable.Magic
-' '           Text.Whitespace
-'STZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
+'STR2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
 '.Mouse/y'    Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
+',draw-cursor/y' Name.Variable.Instance
 ' '           Text.Whitespace
-'.pointer/y'  Name.Variable.Magic
+'STR2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
-'STZ2'        Keyword.Reserved
+'DEO2'        Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'@draw-cursor' Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' color -- '  Comment.Multiline
+')'           Comment.Multiline
+'\n\n\t'      Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'&x'          Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'.Screen/x'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'&y'          Name.Label
+' '           Text.Whitespace
+'$2'          Keyword.Declaration
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'  \n\t'      Text.Whitespace
-'('           Comment.Multiline
-' colorize on state ' Comment.Multiline
-')'           Comment.Multiline
 '\n\t'        Text.Whitespace
-'#41'         Literal.Number.Hex
-' '           Text.Whitespace
-'['           Punctuation
-' '           Text.Whitespace
-'.Mouse/state' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI'         Keyword.Reserved
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-'!'           Name
-' '           Text.Whitespace
-']'           Punctuation
-' '           Text.Whitespace
-'+'           Name
-' '           Text.Whitespace
 '.Screen/sprite' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 '@draw-octave' Name.Function
@@ -2519,24 +2499,34 @@
 '('           Comment.Multiline
 ' -- '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
+'('           Comment.Multiline
+' arrows '    Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'02'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
 '.octave-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
 '#0048'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-';arrow-icns' Name.Variable.Global
-' '           Text.Whitespace
-'.Screen/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
 '.octave-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2546,40 +2536,24 @@
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-'\n\n\t'      Text.Whitespace
 ';arrow-icns' Name.Variable.Global
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.octave-view/y1' Name.Variable.Magic
+'['           Punctuation
 ' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0010'       Literal.Number.Hex
+'01'          Literal
 ' '           Text.Whitespace
-'++'          Name
+'-Screen/sprite' Literal
 ' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
 ';font-hex'   Name.Variable.Global
 ' '           Text.Whitespace
 '.octave'     Name.Variable.Magic
@@ -2588,38 +2562,56 @@
 ' '           Text.Whitespace
 '#03'         Literal.Number.Hex
 ' '           Text.Whitespace
-'+'           Name
+'ADD'         Keyword.Reserved
 ' '           Text.Whitespace
 '#00'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SWP'         Keyword.Reserved
 ' '           Text.Whitespace
-'8**'         Name
+'#30'         Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'SFT2'        Keyword.Reserved
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.octave-view/y1' Name.Variable.Magic
+'['           Punctuation
 ' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
+'02'          Literal
 ' '           Text.Whitespace
-'++'          Name
+'-Screen/sprite' Literal
 ' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+';arrow-icns/down' Name.Variable.Global
+' '           Text.Whitespace
+'.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'#03'         Literal.Number.Hex
+'['           Punctuation
 ' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'01'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' octave '    Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
 '.octave-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
@@ -2636,13 +2628,27 @@
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'AUTO-YADDR'  Name
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'06'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.last-note'  Name.Variable.Magic
+'['           Punctuation
 ' '           Text.Whitespace
-'LDZ'         Keyword.Reserved
+'LITr'        Keyword.Reserved
 ' '           Text.Whitespace
-'STH'         Keyword.Reserved
+'&last'       Name.Label
+' '           Text.Whitespace
+'ff'          Literal
+' '           Text.Whitespace
+']'           Punctuation
 '\n\t'        Text.Whitespace
 ';keys-left-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2650,13 +2656,11 @@
 ' '           Text.Whitespace
 '#00'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-middle-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2664,13 +2668,11 @@
 ' '           Text.Whitespace
 '#02'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-right-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2678,13 +2680,11 @@
 ' '           Text.Whitespace
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-left-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2692,13 +2692,11 @@
 ' '           Text.Whitespace
 '#05'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-middle-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2706,13 +2704,11 @@
 ' '           Text.Whitespace
 '#07'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-middle-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2720,13 +2716,11 @@
 ' '           Text.Whitespace
 '#09'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-key'    Name.Function
 '\n\t'        Text.Whitespace
 ';keys-right-icns' Name.Variable.Global
 ' '           Text.Whitespace
@@ -2734,18 +2728,14 @@
 ' '           Text.Whitespace
 '#0b'         Literal.Number.Hex
 ' '           Text.Whitespace
-'='           Name
+'EQU'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
-' '           Text.Whitespace
-',draw-key'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
-'\n\t'        Text.Whitespace
-'AUTO-NONE'   Name
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'('           Comment.Multiline
+' >> '        Comment.Multiline
+')'           Comment.Multiline
 '\n\n'        Text.Whitespace
 
 '@draw-key'   Name.Function
@@ -2753,7 +2743,7 @@
 '('           Comment.Multiline
 ' addr* color -- ' Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\t\n\t'  Text.Whitespace
+'\n\n\t'      Text.Whitespace
 'STH'         Keyword.Reserved
 '\n\t'        Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
@@ -2780,7 +2770,7 @@
 ' '           Text.Whitespace
 '#0008'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 'ROT'         Keyword.Reserved
 ' '           Text.Whitespace
@@ -2791,7 +2781,7 @@
 'DEO2'        Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 '@draw-adsr'  Name.Function
@@ -2799,7 +2789,7 @@
 '('           Comment.Multiline
 ' -- '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 '('           Comment.Multiline
 ' adsr '      Comment.Multiline
 ')'           Comment.Multiline
@@ -2819,10 +2809,8 @@
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-knob'   Name.Function
 '\n\t'        Text.Whitespace
 '.adsr-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2830,7 +2818,7 @@
 ' '           Text.Whitespace
 '#0018'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2843,10 +2831,8 @@
 '#0f'         Literal.Number.Hex
 ' '           Text.Whitespace
 'AND'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-knob'   Name.Function
 '\n\t'        Text.Whitespace
 '.adsr-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2854,7 +2840,7 @@
 ' '           Text.Whitespace
 '#0030'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2869,10 +2855,8 @@
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-knob'   Name.Function
 '\n\t'        Text.Whitespace
 '.adsr-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2880,7 +2864,7 @@
 ' '           Text.Whitespace
 '#0048'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2895,10 +2879,8 @@
 '#0f'         Literal.Number.Hex
 ' '           Text.Whitespace
 'AND'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-knob'   Name.Function
 '\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' volume '    Comment.Multiline
@@ -2910,7 +2892,7 @@
 ' '           Text.Whitespace
 '#0028'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2923,10 +2905,8 @@
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
 ' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
+'draw-knob'   Name.Function
 '\n\t'        Text.Whitespace
 '.adsr-view/x2' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2934,7 +2914,7 @@
 ' '           Text.Whitespace
 '#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.adsr-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -2947,13 +2927,9 @@
 '#0f'         Literal.Number.Hex
 ' '           Text.Whitespace
 'AND'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-';draw-knob'  Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'!draw-knob'  Name.Function
 '\n\n'        Text.Whitespace
 
 '@draw-wave'  Name.Function
@@ -2961,41 +2937,11 @@
 '('           Comment.Multiline
 ' -- '        Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 '('           Comment.Multiline
-' clear '     Comment.Multiline
+' background ' Comment.Multiline
 ')'           Comment.Multiline
 '\n\t'        Text.Whitespace
-'.wave-view/x1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/y1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/x2' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/y2' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-';fill-rect'  Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-';draw-wave-length' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
 '.wave-view/x1' Name.Variable.Magic
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
@@ -3003,86 +2949,130 @@
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
+'\n\t'        Text.Whitespace
+'.wave-view/y1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/y'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+';fill-icn'   Name.Variable.Global
+' '           Text.Whitespace
+'.Screen/addr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'75'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'#e0'         Literal.Number.Hex
+' '           Text.Whitespace
+'&lbg'        Name.Label
+'\n\t\t'      Text.Whitespace
+';dotted-icn' Name.Variable.Global
+' '           Text.Whitespace
+'.Screen/addr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'0c'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t\t'      Text.Whitespace
+'INC'         Keyword.Reserved
+' '           Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
+'?&lbg'       Name.Function
+'\n\t'        Text.Whitespace
+'POP'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.wave-view/x1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/x'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' waveform '  Comment.Multiline
 ')'           Comment.Multiline
 '\n\t'        Text.Whitespace
-'#ff'         Literal.Number.Hex
+'['           Punctuation
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' \n\t'       Text.Whitespace
-'&loop'       Name.Label
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' dotted line ' Comment.Multiline
-')'           Comment.Multiline
-'\n\t\t'      Text.Whitespace
-'DUP'         Keyword.Reserved
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#01'         Literal.Number.Hex
+'01'          Literal
 ' '           Text.Whitespace
-'AND'         Keyword.Reserved
+'-Screen/auto' Literal
 ' '           Text.Whitespace
-',&no-dot'    Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-' \n\t\t\t'   Text.Whitespace
-'.wave-view/y1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0010'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t\t\t'    Text.Whitespace
-'#03'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/pixel' Name.Variable.Magic
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'&no-dot'     Name.Label
-'\n\t\t'      Text.Whitespace
-'#00'         Literal.Number.Hex
+'\n\t'        Text.Whitespace
+';sin-pcm/end' Name.Variable.Global
 ' '           Text.Whitespace
-'OVR'         Keyword.Reserved
+';sin-pcm'    Name.Variable.Global
+'\n\t'        Text.Whitespace
+'&loop'       Name.Label
+'\n\t\t'      Text.Whitespace
+'DUP2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
+';sin-pcm'    Name.Variable.Global
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Audio0/length' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+'DIV2k'       Keyword.Reserved
+' '           Text.Whitespace
+'MUL2'        Keyword.Reserved
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+';sin-pcm'    Name.Variable.Global
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 'LDA'         Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-'2/'          Name
 '\n\t\t'      Text.Whitespace
-'TOS'         Name
+'#00'         Literal.Number.Hex
 ' '           Text.Whitespace
-'4//'         Name
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'#02'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.wave-view/y1' Name.Variable.Magic
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t\t'      Text.Whitespace
@@ -3090,159 +3080,27 @@
 ' draw '      Comment.Multiline
 ')'           Comment.Multiline
 ' '           Text.Whitespace
-'DUP'         Keyword.Reserved
-' \n\t\t\t'   Text.Whitespace
+'DUP2'        Keyword.Reserved
+' '           Text.Whitespace
+';sin-pcm'    Name.Variable.Global
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'NIP'         Keyword.Reserved
+' '           Text.Whitespace
 '.Audio0/length' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEI2'        Keyword.Reserved
 ' '           Text.Whitespace
 'NIP'         Keyword.Reserved
 ' '           Text.Whitespace
-'>'           Name
-' \n\t\t\t'   Text.Whitespace
-'.Audio0/length' Name.Variable.Magic
+'#01'         Literal.Number.Hex
 ' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
+'SUB'         Keyword.Reserved
 ' '           Text.Whitespace
-'#0100'       Literal.Number.Hex
-' '           Text.Whitespace
-'!!'          Name
-' '           Text.Whitespace
-'#0101'       Literal.Number.Hex
-' '           Text.Whitespace
-'=='          Name
-' '           Text.Whitespace
-'DUP'         Keyword.Reserved
-' '           Text.Whitespace
-'ADD'         Keyword.Reserved
+'GTH'         Keyword.Reserved
 ' '           Text.Whitespace
 'INC'         Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/pixel' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'INC'         Keyword.Reserved
-' '           Text.Whitespace
-'GTHk'        Keyword.Reserved
-' '           Text.Whitespace
-',&loop'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t'        Text.Whitespace
-'POP2'        Keyword.Reserved
-'\n\n\t'      Text.Whitespace
-'('           Comment.Multiline
-' range '     Comment.Multiline
-')'           Comment.Multiline
-'\n\t'        Text.Whitespace
-'AUTO-X'      Name
-'\n\t'        Text.Whitespace
-'.wave-view/x1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/y1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0010'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.Audio0/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#02'         Literal.Number.Hex
-' '           Text.Whitespace
-';draw-short' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/x2' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0020'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.Audio0/length' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#02'         Literal.Number.Hex
-' '           Text.Whitespace
-';draw-short' Name.Variable.Global
-' '           Text.Whitespace
-'JSR2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'AUTO-NONE'   Name
-'\n\n'        Text.Whitespace
-
-'RTN'         Name
-'\n\n'        Text.Whitespace
-
-'@draw-wave-length' Name.Function
-' '           Text.Whitespace
-'('           Comment.Multiline
-' color -- '  Comment.Multiline
-')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
-'STH'         Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/x1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Audio0/length' Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.wave-view/y1' Name.Variable.Magic
-' '           Text.Whitespace
-'LDZ2'        Keyword.Reserved
-' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0020'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'SWP2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'&loop'       Name.Label
-'\n\t\t'      Text.Whitespace
-'DUP2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'STHkr'       Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/pixel' Name.Variable.Magic
 ' '           Text.Whitespace
@@ -3252,18 +3110,114 @@
 ' '           Text.Whitespace
 'GTH2k'       Keyword.Reserved
 ' '           Text.Whitespace
-',&loop'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&loop'      Name.Function
 '\n\t'        Text.Whitespace
 'POP2'        Keyword.Reserved
 ' '           Text.Whitespace
 'POP2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'POPr'        Keyword.Reserved
+'('           Comment.Multiline
+' length line ' Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'.wave-view/x1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Audio0/length' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI2'        Keyword.Reserved
+' '           Text.Whitespace
+'#0001'       Literal.Number.Hex
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'ADD2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/x'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.wave-view/y1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/y'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+';line-icn'   Name.Variable.Global
+' '           Text.Whitespace
+'.Screen/addr' Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'71'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'05'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' range '     Comment.Multiline
+')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'01'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.wave-view/x1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/x'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.wave-view/y1' Name.Variable.Magic
+' '           Text.Whitespace
+'LDZ2'        Keyword.Reserved
+' '           Text.Whitespace
+'#0018'       Literal.Number.Hex
+' '           Text.Whitespace
+'SUB2'        Keyword.Reserved
+' '           Text.Whitespace
+'.Screen/y'   Name.Variable.Magic
+' '           Text.Whitespace
+'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'.Audio0/length' Name.Variable.Magic
+' '           Text.Whitespace
+'DEI2'        Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'!draw-short' Name.Function
 '\n\n'        Text.Whitespace
 
 '@draw-knob'  Name.Function
@@ -3272,153 +3226,73 @@
 ' x* y* value -- ' Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
-'('           Comment.Multiline
-' load '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
 'STH'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'OVR2'        Keyword.Reserved
+' '           Text.Whitespace
+'OVR2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'  '          Text.Whitespace
+' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' circle '    Comment.Multiline
+')'           Comment.Multiline
 '\n\t'        Text.Whitespace
 ';knob-icns'  Name.Variable.Global
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
 ' '           Text.Whitespace
-'#01'         Literal.Number.Hex
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'16'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
+'['           Punctuation
 ' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
+'01'          Literal
 ' '           Text.Whitespace
-'++'          Name
+'-Screen/sprite' Literal
 ' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
+']'           Punctuation
 ' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-';knob-icns'  Name.Variable.Global
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'DEOk'        Keyword.Reserved
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-';knob-icns'  Name.Variable.Global
-' '           Text.Whitespace
-'#0018'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/addr' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
 '('           Comment.Multiline
-' draw '      Comment.Multiline
+' value '     Comment.Multiline
 ')'           Comment.Multiline
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'--'          Name
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-' \n\t'       Text.Whitespace
-';knob-icns'  Name.Variable.Global
-' '           Text.Whitespace
 '#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/addr' Name.Variable.Magic
+'.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-' \n\t\t'     Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'#01'         Literal.Number.Hex
-' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
 '#0004'       Literal.Number.Hex
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEI2'        Keyword.Reserved
-' '           Text.Whitespace
-'#0008'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
@@ -3432,21 +3306,39 @@
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
 ' '           Text.Whitespace
-'#01'         Literal.Number.Hex
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'00'          Literal
+' '           Text.Whitespace
+'-Screen/auto' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'01'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+'\n\t'        Text.Whitespace
+'('           Comment.Multiline
+' marker '    Comment.Multiline
+')'           Comment.Multiline
 '\n\t'        Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
@@ -3454,21 +3346,19 @@
 ' '           Text.Whitespace
 '#0004'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
+'#0000'       Literal.Number.Hex
 ' '           Text.Whitespace
 'STHkr'       Keyword.Reserved
 ' '           Text.Whitespace
 ';knob-offsetx' Name.Variable.Global
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 'LDA'         Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/x'   Name.Variable.Magic
 ' '           Text.Whitespace
@@ -3480,240 +3370,112 @@
 ' '           Text.Whitespace
 '#0010'       Literal.Number.Hex
 ' '           Text.Whitespace
-'--'          Name
+'SUB2'        Keyword.Reserved
 ' '           Text.Whitespace
-'#00'         Literal.Number.Hex
-' '           Text.Whitespace
-'#00'         Literal.Number.Hex
+'#0000'       Literal.Number.Hex
 ' '           Text.Whitespace
 'STHr'        Keyword.Reserved
 ' '           Text.Whitespace
 ';knob-offsety' Name.Variable.Global
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 'LDA'         Keyword.Reserved
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/y'   Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-';knob-icns'  Name.Variable.Global
-' '           Text.Whitespace
-'#0020'       Literal.Number.Hex
-' '           Text.Whitespace
-'++'          Name
+';knob-icns/index' Name.Variable.Global
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
+'\n\t'        Text.Whitespace
+'['           Punctuation
 ' '           Text.Whitespace
-'#05'         Literal.Number.Hex
+'LIT2'        Keyword.Reserved
 ' '           Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'05'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 '@draw-short' Name.Function
 ' '           Text.Whitespace
 '('           Comment.Multiline
-' short* color -- ' Comment.Multiline
+' short* -- ' Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
-'STH'         Keyword.Reserved
-' \n\t'       Text.Whitespace
 'SWP'         Keyword.Reserved
 ' '           Text.Whitespace
-'STHkr'       Keyword.Reserved
-' '           Text.Whitespace
-',draw-byte'  Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
-' \n\t'       Text.Whitespace
-'STHr'        Keyword.Reserved
-' \n\n'       Text.Whitespace
+'draw-byte'   Name.Function
+'\n\n'        Text.Whitespace
 
 '@draw-byte'  Name.Function
 ' '           Text.Whitespace
 '('           Comment.Multiline
-' byte color -- ' Comment.Multiline
+' byte -- '   Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
-'STH'         Keyword.Reserved
-' \n\t'       Text.Whitespace
 'DUP'         Keyword.Reserved
 ' '           Text.Whitespace
 '#04'         Literal.Number.Hex
 ' '           Text.Whitespace
 'SFT'         Keyword.Reserved
 ' '           Text.Whitespace
-'STHkr'       Keyword.Reserved
-' '           Text.Whitespace
-',draw-hex'   Name.Variable.Instance
-' '           Text.Whitespace
-'JSR'         Keyword.Reserved
+'draw-hex'    Name.Function
 ' '           Text.Whitespace
 '#0f'         Literal.Number.Hex
 ' '           Text.Whitespace
 'AND'         Keyword.Reserved
-' \n\t'       Text.Whitespace
-'STHr'        Keyword.Reserved
-' \n\n'       Text.Whitespace
+'\n\n'        Text.Whitespace
 
 '@draw-hex'   Name.Function
 ' '           Text.Whitespace
 '('           Comment.Multiline
-' char color -- ' Comment.Multiline
+' char -- '   Comment.Multiline
 ')'           Comment.Multiline
 '\n\n\t'      Text.Whitespace
+'#00'         Literal.Number.Hex
+' '           Text.Whitespace
 'SWP'         Keyword.Reserved
 ' '           Text.Whitespace
-'TOS'         Name
+'#30'         Literal.Number.Hex
 ' '           Text.Whitespace
-'8**'         Name
+'SFT2'        Keyword.Reserved
 ' '           Text.Whitespace
 ';font-hex'   Name.Variable.Global
 ' '           Text.Whitespace
-'++'          Name
+'ADD2'        Keyword.Reserved
 ' '           Text.Whitespace
 '.Screen/addr' Name.Variable.Magic
 ' '           Text.Whitespace
 'DEO2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
-'.Screen/sprite' Name.Variable.Magic
+'['           Punctuation
+' '           Text.Whitespace
+'LIT2'        Keyword.Reserved
+' '           Text.Whitespace
+'02'          Literal
+' '           Text.Whitespace
+'-Screen/sprite' Literal
+' '           Text.Whitespace
+']'           Punctuation
 ' '           Text.Whitespace
 'DEO'         Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
-'\n\n'        Text.Whitespace
-
-'@fill-rect'  Name.Function
-' '           Text.Whitespace
-'('           Comment.Multiline
-' x1* y1* x2* y2* color -- ' Comment.Multiline
-')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
-',&color'     Name.Variable.Instance
-' '           Text.Whitespace
-'STR'         Keyword.Reserved
-'\n\t'        Text.Whitespace
-'('           Comment.Multiline
-' x1 x2 y1 y2 ' Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'ROT2'        Keyword.Reserved
-'\n\t'        Text.Whitespace
-'&ver'        Name.Label
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' save '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/y'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'STH2'        Keyword.Reserved
-' '           Text.Whitespace
-'STH2'        Keyword.Reserved
-' '           Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'SWP2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'&hor'        Name.Label
-'\n\t\t\t'    Text.Whitespace
-'('           Comment.Multiline
-' save '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'DUP2'        Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/x'   Name.Variable.Magic
-' '           Text.Whitespace
-'DEO2'        Keyword.Reserved
-'\n\t\t\t'    Text.Whitespace
-'('           Comment.Multiline
-' draw '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-',&color'     Name.Variable.Instance
-' '           Text.Whitespace
-'LDR'         Keyword.Reserved
-' '           Text.Whitespace
-'.Screen/pixel' Name.Variable.Magic
-' '           Text.Whitespace
-'DEO'         Keyword.Reserved
-'\n\t\t\t'    Text.Whitespace
-'('           Comment.Multiline
-' incr '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-'\n\t\t\t'    Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'GTS2'        Name
-' '           Text.Whitespace
-',&hor'       Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'POP2'        Keyword.Reserved
-' '           Text.Whitespace
-'POP2'        Keyword.Reserved
-' '           Text.Whitespace
-'STH2r'       Keyword.Reserved
-' '           Text.Whitespace
-'STH2r'       Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'('           Comment.Multiline
-' incr '      Comment.Multiline
-')'           Comment.Multiline
-' '           Text.Whitespace
-'INC2'        Keyword.Reserved
-'\n\t\t'      Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'OVR2'        Keyword.Reserved
-' '           Text.Whitespace
-'GTS2'        Name
-' '           Text.Whitespace
-',&ver'       Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
-'\n\t'        Text.Whitespace
-'POP2'        Keyword.Reserved
-' '           Text.Whitespace
-'POP2'        Keyword.Reserved
-' '           Text.Whitespace
-'POP2'        Keyword.Reserved
-' '           Text.Whitespace
-'POP2'        Keyword.Reserved
-'\n\n'        Text.Whitespace
-
-'RTN'         Name
-'\n\t'        Text.Whitespace
-'&color'      Name.Label
-' '           Text.Whitespace
-'$1'          Keyword.Declaration
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
 '@within-rect' Name.Function
@@ -3721,7 +3483,7 @@
 '('           Comment.Multiline
 ' x* y* rect -- flag ' Comment.Multiline
 ')'           Comment.Multiline
-'\n\t\n\t'    Text.Whitespace
+'\n\n\t'      Text.Whitespace
 'STH'         Keyword.Reserved
 '\n\t'        Text.Whitespace
 '('           Comment.Multiline
@@ -3732,17 +3494,15 @@
 ' '           Text.Whitespace
 'STHkr'       Keyword.Reserved
 ' '           Text.Whitespace
-'#02'         Literal.Number.Hex
+'INC'         Keyword.Reserved
 ' '           Text.Whitespace
-'ADD'         Keyword.Reserved
+'INC'         Keyword.Reserved
 ' '           Text.Whitespace
 'LDZ2'        Keyword.Reserved
 ' '           Text.Whitespace
 'LTH2'        Keyword.Reserved
 ' '           Text.Whitespace
-',&skip'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&skip'      Name.Function
 '\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' y > rect.y2 ' Comment.Multiline
@@ -3760,9 +3520,7 @@
 ' '           Text.Whitespace
 'GTH2'        Keyword.Reserved
 ' '           Text.Whitespace
-',&skip'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&skip'      Name.Function
 '\n\t'        Text.Whitespace
 'SWP2'        Keyword.Reserved
 '\n\t'        Text.Whitespace
@@ -3778,9 +3536,7 @@
 ' '           Text.Whitespace
 'LTH2'        Keyword.Reserved
 ' '           Text.Whitespace
-',&skip'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&skip'      Name.Function
 '\n\t'        Text.Whitespace
 '('           Comment.Multiline
 ' x > rect.x2 ' Comment.Multiline
@@ -3798,9 +3554,7 @@
 ' '           Text.Whitespace
 'GTH2'        Keyword.Reserved
 ' '           Text.Whitespace
-',&skip'      Name.Variable.Instance
-' '           Text.Whitespace
-'JCN'         Keyword.Reserved
+'?&skip'      Name.Function
 '\n\t'        Text.Whitespace
 'POP2'        Keyword.Reserved
 ' '           Text.Whitespace
@@ -3809,9 +3563,9 @@
 'POPr'        Keyword.Reserved
 '\n\t'        Text.Whitespace
 '#01'         Literal.Number.Hex
-' \n'         Text.Whitespace
+'\n'          Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\t'        Text.Whitespace
 '&skip'       Name.Label
 '\n\t'        Text.Whitespace
@@ -3824,11 +3578,191 @@
 '#00'         Literal.Number.Hex
 '\n\n'        Text.Whitespace
 
-'RTN'         Name
+'JMP2r'       Keyword.Reserved
 '\n\n'        Text.Whitespace
 
-'@cursor'     Name.Function
-' \n\t'       Text.Whitespace
+'@phex'       Name.Function
+' '           Text.Whitespace
+'('           Comment.Multiline
+' short* -- ' Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'SWP'         Keyword.Reserved
+' '           Text.Whitespace
+'phex/b'      Name.Function
+' '           Text.Whitespace
+'&b'          Name.Label
+' '           Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
+'#04'         Literal.Number.Hex
+' '           Text.Whitespace
+'SFT'         Keyword.Reserved
+' '           Text.Whitespace
+'phex/c'      Name.Function
+' '           Text.Whitespace
+'&c'          Name.Label
+' '           Text.Whitespace
+'#0f'         Literal.Number.Hex
+' '           Text.Whitespace
+'AND'         Keyword.Reserved
+' '           Text.Whitespace
+'DUP'         Keyword.Reserved
+' '           Text.Whitespace
+'#09'         Literal.Number.Hex
+' '           Text.Whitespace
+'GTH'         Keyword.Reserved
+' '           Text.Whitespace
+'#27'         Literal.Number.Hex
+' '           Text.Whitespace
+'MUL'         Keyword.Reserved
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'#30'         Literal.Number.Hex
+' '           Text.Whitespace
+'ADD'         Keyword.Reserved
+' '           Text.Whitespace
+'#18'         Literal.Number.Hex
+' '           Text.Whitespace
+'DEO'         Keyword.Reserved
+' '           Text.Whitespace
+'JMP2r'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'('           Comment.Multiline
+'\n@|assets ' Comment.Multiline
+')'           Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'@notes-lut'  Name.Function
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
+'30'          Literal
+' '           Text.Whitespace
+'32'          Literal
+' '           Text.Whitespace
+'34'          Literal
+' '           Text.Whitespace
+'35'          Literal
+' '           Text.Whitespace
+'37'          Literal
+' '           Text.Whitespace
+'39'          Literal
+' '           Text.Whitespace
+'3b'          Literal
+' '           Text.Whitespace
+'3c'          Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'@dotted-icn' Name.Function
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'aa00'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+'\n\t'        Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+'0000'        Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'@line-icn'   Name.Function
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+'8080'        Literal
+'\n\t'        Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'@fill-icn'   Name.Function
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
+'ffff'        Literal
+' '           Text.Whitespace
+'ffff'        Literal
+' '           Text.Whitespace
+'ffff'        Literal
+' '           Text.Whitespace
+'ffff'        Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'@cursor-icn' Name.Function
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '80c0'        Literal
 ' '           Text.Whitespace
 'e0f0'        Literal
@@ -3836,10 +3770,14 @@
 'f8e0'        Literal
 ' '           Text.Whitespace
 '1000'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@arrow-icns' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '0010'        Literal
 ' '           Text.Whitespace
 '387c'        Literal
@@ -3847,6 +3785,9 @@
 'fe10'        Literal
 ' '           Text.Whitespace
 '1000'        Literal
+'\n'          Text.Whitespace
+
+'&down'       Name.Label
 '\n\t'        Text.Whitespace
 '0010'        Literal
 ' '           Text.Whitespace
@@ -3855,29 +3796,14 @@
 'fe7c'        Literal
 ' '           Text.Whitespace
 '3810'        Literal
-' \n\n'       Text.Whitespace
-
-'@notes'      Name.Function
-' \n\t'       Text.Whitespace
-'30'          Literal
 ' '           Text.Whitespace
-'32'          Literal
-' '           Text.Whitespace
-'34'          Literal
-' '           Text.Whitespace
-'35'          Literal
-'\n\t'        Text.Whitespace
-'37'          Literal
-' '           Text.Whitespace
-'39'          Literal
-' '           Text.Whitespace
-'3b'          Literal
-' '           Text.Whitespace
-'3c'          Literal
-'\n\n'        Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@keys-left-icns' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '7c7c'        Literal
 ' '           Text.Whitespace
 '7c7c'        Literal
@@ -3901,10 +3827,14 @@
 '7f7f'        Literal
 ' '           Text.Whitespace
 '3e00'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@keys-middle-icns' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '1c1c'        Literal
 ' '           Text.Whitespace
 '1c1c'        Literal
@@ -3928,10 +3858,14 @@
 '7f7f'        Literal
 ' '           Text.Whitespace
 '3e00'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@keys-right-icns' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '1f1f'        Literal
 ' '           Text.Whitespace
 '1f1f'        Literal
@@ -3955,10 +3889,14 @@
 '7f7f'        Literal
 ' '           Text.Whitespace
 '3e00'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@knob-icns'  Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '0003'        Literal
 ' '           Text.Whitespace
 '0c10'        Literal
@@ -3991,6 +3929,8 @@
 ' '           Text.Whitespace
 'c000'        Literal
 '\n\t'        Text.Whitespace
+'&index'      Name.Label
+'\n\t'        Text.Whitespace
 '0000'        Literal
 ' '           Text.Whitespace
 '183c'        Literal
@@ -3998,10 +3938,14 @@
 '3c18'        Literal
 ' '           Text.Whitespace
 '0000'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@knob-offsetx' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '01'          Literal
 ' '           Text.Whitespace
 '00'          Literal
@@ -4033,10 +3977,14 @@
 '08'          Literal
 ' '           Text.Whitespace
 '07'          Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@knob-offsety' Name.Function
-' \n\t'       Text.Whitespace
+' '           Text.Whitespace
+'['           Punctuation
+'\n\t'        Text.Whitespace
 '07'          Literal
 ' '           Text.Whitespace
 '06'          Literal
@@ -4068,13 +4016,13 @@
 '06'          Literal
 ' '           Text.Whitespace
 '07'          Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@font-hex'   Name.Function
 ' '           Text.Whitespace
-'('           Comment.Multiline
-' 0-F '       Comment.Multiline
-')'           Comment.Multiline
+'['           Punctuation
 '\n\t'        Text.Whitespace
 '007c'        Literal
 ' '           Text.Whitespace
@@ -4203,9 +4151,26 @@
 'f080'        Literal
 ' '           Text.Whitespace
 '8080'        Literal
-' \n\n'       Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'('           Comment.Multiline
+' pad '       Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
 
 '@sin-pcm'    Name.Function
+' '           Text.Whitespace
+'['           Punctuation
 '\n\t'        Text.Whitespace
 '8083'        Literal
 ' '           Text.Whitespace
@@ -4462,4 +4427,21 @@
 '7477'        Literal
 ' '           Text.Whitespace
 '7a7d'        Literal
+' '           Text.Whitespace
+']'           Punctuation
+'\n\t'        Text.Whitespace
+'&end'        Name.Label
+'\n'          Text.Whitespace
+
+'('           Comment.Multiline
+' pad '       Comment.Multiline
+')'           Comment.Multiline
+' '           Text.Whitespace
+'['           Punctuation
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+'8080'        Literal
+' '           Text.Whitespace
+']'           Punctuation
 '\n'          Text.Whitespace


### PR DESCRIPTION
Since the lexer was originally created the ' and : runes have been deprecated, and the -_=?! runes have been added. 

Uxntal reference: https://wiki.xxiivv.com/site/uxntal.html

The original example piano.tal file has been updated with a newer reference file (used with permission), as the old one included a macro which conflicted with the new - rune, and used fairly old uxntal coding style.