### PR TITLE
Add Generic.EmphStrong token

### DIFF
--- a/doc/docs/tokens.rst
+++ b/doc/docs/tokens.rst
@@ -369,6 +369,9 @@ highlight a programming language but a patch file.
 `Generic.Strong`
     Marks the token value as bold (e.g. for rst lexer).
 
+`Generic.EmphStrong`
+    Marks the token value as bold and emphasized.
+
 `Generic.Subheading`
     Marks the token value as subheadline.
 

--- a/pygments/styles/autumn.py
+++ b/pygments/styles/autumn.py
@@ -54,6 +54,7 @@ class AutumnStyle(Style):
         Generic.Error:              '#aa0000',
         Generic.Emph:               'italic',
         Generic.Strong:             'bold',
+        Generic.EmphStrong:         'bold italic',
         Generic.Prompt:             '#555555',
         Generic.Output:             '#888888',
         Generic.Traceback:          '#aa0000',

--- a/pygments/styles/borland.py
+++ b/pygments/styles/borland.py
@@ -40,6 +40,7 @@ class BorlandStyle(Style):
         Generic.Error:          '#aa0000',
         Generic.Emph:           'italic',
         Generic.Strong:         'bold',
+        Generic.EmphStrong:     'bold italic',
         Generic.Prompt:         '#555555',
         Generic.Output:         '#888888',
         Generic.Traceback:      '#aa0000',

--- a/pygments/styles/bw.py
+++ b/pygments/styles/bw.py
@@ -41,6 +41,7 @@ class BlackWhiteStyle(Style):
         Generic.Subheading:        "bold",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold",
 
         Error:                     "border:#FF0000"

--- a/pygments/styles/colorful.py
+++ b/pygments/styles/colorful.py
@@ -70,6 +70,7 @@ class ColorfulStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #c65d09",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/default.py
+++ b/pygments/styles/default.py
@@ -63,6 +63,7 @@ class DefaultStyle(Style):
         Generic.Error:             "#E40000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #000080",
         Generic.Output:            "#717171",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/dracula.py
+++ b/pygments/styles/dracula.py
@@ -44,6 +44,7 @@ class DraculaStyle(Style):
         Generic.Output: "#44475a",
         Generic.Prompt: "#f8f8f2",
         Generic.Strong: "#f8f8f2",
+        Generic.EmphStrong: "#f8f8f2 underline",
         Generic.Subheading: "#f8f8f2 bold",
         Generic.Traceback: "#f8f8f2",
 

--- a/pygments/styles/emacs.py
+++ b/pygments/styles/emacs.py
@@ -62,6 +62,7 @@ class EmacsStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #000080",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/friendly.py
+++ b/pygments/styles/friendly.py
@@ -63,6 +63,7 @@ class FriendlyStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #c65d09",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/friendly_grayscale.py
+++ b/pygments/styles/friendly_grayscale.py
@@ -67,6 +67,7 @@ class FriendlyGrayscaleStyle(Style):
         Generic.Error:             "#898989",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #7E7E7E",
         Generic.Output:            "#888888",
         Generic.Traceback:         "#6D6D6D",

--- a/pygments/styles/gh_dark.py
+++ b/pygments/styles/gh_dark.py
@@ -99,6 +99,7 @@ class GhDarkStyle(Style):
         Generic.Output:             GRAY_3,
         Generic.Prompt:             GRAY_3,
         Generic.Strong:             "bold",
+        Generic.EmphStrong:         "bold italic",
         Generic.Subheading:         BLUE_2,
         Generic.Traceback:          RED_3,
         Generic.Underline:          "underline",

--- a/pygments/styles/gruvbox.py
+++ b/pygments/styles/gruvbox.py
@@ -55,6 +55,7 @@ class GruvboxDarkStyle(Style):
         Generic.Error:      '#fb4934',
         Generic.Emph:       'italic',
         Generic.Strong:     'bold',
+        Generic.EmphStrong: 'bold italic',
         Generic.Prompt:     '#a89984',
         Generic.Output:     '#f2e5bc',
         Generic.Traceback:  '#fb4934',

--- a/pygments/styles/inkpot.py
+++ b/pygments/styles/inkpot.py
@@ -59,6 +59,7 @@ class InkPotStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #000080",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/lovelace.py
+++ b/pygments/styles/lovelace.py
@@ -88,6 +88,7 @@ class LovelaceStyle(Style):
         Generic.Output:      '#666666',
         Generic.Prompt:      '#444444',
         Generic.Strong:      'bold',
+        Generic.EmphStrong:  'bold italic',
         Generic.Traceback:   _KW_BLUE,
 
         Error:               'bg:'+_OW_PURPLE,

--- a/pygments/styles/manni.py
+++ b/pygments/styles/manni.py
@@ -66,6 +66,7 @@ class ManniStyle(Style):
         Generic.Error:      '#FF0000',
         Generic.Emph:       'italic',
         Generic.Strong:     'bold',
+        Generic.EmphStrong: 'bold italic',
         Generic.Prompt:     'bold #000099',
         Generic.Output:     '#AAAAAA',
         Generic.Traceback:  '#99CC66',

--- a/pygments/styles/material.py
+++ b/pygments/styles/material.py
@@ -112,6 +112,7 @@ class MaterialStyle(Style):
         Generic.Output:                faded,
         Generic.Prompt:                yellow,
         Generic.Strong:                red,
+        Generic.EmphStrong:            yellow,
         Generic.Subheading:            cyan,
         Generic.Traceback:             red,
     }

--- a/pygments/styles/monokai.py
+++ b/pygments/styles/monokai.py
@@ -101,6 +101,7 @@ class MonokaiStyle(Style):
         Generic.Output:            "#66d9ef", # class: 'go'
         Generic.Prompt:            "bold #f92672", # class: 'gp'
         Generic.Strong:            "bold",    # class: 'gs'
+        Generic.EmphStrong:        "bold italic",  # class: 'ges'
         Generic.Subheading:        "#75715e", # class: 'gu'
         Generic.Traceback:         "",        # class: 'gt'
     }

--- a/pygments/styles/murphy.py
+++ b/pygments/styles/murphy.py
@@ -69,6 +69,7 @@ class MurphyStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #c65d09",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/native.py
+++ b/pygments/styles/native.py
@@ -57,6 +57,7 @@ class NativeStyle(Style):
         Generic.Error:      '#d22323',
         Generic.Emph:       'italic',
         Generic.Strong:     'bold',
+        Generic.EmphStrong: 'bold italic',
         Generic.Prompt:     '#aaaaaa',
         Generic.Output:     '#cccccc',
         Generic.Traceback:  '#d22323',

--- a/pygments/styles/nord.py
+++ b/pygments/styles/nord.py
@@ -73,6 +73,7 @@ class NordStyle(Style):
         Generic.Error:              '#bf616a',
         Generic.Emph:               'italic',
         Generic.Strong:             'bold',
+        Generic.EmphStrong:         'bold italic',
         Generic.Prompt:             'bold #616e88',
         Generic.Output:             '#d8dee9',
         Generic.Traceback:          '#bf616a',

--- a/pygments/styles/paraiso_dark.py
+++ b/pygments/styles/paraiso_dark.py
@@ -114,6 +114,7 @@ class ParaisoDarkStyle(Style):
         Generic.Output:            "",                    # class: 'go'
         Generic.Prompt:            "bold " + COMMENT,     # class: 'gp'
         Generic.Strong:            "bold",                # class: 'gs'
+        Generic.EmphStrong:        "bold italic",         # class: 'ges'
         Generic.Subheading:        "bold " + AQUA,        # class: 'gu'
         Generic.Traceback:         "",                    # class: 'gt'
     }

--- a/pygments/styles/paraiso_light.py
+++ b/pygments/styles/paraiso_light.py
@@ -114,6 +114,7 @@ class ParaisoLightStyle(Style):
         Generic.Output:            "",                    # class: 'go'
         Generic.Prompt:            "bold " + COMMENT,     # class: 'gp'
         Generic.Strong:            "bold",                # class: 'gs'
+        Generic.EmphStrong:        "bold italic",         # class: 'ges'
         Generic.Subheading:        "bold " + AQUA,        # class: 'gu'
         Generic.Traceback:         "",                    # class: 'gt'
     }

--- a/pygments/styles/pastie.py
+++ b/pygments/styles/pastie.py
@@ -64,6 +64,7 @@ class PastieStyle(Style):
         Generic.Error:          '#aa0000',
         Generic.Emph:           'italic',
         Generic.Strong:         'bold',
+        Generic.EmphStrong:     'bold italic',
         Generic.Prompt:         '#555555',
         Generic.Output:         '#888888',
         Generic.Traceback:      '#aa0000',

--- a/pygments/styles/perldoc.py
+++ b/pygments/styles/perldoc.py
@@ -59,6 +59,7 @@ class PerldocStyle(Style):
         Generic.Error:          '#aa0000',
         Generic.Emph:           'italic',
         Generic.Strong:         'bold',
+        Generic.EmphStrong:     'bold italic',
         Generic.Prompt:         '#555555',
         Generic.Output:         '#888888',
         Generic.Traceback:      '#aa0000',

--- a/pygments/styles/rainbow_dash.py
+++ b/pygments/styles/rainbow_dash.py
@@ -54,6 +54,7 @@ class RainbowDashStyle(Style):
         Generic.Output: GREY,
         Generic.Prompt: 'bold {}'.format(BLUE),
         Generic.Strong: 'bold',
+        Generic.EmphStrong: 'bold italic',
         Generic.Subheading: 'bold {}'.format(BLUE),
         Generic.Traceback: RED_DARK,
 

--- a/pygments/styles/solarized.py
+++ b/pygments/styles/solarized.py
@@ -67,6 +67,7 @@ def make_style(colors):
         Generic.Output:      colors['base0'],
         Generic.Prompt:      'bold ' + colors['blue'],
         Generic.Strong:      'bold',
+        Generic.EmphStrong:  'bold italic',
         Generic.Traceback:   colors['blue'],
 
         Error:               'bg:' + colors['red'],

--- a/pygments/styles/tango.py
+++ b/pygments/styles/tango.py
@@ -134,6 +134,7 @@ class TangoStyle(Style):
         Generic.Output:            "italic #000000", # class: 'go'
         Generic.Prompt:            "#8f5902",        # class: 'gp'
         Generic.Strong:            "bold #000000",   # class: 'gs'
+        Generic.EmphStrong:        "bold italic #000000",  # class: 'ges'
         Generic.Subheading:        "bold #800080",   # class: 'gu'
         Generic.Traceback:         "bold #a40000",   # class: 'gt'
     }

--- a/pygments/styles/trac.py
+++ b/pygments/styles/trac.py
@@ -52,6 +52,7 @@ class TracStyle(Style):
         Generic.Error:          '#aa0000',
         Generic.Emph:           'italic',
         Generic.Strong:         'bold',
+        Generic.EmphStrong:     'bold italic',
         Generic.Prompt:         '#555555',
         Generic.Output:         '#888888',
         Generic.Traceback:      '#aa0000',

--- a/pygments/styles/vim.py
+++ b/pygments/styles/vim.py
@@ -53,6 +53,7 @@ class VimStyle(Style):
         Generic.Error:             "#FF0000",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold #000080",
         Generic.Output:            "#888",
         Generic.Traceback:         "#04D",

--- a/pygments/styles/vs.py
+++ b/pygments/styles/vs.py
@@ -30,6 +30,7 @@ class VisualStudioStyle(Style):
         Generic.Subheading:        "bold",
         Generic.Emph:              "italic",
         Generic.Strong:            "bold",
+        Generic.EmphStrong:        "bold italic",
         Generic.Prompt:            "bold",
 
         Error:                     "border:#FF0000"

--- a/pygments/token.py
+++ b/pygments/token.py
@@ -209,5 +209,6 @@ STANDARD_TYPES = {
     Generic.Prompt:                'gp',
     Generic.Strong:                'gs',
     Generic.Subheading:            'gu',
+    Generic.EmphStrong:            'ges',
     Generic.Traceback:             'gt',
 }


### PR DESCRIPTION
Note that some theme do not use bold or italic styling for Generic.Emph or Generic.Strong token. For these themes, I didn't touch them.

Tested to work on default theme.

Closes #2307.