### PR TITLE
Fix cypher's comment matching (and add one keyword)

### DIFF
--- a/pygments/lexers/graph.py
+++ b/pygments/lexers/graph.py
@@ -35,16 +35,13 @@ class CypherLexer(RegexLexer):
 
     tokens = {
         'root': [
-            include('comment'),
             include('clauses'),
             include('keywords'),
             include('relations'),
             include('strings'),
             include('whitespace'),
             include('barewords'),
-        ],
-        'comment': [
-            (r'^.*//.*$', Comment.Single),
+            include('comment'),
         ],
         'keywords': [
             (r'(create|order|match|limit|set|skip|start|return|with|where|'
@@ -81,7 +78,7 @@ class CypherLexer(RegexLexer):
                 'delete', 'desc', 'descending', 'distinct', 'end', 'fieldterminator',
                 'foreach', 'in', 'limit', 'match', 'merge', 'none', 'not', 'null',
                 'remove', 'return', 'set', 'skip', 'single', 'start', 'then', 'union',
-                'unwind', 'yield', 'where', 'when', 'with'), suffix=r'\b'), Keyword),
+                'unwind', 'yield', 'where', 'when', 'with', 'collect'), suffix=r'\b'), Keyword),
         ],
         'relations': [
             (r'(-\[)(.*?)(\]->)', bygroups(Operator, using(this), Operator)),
@@ -92,7 +89,7 @@ class CypherLexer(RegexLexer):
             (r'[.*{}]', Punctuation),
         ],
         'strings': [
-            (r'"(?:\\[tbnrf\'"\\]|[^\\"])*"', String),
+            (r'([\'"])(?:\\[tbnrf\'"\\]|[^\\])*?\1', String),
             (r'`(?:``|[^`])+`', Name.Variable),
         ],
         'whitespace': [
@@ -101,5 +98,8 @@ class CypherLexer(RegexLexer):
         'barewords': [
             (r'[a-z]\w*', Name),
             (r'\d+', Number),
+        ],
+        'comment': [
+            (r'//.*$', Comment.Single),
         ],
     }

--- a/tests/examplefiles/cypher/test.cyp
+++ b/tests/examplefiles/cypher/test.cyp
@@ -1,4 +1,5 @@
 //test comment
+  //another test comment
 START a = node(*)
 MATCH (a)-[:ACTED_IN]->(m)<-[:DIRECTED]-(d)
 RETURN a.name, m.title, d.name;
@@ -117,7 +118,11 @@ RETURN extract(n in nodes(p) | n.name)[1];
 
 START actors=node:
 
-MATCH (alice)-[:`REALLY LIKES`]->(bob)
+MATCH (alice)-[:`REALLY LIKES`]->(bob)  // comment to something
 MATCH (alice)-[:`REALLY ``LIKES```]->(bob)
 myFancyIdentifier.`(weird property name)`
 "string\t\n\b\f\\\''\""
+'also string'
+
+MATCH (p:Person {uri:"http://example.com/thing/1"})
+RETURN p

--- a/tests/examplefiles/cypher/test.cyp.output
+++ b/tests/examplefiles/cypher/test.cyp.output
@@ -1,4 +1,6 @@
 '//test comment' Comment.Single
+'\n  '        Text.Whitespace
+'//another test comment' Comment.Single
 '\n'          Text.Whitespace
 
 'START'       Keyword
@@ -384,7 +386,7 @@
 ' '           Text.Whitespace
 'Movies'      Name
 ','           Punctuation
-'collect'     Name
+'collect'     Keyword
 '('           Punctuation
 'm'           Name
 '.'           Punctuation
@@ -1273,6 +1275,8 @@
 '('           Punctuation
 'bob'         Name
 ')'           Punctuation
+'  '          Text.Whitespace
+'// comment to something' Comment.Single
 '\n'          Text.Whitespace
 
 'MATCH'       Keyword
@@ -1295,4 +1299,27 @@
 '\n'          Text.Whitespace
 
 '"string\\t\\n\\b\\f\\\\\\\'\'\\""' Literal.String
+'\n'          Text.Whitespace
+
+"'also string'" Literal.String
+'\n\n'        Text.Whitespace
+
+'MATCH'       Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'p'           Name
+':'           Punctuation
+'Person'      Name
+' '           Text.Whitespace
+'{'           Punctuation
+'uri'         Name
+':'           Punctuation
+'"http://example.com/thing/1"' Literal.String
+'}'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'RETURN'      Keyword
+' '           Text.Whitespace
+'p'           Name
 '\n'          Text.Whitespace


### PR DESCRIPTION
Previously, comments matched the whole line, no matter what. 
Now they only match everything after '//'.

Also fixes #1364.

Furthermore, single quote strings are now also valid.