### PR TITLE
A couple small fixes in the OCaml lexer.

### DIFF
--- a/pygments/lexers/ml.py
+++ b/pygments/lexers/ml.py
@@ -366,7 +366,7 @@ class OcamlLexer(RegexLexer):
     mimetypes = ['text/x-ocaml']
 
     keywords = (
-        'as', 'assert', 'begin', 'class', 'constraint', 'do', 'done',
+        'and', 'as', 'assert', 'begin', 'class', 'constraint', 'do', 'done',
         'downto', 'else', 'end', 'exception', 'external', 'false',
         'for', 'fun', 'function', 'functor', 'if', 'in', 'include',
         'inherit', 'initializer', 'lazy', 'let', 'match', 'method',
@@ -382,7 +382,7 @@ class OcamlLexer(RegexLexer):
     )
 
     operators = r'[!$%&*+\./:<=>?@^|~-]'
-    word_operators = ('and', 'asr', 'land', 'lor', 'lsl', 'lxor', 'mod', 'or')
+    word_operators = ('asr', 'land', 'lor', 'lsl', 'lxor', 'mod', 'or')
     prefix_syms = r'[!?~]'
     infix_syms = r'[=<>@^|&+\*/$%-]'
     primitives = ('unit', 'int', 'float', 'bool', 'string', 'char', 'list', 'array')

--- a/pygments/lexers/ml.py
+++ b/pygments/lexers/ml.py
@@ -372,7 +372,7 @@ class OcamlLexer(RegexLexer):
         'inherit', 'initializer', 'lazy', 'let', 'match', 'method',
         'module', 'mutable', 'new', 'object', 'of', 'open', 'private',
         'raise', 'rec', 'sig', 'struct', 'then', 'to', 'true', 'try',
-        'type', 'value', 'val', 'virtual', 'when', 'while', 'with',
+        'type', 'val', 'virtual', 'when', 'while', 'with',
     )
     keyopts = (
         '!=', '#', '&', '&&', r'\(', r'\)', r'\*', r'\+', ',', '-',


### PR DESCRIPTION
This PR makes `and` a keyword (so far, it was wrongly considered an infix operator) and removes `value` from the set of keywords (it is not a keyword).