### PR TITLE
Update Macaulay2 URL

### DIFF
--- a/pygments/lexers/macaulay2.py
+++ b/pygments/lexers/macaulay2.py
@@ -1719,7 +1719,7 @@ class Macaulay2Lexer(RegexLexer):
     """Lexer for Macaulay2, a software system for research in algebraic geometry."""
 
     name = 'Macaulay2'
-    url = 'https://faculty.math.illinois.edu/Macaulay2/'
+    url = 'https://macaulay2.com/'
     aliases = ['macaulay2']
     filenames = ['*.m2']
 


### PR DESCRIPTION
The old site hosted by the University of Illinois no longer exists.