### PR TITLE
Add a lexer for the TLS presentation language

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Other contributors, listed alphabetically, are:
 * Michael Bayer -- Myghty lexers
 * Thomas Beale -- Archetype lexers
 * John Benediktsson -- Factor lexer
+* David Benjamin, Google LLC -- TLS lexer
 * Trevor Bergeron -- mIRC formatter
 * Vincent Bernat -- LessCSS lexer
 * Christopher Bertels -- Fancy lexer

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -502,6 +502,7 @@ LEXERS = {
     'ThriftLexer': ('pygments.lexers.dsls', 'Thrift', ('thrift',), ('*.thrift',), ('application/x-thrift',)),
     'TiddlyWiki5Lexer': ('pygments.lexers.markup', 'tiddler', ('tid',), ('*.tid',), ('text/vnd.tiddlywiki',)),
     'TlbLexer': ('pygments.lexers.tlb', 'Tl-b', ('tlb',), ('*.tlb',), ()),
+    'TlsLexer': ('pygments.lexers.tls', 'TLS Presentation Language', ('tls',), (), ()),
     'TodotxtLexer': ('pygments.lexers.textfmts', 'Todotxt', ('todotxt',), ('todo.txt', '*.todotxt'), ('text/x-todo',)),
     'TransactSqlLexer': ('pygments.lexers.sql', 'Transact-SQL', ('tsql', 't-sql'), ('*.sql',), ('text/x-tsql',)),
     'TreetopLexer': ('pygments.lexers.parsers', 'Treetop', ('treetop',), ('*.treetop', '*.tt'), ()),

--- a/pygments/lexers/tls.py
+++ b/pygments/lexers/tls.py
@@ -1,0 +1,58 @@
+"""
+    pygments.lexers.tls
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for the TLS presentation language.
+
+    :copyright: Copyright 2006-2023 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+import re
+
+from pygments.lexer import RegexLexer, bygroups, words
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Whitespace
+
+__all__ = ['TlsLexer']
+
+
+class TlsLexer(RegexLexer):
+    """
+    The TLS presentation language, described in RFC 8446.
+
+    .. versionadded:: 2.16
+    """
+    name = 'TLS Presentation Language'
+    url = 'https://www.rfc-editor.org/rfc/rfc8446#section-3'
+    filenames = []
+    aliases = ['tls']
+    mimetypes = []
+
+    flags = re.MULTILINE | re.DOTALL
+
+    tokens = {
+        'root': [
+            (r'\n', Whitespace),
+            (r'\s+', Whitespace),
+            (r'\\\n', Text),
+            # comments
+            (r'/[*](.|\n)*?[*]/', Comment.Multiline),
+            # Keywords
+            (words(('struct', 'enum', 'select', 'case'), suffix=r'\b'),
+             Keyword),
+            (words(('uint8', 'uint16', 'uint24', 'uint32', 'uint64', 'opaque'),
+                   suffix=r'\b'), Keyword.Type),
+            # numeric literals
+            (r'0x[0-9a-fA-F]+', Number.Hex),
+            (r'[0-9]+', Number.Integer),
+            # string literal
+            (r'"(\\.|[^"\\])*"', String),
+            # tokens
+            (r'[.]{2}', Operator),
+            (r'[+\-*/&^]', Operator),
+            (r'\[\[|\]\]', Punctuation),
+            (r'[|<>=!()\[\]{}.,;:\?]', Punctuation),
+            # identifiers
+            (r'[^\W\d]\w*', Name.Other),
+        ]
+    }

--- a/tests/examplefiles/tls/example.txt
+++ b/tests/examplefiles/tls/example.txt
@@ -1,0 +1,435 @@
+/*
+Multi-line
+comment
+
+struct { } ShouldBeIgnored
+*/
+
+/* RFC 8446, Section 3.5 */
+enum { red(3), blue(5), white(7) } Color;
+enum { sweet(1), sour(2), bitter(4), (32000) } Taste;
+Color color = blue;           /* correct, type implicit */
+enum { sad(0), meh(1..254), happy(255) } Mood;
+
+/* RFC 8446, Section 3.8 */
+enum { apple(0), orange(1) } VariantTag;
+
+struct {
+    uint16 number;
+    opaque string<0..10>; /* variable length */
+} V1;
+
+struct {
+    uint32 number;
+    opaque string[10];    /* fixed length */
+} V2;
+
+struct {
+    VariantTag type;
+    select (VariantRecord.type) {
+        case apple:  V1;
+        case orange: V2;
+    };
+} VariantRecord;
+
+/* RFC 8446, Section 7.1 */
+struct {
+    uint16 length = Length;
+    opaque label<7..255> = "tls13 " + Label;
+    opaque context<0..255> = Context;
+} HkdfLabel;
+
+/* RFC 8446, Appendix B */
+enum {
+    invalid(0),
+    change_cipher_spec(20),
+    alert(21),
+    handshake(22),
+    application_data(23),
+    heartbeat(24),  /* RFC 6520 */
+    (255)
+} ContentType;
+
+struct {
+    ContentType type;
+    ProtocolVersion legacy_record_version;
+    uint16 length;
+    opaque fragment[TLSPlaintext.length];
+} TLSPlaintext;
+
+struct {
+    opaque content[TLSPlaintext.length];
+    ContentType type;
+    uint8 zeros[length_of_padding];
+} TLSInnerPlaintext;
+
+struct {
+    ContentType opaque_type = application_data; /* 23 */
+    ProtocolVersion legacy_record_version = 0x0303; /* TLS v1.2 */
+    uint16 length;
+    opaque encrypted_record[TLSCiphertext.length];
+} TLSCiphertext;
+
+enum { warning(1), fatal(2), (255) } AlertLevel;
+
+enum {
+    close_notify(0),
+    unexpected_message(10),
+    bad_record_mac(20),
+    decryption_failed_RESERVED(21),
+    record_overflow(22),
+    decompression_failure_RESERVED(30),
+    handshake_failure(40),
+    no_certificate_RESERVED(41),
+    bad_certificate(42),
+    unsupported_certificate(43),
+    certificate_revoked(44),
+    certificate_expired(45),
+    certificate_unknown(46),
+    illegal_parameter(47),
+    unknown_ca(48),
+    access_denied(49),
+    decode_error(50),
+    decrypt_error(51),
+    export_restriction_RESERVED(60),
+    protocol_version(70),
+    insufficient_security(71),
+    internal_error(80),
+    inappropriate_fallback(86),
+    user_canceled(90),
+    no_renegotiation_RESERVED(100),
+    missing_extension(109),
+    unsupported_extension(110),
+    certificate_unobtainable_RESERVED(111),
+    unrecognized_name(112),
+    bad_certificate_status_response(113),
+    bad_certificate_hash_value_RESERVED(114),
+    unknown_psk_identity(115),
+    certificate_required(116),
+    no_application_protocol(120),
+    (255)
+} AlertDescription;
+
+struct {
+    AlertLevel level;
+    AlertDescription description;
+} Alert;
+
+enum {
+    hello_request_RESERVED(0),
+    client_hello(1),
+    server_hello(2),
+    hello_verify_request_RESERVED(3),
+    new_session_ticket(4),
+    end_of_early_data(5),
+    hello_retry_request_RESERVED(6),
+    encrypted_extensions(8),
+    certificate(11),
+    server_key_exchange_RESERVED(12),
+    certificate_request(13),
+    server_hello_done_RESERVED(14),
+    certificate_verify(15),
+    client_key_exchange_RESERVED(16),
+    finished(20),
+    certificate_url_RESERVED(21),
+    certificate_status_RESERVED(22),
+    supplemental_data_RESERVED(23),
+    key_update(24),
+    message_hash(254),
+    (255)
+} HandshakeType;
+
+struct {
+    HandshakeType msg_type;    /* handshake type */
+    uint24 length;             /* bytes in message */
+    select (Handshake.msg_type) {
+        case client_hello:          ClientHello;
+        case server_hello:          ServerHello;
+        case end_of_early_data:     EndOfEarlyData;
+        case encrypted_extensions:  EncryptedExtensions;
+        case certificate_request:   CertificateRequest;
+        case certificate:           Certificate;
+        case certificate_verify:    CertificateVerify;
+        case finished:              Finished;
+        case new_session_ticket:    NewSessionTicket;
+        case key_update:            KeyUpdate;
+    };
+} Handshake;
+
+uint16 ProtocolVersion;
+opaque Random[32];
+
+uint8 CipherSuite[2];    /* Cryptographic suite selector */
+
+struct {
+    ProtocolVersion legacy_version = 0x0303;    /* TLS v1.2 */
+    Random random;
+    opaque legacy_session_id<0..32>;
+    CipherSuite cipher_suites<2..2^16-2>;
+    opaque legacy_compression_methods<1..2^8-1>;
+    Extension extensions<8..2^16-1>;
+} ClientHello;
+
+struct {
+    ProtocolVersion legacy_version = 0x0303;    /* TLS v1.2 */
+    Random random;
+    opaque legacy_session_id_echo<0..32>;
+    CipherSuite cipher_suite;
+    uint8 legacy_compression_method = 0;
+    Extension extensions<6..2^16-1>;
+} ServerHello;
+
+struct {
+    ExtensionType extension_type;
+    opaque extension_data<0..2^16-1>;
+} Extension;
+
+enum {
+    server_name(0),                             /* RFC 6066 */
+    max_fragment_length(1),                     /* RFC 6066 */
+    status_request(5),                          /* RFC 6066 */
+    supported_groups(10),                       /* RFC 8422, 7919 */
+    signature_algorithms(13),                   /* RFC 8446 */
+    use_srtp(14),                               /* RFC 5764 */
+    heartbeat(15),                              /* RFC 6520 */
+    application_layer_protocol_negotiation(16), /* RFC 7301 */
+    signed_certificate_timestamp(18),           /* RFC 6962 */
+    client_certificate_type(19),                /* RFC 7250 */
+    server_certificate_type(20),                /* RFC 7250 */
+    padding(21),                                /* RFC 7685 */
+    RESERVED(40),                               /* Used but never
+                                                    assigned */
+    pre_shared_key(41),                         /* RFC 8446 */
+    early_data(42),                             /* RFC 8446 */
+    supported_versions(43),                     /* RFC 8446 */
+    cookie(44),                                 /* RFC 8446 */
+    psk_key_exchange_modes(45),                 /* RFC 8446 */
+    RESERVED(46),                               /* Used but never
+                                                    assigned */
+    certificate_authorities(47),                /* RFC 8446 */
+    oid_filters(48),                            /* RFC 8446 */
+    post_handshake_auth(49),                    /* RFC 8446 */
+    signature_algorithms_cert(50),              /* RFC 8446 */
+    key_share(51),                              /* RFC 8446 */
+    (65535)
+} ExtensionType;
+
+struct {
+    NamedGroup group;
+    opaque key_exchange<1..2^16-1>;
+} KeyShareEntry;
+
+struct {
+    KeyShareEntry client_shares<0..2^16-1>;
+} KeyShareClientHello;
+
+struct {
+    NamedGroup selected_group;
+} KeyShareHelloRetryRequest;
+
+struct {
+    KeyShareEntry server_share;
+} KeyShareServerHello;
+
+struct {
+    uint8 legacy_form = 4;
+    opaque X[coordinate_length];
+    opaque Y[coordinate_length];
+} UncompressedPointRepresentation;
+
+enum { psk_ke(0), psk_dhe_ke(1), (255) } PskKeyExchangeMode;
+
+struct {
+    PskKeyExchangeMode ke_modes<1..255>;
+} PskKeyExchangeModes;
+
+struct {} Empty;
+
+struct {
+    select (Handshake.msg_type) {
+        case new_session_ticket:   uint32 max_early_data_size;
+        case client_hello:         Empty;
+        case encrypted_extensions: Empty;
+    };
+} EarlyDataIndication;
+
+struct {
+    opaque identity<1..2^16-1>;
+    uint32 obfuscated_ticket_age;
+} PskIdentity;
+
+opaque PskBinderEntry<32..255>;
+
+struct {
+    PskIdentity identities<7..2^16-1>;
+    PskBinderEntry binders<33..2^16-1>;
+} OfferedPsks;
+
+struct {
+    select (Handshake.msg_type) {
+        case client_hello: OfferedPsks;
+        case server_hello: uint16 selected_identity;
+    };
+} PreSharedKeyExtension;
+
+struct {
+    select (Handshake.msg_type) {
+        case client_hello:
+            ProtocolVersion versions<2..254>;
+
+        case server_hello: /* and HelloRetryRequest */
+            ProtocolVersion selected_version;
+    };
+} SupportedVersions;
+
+struct {
+    opaque cookie<1..2^16-1>;
+} Cookie;
+
+enum {
+    /* RSASSA-PKCS1-v1_5 algorithms */
+    rsa_pkcs1_sha256(0x0401),
+    rsa_pkcs1_sha384(0x0501),
+    rsa_pkcs1_sha512(0x0601),
+
+    /* ECDSA algorithms */
+    ecdsa_secp256r1_sha256(0x0403),
+    ecdsa_secp384r1_sha384(0x0503),
+    ecdsa_secp521r1_sha512(0x0603),
+
+    /* RSASSA-PSS algorithms with public key OID rsaEncryption */
+    rsa_pss_rsae_sha256(0x0804),
+    rsa_pss_rsae_sha384(0x0805),
+    rsa_pss_rsae_sha512(0x0806),
+
+    /* EdDSA algorithms */
+    ed25519(0x0807),
+    ed448(0x0808),
+
+    /* RSASSA-PSS algorithms with public key OID RSASSA-PSS */
+    rsa_pss_pss_sha256(0x0809),
+    rsa_pss_pss_sha384(0x080a),
+    rsa_pss_pss_sha512(0x080b),
+
+    /* Legacy algorithms */
+    rsa_pkcs1_sha1(0x0201),
+    ecdsa_sha1(0x0203),
+
+    /* Reserved Code Points */
+    obsolete_RESERVED(0x0000..0x0200),
+    dsa_sha1_RESERVED(0x0202),
+    obsolete_RESERVED(0x0204..0x0400),
+    dsa_sha256_RESERVED(0x0402),
+    obsolete_RESERVED(0x0404..0x0500),
+    dsa_sha384_RESERVED(0x0502),
+    obsolete_RESERVED(0x0504..0x0600),
+    dsa_sha512_RESERVED(0x0602),
+    obsolete_RESERVED(0x0604..0x06FF),
+    private_use(0xFE00..0xFFFF),
+    (0xFFFF)
+} SignatureScheme;
+
+struct {
+    SignatureScheme supported_signature_algorithms<2..2^16-2>;
+} SignatureSchemeList;
+
+enum {
+    unallocated_RESERVED(0x0000),
+
+    /* Elliptic Curve Groups (ECDHE) */
+    obsolete_RESERVED(0x0001..0x0016),
+    secp256r1(0x0017), secp384r1(0x0018), secp521r1(0x0019),
+    obsolete_RESERVED(0x001A..0x001C),
+    x25519(0x001D), x448(0x001E),
+
+    /* Finite Field Groups (DHE) */
+    ffdhe2048(0x0100), ffdhe3072(0x0101), ffdhe4096(0x0102),
+    ffdhe6144(0x0103), ffdhe8192(0x0104),
+
+    /* Reserved Code Points */
+    ffdhe_private_use(0x01FC..0x01FF),
+    ecdhe_private_use(0xFE00..0xFEFF),
+    obsolete_RESERVED(0xFF01..0xFF02),
+    (0xFFFF)
+} NamedGroup;
+
+struct {
+    NamedGroup named_group_list<2..2^16-1>;
+} NamedGroupList;
+
+opaque DistinguishedName<1..2^16-1>;
+
+struct {
+    DistinguishedName authorities<3..2^16-1>;
+} CertificateAuthoritiesExtension;
+
+struct {
+    opaque certificate_extension_oid<1..2^8-1>;
+    opaque certificate_extension_values<0..2^16-1>;
+} OIDFilter;
+
+struct {
+    OIDFilter filters<0..2^16-1>;
+} OIDFilterExtension;
+
+struct {} PostHandshakeAuth;
+
+struct {
+    Extension extensions<0..2^16-1>;
+} EncryptedExtensions;
+
+struct {
+    opaque certificate_request_context<0..2^8-1>;
+    Extension extensions<2..2^16-1>;
+} CertificateRequest;
+
+enum {
+    X509(0),
+    OpenPGP_RESERVED(1),
+    RawPublicKey(2),
+    (255)
+} CertificateType;
+
+struct {
+    select (certificate_type) {
+        case RawPublicKey:
+        /* From RFC 7250 ASN.1_subjectPublicKeyInfo */
+        opaque ASN1_subjectPublicKeyInfo<1..2^24-1>;
+
+        case X509:
+        opaque cert_data<1..2^24-1>;
+    };
+    Extension extensions<0..2^16-1>;
+} CertificateEntry;
+
+struct {
+    opaque certificate_request_context<0..2^8-1>;
+    CertificateEntry certificate_list<0..2^24-1>;
+} Certificate;
+
+struct {
+    SignatureScheme algorithm;
+    opaque signature<0..2^16-1>;
+} CertificateVerify;
+
+struct {
+    opaque verify_data[Hash.length];
+} Finished;
+
+struct {
+    uint32 ticket_lifetime;
+    uint32 ticket_age_add;
+    opaque ticket_nonce<0..255>;
+    opaque ticket<1..2^16-1>;
+    Extension extensions<0..2^16-2>;
+} NewSessionTicket;
+
+struct {} EndOfEarlyData;
+
+enum {
+    update_not_requested(0), update_requested(1), (255)
+} KeyUpdateRequest;
+
+struct {
+    KeyUpdateRequest request_update;
+} KeyUpdate;

--- a/tests/examplefiles/tls/example.txt.output
+++ b/tests/examplefiles/tls/example.txt.output
@@ -1,0 +1,3307 @@
+'/*\nMulti-line\ncomment\n\nstruct { } ShouldBeIgnored\n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* RFC 8446, Section 3.5 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'red'         Name.Other
+'('           Punctuation
+'3'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'blue'        Name.Other
+'('           Punctuation
+'5'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'white'       Name.Other
+'('           Punctuation
+'7'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'Color'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'sweet'       Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'sour'        Name.Other
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'bitter'      Name.Other
+'('           Punctuation
+'4'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'32000'       Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'Taste'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'Color'       Name.Other
+' '           Text.Whitespace
+'color'       Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'blue'        Name.Other
+';'           Punctuation
+'           ' Text.Whitespace
+'/* correct, type implicit */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'sad'         Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'meh'         Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'254'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'happy'       Name.Other
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'Mood'        Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* RFC 8446, Section 3.8 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'apple'       Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'orange'      Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'VariantTag'  Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'number'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'string'      Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'10'          Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+' '           Text.Whitespace
+'/* variable length */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'V1'          Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint32'      Keyword.Type
+' '           Text.Whitespace
+'number'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'string'      Name.Other
+'['           Punctuation
+'10'          Literal.Number.Integer
+']'           Punctuation
+';'           Punctuation
+'    '        Text.Whitespace
+'/* fixed length */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'V2'          Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'VariantTag'  Name.Other
+' '           Text.Whitespace
+'type'        Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'VariantRecord' Name.Other
+'.'           Punctuation
+'type'        Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'apple'       Name.Other
+':'           Punctuation
+'  '          Text.Whitespace
+'V1'          Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'orange'      Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'V2'          Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'VariantRecord' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* RFC 8446, Section 7.1 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'length'      Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'Length'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'label'       Name.Other
+'<'           Punctuation
+'7'           Literal.Number.Integer
+'..'          Operator
+'255'         Literal.Number.Integer
+'>'           Punctuation
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"tls13 "'    Literal.String
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'Label'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'context'     Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'255'         Literal.Number.Integer
+'>'           Punctuation
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'Context'     Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'HkdfLabel'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* RFC 8446, Appendix B */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'invalid'     Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'change_cipher_spec' Name.Other
+'('           Punctuation
+'20'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'alert'       Name.Other
+'('           Punctuation
+'21'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'handshake'   Name.Other
+'('           Punctuation
+'22'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'application_data' Name.Other
+'('           Punctuation
+'23'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'heartbeat'   Name.Other
+'('           Punctuation
+'24'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'  '          Text.Whitespace
+'/* RFC 6520 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'ContentType' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ContentType' Name.Other
+' '           Text.Whitespace
+'type'        Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'legacy_record_version' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'length'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'fragment'    Name.Other
+'['           Punctuation
+'TLSPlaintext' Name.Other
+'.'           Punctuation
+'length'      Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'TLSPlaintext' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'content'     Name.Other
+'['           Punctuation
+'TLSPlaintext' Name.Other
+'.'           Punctuation
+'length'      Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ContentType' Name.Other
+' '           Text.Whitespace
+'type'        Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint8'       Keyword.Type
+' '           Text.Whitespace
+'zeros'       Name.Other
+'['           Punctuation
+'length_of_padding' Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'TLSInnerPlaintext' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ContentType' Name.Other
+' '           Text.Whitespace
+'opaque_type' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'application_data' Name.Other
+';'           Punctuation
+' '           Text.Whitespace
+'/* 23 */'    Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'legacy_record_version' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0x0303'      Literal.Number.Hex
+';'           Punctuation
+' '           Text.Whitespace
+'/* TLS v1.2 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'length'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'encrypted_record' Name.Other
+'['           Punctuation
+'TLSCiphertext' Name.Other
+'.'           Punctuation
+'length'      Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'TLSCiphertext' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'warning'     Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'fatal'       Name.Other
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'AlertLevel'  Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'close_notify' Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unexpected_message' Name.Other
+'('           Punctuation
+'10'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'bad_record_mac' Name.Other
+'('           Punctuation
+'20'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'decryption_failed_RESERVED' Name.Other
+'('           Punctuation
+'21'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'record_overflow' Name.Other
+'('           Punctuation
+'22'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'decompression_failure_RESERVED' Name.Other
+'('           Punctuation
+'30'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'handshake_failure' Name.Other
+'('           Punctuation
+'40'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'no_certificate_RESERVED' Name.Other
+'('           Punctuation
+'41'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'bad_certificate' Name.Other
+'('           Punctuation
+'42'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unsupported_certificate' Name.Other
+'('           Punctuation
+'43'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_revoked' Name.Other
+'('           Punctuation
+'44'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_expired' Name.Other
+'('           Punctuation
+'45'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_unknown' Name.Other
+'('           Punctuation
+'46'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'illegal_parameter' Name.Other
+'('           Punctuation
+'47'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unknown_ca'  Name.Other
+'('           Punctuation
+'48'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'access_denied' Name.Other
+'('           Punctuation
+'49'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'decode_error' Name.Other
+'('           Punctuation
+'50'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'decrypt_error' Name.Other
+'('           Punctuation
+'51'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'export_restriction_RESERVED' Name.Other
+'('           Punctuation
+'60'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'protocol_version' Name.Other
+'('           Punctuation
+'70'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'insufficient_security' Name.Other
+'('           Punctuation
+'71'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'internal_error' Name.Other
+'('           Punctuation
+'80'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'inappropriate_fallback' Name.Other
+'('           Punctuation
+'86'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'user_canceled' Name.Other
+'('           Punctuation
+'90'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'no_renegotiation_RESERVED' Name.Other
+'('           Punctuation
+'100'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'missing_extension' Name.Other
+'('           Punctuation
+'109'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unsupported_extension' Name.Other
+'('           Punctuation
+'110'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_unobtainable_RESERVED' Name.Other
+'('           Punctuation
+'111'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unrecognized_name' Name.Other
+'('           Punctuation
+'112'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'bad_certificate_status_response' Name.Other
+'('           Punctuation
+'113'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'bad_certificate_hash_value_RESERVED' Name.Other
+'('           Punctuation
+'114'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unknown_psk_identity' Name.Other
+'('           Punctuation
+'115'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_required' Name.Other
+'('           Punctuation
+'116'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'no_application_protocol' Name.Other
+'('           Punctuation
+'120'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'AlertDescription' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'AlertLevel'  Name.Other
+' '           Text.Whitespace
+'level'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'AlertDescription' Name.Other
+' '           Text.Whitespace
+'description' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Alert'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'hello_request_RESERVED' Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'client_hello' Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'server_hello' Name.Other
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'hello_verify_request_RESERVED' Name.Other
+'('           Punctuation
+'3'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'new_session_ticket' Name.Other
+'('           Punctuation
+'4'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'end_of_early_data' Name.Other
+'('           Punctuation
+'5'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'hello_retry_request_RESERVED' Name.Other
+'('           Punctuation
+'6'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'encrypted_extensions' Name.Other
+'('           Punctuation
+'8'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate' Name.Other
+'('           Punctuation
+'11'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'server_key_exchange_RESERVED' Name.Other
+'('           Punctuation
+'12'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_request' Name.Other
+'('           Punctuation
+'13'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'server_hello_done_RESERVED' Name.Other
+'('           Punctuation
+'14'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_verify' Name.Other
+'('           Punctuation
+'15'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'client_key_exchange_RESERVED' Name.Other
+'('           Punctuation
+'16'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'finished'    Name.Other
+'('           Punctuation
+'20'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_url_RESERVED' Name.Other
+'('           Punctuation
+'21'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_status_RESERVED' Name.Other
+'('           Punctuation
+'22'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'supplemental_data_RESERVED' Name.Other
+'('           Punctuation
+'23'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'key_update'  Name.Other
+'('           Punctuation
+'24'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'message_hash' Name.Other
+'('           Punctuation
+'254'         Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'HandshakeType' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'HandshakeType' Name.Other
+' '           Text.Whitespace
+'msg_type'    Name.Other
+';'           Punctuation
+'    '        Text.Whitespace
+'/* handshake type */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint24'      Keyword.Type
+' '           Text.Whitespace
+'length'      Name.Other
+';'           Punctuation
+'             ' Text.Whitespace
+'/* bytes in message */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'Handshake'   Name.Other
+'.'           Punctuation
+'msg_type'    Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'client_hello' Name.Other
+':'           Punctuation
+'          '  Text.Whitespace
+'ClientHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'server_hello' Name.Other
+':'           Punctuation
+'          '  Text.Whitespace
+'ServerHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'end_of_early_data' Name.Other
+':'           Punctuation
+'     '       Text.Whitespace
+'EndOfEarlyData' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'encrypted_extensions' Name.Other
+':'           Punctuation
+'  '          Text.Whitespace
+'EncryptedExtensions' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'certificate_request' Name.Other
+':'           Punctuation
+'   '         Text.Whitespace
+'CertificateRequest' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'certificate' Name.Other
+':'           Punctuation
+'           ' Text.Whitespace
+'Certificate' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'certificate_verify' Name.Other
+':'           Punctuation
+'    '        Text.Whitespace
+'CertificateVerify' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'finished'    Name.Other
+':'           Punctuation
+'              ' Text.Whitespace
+'Finished'    Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'new_session_ticket' Name.Other
+':'           Punctuation
+'    '        Text.Whitespace
+'NewSessionTicket' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'key_update'  Name.Other
+':'           Punctuation
+'            ' Text.Whitespace
+'KeyUpdate'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Handshake'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'ProtocolVersion' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'Random'      Name.Other
+'['           Punctuation
+'32'          Literal.Number.Integer
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'uint8'       Keyword.Type
+' '           Text.Whitespace
+'CipherSuite' Name.Other
+'['           Punctuation
+'2'           Literal.Number.Integer
+']'           Punctuation
+';'           Punctuation
+'    '        Text.Whitespace
+'/* Cryptographic suite selector */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'legacy_version' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0x0303'      Literal.Number.Hex
+';'           Punctuation
+'    '        Text.Whitespace
+'/* TLS v1.2 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Random'      Name.Other
+' '           Text.Whitespace
+'random'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'legacy_session_id' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'32'          Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'CipherSuite' Name.Other
+' '           Text.Whitespace
+'cipher_suites' Name.Other
+'<'           Punctuation
+'2'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'2'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'legacy_compression_methods' Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'8'           Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'8'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'ClientHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'legacy_version' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0x0303'      Literal.Number.Hex
+';'           Punctuation
+'    '        Text.Whitespace
+'/* TLS v1.2 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Random'      Name.Other
+' '           Text.Whitespace
+'random'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'legacy_session_id_echo' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'32'          Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'CipherSuite' Name.Other
+' '           Text.Whitespace
+'cipher_suite' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint8'       Keyword.Type
+' '           Text.Whitespace
+'legacy_compression_method' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'6'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'ServerHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ExtensionType' Name.Other
+' '           Text.Whitespace
+'extension_type' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'extension_data' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Extension'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'server_name' Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                             ' Text.Whitespace
+'/* RFC 6066 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'max_fragment_length' Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                     ' Text.Whitespace
+'/* RFC 6066 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'status_request' Name.Other
+'('           Punctuation
+'5'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                          ' Text.Whitespace
+'/* RFC 6066 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'supported_groups' Name.Other
+'('           Punctuation
+'10'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                       ' Text.Whitespace
+'/* RFC 8422, 7919 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'signature_algorithms' Name.Other
+'('           Punctuation
+'13'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                   ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'use_srtp'    Name.Other
+'('           Punctuation
+'14'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                               ' Text.Whitespace
+'/* RFC 5764 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'heartbeat'   Name.Other
+'('           Punctuation
+'15'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                              ' Text.Whitespace
+'/* RFC 6520 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'application_layer_protocol_negotiation' Name.Other
+'('           Punctuation
+'16'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'/* RFC 7301 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'signed_certificate_timestamp' Name.Other
+'('           Punctuation
+'18'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'           ' Text.Whitespace
+'/* RFC 6962 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'client_certificate_type' Name.Other
+'('           Punctuation
+'19'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                ' Text.Whitespace
+'/* RFC 7250 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'server_certificate_type' Name.Other
+'('           Punctuation
+'20'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                ' Text.Whitespace
+'/* RFC 7250 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'padding'     Name.Other
+'('           Punctuation
+'21'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                                ' Text.Whitespace
+'/* RFC 7685 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'RESERVED'    Name.Other
+'('           Punctuation
+'40'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                               ' Text.Whitespace
+'/* Used but never\n                                                    assigned */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'pre_shared_key' Name.Other
+'('           Punctuation
+'41'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                         ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'early_data'  Name.Other
+'('           Punctuation
+'42'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                             ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'supported_versions' Name.Other
+'('           Punctuation
+'43'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                     ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'cookie'      Name.Other
+'('           Punctuation
+'44'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                                 ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'psk_key_exchange_modes' Name.Other
+'('           Punctuation
+'45'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                 ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'RESERVED'    Name.Other
+'('           Punctuation
+'46'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                               ' Text.Whitespace
+'/* Used but never\n                                                    assigned */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'certificate_authorities' Name.Other
+'('           Punctuation
+'47'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'oid_filters' Name.Other
+'('           Punctuation
+'48'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                            ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'post_handshake_auth' Name.Other
+'('           Punctuation
+'49'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                    ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'signature_algorithms_cert' Name.Other
+'('           Punctuation
+'50'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'              ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'key_share'   Name.Other
+'('           Punctuation
+'51'          Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'                              ' Text.Whitespace
+'/* RFC 8446 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'65535'       Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'ExtensionType' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'NamedGroup'  Name.Other
+' '           Text.Whitespace
+'group'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'key_exchange' Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyShareEntry' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'KeyShareEntry' Name.Other
+' '           Text.Whitespace
+'client_shares' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyShareClientHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'NamedGroup'  Name.Other
+' '           Text.Whitespace
+'selected_group' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyShareHelloRetryRequest' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'KeyShareEntry' Name.Other
+' '           Text.Whitespace
+'server_share' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyShareServerHello' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint8'       Keyword.Type
+' '           Text.Whitespace
+'legacy_form' Name.Other
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'4'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'X'           Name.Other
+'['           Punctuation
+'coordinate_length' Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'Y'           Name.Other
+'['           Punctuation
+'coordinate_length' Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'UncompressedPointRepresentation' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'psk_ke'      Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'psk_dhe_ke'  Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'PskKeyExchangeMode' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'PskKeyExchangeMode' Name.Other
+' '           Text.Whitespace
+'ke_modes'    Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'255'         Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'PskKeyExchangeModes' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+' '           Text.Whitespace
+'Empty'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'Handshake'   Name.Other
+'.'           Punctuation
+'msg_type'    Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'new_session_ticket' Name.Other
+':'           Punctuation
+'   '         Text.Whitespace
+'uint32'      Keyword.Type
+' '           Text.Whitespace
+'max_early_data_size' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'client_hello' Name.Other
+':'           Punctuation
+'         '   Text.Whitespace
+'Empty'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'encrypted_extensions' Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'Empty'       Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'EarlyDataIndication' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'identity'    Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint32'      Keyword.Type
+' '           Text.Whitespace
+'obfuscated_ticket_age' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'PskIdentity' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'PskBinderEntry' Name.Other
+'<'           Punctuation
+'32'          Literal.Number.Integer
+'..'          Operator
+'255'         Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'PskIdentity' Name.Other
+' '           Text.Whitespace
+'identities'  Name.Other
+'<'           Punctuation
+'7'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'PskBinderEntry' Name.Other
+' '           Text.Whitespace
+'binders'     Name.Other
+'<'           Punctuation
+'33'          Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'OfferedPsks' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'Handshake'   Name.Other
+'.'           Punctuation
+'msg_type'    Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'client_hello' Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'OfferedPsks' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'server_hello' Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'uint16'      Keyword.Type
+' '           Text.Whitespace
+'selected_identity' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'PreSharedKeyExtension' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'Handshake'   Name.Other
+'.'           Punctuation
+'msg_type'    Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'client_hello' Name.Other
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'            ' Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'versions'    Name.Other
+'<'           Punctuation
+'2'           Literal.Number.Integer
+'..'          Operator
+'254'         Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'server_hello' Name.Other
+':'           Punctuation
+' '           Text.Whitespace
+'/* and HelloRetryRequest */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'            ' Text.Whitespace
+'ProtocolVersion' Name.Other
+' '           Text.Whitespace
+'selected_version' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'SupportedVersions' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'cookie'      Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Cookie'      Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* RSASSA-PKCS1-v1_5 algorithms */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pkcs1_sha256' Name.Other
+'('           Punctuation
+'0x0401'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pkcs1_sha384' Name.Other
+'('           Punctuation
+'0x0501'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pkcs1_sha512' Name.Other
+'('           Punctuation
+'0x0601'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* ECDSA algorithms */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ecdsa_secp256r1_sha256' Name.Other
+'('           Punctuation
+'0x0403'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ecdsa_secp384r1_sha384' Name.Other
+'('           Punctuation
+'0x0503'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ecdsa_secp521r1_sha512' Name.Other
+'('           Punctuation
+'0x0603'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* RSASSA-PSS algorithms with public key OID rsaEncryption */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_rsae_sha256' Name.Other
+'('           Punctuation
+'0x0804'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_rsae_sha384' Name.Other
+'('           Punctuation
+'0x0805'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_rsae_sha512' Name.Other
+'('           Punctuation
+'0x0806'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* EdDSA algorithms */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ed25519'     Name.Other
+'('           Punctuation
+'0x0807'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ed448'       Name.Other
+'('           Punctuation
+'0x0808'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* RSASSA-PSS algorithms with public key OID RSASSA-PSS */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_pss_sha256' Name.Other
+'('           Punctuation
+'0x0809'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_pss_sha384' Name.Other
+'('           Punctuation
+'0x080a'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pss_pss_sha512' Name.Other
+'('           Punctuation
+'0x080b'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* Legacy algorithms */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'rsa_pkcs1_sha1' Name.Other
+'('           Punctuation
+'0x0201'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ecdsa_sha1'  Name.Other
+'('           Punctuation
+'0x0203'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* Reserved Code Points */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0000'      Literal.Number.Hex
+'..'          Operator
+'0x0200'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'dsa_sha1_RESERVED' Name.Other
+'('           Punctuation
+'0x0202'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0204'      Literal.Number.Hex
+'..'          Operator
+'0x0400'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'dsa_sha256_RESERVED' Name.Other
+'('           Punctuation
+'0x0402'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0404'      Literal.Number.Hex
+'..'          Operator
+'0x0500'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'dsa_sha384_RESERVED' Name.Other
+'('           Punctuation
+'0x0502'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0504'      Literal.Number.Hex
+'..'          Operator
+'0x0600'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'dsa_sha512_RESERVED' Name.Other
+'('           Punctuation
+'0x0602'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0604'      Literal.Number.Hex
+'..'          Operator
+'0x06FF'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'private_use' Name.Other
+'('           Punctuation
+'0xFE00'      Literal.Number.Hex
+'..'          Operator
+'0xFFFF'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'0xFFFF'      Literal.Number.Hex
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'SignatureScheme' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'SignatureScheme' Name.Other
+' '           Text.Whitespace
+'supported_signature_algorithms' Name.Other
+'<'           Punctuation
+'2'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'2'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'SignatureSchemeList' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'unallocated_RESERVED' Name.Other
+'('           Punctuation
+'0x0000'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* Elliptic Curve Groups (ECDHE) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x0001'      Literal.Number.Hex
+'..'          Operator
+'0x0016'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'secp256r1'   Name.Other
+'('           Punctuation
+'0x0017'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'secp384r1'   Name.Other
+'('           Punctuation
+'0x0018'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'secp521r1'   Name.Other
+'('           Punctuation
+'0x0019'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0x001A'      Literal.Number.Hex
+'..'          Operator
+'0x001C'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'x25519'      Name.Other
+'('           Punctuation
+'0x001D'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'x448'        Name.Other
+'('           Punctuation
+'0x001E'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* Finite Field Groups (DHE) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ffdhe2048'   Name.Other
+'('           Punctuation
+'0x0100'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'ffdhe3072'   Name.Other
+'('           Punctuation
+'0x0101'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'ffdhe4096'   Name.Other
+'('           Punctuation
+'0x0102'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ffdhe6144'   Name.Other
+'('           Punctuation
+'0x0103'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'ffdhe8192'   Name.Other
+'('           Punctuation
+'0x0104'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'/* Reserved Code Points */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ffdhe_private_use' Name.Other
+'('           Punctuation
+'0x01FC'      Literal.Number.Hex
+'..'          Operator
+'0x01FF'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'ecdhe_private_use' Name.Other
+'('           Punctuation
+'0xFE00'      Literal.Number.Hex
+'..'          Operator
+'0xFEFF'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'obsolete_RESERVED' Name.Other
+'('           Punctuation
+'0xFF01'      Literal.Number.Hex
+'..'          Operator
+'0xFF02'      Literal.Number.Hex
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'0xFFFF'      Literal.Number.Hex
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'NamedGroup'  Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'NamedGroup'  Name.Other
+' '           Text.Whitespace
+'named_group_list' Name.Other
+'<'           Punctuation
+'2'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'NamedGroupList' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'DistinguishedName' Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'DistinguishedName' Name.Other
+' '           Text.Whitespace
+'authorities' Name.Other
+'<'           Punctuation
+'3'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'CertificateAuthoritiesExtension' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'certificate_extension_oid' Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'8'           Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'certificate_extension_values' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'OIDFilter'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'OIDFilter'   Name.Other
+' '           Text.Whitespace
+'filters'     Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'OIDFilterExtension' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+' '           Text.Whitespace
+'PostHandshakeAuth' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'EncryptedExtensions' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'certificate_request_context' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'8'           Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'2'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'CertificateRequest' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'X509'        Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'OpenPGP_RESERVED' Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'RawPublicKey' Name.Other
+'('           Punctuation
+'2'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'CertificateType' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'select'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'certificate_type' Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'RawPublicKey' Name.Other
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'/* From RFC 7250 ASN.1_subjectPublicKeyInfo */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'ASN1_subjectPublicKeyInfo' Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'24'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'X509'        Name.Other
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'cert_data'   Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'24'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'CertificateEntry' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'certificate_request_context' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'8'           Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'CertificateEntry' Name.Other
+' '           Text.Whitespace
+'certificate_list' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'24'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Certificate' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'SignatureScheme' Name.Other
+' '           Text.Whitespace
+'algorithm'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'signature'   Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'CertificateVerify' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'verify_data' Name.Other
+'['           Punctuation
+'Hash'        Name.Other
+'.'           Punctuation
+'length'      Name.Other
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'Finished'    Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint32'      Keyword.Type
+' '           Text.Whitespace
+'ticket_lifetime' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'uint32'      Keyword.Type
+' '           Text.Whitespace
+'ticket_age_add' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'ticket_nonce' Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'255'         Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'opaque'      Keyword.Type
+' '           Text.Whitespace
+'ticket'      Name.Other
+'<'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'1'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Extension'   Name.Other
+' '           Text.Whitespace
+'extensions'  Name.Other
+'<'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
+'2'           Literal.Number.Integer
+'^'           Operator
+'16'          Literal.Number.Integer
+'-'           Operator
+'2'           Literal.Number.Integer
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'NewSessionTicket' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+' '           Text.Whitespace
+'EndOfEarlyData' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'update_not_requested' Name.Other
+'('           Punctuation
+'0'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'update_requested' Name.Other
+'('           Punctuation
+'1'           Literal.Number.Integer
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'255'         Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyUpdateRequest' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'struct'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'KeyUpdateRequest' Name.Other
+' '           Text.Whitespace
+'request_update' Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+' '           Text.Whitespace
+'KeyUpdate'   Name.Other
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This is the syntax used to define TLS structures. It is defined (somewhat loosely) here:
https://www.rfc-editor.org/rfc/rfc8446#section-3

I patterned it after the Carbon syntax, mostly as an example of a small, vaguely-C-like lexer. Let me know if I got any of the project conventions wrong! I mostly mimicking other files and don't fully understand how the project works. 😄

CC: @dvorak42 @jyasskin