### PR TITLE
Change pygmentize to not strip ansi escapes on windows

### DIFF
--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -474,7 +474,7 @@ def main_inner(parser, argns):
             pass
         else:
             outfile = colorama.initialise.wrap_stream(
-                outfile, convert=None, strip=None, autoreset=False, wrap=True)
+                outfile, convert=None, strip=False, autoreset=False, wrap=True)
 
     # When using the LaTeX formatter and the option `escapeinside` is
     # specified, we need a special lexer which collects escaped text


### PR DESCRIPTION
Fixes #2491. This maintains the colorama conversion behavior when needed (only for the legacy Windows console) but does not strip them for non-console output, e.g. to pipes.