### PR TITLE
Add `Lexer.add_filter()` in api.rst

### DIFF
--- a/doc/docs/api.rst
+++ b/doc/docs/api.rst
@@ -56,7 +56,7 @@ Lexers
 The base lexer class from which all lexers are derived is:
 
 .. autoclass:: Lexer
-   :members: __init__, get_tokens, get_tokens_unprocessed, analyse_text
+   :members: __init__, add_filter, get_tokens, get_tokens_unprocessed, analyse_text
 
 There are several base class derived from ``Lexer`` you can use to build your lexer from:
 


### PR DESCRIPTION
Hi😊 I added 'add_filter()' to Lexer's document, which was not originally available. See #2518 .