### PR TITLE
CI: If one job fails, allow others to continue

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]


### PR DESCRIPTION
Re: https://github.com/pygments/pygments/pull/2444#issuecomment-1566271577

Allow other jobs to continue, even if 3.12 falls. 