### PR TITLE
Bump checkout action to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,8 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -32,7 +33,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
@@ -45,7 +47,8 @@ jobs:
   check-mapfiles:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
@@ -63,7 +66,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -22,7 +22,7 @@ jobs:
       with:
         python-version: "3.x"
     - name: Checkout Pygments
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install tox
       run: pip install -r requirements.txt
     - name: Sphinx build


### PR DESCRIPTION
Upgrade checkout action to v4 to make use of Node 20.
Node 16, which v3 is using, reached end of life on 2023-09-11.