### PR TITLE
Bugfix: Restore `native`  in __init__.py

### DIFF
--- a/pygments/styles/__init__.py
+++ b/pygments/styles/__init__.py
@@ -40,6 +40,7 @@ STYLE_MAP = {
     'material': 'material::MaterialStyle',
     'monokai': 'monokai::MonokaiStyle',
     'murphy': 'murphy::MurphyStyle',
+    'native':   'native::NativeStyle',
     'nord': 'nord::NordStyle',
     'nord-darker': 'nord::NordDarkerStyle',
     'one-dark': 'onedark::OneDarkStyle',


### PR DESCRIPTION
Over at https://github.com/napari/napari
We're getting test failures due to a validation error:
https://github.com/napari/napari/issues/6121
```
napari/utils/events/evented_model.py:246: in __init__
    super().__init__(**kwargs)
pydantic/main.py:341: in pydantic.main.BaseModel.__init__
    ???
E   pydantic.error_wrappers.ValidationError: 1 validation error for Theme
E   syntax_style
E     Incorrect `syntax_style` value: native provided. Please use one of the following:  abap, algol, algol_nu, arduino, autumn, bw, borland, colorful, default, dracula, emacs, fruity, friendly, friendly_grayscale, github-dark, gruvbox-dark, gruvbox-light, igor, inkpot, lightbulb, lilypond, lovelace, manni, material, monokai, murphy, nord, nord-darker, one-dark, paraiso-dark, paraiso-light, pastie, perldoc, rainbow_dash, rrt, sas, solarized-dark, solarized-light, staroffice, stata, stata-dark, stata-light, tango, trac, vim, vs, xcode, zenburn
E   assert 'native' in {'abap': 'abap::AbapStyle', 'algol': 'algol::AlgolStyle', 'algol_nu': 'algol_nu::Algol_NuStyle', 'arduino': 'arduino::ArduinoStyle', ...} (type=assertion_error)
```

Investigating, I noticed that in PR https://github.com/pygments/pygments/pull/2443 `native` was dropped from the list. I assume it was not intentional, because the style itself does not appear to have been removed:
https://github.com/pygments/pygments/blob/master/pygments/styles/native.py

So in this PR I re-add `'native':   'native::NativeStyle',` to the list in the proper alphabetical spot.
This fixes our issues in napari.