### PR TITLE
support blank nodes in TurtleLexer

### DIFF
--- a/pygments/lexers/rdf.py
+++ b/pygments/lexers/rdf.py
@@ -260,6 +260,10 @@ class TurtleLexer(RegexLexer):
             (r'(' + PN_PREFIX + r')?(\:)(' + PN_LOCAL + r')?',
              bygroups(Name.Namespace, Punctuation, Name.Tag)),
 
+            # BlankNodeLabel
+            (r'(\_)(\:)([' + PN_CHARS_U_GRP + r'0-9]([' + PN_CHARS_GRP + r'.]*' + PN_CHARS + ')?)',
+             bygroups(Name.Namespace, Punctuation, Name.Tag)),
+
             # Comment
             (r'#[^\n]+', Comment),
 

--- a/tests/examplefiles/turtle/example.ttl
+++ b/tests/examplefiles/turtle/example.ttl
@@ -7,6 +7,8 @@ PREFIX dc: <http://purl.org/dc/elements/1.1/>  # SPARQL-like syntax is OK
 
 <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
 
+_:BlankNode1 a _:BlankNode2 .
+
 <#doc1> a <#document>;
 	dc:creator "Smith", "Jones"; 
 	:knows <http://getopenid.com/jsmith>;

--- a/tests/examplefiles/turtle/example.ttl.output
+++ b/tests/examplefiles/turtle/example.ttl.output
@@ -68,6 +68,19 @@
 '.'           Punctuation
 '\n\n'        Text
 
+'_'           Name.Namespace
+':'           Punctuation
+'BlankNode1'  Name.Tag
+' '           Text
+'a'           Keyword.Type
+' '           Text
+'_'           Name.Namespace
+':'           Punctuation
+'BlankNode2'  Name.Tag
+' '           Text
+'.'           Punctuation
+'\n\n'        Text
+
 '<#doc1>'     Name.Variable
 ' '           Text
 'a'           Keyword.Type


### PR DESCRIPTION
Adding support for blank nodes to the TurtleLexer.

E.g. `_:a a _:b .` is now possible.

It's my first contribution to pygments - I hope it's okay.