### PR TITLE
formatters/html: Fold newlines into spans

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -887,7 +887,7 @@ class HtmlFormatter(Formatter):
                     yield 1, ''.join(line)
                     line = []
                 elif part:
-                    yield 1, ''.join((cspan, part, (cspan and '</span>'), lsep))
+                    yield 1, ''.join((cspan, part, lsep, (cspan and '</span>')))
                 else:
                     yield 1, lsep
             # for the last line


### PR DESCRIPTION
This PR updates the HTML formatter so it folds line separators into spans instead of leaving them outside spans.
This does allow the attributes for classes to also extend to the newline characters.
See #2499 for a detailed description and a before-and-after example.

Closes #2499