### PR TITLE
Snowball len fix

### DIFF
--- a/pygments/lexers/dsls.py
+++ b/pygments/lexers/dsls.py
@@ -929,7 +929,8 @@ class SnowballLexer(ExtendedRegexLexer):
 
     tokens = {
         'root': [
-            (words(('len', 'lenof'), suffix=r'\b'), Operator.Word),
+            (r'len\b', Name.Builtin),
+            (r'lenof\b', Operator.Word),
             include('root1'),
         ],
         'root1': [

--- a/pygments/lexers/dsls.py
+++ b/pygments/lexers/dsls.py
@@ -879,7 +879,7 @@ class SnowballLexer(ExtendedRegexLexer):
     """
 
     name = 'Snowball'
-    url = 'http://snowballstem.org/'
+    url = 'https://snowballstem.org/'
     aliases = ['snowball']
     filenames = ['*.sbl']
 

--- a/tests/examplefiles/snowball/example.sbl
+++ b/tests/examplefiles/snowball/example.sbl
@@ -106,4 +106,6 @@ define stem as (
         short_word or interjection or
         correlative or unuj or do standard_suffix
     )
+    $(lenof 'a' <= sizeof 'a')
+    $(len <= size)
 )

--- a/tests/examplefiles/snowball/example.sbl.output
+++ b/tests/examplefiles/snowball/example.sbl.output
@@ -881,6 +881,32 @@
 'standard_suffix' Name
 '\n    '      Text.Whitespace
 ')'           Punctuation
+'\n    '      Text.Whitespace
+'$'           Operator
+'('           Punctuation
+'lenof'       Operator.Word
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'a'           Literal.String.Single
+"'"           Literal.String.Single
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'sizeof'      Operator.Word
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'a'           Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n    '      Text.Whitespace
+'$'           Operator
+'('           Punctuation
+'len'         Name.Builtin
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'size'        Name.Builtin
+')'           Punctuation
 '\n'          Text.Whitespace
 
 ')'           Punctuation


### PR DESCRIPTION
Treat Snowball's `len` like `size`
    
In Snowball `len` is very like `size` (the difference is `len` gives the length in Unicode characters rather than bytes), so change `len` to be Name.Builtin to be consistent with the existing highlighting of `size`.