### PR TITLE
Revise TOML lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -493,7 +493,7 @@ LEXERS = {
     'SystemdLexer': ('pygments.lexers.configs', 'Systemd', ('systemd',), ('*.service', '*.socket', '*.device', '*.mount', '*.automount', '*.swap', '*.target', '*.path', '*.timer', '*.slice', '*.scope'), ()),
     'TAPLexer': ('pygments.lexers.testing', 'TAP', ('tap',), ('*.tap',), ()),
     'TNTLexer': ('pygments.lexers.tnt', 'Typographic Number Theory', ('tnt',), ('*.tnt',), ()),
-    'TOMLLexer': ('pygments.lexers.configs', 'TOML', ('toml',), ('*.toml', 'Pipfile', 'poetry.lock'), ()),
+    'TOMLLexer': ('pygments.lexers.configs', 'TOML', ('toml',), ('*.toml', 'Pipfile', 'poetry.lock'), ('application/toml',)),
     'Tads3Lexer': ('pygments.lexers.int_fiction', 'TADS 3', ('tads3',), ('*.t',), ()),
     'TalLexer': ('pygments.lexers.tal', 'Tal', ('tal', 'uxntal'), ('*.tal',), ('text/x-uxntal',)),
     'TasmLexer': ('pygments.lexers.asm', 'TASM', ('tasm',), ('*.asm', '*.ASM', '*.tasm'), ('text/x-tasm',)),

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -1114,54 +1114,168 @@ class AugeasLexer(RegexLexer):
 
 class TOMLLexer(RegexLexer):
     """
-    Lexer for TOML, a simple language
-    for config files.
+    Lexer for TOML, a simple language for config files.
 
     .. versionadded:: 2.4
     """
 
     name = 'TOML'
-    url = 'https://github.com/toml-lang/toml'
     aliases = ['toml']
     filenames = ['*.toml', 'Pipfile', 'poetry.lock']
+    mimetypes = ['application/toml']
+    url = 'https://toml.io'
+
+    # Based on the TOML spec: https://toml.io/en/v1.0.0
+
+    # The following is adapted from CPython's tomllib:
+    _time = r"\d\d:\d\d:\d\d(\.\d+)?"
+    _datetime = rf"""(?x)
+                  \d\d\d\d-\d\d-\d\d # date, e.g., 1988-10-27
+                (
+                  [Tt ] {_time} # optional time
+                  (
+                    [Zz]|[+-]\d\d:\d\d # optional time offset
+                  )?
+                )?
+              """
 
     tokens = {
         'root': [
-            # Table
-            (r'^(\s*)(\[.*?\])$', bygroups(Whitespace, Keyword)),
+            # Note that we make an effort in order to distinguish
+            # moments at which we're parsing a key and moments at
+            # which we're parsing a value. In the TOML code
+            #
+            #   1234 = 1234
+            #
+            # the first "1234" should be Name, the second Integer.
 
-            # Basics, comments, strings
-            (r'[ \t]+', Whitespace),
-            (r'\n', Whitespace),
-            (r'#.*?$', Comment.Single),
-            # Basic string
-            (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
-            # Literal string
-            (r'\'\'\'(.*)\'\'\'', String),
-            (r'\'[^\']*\'', String),
-            (r'(true|false)$', Keyword.Constant),
-            (r'[a-zA-Z_][\w\-]*', Name),
+            # Whitespace
+            (r'\s+', Whitespace),
 
-            # Datetime
-            # TODO this needs to be expanded, as TOML is rather flexible:
-            # https://github.com/toml-lang/toml#offset-date-time
-            (r'\d{4}-\d{2}-\d{2}(?:T| )\d{2}:\d{2}:\d{2}(?:Z|[-+]\d{2}:\d{2})', Number.Integer),
+            # Comment
+            (r'#.*', Comment.Single),
 
-            # Numbers
-            (r'(\d+\.\d*|\d*\.\d+)([eE][+-]?[0-9]+)?j?', Number.Float),
-            (r'\d+[eE][+-]?[0-9]+j?', Number.Float),
-            # Handle +-inf, +-infinity, +-nan
-            (r'[+-]?(?:(inf(?:inity)?)|nan)', Number.Float),
-            (r'[+-]?\d+', Number.Integer),
+            # Assignment keys
+            include('key'),
 
-            # Punctuation
-            (r'[]{}:(),;[]', Punctuation),
+            # After "=", find a value
+            (r'(=)(\s*)', bygroups(Operator, Whitespace), 'value'),
+
+            # Table header
+            (r'\[\[?', Keyword, 'table-key'),
+        ],
+        'key': [
+            # Start of bare key (only ASCII is allowed here).
+            (r'[A-Za-z0-9_-]+', Name),
+            # Quoted key
+            (r'"', String.Double, 'basic-string'),
+            (r"'", String.Single, 'literal-string'),
+            # Dots act as separators in keys
             (r'\.', Punctuation),
+        ],
+        'table-key': [
+            # This is like 'key', but highlights the name components
+            # and separating dots as Keyword because it looks better
+            # when the whole table header is Keyword. We do highlight
+            # strings as strings though.
+            # Start of bare key (only ASCII is allowed here).
+            (r'[A-Za-z0-9_-]+', Keyword),
+            (r'"', String.Double, 'basic-string'),
+            (r"'", String.Single, 'literal-string'),
+            (r'\.', Keyword),
+            (r'\]\]?', Keyword, '#pop'),
+        ],
+        'value': [
+            # Datetime, baretime
+            (_datetime, Literal.Date, '#pop'),
+            (_time, Literal.Date, '#pop'),
 
-            # Operators
-            (r'=', Operator)
+            # Recognize as float if there is a fractional part
+            # and/or an exponent.
+            (r'[+-]?\d[0-9_]*[eE][+-]?\d[0-9_]*', Number.Float, '#pop'),
+            (r'[+-]?\d[0-9_]*\.\d[0-9_]*([eE][+-]?\d[0-9_]*)?',
+             Number.Float, '#pop'),
 
-        ]
+            # Infinities and NaN
+            (r'[+-]?(inf|nan)', Number.Float, '#pop'),
+
+            # Integers
+            (r'-?0b[01_]+', Number.Bin, '#pop'),
+            (r'-?0o[0-7_]+', Number.Oct, '#pop'),
+            (r'-?0x[0-9a-fA-F_]+', Number.Hex, '#pop'),
+            (r'[+-]?[0-9_]+', Number.Integer, '#pop'),
+
+            # Strings
+            (r'"""', String.Double, ('#pop', 'multiline-basic-string')),
+            (r'"', String.Double, ('#pop', 'basic-string')),
+            (r"'''", String.Single, ('#pop', 'multiline-literal-string')),
+            (r"'", String.Single, ('#pop', 'literal-string')),
+
+            # Booleans
+            (r'true|false', Keyword.Constant, '#pop'),
+
+            # Start of array
+            (r'\[', Punctuation, ('#pop', 'array')),
+
+            # Start of inline table
+            (r'\{', Punctuation, ('#pop', 'inline-table')),
+        ],
+        'array': [
+            # Whitespace, including newlines, is ignored inside arrays,
+            # and comments are allowed.
+            (r'\s+', Whitespace),
+            (r'#.*', Comment.Single),
+
+            # Delimiters
+            (r',', Punctuation),
+
+            # End of array
+            (r'\]', Punctuation, '#pop'),
+
+            # Parse a value and come back
+            default('value'),
+        ],
+        'inline-table': [
+            # Note that unlike inline arrays, inline tables do not
+            # allow newlines or comments.
+            (r'[ \t]+', Whitespace),
+
+            # Keys
+            include('key'),
+
+            # Values
+            (r'(=)(\s*)', bygroups(Punctuation, Whitespace), 'value'),
+
+            # Delimiters
+            (r',', Punctuation),
+
+            # End of inline table
+            (r'\}', Punctuation, '#pop'),
+        ],
+        'basic-string': [
+            (r'"', String.Double, '#pop'),
+            include('escapes'),
+            (r'[^"\\]+', String.Double),
+        ],
+        'literal-string': [
+            (r".*'", String.Single, '#pop'),
+        ],
+        'multiline-basic-string': [
+            (r'"""', String.Double, '#pop'),
+            (r'(\\)(\n)', bygroups(String.Escape, Whitespace)),
+            include('escapes'),
+            (r'[^"\\]+', String.Double),
+            (r'"', String.Double),
+        ],
+        'multiline-literal-string': [
+            (r"'''", String.Single, '#pop'),
+            (r"[^']+", String.Single),
+            (r"'", String.Single),
+        ],
+        'escapes': [
+            (r'\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}', String.Escape),
+            (r'\\.', String.Escape),
+        ],
     }
 
 class NestedTextLexer(RegexLexer):

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -1184,6 +1184,9 @@ class TOMLLexer(RegexLexer):
             (r"'", String.Single, 'literal-string'),
             (r'\.', Keyword),
             (r'\]\]?', Keyword, '#pop'),
+
+            # Inline whitespace allowed
+            (r'[ \t]+', Whitespace),
         ],
         'value': [
             # Datetime, baretime

--- a/tests/examplefiles/toml/example.toml.output
+++ b/tests/examplefiles/toml/example.toml.output
@@ -1,20 +1,20 @@
 '# This is a TOML document comment' Comment.Single
-'\n'          Text.Whitespace
-
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
 'title'       Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"TOML example file"' Literal.String
+'"'           Literal.String.Double
+'TOML example file' Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '# This is an inline comment' Comment.Single
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[examples]'  Keyword
+'['           Keyword
+'examples'    Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 '# Examples taken from https://github.com/toml-lang/toml/blob/master/README.md' Comment.Single
@@ -24,70 +24,98 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'bare_key'    Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'bare-key'    Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-'1234'        Literal.Number.Integer
+'1234'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-'"127.0.0.1"' Literal.String
+'"'           Literal.String.Double
+'127.0.0.1'   Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-'"character encoding"' Literal.String
+'"'           Literal.String.Double
+'character encoding' Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-'"ʎǝʞ"'       Literal.String
+'"'           Literal.String.Double
+'ʎǝʞ'         Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-"'key2'"      Literal.String
+"'"           Literal.String.Single
+"key2'"       Literal.String.Single
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
-'\'quoted "value"\'' Literal.String
+"'"           Literal.String.Single
+'quoted "value"\'' Literal.String.Single
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"value"'     Literal.String
+'"'           Literal.String.Double
+'value'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"Orange"'    Literal.String
+'"'           Literal.String.Double
+'Orange'      Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'physical'    Name
@@ -96,7 +124,9 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"orange"'    Literal.String
+'"'           Literal.String.Double
+'orange'      Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'physical'    Name
@@ -105,12 +135,16 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"round"'     Literal.String
+'"'           Literal.String.Double
+'round'       Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'site'        Name
 '.'           Punctuation
-'"google.com"' Literal.String
+'"'           Literal.String.Double
+'google.com'  Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
@@ -135,136 +169,180 @@
 '='           Operator
 ' '           Text.Whitespace
 '2'           Literal.Number.Integer
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[strings]'   Keyword
+'['           Keyword
+'strings'     Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'str'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"I\'m a string. \\"You can quote me\\". Name\\tJos\\u00E9\\nLocation\\tSF."' Literal.String
+'"'           Literal.String.Double
+"I'm a string. " Literal.String.Double
+'\\"'         Literal.String.Escape
+'You can quote me' Literal.String.Double
+'\\"'         Literal.String.Escape
+'. Name'      Literal.String.Double
+'\\t'         Literal.String.Escape
+'Jos'         Literal.String.Double
+'\\u00E9'     Literal.String.Escape
+'\\n'         Literal.String.Escape
+'Location'    Literal.String.Double
+'\\t'         Literal.String.Escape
+'SF.'         Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'str1'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'""'          Literal.String
-'"\nRoses are red\nViolets are blue"' Literal.String
-'""'          Literal.String
+'"""'         Literal.String.Double
+'\nRoses are red\nViolets are blue' Literal.String.Double
+'"""'         Literal.String.Double
 '\n'          Text.Whitespace
 
 'str2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"Roses are red\\nViolets are blue"' Literal.String
+'"'           Literal.String.Double
+'Roses are red' Literal.String.Double
+'\\n'         Literal.String.Escape
+'Violets are blue' Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace
 
 'str3'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"Roses are red\\r\\nViolets are blue"' Literal.String
-'\n'          Text.Whitespace
-
+'"'           Literal.String.Double
+'Roses are red' Literal.String.Double
+'\\r'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'Violets are blue' Literal.String.Double
+'"'           Literal.String.Double
+'\n\n  '      Text.Whitespace
+'['           Keyword
+'strings'     Keyword
+'.'           Keyword
+'equivalents' Keyword
+']'           Keyword
 '\n  '        Text.Whitespace
-'[strings.equivalents]' Keyword
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
 'str1'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"The quick brown fox jumps over the lazy dog."' Literal.String
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+'"'           Literal.String.Double
+'The quick brown fox jumps over the lazy dog.' Literal.String.Double
+'"'           Literal.String.Double
+'\n  '        Text.Whitespace
 'str2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'""'          Literal.String
-'"\nThe quick brown \\\n\n\n    fox jumps over \\\n      the lazy dog."' Literal.String
-'""'          Literal.String
+'"""'         Literal.String.Double
+'\nThe quick brown ' Literal.String.Double
+'\\'          Literal.String.Escape
 '\n'          Text.Whitespace
 
-'  '          Text.Whitespace
+'\n\n    fox jumps over ' Literal.String.Double
+'\\'          Literal.String.Escape
+'\n'          Text.Whitespace
+
+'      the lazy dog.' Literal.String.Double
+'"""'         Literal.String.Double
+'\n  '        Text.Whitespace
 'str3'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'""'          Literal.String
-'"\\\n         The quick brown \\\n         fox jumps over \\\n         the lazy dog.\\\n         "' Literal.String
-'""'          Literal.String
+'"""'         Literal.String.Double
+'\\'          Literal.String.Escape
 '\n'          Text.Whitespace
 
+'         The quick brown ' Literal.String.Double
+'\\'          Literal.String.Escape
+'\n'          Text.Whitespace
+
+'         fox jumps over ' Literal.String.Double
+'\\'          Literal.String.Escape
+'\n'          Text.Whitespace
+
+'         the lazy dog.' Literal.String.Double
+'\\'          Literal.String.Escape
+'\n'          Text.Whitespace
+
+'         '   Literal.String.Double
+'"""'         Literal.String.Double
+'\n\n  '      Text.Whitespace
+'['           Keyword
+'strings'     Keyword
+'.'           Keyword
+'literal'     Keyword
+']'           Keyword
 '\n  '        Text.Whitespace
-'[strings.literal]' Keyword
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
 'winpath'     Name
 '  '          Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-"'C:\\Users\\nodejs\\templates'" Literal.String
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+"'"           Literal.String.Single
+"C:\\Users\\nodejs\\templates'" Literal.String.Single
+'\n  '        Text.Whitespace
 'winpath2'    Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-"'\\\\ServerX\\admin$\\system32\\'" Literal.String
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+"'"           Literal.String.Single
+"\\\\ServerX\\admin$\\system32\\'" Literal.String.Single
+'\n  '        Text.Whitespace
 'quoted'      Name
 '   '         Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'\'Tom "Dubs" Preston-Werner\'' Literal.String
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+"'"           Literal.String.Single
+'Tom "Dubs" Preston-Werner\'' Literal.String.Single
+'\n  '        Text.Whitespace
 'regex'       Name
 '    '        Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-"'<\\i\\c*\\s*>'" Literal.String
-'\n'          Text.Whitespace
-
+"'"           Literal.String.Single
+"<\\i\\c*\\s*>'" Literal.String.Single
+'\n\n  '      Text.Whitespace
+'['           Keyword
+'strings'     Keyword
+'.'           Keyword
+'multiline'   Keyword
+']'           Keyword
 '\n  '        Text.Whitespace
-'[strings.multiline]' Keyword
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
 'regex2'      Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-"'''I [dw]on't need \\d{2} apples'''" Literal.String
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+"'''"         Literal.String.Single
+'I [dw]on'    Literal.String.Single
+"'"           Literal.String.Single
+'t need \\d{2} apples' Literal.String.Single
+"'''"         Literal.String.Single
+'\n  '        Text.Whitespace
 'lines'       Name
 '  '          Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-"''"          Literal.String
-"'\nThe first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n'" Literal.String
-"''"          Literal.String
-'\n'          Text.Whitespace
+"'''"         Literal.String.Single
+'\nThe first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n' Literal.String.Single
 
-'\n'          Text.Whitespace
+"'''"         Literal.String.Single
+'\n\n'        Text.Whitespace
 
-'[integers]'  Keyword
+'['           Keyword
+'integers'    Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'int1'        Name
@@ -299,24 +377,21 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1'           Literal.Number.Integer
-'_000'        Name
+'1_000'       Literal.Number.Integer
 '\n'          Text.Whitespace
 
 'int6'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'5'           Literal.Number.Integer
-'_349_221'    Name
+'5_349_221'   Literal.Number.Integer
 '\n'          Text.Whitespace
 
 'int7'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1'           Literal.Number.Integer
-'_2_3_4_5'    Name
+'1_2_3_4_5'   Literal.Number.Integer
 ' '           Text.Whitespace
 '# discouraged format' Comment.Single
 '\n'          Text.Whitespace
@@ -328,24 +403,21 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'xDEADBEEF'   Name
+'0xDEADBEEF'  Literal.Number.Hex
 '\n'          Text.Whitespace
 
 'hex2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'xdeadbeef'   Name
+'0xdeadbeef'  Literal.Number.Hex
 '\n'          Text.Whitespace
 
 'hex3'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'xdead_beef'  Name
+'0xdead_beef' Literal.Number.Hex
 '\n'          Text.Whitespace
 
 '# octal with prefix `0o`' Comment.Single
@@ -355,16 +427,14 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'o01234567'   Name
+'0o01234567'  Literal.Number.Oct
 '\n'          Text.Whitespace
 
 'oct2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'o755'        Name
+'0o755'       Literal.Number.Oct
 ' '           Text.Whitespace
 '# useful for Unix file permissions' Comment.Single
 '\n'          Text.Whitespace
@@ -376,13 +446,12 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number.Integer
-'b11010110'   Name
-'\n'          Text.Whitespace
+'0b11010110'  Literal.Number.Bin
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[floats]'    Keyword
+'['           Keyword
+'floats'      Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 '# fractional' Comment.Single
@@ -392,8 +461,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'+1'          Literal.Number.Integer
-'.0'          Literal.Number.Float
+'+1.0'        Literal.Number.Float
 '\n'          Text.Whitespace
 
 'flt2'        Name
@@ -407,8 +475,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'-0'          Literal.Number.Integer
-'.01'         Literal.Number.Float
+'-0.01'       Literal.Number.Float
 '\n'          Text.Whitespace
 
 '# exponent'  Comment.Single
@@ -432,8 +499,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'-2'          Literal.Number.Integer
-'E-2'         Name
+'-2E-2'       Literal.Number.Float
 '\n'          Text.Whitespace
 
 '# both'      Comment.Single
@@ -453,10 +519,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'224'         Literal.Number.Integer
-'_617'        Name
-'.445'        Literal.Number.Float
-'_991_228'    Name
+'224_617.445_991_228' Literal.Number.Float
 '\n'          Text.Whitespace
 
 '# infinity'  Comment.Single
@@ -466,7 +529,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'inf'         Name
+'inf'         Literal.Number.Float
 '  '          Text.Whitespace
 '# positive infinity' Comment.Single
 '\n'          Text.Whitespace
@@ -496,7 +559,7 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'nan'         Name
+'nan'         Literal.Number.Float
 '  '          Text.Whitespace
 '# actual sNaN/qNaN encoding is implementation specific' Comment.Single
 '\n'          Text.Whitespace
@@ -526,21 +589,19 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'+0'          Literal.Number.Integer
-'.0'          Literal.Number.Float
+'+0.0'        Literal.Number.Float
 '\n'          Text.Whitespace
 
 'sf0_2'       Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'-0'          Literal.Number.Integer
-'.0'          Literal.Number.Float
-'\n'          Text.Whitespace
+'-0.0'        Literal.Number.Float
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[booleans]'  Keyword
+'['           Keyword
+'booleans'    Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'bool1'       Name
@@ -555,128 +616,102 @@
 '='           Operator
 ' '           Text.Whitespace
 'false'       Keyword.Constant
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[datetime.offset]' Keyword
+'['           Keyword
+'datetime'    Keyword
+'.'           Keyword
+'offset'      Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'odt1'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979-05-27T07:32:00Z' Literal.Number.Integer
+'1979-05-27T07:32:00Z' Literal.Date
 '\n'          Text.Whitespace
 
 'odt2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979-05-27T00:32:00-07:00' Literal.Number.Integer
+'1979-05-27T00:32:00-07:00' Literal.Date
 '\n'          Text.Whitespace
 
 'odt3'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979'        Literal.Number.Integer
-'-05'         Literal.Number.Integer
-'-27'         Literal.Number.Integer
-'T00'         Name
-':'           Punctuation
-'32'          Literal.Number.Integer
-':'           Punctuation
-'00.999999'   Literal.Number.Float
-'-07'         Literal.Number.Integer
-':'           Punctuation
-'00'          Literal.Number.Integer
+'1979-05-27T00:32:00.999999-07:00' Literal.Date
 '\n'          Text.Whitespace
 
 'odt4'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979-05-27 07:32:00Z' Literal.Number.Integer
-'\n'          Text.Whitespace
+'1979-05-27 07:32:00Z' Literal.Date
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[datetime.local]' Keyword
+'['           Keyword
+'datetime'    Keyword
+'.'           Keyword
+'local'       Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'ldt1'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979'        Literal.Number.Integer
-'-05'         Literal.Number.Integer
-'-27'         Literal.Number.Integer
-'T07'         Name
-':'           Punctuation
-'32'          Literal.Number.Integer
-':'           Punctuation
-'00'          Literal.Number.Integer
+'1979-05-27T07:32:00' Literal.Date
 '\n'          Text.Whitespace
 
 'ldt2'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979'        Literal.Number.Integer
-'-05'         Literal.Number.Integer
-'-27'         Literal.Number.Integer
-'T00'         Name
-':'           Punctuation
-'32'          Literal.Number.Integer
-':'           Punctuation
-'00.999999'   Literal.Number.Float
-'\n'          Text.Whitespace
+'1979-05-27T00:32:00.999999' Literal.Date
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[date.local]' Keyword
+'['           Keyword
+'date'        Keyword
+'.'           Keyword
+'local'       Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'ld1'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'1979'        Literal.Number.Integer
-'-05'         Literal.Number.Integer
-'-27'         Literal.Number.Integer
-'\n'          Text.Whitespace
+'1979-05-27'  Literal.Date
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[time.local]' Keyword
+'['           Keyword
+'time'        Keyword
+'.'           Keyword
+'local'       Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'lt1'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'07'          Literal.Number.Integer
-':'           Punctuation
-'32'          Literal.Number.Integer
-':'           Punctuation
-'00'          Literal.Number.Integer
+'07:32:00'    Literal.Date
 '\n'          Text.Whitespace
 
 'lt2'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'00'          Literal.Number.Integer
-':'           Punctuation
-'32'          Literal.Number.Integer
-':'           Punctuation
-'00.999999'   Literal.Number.Float
-'\n'          Text.Whitespace
+'00:32:00.999999' Literal.Date
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'[arrays]'    Keyword
+'['           Keyword
+'arrays'      Keyword
+']'           Keyword
 '\n'          Text.Whitespace
 
 'arr1'        Name
@@ -702,13 +737,19 @@
 ' '           Text.Whitespace
 '['           Punctuation
 ' '           Text.Whitespace
-'"red"'       Literal.String
+'"'           Literal.String.Double
+'red'         Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
-'"yellow"'    Literal.String
+'"'           Literal.String.Double
+'yellow'      Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
-'"green"'     Literal.String
+'"'           Literal.String.Double
+'green'       Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 ']'           Punctuation
 '\n'          Text.Whitespace
@@ -748,18 +789,13 @@
 ' '           Text.Whitespace
 '['           Punctuation
 ' '           Text.Whitespace
-'"all"'       Literal.String
+'"'           Literal.String.Double
+'all'         Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
-"'strings'"   Literal.String
-','           Punctuation
-' '           Text.Whitespace
-'""'          Literal.String
-'"are the same"' Literal.String
-'""'          Literal.String
-','           Punctuation
-' '           Text.Whitespace
-"'''type'''"  Literal.String
+"'"           Literal.String.Single
+'strings\', """are the same""", \'\'\'type\'\'\'' Literal.String.Single
 ']'           Punctuation
 '\n'          Text.Whitespace
 
@@ -780,13 +816,19 @@
 ','           Punctuation
 ' '           Text.Whitespace
 '['           Punctuation
-'"a"'         Literal.String
+'"'           Literal.String.Double
+'a'           Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
-'"b"'         Literal.String
+'"'           Literal.String.Double
+'b'           Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
-'"c"'         Literal.String
+'"'           Literal.String.Double
+'c'           Literal.String.Double
+'"'           Literal.String.Double
 ']'           Punctuation
 ' '           Text.Whitespace
 ']'           Punctuation
@@ -813,9 +855,7 @@
 '='           Operator
 ' '           Text.Whitespace
 '['           Punctuation
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+'\n  '        Text.Whitespace
 '1'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
@@ -833,14 +873,10 @@
 '='           Operator
 ' '           Text.Whitespace
 '['           Punctuation
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+'\n  '        Text.Whitespace
 '1'           Literal.Number.Integer
 ','           Punctuation
-'\n'          Text.Whitespace
-
-'  '          Text.Whitespace
+'\n  '        Text.Whitespace
 '2'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
@@ -848,11 +884,13 @@
 '\n'          Text.Whitespace
 
 ']'           Punctuation
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'["inline tables"]' Keyword
+'['           Keyword
+'"'           Literal.String.Double
+'inline tables' Literal.String.Double
+'"'           Literal.String.Double
+']'           Keyword
 '\n'          Text.Whitespace
 
 'name'        Name
@@ -863,16 +901,20 @@
 ' '           Text.Whitespace
 'first'       Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
-'"Tom"'       Literal.String
+'"'           Literal.String.Double
+'Tom'         Literal.String.Double
+'"'           Literal.String.Double
 ','           Punctuation
 ' '           Text.Whitespace
 'last'        Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
-'"Preston-Werner"' Literal.String
+'"'           Literal.String.Double
+'Preston-Werner' Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '}'           Punctuation
 '\n'          Text.Whitespace
@@ -885,14 +927,14 @@
 ' '           Text.Whitespace
 'x'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'y'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '2'           Literal.Number.Integer
 ' '           Text.Whitespace
@@ -909,16 +951,20 @@
 '.'           Punctuation
 'name'        Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
-'"pug"'       Literal.String
+'"'           Literal.String.Double
+'pug'         Literal.String.Double
+'"'           Literal.String.Double
 ' '           Text.Whitespace
 '}'           Punctuation
-'\n'          Text.Whitespace
+'\n\n'        Text.Whitespace
 
-'\n'          Text.Whitespace
-
-'["arrays of tables"]' Keyword
+'['           Keyword
+'"'           Literal.String.Double
+'arrays of tables' Literal.String.Double
+'"'           Literal.String.Double
+']'           Keyword
 '\n'          Text.Whitespace
 
 'points'      Name
@@ -931,219 +977,219 @@
 ' '           Text.Whitespace
 'x'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '1'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'y'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '2'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'z'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '3'           Literal.Number.Integer
 ' '           Text.Whitespace
 '}'           Punctuation
 ','           Punctuation
-'\n'          Text.Whitespace
-
-'           ' Text.Whitespace
+'\n           ' Text.Whitespace
 '{'           Punctuation
 ' '           Text.Whitespace
 'x'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '7'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'y'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '8'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'z'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '9'           Literal.Number.Integer
 ' '           Text.Whitespace
 '}'           Punctuation
 ','           Punctuation
-'\n'          Text.Whitespace
-
-'           ' Text.Whitespace
+'\n           ' Text.Whitespace
 '{'           Punctuation
 ' '           Text.Whitespace
 'x'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '2'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'y'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '4'           Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'z'           Name
 ' '           Text.Whitespace
-'='           Operator
+'='           Punctuation
 ' '           Text.Whitespace
 '8'           Literal.Number.Integer
 ' '           Text.Whitespace
 '}'           Punctuation
 ' '           Text.Whitespace
 ']'           Punctuation
-'\n'          Text.Whitespace
-
-'\n  '        Text.Whitespace
-'[products]'  Keyword
-'\n'          Text.Whitespace
-
+'\n\n  '      Text.Whitespace
+'['           Keyword
+'products'    Keyword
+']'           Keyword
+'\n\n    '    Text.Whitespace
+'[['          Keyword
+'products'    Keyword
+']]'          Keyword
 '\n    '      Text.Whitespace
-'[[products]]' Keyword
-'\n'          Text.Whitespace
-
-'    '        Text.Whitespace
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"Hammer"'    Literal.String
-'\n'          Text.Whitespace
-
-'    '        Text.Whitespace
+'"'           Literal.String.Double
+'Hammer'      Literal.String.Double
+'"'           Literal.String.Double
+'\n    '      Text.Whitespace
 'sku'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '738594937'   Literal.Number.Integer
-'\n'          Text.Whitespace
-
+'\n\n    '    Text.Whitespace
+'[['          Keyword
+'products'    Keyword
+']]'          Keyword
+'\n\n    '    Text.Whitespace
+'[['          Keyword
+'products'    Keyword
+']]'          Keyword
 '\n    '      Text.Whitespace
-'[[products]]' Keyword
-'\n'          Text.Whitespace
-
-'\n    '      Text.Whitespace
-'[[products]]' Keyword
-'\n'          Text.Whitespace
-
-'    '        Text.Whitespace
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"Nail"'      Literal.String
-'\n'          Text.Whitespace
-
-'    '        Text.Whitespace
+'"'           Literal.String.Double
+'Nail'        Literal.String.Double
+'"'           Literal.String.Double
+'\n    '      Text.Whitespace
 'sku'         Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '284758393'   Literal.Number.Integer
-'\n'          Text.Whitespace
-
-'    '        Text.Whitespace
+'\n    '      Text.Whitespace
 'color'       Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"gray"'      Literal.String
-'\n'          Text.Whitespace
-
-'\n  '        Text.Whitespace
-'[fruits]'    Keyword
-'\n'          Text.Whitespace
-
-'\n    '      Text.Whitespace
-'[[fruit]]'   Keyword
-'\n'          Text.Whitespace
-
-'      '      Text.Whitespace
+'"'           Literal.String.Double
+'gray'        Literal.String.Double
+'"'           Literal.String.Double
+'\n\n  '      Text.Whitespace
+'['           Keyword
+'fruits'      Keyword
+']'           Keyword
+'\n\n    '    Text.Whitespace
+'[['          Keyword
+'fruit'       Keyword
+']]'          Keyword
+'\n      '    Text.Whitespace
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"apple"'     Literal.String
-'\n'          Text.Whitespace
-
-'\n      '    Text.Whitespace
-'[fruit.physical]' Keyword
-'\n'          Text.Whitespace
-
-'        '    Text.Whitespace
+'"'           Literal.String.Double
+'apple'       Literal.String.Double
+'"'           Literal.String.Double
+'\n\n      '  Text.Whitespace
+'['           Keyword
+'fruit'       Keyword
+'.'           Keyword
+'physical'    Keyword
+']'           Keyword
+'\n        '  Text.Whitespace
 'color'       Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"red"'       Literal.String
-'\n'          Text.Whitespace
-
-'        '    Text.Whitespace
+'"'           Literal.String.Double
+'red'         Literal.String.Double
+'"'           Literal.String.Double
+'\n        '  Text.Whitespace
 'shape'       Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"round"'     Literal.String
-'\n'          Text.Whitespace
-
+'"'           Literal.String.Double
+'round'       Literal.String.Double
+'"'           Literal.String.Double
+'\n\n      '  Text.Whitespace
+'[['          Keyword
+'fruit'       Keyword
+'.'           Keyword
+'variety'     Keyword
+']]'          Keyword
+'\n        '  Text.Whitespace
+'name'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'red delicious' Literal.String.Double
+'"'           Literal.String.Double
+'\n\n      '  Text.Whitespace
+'[['          Keyword
+'fruit'       Keyword
+'.'           Keyword
+'variety'     Keyword
+']]'          Keyword
+'\n        '  Text.Whitespace
+'name'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'granny smith' Literal.String.Double
+'"'           Literal.String.Double
+'\n\n    '    Text.Whitespace
+'[['          Keyword
+'fruit'       Keyword
+']]'          Keyword
 '\n      '    Text.Whitespace
-'[[fruit.variety]]' Keyword
-'\n'          Text.Whitespace
-
-'        '    Text.Whitespace
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"red delicious"' Literal.String
-'\n'          Text.Whitespace
-
-'\n      '    Text.Whitespace
-'[[fruit.variety]]' Keyword
-'\n'          Text.Whitespace
-
-'        '    Text.Whitespace
+'"'           Literal.String.Double
+'banana'      Literal.String.Double
+'"'           Literal.String.Double
+'\n\n      '  Text.Whitespace
+'[['          Keyword
+'fruit'       Keyword
+'.'           Keyword
+'variety'     Keyword
+']]'          Keyword
+'\n        '  Text.Whitespace
 'name'        Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'"granny smith"' Literal.String
-'\n'          Text.Whitespace
-
-'\n    '      Text.Whitespace
-'[[fruit]]'   Keyword
-'\n'          Text.Whitespace
-
-'      '      Text.Whitespace
-'name'        Name
-' '           Text.Whitespace
-'='           Operator
-' '           Text.Whitespace
-'"banana"'    Literal.String
-'\n'          Text.Whitespace
-
-'\n      '    Text.Whitespace
-'[[fruit.variety]]' Keyword
-'\n'          Text.Whitespace
-
-'        '    Text.Whitespace
-'name'        Name
-' '           Text.Whitespace
-'='           Operator
-' '           Text.Whitespace
-'"plantain"'  Literal.String
+'"'           Literal.String.Double
+'plantain'    Literal.String.Double
+'"'           Literal.String.Double
 '\n'          Text.Whitespace

--- a/tests/snippets/toml/bool-comment.txt
+++ b/tests/snippets/toml/bool-comment.txt
@@ -1,0 +1,12 @@
+---input---
+foo = true # comment used to prevent bool from being recognized
+
+---tokens---
+'foo'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Keyword.Constant
+' '           Text.Whitespace
+'# comment used to prevent bool from being recognized' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/comment-section-header.txt
+++ b/tests/snippets/toml/comment-section-header.txt
@@ -1,0 +1,20 @@
+---input---
+[example] # A comment can appear on the same line as a section header
+foo = "bar"
+
+---tokens---
+'['           Keyword
+'example'     Keyword
+']'           Keyword
+' '           Text.Whitespace
+'# A comment can appear on the same line as a section header' Comment.Single
+'\n'          Text.Whitespace
+
+'foo'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'bar'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/multiline-string-comment.txt
+++ b/tests/snippets/toml/multiline-string-comment.txt
@@ -1,0 +1,15 @@
+---input---
+message = """multiline strings
+            can be followed by""" # comments
+
+---tokens---
+'message'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"""'         Literal.String.Double
+'multiline strings\n            can be followed by' Literal.String.Double
+'"""'         Literal.String.Double
+' '           Text.Whitespace
+'# comments'  Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/number-keys.txt
+++ b/tests/snippets/toml/number-keys.txt
@@ -1,0 +1,64 @@
+---input---
+1234 = "foo" # 1234 is a name
+foo = 1234 # 1234 is a number
+foo2 = [
+  1234, # number
+  { 1234 = "foo", foo = 1234 } # name then number
+]
+
+---tokens---
+'1234'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'foo'         Literal.String.Double
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'# 1234 is a name' Comment.Single
+'\n'          Text.Whitespace
+
+'foo'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'1234'        Literal.Number.Integer
+' '           Text.Whitespace
+'# 1234 is a number' Comment.Single
+'\n'          Text.Whitespace
+
+'foo2'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'\n  '        Text.Whitespace
+'1234'        Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'# number'    Comment.Single
+'\n  '        Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'1234'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'foo'         Literal.String.Double
+'"'           Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'foo'         Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'1234'        Literal.Number.Integer
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'# name then number' Comment.Single
+'\n'          Text.Whitespace
+
+']'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/section-header-whitespace.txt
+++ b/tests/snippets/toml/section-header-whitespace.txt
@@ -1,0 +1,16 @@
+---input---
+[ foo . bar ] # whitespace allowed in table headers
+
+---tokens---
+'['           Keyword
+' '           Text.Whitespace
+'foo'         Keyword
+' '           Text.Whitespace
+'.'           Keyword
+' '           Text.Whitespace
+'bar'         Keyword
+' '           Text.Whitespace
+']'           Keyword
+' '           Text.Whitespace
+'# whitespace allowed in table headers' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/string-escapes.txt
+++ b/tests/snippets/toml/string-escapes.txt
@@ -1,0 +1,86 @@
+---input---
+[strings]
+basic-string = "I'm a basic string. I can contain 'single quotes', \u0055nicode escapes \U0001f61b \U0001F61B, \"escaped\" double quotes, \n and \t more."
+literal-string = 'I am literal string. Escapes like \this have no effect on me. I can contain "double quotes".'
+multiline-basic-string = """
+I'm a multiline basic string.
+I can span several lines and contain 'single' and "double" quotes
+as well as \u0055nicode escapes. Line continuations \
+   work too.
+"""
+multiline-literal-string = '''
+I'm a "multiline" 'literal' string.
+Escapes like \this have no effect on me. Neither does this: \
+   it is not a line continuation.'''
+
+---tokens---
+'['           Keyword
+'strings'     Keyword
+']'           Keyword
+'\n'          Text.Whitespace
+
+'basic-string' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+"I'm a basic string. I can contain 'single quotes', " Literal.String.Double
+'\\u0055'     Literal.String.Escape
+'nicode escapes ' Literal.String.Double
+'\\U0001f61b' Literal.String.Escape
+' '           Literal.String.Double
+'\\U0001F61B' Literal.String.Escape
+', '          Literal.String.Double
+'\\"'         Literal.String.Escape
+'escaped'     Literal.String.Double
+'\\"'         Literal.String.Escape
+' double quotes, ' Literal.String.Double
+'\\n'         Literal.String.Escape
+' and '       Literal.String.Double
+'\\t'         Literal.String.Escape
+' more.'      Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'literal-string' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'I am literal string. Escapes like \\this have no effect on me. I can contain "double quotes".\'' Literal.String.Single
+'\n'          Text.Whitespace
+
+'multiline-basic-string' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"""'         Literal.String.Double
+"\nI'm a multiline basic string.\nI can span several lines and contain 'single' and " Literal.String.Double
+'"'           Literal.String.Double
+'double'      Literal.String.Double
+'"'           Literal.String.Double
+' quotes\nas well as ' Literal.String.Double
+'\\u0055'     Literal.String.Escape
+'nicode escapes. Line continuations ' Literal.String.Double
+'\\'          Literal.String.Escape
+'\n'          Text.Whitespace
+
+'   work too.\n' Literal.String.Double
+
+'"""'         Literal.String.Double
+'\n'          Text.Whitespace
+
+'multiline-literal-string' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'''"         Literal.String.Single
+'\nI'         Literal.String.Single
+"'"           Literal.String.Single
+'m a "multiline" ' Literal.String.Single
+"'"           Literal.String.Single
+'literal'     Literal.String.Single
+"'"           Literal.String.Single
+' string.\nEscapes like \\this have no effect on me. Neither does this: \\\n   it is not a line continuation.' Literal.String.Single
+"'''"         Literal.String.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/strings-eager.txt
+++ b/tests/snippets/toml/strings-eager.txt
@@ -1,0 +1,47 @@
+---input---
+foo = "this string should" # not extend into the comment that contains "quotes"
+bar = 'same with a' # basic 'string'
+baz = """same with a""" # multiline """basic string"""
+spam = '''same with a''' # multiline '''literal string'''
+
+---tokens---
+'foo'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'this string should' Literal.String.Double
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'# not extend into the comment that contains "quotes"' Comment.Single
+'\n'          Text.Whitespace
+
+'bar'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Single
+"same with a' # basic 'string'" Literal.String.Single
+'\n'          Text.Whitespace
+
+'baz'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"""'         Literal.String.Double
+'same with a' Literal.String.Double
+'"""'         Literal.String.Double
+' '           Text.Whitespace
+'# multiline """basic string"""' Comment.Single
+'\n'          Text.Whitespace
+
+'spam'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'''"         Literal.String.Single
+'same with a' Literal.String.Single
+"'''"         Literal.String.Single
+' '           Text.Whitespace
+"# multiline '''literal string'''" Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/toml/table-header-string.txt
+++ b/tests/snippets/toml/table-header-string.txt
@@ -1,0 +1,27 @@
+---input---
+[table.header.with.some."strings".and."escape\nsequences\u263a"]
+
+---tokens---
+'['           Keyword
+'table'       Keyword
+'.'           Keyword
+'header'      Keyword
+'.'           Keyword
+'with'        Keyword
+'.'           Keyword
+'some'        Keyword
+'.'           Keyword
+'"'           Literal.String.Double
+'strings'     Literal.String.Double
+'"'           Literal.String.Double
+'.'           Keyword
+'and'         Keyword
+'.'           Keyword
+'"'           Literal.String.Double
+'escape'      Literal.String.Double
+'\\n'         Literal.String.Escape
+'sequences'   Literal.String.Double
+'\\u263a'     Literal.String.Escape
+'"'           Literal.String.Double
+']'           Keyword
+'\n'          Text.Whitespace


### PR DESCRIPTION
The new lexer matches the TOML spec much more closely.

User-visible differences should be these:

* Add MIME type
* Highlight string escapes
* Recognize \uXXXX and \UXXXX escapes
* Also recognize booleans if they are followed by a comment
* Fix single quotes inside multiline literal strings (closes #2488)
* Prevent multiline literal strings from eating comments
* Add multiline basic strings (""")
* Improve datetime recognition: recognize times without dates, dates without times and datetimes without time zone; allow sub-millisecond precision
* Recognize floats with exponents (they used not to be recognized when having a decimal point)
* Recognize binary, octal and hex literals
* Recognize strings inside table headers
* Recognize table headers followed by comments
* Don't parse sequences of digits as integers when they are actually keys

Includes several new tests, most of which were not working before.