### PR TITLE
Markdown: allow extra characters after language name in code blocks

### DIFF
--- a/tests/examplefiles/arturo/arturo_test.art.output
+++ b/tests/examplefiles/arturo/arturo_test.art.output
@@ -124,7 +124,7 @@
 
 '\n    ```'   Literal.String.Backtick
 'c'           Literal.String.Backtick
-'\n'          Text
+'\n'          Text.Whitespace
 
 '    '        Text.Whitespace
 '#'           Comment.Preproc

--- a/tests/examplefiles/md/example.md.output
+++ b/tests/examplefiles/md/example.md.output
@@ -363,7 +363,7 @@
 
 '\n```'       Literal.String.Backtick
 'python'      Literal.String.Backtick
-'\n'          Text
+'\n'          Text.Whitespace
 
 'from'        Keyword.Namespace
 ' '           Text

--- a/tests/snippets/markdown/test_code.txt
+++ b/tests/snippets/markdown/test_code.txt
@@ -17,6 +17,12 @@ Code fence with unknown language:
 foo
 ```
 
+Code fence with extra stuff after the language name:
+
+```shell-session $?
+$ unknown
+```
+
 ---tokens---
 'Code'        Text
 ' '           Text
@@ -38,7 +44,7 @@ foo
 
 '\n```'       Literal.String.Backtick
 'python'      Literal.String.Backtick
-'\n'          Text
+'\n'          Text.Whitespace
 
 'import'      Keyword.Namespace
 ' '           Text
@@ -60,13 +66,43 @@ foo
 'language:'   Text
 '\n'          Text.Whitespace
 
+'\n```'       Literal.String.Backtick
+'invalid-lexer' Literal.String.Backtick
 '\n'          Text.Whitespace
 
-'```invalid-lexer' Text
+'foo\n'       Literal.String
+
+'```\n'       Literal.String.Backtick
+
 '\n'          Text.Whitespace
 
-'foo'         Text
+'Code'        Text
+' '           Text
+'fence'       Text
+' '           Text
+'with'        Text
+' '           Text
+'extra'       Text
+' '           Text
+'stuff'       Text
+' '           Text
+'after'       Text
+' '           Text
+'the'         Text
+' '           Text
+'language'    Text
+' '           Text
+'name:'       Text
 '\n'          Text.Whitespace
 
-'```'         Text
+'\n```'       Literal.String.Backtick
+'shell-session' Literal.String.Backtick
+' '           Text.Whitespace
+'$?'          Text
 '\n'          Text.Whitespace
+
+'$ '          Generic.Prompt
+'unknown'     Text
+'\n'          Text.Whitespace
+
+'```\n'       Literal.String.Backtick

--- a/tests/snippets/md/test_code_block_with_language.txt
+++ b/tests/snippets/md/test_code_block_with_language.txt
@@ -6,7 +6,7 @@ import this
 ---tokens---
 '```'         Literal.String.Backtick
 'python'      Literal.String.Backtick
-'\n'          Text
+'\n'          Text.Whitespace
 
 'import'      Keyword.Namespace
 ' '           Text


### PR DESCRIPTION
Fixes #2426