### PR TITLE
Change `gdscript_example.gd` indentation to tabs

### DIFF
--- a/tests/examplefiles/gdscript/gdscript_example.gd
+++ b/tests/examplefiles/gdscript/gdscript_example.gd
@@ -37,41 +37,41 @@ var v3 = Vector3(1, 2, 3)
 # Function
 
 func some_function(param1, param2):
-    var local_var = 5
+	var local_var = 5
 
-    if param1 < local_var:
-        print(param1)
-    elif param2 > 5:
-        print(param2)
-    else:
-        print("Fail!")
+	if param1 < local_var:
+		print(param1)
+	elif param2 > 5:
+		print(param2)
+	else:
+		print("Fail!")
 
-    for i in range(20):
-        print(i)
+	for i in range(20):
+		print(i)
 
-    while param2 != 0:
-        param2 -= 1
+	while param2 != 0:
+		param2 -= 1
 
-    var local_var2 = param1 + 3
-    return local_var2
+	var local_var2 = param1 + 3
+	return local_var2
 
 
 # Functions override functions with the same name on the base/parent class.
 # If you still want to call them, use '.' (like 'super' in other languages).
 
 func something(p1, p2):
-    .something(p1, p2)
+	.something(p1, p2)
 
 
 # Inner class
 
 class Something:
-    var a = 10
+	var a = 10
 
 
 # Constructor
 
 func _init():
-    print("Constructed!")
-    var lv = Something.new()
-    print(lv.a)
+	print("Constructed!")
+	var lv = Something.new()
+	print(lv.a)

--- a/tests/examplefiles/gdscript/gdscript_example.gd.output
+++ b/tests/examplefiles/gdscript/gdscript_example.gd.output
@@ -248,7 +248,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'var'         Keyword
 ' '           Text.Whitespace
 'local_var'   Name
@@ -260,7 +260,7 @@
 
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'if'          Keyword
 ' '           Text.Whitespace
 'param1'      Name
@@ -271,14 +271,14 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'        '    Text.Whitespace
+'\t\t'        Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 'param1'      Name
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'elif'        Keyword
 ' '           Text.Whitespace
 'param2'      Name
@@ -289,19 +289,19 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'        '    Text.Whitespace
+'\t\t'        Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 'param2'      Name
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'else'        Keyword
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'        '    Text.Whitespace
+'\t\t'        Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 '"'           Literal.String.Double
@@ -312,7 +312,7 @@
 
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'for'         Keyword
 ' '           Text.Whitespace
 'i'           Name
@@ -326,7 +326,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'        '    Text.Whitespace
+'\t\t'        Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 'i'           Name
@@ -335,7 +335,7 @@
 
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'while'       Keyword
 ' '           Text.Whitespace
 'param2'      Name
@@ -346,7 +346,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'        '    Text.Whitespace
+'\t\t'        Text.Whitespace
 'param2'      Name
 ' '           Text.Whitespace
 '-='          Operator
@@ -356,7 +356,7 @@
 
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'var'         Keyword
 ' '           Text.Whitespace
 'local_var2'  Name
@@ -370,7 +370,7 @@
 '3'           Literal.Number.Integer
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'return'      Keyword
 ' '           Text.Whitespace
 'local_var2'  Name
@@ -400,7 +400,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 '.'           Operator
 'something'   Name
 '('           Punctuation
@@ -426,7 +426,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'var'         Keyword
 ' '           Text.Whitespace
 'a'           Name
@@ -453,7 +453,7 @@
 ':'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 '"'           Literal.String.Double
@@ -462,7 +462,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'var'         Keyword
 ' '           Text.Whitespace
 'lv'          Name
@@ -476,7 +476,7 @@
 ')'           Punctuation
 '\n'          Text.Whitespace
 
-'    '        Text.Whitespace
+'\t'          Text.Whitespace
 'print'       Name.Builtin
 '('           Punctuation
 'lv'          Name


### PR DESCRIPTION
GDScript by default will expect tabs instead of spaces, and the `snippets` files respect this. `examplefiles` was an exception to this, using spaces instead of tabs. This PR rectifies that & updates the `.output` file accordingly