### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 doc
 tests
-Pygments.egg-info
 TAGS
 build
 dist
@@ -8,8 +7,6 @@ htmlcov
 venv
 **/__pycache__
 .*
-*.rst
-*.egg
 *.pyo
 .*.sw[op]
 


### PR DESCRIPTION
Ignoring .rst files made the CI fails because unlike setuptools, hatchling gives an error if the description file is not found.

Also remove files that were generated by setuptools.