### PR TITLE
Fix parsing of dns zone record line succeeding record with comment

### DIFF
--- a/pygments/lexers/dns.py
+++ b/pygments/lexers/dns.py
@@ -73,22 +73,26 @@ class DnsZoneLexer(RegexLexer):
         'values': [
             (r'\n', Whitespace, "#pop"),
             (r'\(', Punctuation, 'nested'),
-            include('simple-values'),
+            include('simple-value'),
         ],
         # Parsing nested values (...):
         'nested': [
             (r'\)', Punctuation, "#pop"),
-            include('simple-values'),
+            include('multiple-simple-values'),
         ],
         # Parsing values:
-        'simple-values': [
-            (r'(;.*)(\n)', bygroups(Comment.Single, Whitespace)),
+        'simple-value': [
+            (r'(;.*)', bygroups(Comment.Single)),
             (r'[ \t]+', Whitespace),
             (r"@\b", Operator),
             ('"', String, 'string'),
             (r'[0-9]+[smhdw]?$', Number.Integer),
             (r'([0-9]+[smhdw]?)([ \t]+)', bygroups(Number.Integer, Whitespace)),
             (r'\S+', Literal),
+        ],
+        'multiple-simple-values': [
+            include('simple-value'),
+            (r'[\n]+', Whitespace),
         ],
         'include': [
             (r'([ \t]+)([^ \t\n]+)([ \t]+)([-\._a-zA-Z]+)([ \t]+)(;.*)?$',

--- a/tests/snippets/zone/a-record.txt
+++ b/tests/snippets/zone/a-record.txt
@@ -1,5 +1,6 @@
 ---input---
-delta           A      192.0.2.4
+delta           A      192.0.2.4 ; comment
+delta2           A      192.0.2.5
 
 ---tokens---
 'delta'       Name
@@ -7,4 +8,13 @@ delta           A      192.0.2.4
 'A'           Keyword.Type
 '      '      Text.Whitespace
 '192.0.2.4'   Literal
+' '           Text.Whitespace
+'; comment'   Comment.Single
+'\n'          Text.Whitespace
+
+'delta2'      Name
+'           ' Text.Whitespace
+'A'           Keyword.Type
+'      '      Text.Whitespace
+'192.0.2.5'   Literal
 '\n'          Text.Whitespace


### PR DESCRIPTION
A tweak of #2464 

Previously, the second line was treated as a series of Literals following 192.0.2.4, instead of a separate record line
```
delta           A      192.0.2.4 ; comment
delta2           A      192.0.2.5
```