### PR TITLE
fix building from source on macos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ Changelog = "https://github.com/pygments/pygments/blob/master/CHANGES"
 [project.scripts]
 pygmentize = "pygments.cmdline:main"
 
+[tool.hatch.build]
+packages = ["pygments"]
+
 [tool.hatch.version]
 path = "pygments/__init__.py"
 


### PR DESCRIPTION
Since #2573 switched to `hatchling`, macOS users cannot build from source:

```console
$ python3 -m venv .venv
$ .venv/bin/pip install --no-binary=pygments pygments
$ .venv/bin/python3 -c 'import pygments'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'pygments'
```

This is because the wheel gets packaged as `Pygments` (prob due to macOS's case-insensitive filesystem). This explicitly tells `hatchling` that the package is `pygments`.
