### PR TITLE
Clea(r|n)er file for the Dracula style (no style changes)

### DIFF
--- a/pygments/styles/dracula.py
+++ b/pygments/styles/dracula.py
@@ -22,86 +22,67 @@ __all__ = ['DraculaStyle']
 class DraculaStyle(Style):
     name = 'dracula'
 
-    background_color = "#282a36"
-    highlight_color = "#44475a"
-    line_number_color = "#f1fa8c"
-    line_number_background_color = "#44475a"
-    line_number_special_color = "#50fa7b"
-    line_number_special_background_color = "#6272a4"
+    background = "#282A36"
+    foreground = "#F8F8F2"
+    selection  = "#44475A"
+    comment    = "#6272A4"
+    cyan       = "#8BE9FD"
+    green      = "#50FA7B"
+    orange     = "#FFB86C"
+    pink       = "#FF79C6"
+    purple     = "#BD93F9"
+    red        = "#FF5555"
+    yellow     = "#F1FA8C"
+
+    deletion   = "#f1fa8c"
 
     styles = {
-        Whitespace: "#f8f8f2",
+        Whitespace             : foreground         ,
 
-        Comment: "#6272a4",
-        Comment.Hashbang: "#6272a4",
-        Comment.Multiline: "#6272a4",
-        Comment.Preproc: "#ff79c6",
-        Comment.Single: "#6272a4",
-        Comment.Special: "#6272a4",
+        Comment                : comment            ,
+        Comment.Preproc        : pink               ,
 
-        Generic: "#f8f8f2",
-        Generic.Deleted: "#8b080b",
-        Generic.Emph: "#f8f8f2 underline",
-        Generic.Error: "#f8f8f2",
-        Generic.Heading: "#f8f8f2 bold",
-        Generic.Inserted: "#f8f8f2 bold",
-        Generic.Output: "#44475a",
-        Generic.Prompt: "#f8f8f2",
-        Generic.Strong: "#f8f8f2",
-        Generic.EmphStrong: "#f8f8f2 underline",
-        Generic.Subheading: "#f8f8f2 bold",
-        Generic.Traceback: "#f8f8f2",
+        Generic                : foreground         ,
+        Generic.Deleted        : deletion           ,
+        Generic.Emph           : "underline"        ,
+        Generic.Heading        : "bold"             ,
+        Generic.Inserted       : "bold"             ,
+        Generic.Output         : selection          ,
+        Generic.EmphStrong     : "underline"        ,
+        Generic.Subheading     : "bold"             ,
 
-        Error: "#f8f8f2",
-        Keyword: "#ff79c6",
-        Keyword.Constant: "#ff79c6",
-        Keyword.Declaration: "#8be9fd italic",
-        Keyword.Namespace: "#ff79c6",
-        Keyword.Pseudo: "#ff79c6",
-        Keyword.Reserved: "#ff79c6",
-        Keyword.Type: "#8be9fd",
-        Literal: "#f8f8f2",
-        Literal.Date: "#f8f8f2",
-        Name: "#f8f8f2",
-        Name.Attribute: "#50fa7b",
-        Name.Builtin: "#8be9fd italic",
-        Name.Builtin.Pseudo: "#f8f8f2",
-        Name.Class: "#50fa7b",
-        Name.Constant: "#f8f8f2",
-        Name.Decorator: "#f8f8f2",
-        Name.Entity: "#f8f8f2",
-        Name.Exception: "#f8f8f2",
-        Name.Function: "#50fa7b",
-        Name.Label: "#8be9fd italic",
-        Name.Namespace: "#f8f8f2",
-        Name.Other: "#f8f8f2",
-        Name.Tag: "#ff79c6",
-        Name.Variable: "#8be9fd italic",
-        Name.Variable.Class: "#8be9fd italic",
-        Name.Variable.Global: "#8be9fd italic",
-        Name.Variable.Instance: "#8be9fd italic",
-        Number: "#ffb86c",
-        Number.Bin: "#ffb86c",
-        Number.Float: "#ffb86c",
-        Number.Hex: "#ffb86c",
-        Number.Integer: "#ffb86c",
-        Number.Integer.Long: "#ffb86c",
-        Number.Oct: "#ffb86c",
-        Operator: "#ff79c6",
-        Operator.Word: "#ff79c6",
-        Other: "#f8f8f2",
-        Punctuation: "#f8f8f2",
-        String: "#bd93f9",
-        String.Backtick: "#bd93f9",
-        String.Char: "#bd93f9",
-        String.Doc: "#bd93f9",
-        String.Double: "#bd93f9",
-        String.Escape: "#bd93f9",
-        String.Heredoc: "#bd93f9",
-        String.Interpol: "#bd93f9",
-        String.Other: "#bd93f9",
-        String.Regex: "#bd93f9",
-        String.Single: "#bd93f9",
-        String.Symbol: "#bd93f9",
-        Text: "#f8f8f2",
+        Error                  : foreground         ,
+
+        Keyword                : pink               ,
+        Keyword.Constant       : pink               ,
+        Keyword.Declaration    : cyan + " italic"   ,
+        Keyword.Namespace      : pink + " italic"   ,
+        Keyword.Type           : cyan               ,
+
+        Literal                : foreground         ,
+        Literal.Date           : foreground         ,
+
+        Name                   : foreground         ,
+        Name.Attribute         : green              ,
+        Name.Builtin           : cyan               ,
+        Name.Class             : green              ,
+        Name.Function          : green              ,
+        Name.Label             : cyan + " italic"   ,
+        Name.Tag               : pink               ,
+        Name.Variable          : cyan + " italic"   ,
+        Name.Variable.Class    : cyan + " italic"   ,
+        Name.Variable.Global   : cyan + " italic"   ,
+        Name.Variable.Instance : cyan + " italic"   ,
+
+        Number                 : orange             ,
+
+        Operator               : pink               ,
+
+        Other                  : foreground         ,
+
+        Punctuation            : foreground         ,
+
+        String                 : purple             ,
+
+        Text                   : foreground         ,
     }


### PR DESCRIPTION
Here is a clea(r|n)er file for the Dracula style, with no changes to the style by itself. 

BTW, this style doesn't follow the [official `Dracula` style specifications](https://spec.draculatheme.com/#). For instance:

- [`Error`](https://github.com/pygments/pygments/blob/master/pygments/styles/dracula.py#L55)  should be [`red`](https://spec.draculatheme.com/#Error) and not `#f8f8f2` (`foreground`),
- [`Generic.Deleted`](https://github.com/pygments/pygments/blob/master/pygments/styles/dracula.py#L43), corresponding to `Dracula`'s `DiffDeleted` should be [`red`](https://spec.draculatheme.com/#DiffDeleted) and not `#8b080b`.

Is it worth to provide an “official” `Dracula` style?