### PR TITLE
Use hatchling as build backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*.egg
 *.pyc
 *.pyo
 .*.sw[op]
@@ -8,7 +7,6 @@
 /.tags
 /.tox/
 /.cache/
-/Pygments.egg-info/*
 /TAGS
 /build/*
 /dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include Makefile CHANGES LICENSE AUTHORS
-include external/*
-recursive-include tests *
-recursive-include doc *
-recursive-include scripts *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
-# setuptools added pyproject.toml support in v61.0.0
-requires = ["setuptools >= 61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "Pygments"
@@ -54,8 +53,5 @@ Changelog = "https://github.com/pygments/pygments/blob/master/CHANGES"
 [project.scripts]
 pygmentize = "pygments.cmdline:main"
 
-[tool.setuptools.dynamic]
-version = {attr = "pygments.__version__" }
-
-[tool.setuptools.packages.find]
-include = ["pygments", "pygments.*"]
+[tool.hatch.version]
+path = "pygments/__init__.py"


### PR DESCRIPTION
This reduces tox's setup time, as measured on an environment with no commands, from ~1.7s to ~0.8s.

It also fixes requirements.txt and tox.ini not being included in sdists in spite of being part of the source tree.