### PR TITLE
Fixes for HttpLexer

### DIFF
--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -184,7 +184,7 @@ class HttpLexer(RegexLexer):
              'headers'),
         ],
         'headers': [
-            (r'([^\s:]+)( *)(:)( *)([^\r\n]+)(\r?\n|\Z)', header_callback),
+            (r'([^\s:]+)( *)(:)( *)([^\r\n]*)(\r?\n|\Z)', header_callback),
             (r'([\t ]+)([^\r\n]+)(\r?\n|\Z)', continuous_header_callback),
             (r'\r?\n', Text, 'content')
         ],


### PR DESCRIPTION
Example UPnP message found in the wild:

HTTP/1.1 200 OK
CACHE-CONTROL: max-age=1800
DATE: Tue, 18 Aug 2020 22:30:55 GMT
EXT:
LOCATION: http://192.168.1.1:60000/62177d51/gatedesc.xml SERVER: Unspecified, UPnP/1.0, SoftAtHome
ST: upnp:rootdevice
USN: uuid:62177d51-6ebe-4d59-9e8d-59cc417d3f9c::upnp:rootdevice