### PR TITLE
CI: Disallow warnings for 3.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,15 +26,8 @@ jobs:
         cache: 'pip'
     - name: Install tox
       run: pip install -r requirements.txt
-    - name: Test package (< 3.12)
-      if: matrix.python-version != '3.12-dev'
+    - name: Test package
       run: tox -- -W error
-    - name: Test package (3.12)
-      if: matrix.python-version == '3.12-dev'
-      # Temporarily allow warnings until pytest
-      # has fixed deprecation warnings:
-      # https://github.com/pytest-dev/pytest/pull/10894
-      run: tox
 
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow on from https://github.com/pygments/pygments/pull/2445.

pytest 7.3.2 has been released, fixing the deprecation warnings in Python 3.12:

* https://github.com/pytest-dev/pytest/pull/10894
* https://github.com/pytest-dev/pytest/releases/tag/7.3.2

So we can undo the special case and also disallow warnings for 3.12.