### PR TITLE
Yet another formatting fix in CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,7 +47,7 @@ Version 2.17.0
   * Turtle: support blank nodes (#2581)
   * Wikitext: fix erroneous highlighting of LanguageConverter markup
     (#2493), add missing variant languages (#2494)
-  * CMake: support ``[=[ bracketed arguments ]=]``` (#2549)
+  * CMake: support ``[=[ bracketed arguments ]=]`` (#2549)
 
 - Fix ctags support and tests (#2487)
 - Include ``Lexer.add_filter`` in the documentation (#2519)


### PR DESCRIPTION
Three backticks were used, while only two were needed.

Introduced in commit 5874c34 (Fix code formatting in the CHANGES file., 2023-11-18).