### PR TITLE
Add missing variant langs

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -930,7 +930,9 @@ class WikitextLexer(RegexLexer):
     variant_langs = {
         # ZhConverter.php
         'zh', 'zh-hans', 'zh-hant', 'zh-cn', 'zh-hk', 'zh-mo', 'zh-my', 'zh-sg', 'zh-tw',
-        # UnConverter.php
+        # WuuConverter.php
+        'wuu', 'wuu-hans', 'wuu-hant',
+        # UzConverter.php
         'uz', 'uz-latn', 'uz-cyrl',
         # TlyConverter.php
         'tly', 'tly-cyrl',


### PR DESCRIPTION
Following up #2493, somebody pointed out that several variants which were added to MediaWiki in May 2023 were missing here.