### PR TITLE
Add a primitive lexer for Typst

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -525,6 +525,7 @@ LEXERS = {
     'TypoScriptCssDataLexer': ('pygments.lexers.typoscript', 'TypoScriptCssData', ('typoscriptcssdata',), (), ()),
     'TypoScriptHtmlDataLexer': ('pygments.lexers.typoscript', 'TypoScriptHtmlData', ('typoscripthtmldata',), (), ()),
     'TypoScriptLexer': ('pygments.lexers.typoscript', 'TypoScript', ('typoscript',), ('*.typoscript',), ('text/x-typoscript',)),
+    'TypstLexer': ('pygments.lexers.typst', 'Typst', ('typst',), ('*.typ',), ('text/x-typst',)),
     'UL4Lexer': ('pygments.lexers.ul4', 'UL4', ('ul4',), ('*.ul4',), ()),
     'UcodeLexer': ('pygments.lexers.unicon', 'ucode', ('ucode',), ('*.u', '*.u1', '*.u2'), ()),
     'UniconLexer': ('pygments.lexers.unicon', 'Unicon', ('unicon',), ('*.icn',), ('text/unicon',)),

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -64,8 +64,9 @@ class TypstLexer(RegexLexer):
         ],
         'maths': [
             include('comment'),
-            (words((r'_', r'^', r'+', r'-', r'/', r'*', r'->', r'<-', r'!=', r'=='), suffix=r'\b'), Operator),
-            (words((r'\\', r'$='), suffix=r'\b'), Operator),  # maths markup operators
+            (words(('_', '^', '+', '-', '/', '*', '->', '<-', '!=', '=='),
+                   suffix=r'\b'), Operator),
+            (words((r'\\', '$='), suffix=r'\b'), Operator),  # maths markup operators
             (r'\\\$', Punctuation),  # escaped
             (r'\$', Punctuation, '#pop'),  # end of math mode
             include('code'),

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -32,7 +32,7 @@ class TypstLexer(RegexLexer):
             include('markup'),
         ],
         'common': [
-            (r' |\t', Whitespace),
+            (r'[ \t]+', Whitespace),
             (r'((?!=[*_$`\-+0-9/<@\\#\[]|https).)+', Text),
         ],
         'markup': [

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -1,0 +1,99 @@
+"""
+    pygments.lexers.typst
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for Typst language.
+
+    :copyright: Copyright 2006-2023 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, words, bygroups, include
+from pygments.token import Comment, Keyword, Name, String, Punctuation, \
+    Whitespace, Generic, Operator, Number, Text
+
+__all__ = ['TypstLexer']
+
+
+class TypstLexer(RegexLexer):
+    """
+    For Typst code.
+    """
+
+    name = 'Typst'
+    aliases = ['typst']
+    filenames = ['*.typ']
+    mimetypes = ['text/x-typst']
+    url = 'https://typst.app'
+    version_added = '2.18'
+
+    tokens = {
+        'root': [
+            include('markup'),
+        ],
+        'common': [
+            (r' |\t', Whitespace),
+            (r'((?!=[*_$`\-+0-9/<@\\#\[]|https).)+', Text),
+        ],
+        'markup': [
+            include('comment'),
+            (r'^\s*=+.*$', Generic.Heading),
+            (r'[*][^*]*[*]', Generic.Strong),
+            (r'_[^_]*_', Generic.Emph),
+            (r'\$', Punctuation, 'maths'),
+            (r'`[^`]*`', String.Backtick),  # inline code
+            (r'^\s*-', Punctuation),  # unnumbered list
+            (r'^\s*\+', Punctuation),  # numbered list
+            (r'^\s*[0-9.]+', Punctuation),  # numbered list variant
+            (r'^(\s*/\s+)([^:]+)(:)', bygroups(Punctuation, Name.Variable, Punctuation)),  # definitions
+            (r'<[a-zA-Z_][a-zA-Z0-9_-]*>', Name.Label),  # label
+            (r'@[a-zA-Z_][a-zA-Z0-9_-]*', Name.Label),  # reference
+            (r'\\#', Text), # escaped
+            (words(('#let', '#set', '#show'), suffix=r'\b'), Keyword.Declaration, 'inline_code'),
+            (r'(#[a-zA-Z_][a-zA-Z0-9_]*)(\[)', bygroups(Name.Function, Punctuation), 'markup'),
+            (r'(#[a-zA-Z_][a-zA-Z0-9_]*)(\()', bygroups(Name.Function, Punctuation), 'inline_code'),
+            (r'#[a-zA-Z_][a-zA-Z0-9_]*', Name.Variable),
+            (r'```(?:.|\n)*?```', String.Backtick),  # code block
+            (r'https?://[0-9a-zA-Z~/%#&=\',;\.\+\?]*', Generic.Emph),  # links
+            (words((r'---', r'\\', r'~', r'--', r'...'), suffix=r'\b'), Punctuation),  # special chars shorthand
+            (r'\\\[', Punctuation),  # escaped
+            (r'\\\]', Punctuation),  # escaped
+            (r'\[', Punctuation, '#push'),
+            (r'\]', Punctuation, '#pop'),
+            include('common'),
+        ],
+        'maths': [
+            include('comment'),
+            (words((r'_', r'^', r'+', r'-', r'/', r'*', r'->', r'<-', r'!=', r'=='), suffix=r'\b'), Operator),
+            (words((r'\\', r'$='), suffix=r'\b'), Operator),  # maths markup operators
+            (r'\\\$', Punctuation),  # escaped
+            (r'\$', Punctuation, '#pop'),  # end of math mode
+            include('code'),
+        ],
+        'comment': [
+            (r'//.*$', Comment.Single),
+            (r'/[*](.|\n)*?[*]/', Comment.Multiline),
+        ],
+        'code': [
+            include('comment'),
+            (r'\[', Punctuation, 'markup'),
+            (r'\(|\{', Punctuation, 'code'),
+            (r'\)|\}', Punctuation, '#pop'),
+            (r'"[^"]*"', String.Double),
+            (r'[=,]', Operator),
+            (words(('and', 'or', 'not'), suffix=r'\b'), Operator.Word),
+            (r'=>|<=|==|!=|>|<|-=|\+=|\*=|/=|\+|-|\\|\*', Operator), # comparisons
+            (r'([a-zA-Z_][a-zA-Z0-9_]*)(:)', bygroups(Name.Variable, Punctuation), '#push'),
+            (r'([a-zA-Z_][a-zA-Z0-9_]*)(\()', bygroups(Name.Function, Punctuation), '#push'),
+            (words(('as', 'break', 'export', 'continue', 'else', 'for', 'if', 'import', 'in', 'include', 'return', 'while'), suffix=r'\b'), Keyword.Reserved),
+            (words(('auto', 'none', 'true', 'false'), suffix=r'\b'), Keyword.Constant),
+            (r'([0-9.]+)(mm|pt|cm|in|em|fr|%)', bygroups(Number, Keyword.Reserved)),
+            (words(('let', 'set', 'show'), suffix=r'\b'), Keyword.Declaration),
+            (r'(import|include)( )(")([^"])(")', bygroups(Keyword.Reserved, Text, Punctuation, String.Double, Punctuation)),
+            include('common'),
+        ],
+        'inline_code': [
+            (r';$', Punctuation, '#pop'),
+            include('code'),
+        ],
+    }

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -33,7 +33,7 @@ class TypstLexer(RegexLexer):
         ],
         'common': [
             (r'[ \t]+', Whitespace),
-            (r'((?!=[*_$`\-+0-9/<@\\#\[]|https).)+', Text),
+            (r'((?!=[*_$`\-+0-9/<@\\#\[]|https?://).)+', Text),
         ],
         'markup': [
             include('comment'),

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -54,7 +54,7 @@ class TypstLexer(RegexLexer):
             (r'(#[a-zA-Z_][a-zA-Z0-9_]*)(\()', bygroups(Name.Function, Punctuation), 'inline_code'),
             (r'#[a-zA-Z_][a-zA-Z0-9_]*', Name.Variable),
             (r'```(?:.|\n)*?```', String.Backtick),  # code block
-            (r'https?://[0-9a-zA-Z~/%#&=\',;\.\+\?]*', Generic.Emph),  # links
+            (r'https?://[0-9a-zA-Z~/%#&=\',;.+?]*', Generic.Emph),  # links
             (words((r'---', r'\\', r'~', r'--', r'...'), suffix=r'\b'), Punctuation),  # special chars shorthand
             (r'\\\[', Punctuation),  # escaped
             (r'\\\]', Punctuation),  # escaped

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -92,8 +92,9 @@ class TypstLexer(RegexLexer):
             (words(('auto', 'none', 'true', 'false'), suffix=r'\b'), Keyword.Constant),
             (r'([0-9.]+)(mm|pt|cm|in|em|fr|%)', bygroups(Number, Keyword.Reserved)),
             (words(('let', 'set', 'show'), suffix=r'\b'), Keyword.Declaration),
-            (r'(import|include)( *)(")([^"])(")',
-             bygroups(Keyword.Reserved, Text, Punctuation, String.Double, Punctuation)),
+            # FIXME: make this work
+            ## (r'(import|include)( *)(")([^"])(")',
+            ##  bygroups(Keyword.Reserved, Text, Punctuation, String.Double, Punctuation)),
             include('common'),
         ],
         'inline_code': [

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -86,7 +86,9 @@ class TypstLexer(RegexLexer):
             (r'=>|<=|==|!=|>|<|-=|\+=|\*=|/=|\+|-|\\|\*', Operator), # comparisons
             (r'([a-zA-Z_][a-zA-Z0-9_]*)(:)', bygroups(Name.Variable, Punctuation), '#push'),
             (r'([a-zA-Z_][a-zA-Z0-9_]*)(\()', bygroups(Name.Function, Punctuation), '#push'),
-            (words(('as', 'break', 'export', 'continue', 'else', 'for', 'if', 'import', 'in', 'include', 'return', 'while'), suffix=r'\b'), Keyword.Reserved),
+            (words(('as', 'break', 'export', 'continue', 'else', 'for', 'if',
+                    'import', 'in', 'include', 'return', 'while'), suffix=r'\b'),
+             Keyword.Reserved),
             (words(('auto', 'none', 'true', 'false'), suffix=r'\b'), Keyword.Constant),
             (r'([0-9.]+)(mm|pt|cm|in|em|fr|%)', bygroups(Number, Keyword.Reserved)),
             (words(('let', 'set', 'show'), suffix=r'\b'), Keyword.Declaration),

--- a/pygments/lexers/typst.py
+++ b/pygments/lexers/typst.py
@@ -90,7 +90,8 @@ class TypstLexer(RegexLexer):
             (words(('auto', 'none', 'true', 'false'), suffix=r'\b'), Keyword.Constant),
             (r'([0-9.]+)(mm|pt|cm|in|em|fr|%)', bygroups(Number, Keyword.Reserved)),
             (words(('let', 'set', 'show'), suffix=r'\b'), Keyword.Declaration),
-            (r'(import|include)( )(")([^"])(")', bygroups(Keyword.Reserved, Text, Punctuation, String.Double, Punctuation)),
+            (r'(import|include)( *)(")([^"])(")',
+             bygroups(Keyword.Reserved, Text, Punctuation, String.Double, Punctuation)),
             include('common'),
         ],
         'inline_code': [

--- a/tests/examplefiles/typst/test.typ
+++ b/tests/examplefiles/typst/test.typ
@@ -21,3 +21,6 @@
 )
 
 Another link, with http instead of https: http://example.com
+
+
+#include  "other.typ"

--- a/tests/examplefiles/typst/test.typ
+++ b/tests/examplefiles/typst/test.typ
@@ -1,0 +1,21 @@
+#show link: set text(navy)
+#show par: set block(below: 1.75em)
+#set text(font: "Palatino", hyphenate: false, lang: "gb")
+#set page(margin: (x: 1.5cm, y: 2.5cm), numbering: "1 / 1")
+#let section(title, content) = grid(
+      columns: (55pt, 1fr),
+      text(darkgrey)[#date]
+      h(1fr)
+      content
+)
+
+== Title
+#link("mailto:spam@example.com")
+#text(darkgrey)[ | ] #link("https://example.com")[super example]
+#line(length: 100%, stroke: 0.2mm)
+#section([another \ test], [
+  *#link("https://github.com/typst/typst")[typst]* --- bob #section_date([2022 -- present]) \
+    some text
+  ]
+  / Itemone: -- first item
+)

--- a/tests/examplefiles/typst/test.typ
+++ b/tests/examplefiles/typst/test.typ
@@ -21,6 +21,3 @@
 )
 
 Another link, with http instead of https: http://example.com
-
-
-#include  "other.typ"

--- a/tests/examplefiles/typst/test.typ
+++ b/tests/examplefiles/typst/test.typ
@@ -19,3 +19,5 @@
   ]
   / Itemone: -- first item
 )
+
+Another link, with http instead of https: http://example.com

--- a/tests/examplefiles/typst/test.typ.output
+++ b/tests/examplefiles/typst/test.typ.output
@@ -169,3 +169,9 @@
 
 ')'           Text
 '\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Another link, with http instead of https: ' Text
+'http://example.com' Generic.Emph
+'\n'          Text.Whitespace

--- a/tests/examplefiles/typst/test.typ.output
+++ b/tests/examplefiles/typst/test.typ.output
@@ -1,0 +1,196 @@
+'#show'       Keyword.Declaration
+' '           Text.Whitespace
+'link'        Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'set'         Keyword.Declaration
+' '           Text.Whitespace
+'text'        Name.Function
+'('           Punctuation
+'navy)'       Text
+'\n'          Text.Whitespace
+
+'#show'       Keyword.Declaration
+' '           Text.Whitespace
+'par'         Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'set'         Keyword.Declaration
+' '           Text.Whitespace
+'block'       Name.Function
+'('           Punctuation
+'below'       Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'1.75'        Literal.Number
+'em'          Keyword.Reserved
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'#set'        Keyword.Declaration
+' '           Text.Whitespace
+'text'        Name.Function
+'('           Punctuation
+'font'        Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'"Palatino"'  Literal.String.Double
+','           Operator
+' '           Text.Whitespace
+'hyphenate'   Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'false'       Keyword.Constant
+','           Operator
+' '           Text.Whitespace
+'lang'        Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'"gb"'        Literal.String.Double
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'#set'        Keyword.Declaration
+' '           Text.Whitespace
+'page'        Name.Function
+'('           Punctuation
+'margin'      Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'x'           Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'1.5'         Literal.Number
+'cm'          Keyword.Reserved
+','           Operator
+' '           Text.Whitespace
+'y'           Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'2.5'         Literal.Number
+'cm'          Keyword.Reserved
+')'           Punctuation
+','           Operator
+' '           Text.Whitespace
+'numbering'   Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'"1 / 1"'     Literal.String.Double
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'#let'        Keyword.Declaration
+' '           Text.Whitespace
+'section'     Name.Function
+'('           Punctuation
+'title, content) = grid(' Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+'columns: (55pt, 1fr),' Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+'text(darkgrey)[#date]' Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+'h(1fr)'      Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+'content'     Text
+'\n'          Text.Whitespace
+
+')'           Text
+'\n'          Text.Whitespace
+
+'\n== Title'  Generic.Heading
+'\n'          Text.Whitespace
+
+'#link'       Name.Function
+'('           Punctuation
+'"mailto:spam@example.com"' Literal.String.Double
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'#text'       Name.Function
+'('           Punctuation
+'darkgrey)[ | ] #link("' Text
+'https'       Name.Variable
+':'           Punctuation
+'//example.com")[super example]' Comment.Single
+'\n'          Text.Whitespace
+
+'#line'       Name.Function
+'('           Punctuation
+'length'      Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'100'         Literal.Number
+'%'           Keyword.Reserved
+','           Operator
+' '           Text.Whitespace
+'stroke'      Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'0.2'         Literal.Number
+'mm'          Keyword.Reserved
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'#section'    Name.Function
+'('           Punctuation
+'['           Punctuation
+'another \\ test], [' Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+'*#link("https://github.com/typst/typst")[typst]*' Generic.Strong
+' '           Text.Whitespace
+'--- bob #section_date([2022 -- present]) \\' Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+' '           Text.Whitespace
+'some text'   Text
+'\n'          Text.Whitespace
+
+' '           Text.Whitespace
+' '           Text.Whitespace
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'  / '        Punctuation
+'Itemone'     Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'-- first item' Text
+'\n'          Text.Whitespace
+
+')'           Text
+'\n'          Text.Whitespace

--- a/tests/examplefiles/typst/test.typ.output
+++ b/tests/examplefiles/typst/test.typ.output
@@ -87,39 +87,19 @@
 'title, content) = grid(' Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
+'      '      Text.Whitespace
 'columns: (55pt, 1fr),' Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
+'      '      Text.Whitespace
 'text(darkgrey)[#date]' Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
+'      '      Text.Whitespace
 'h(1fr)'      Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
+'      '      Text.Whitespace
 'content'     Text
 '\n'          Text.Whitespace
 
@@ -166,22 +146,17 @@
 'another \\ test], [' Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
+'  '          Text.Whitespace
 '*#link("https://github.com/typst/typst")[typst]*' Generic.Strong
 ' '           Text.Whitespace
 '--- bob #section_date([2022 -- present]) \\' Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
-' '           Text.Whitespace
+'    '        Text.Whitespace
 'some text'   Text
 '\n'          Text.Whitespace
 
-' '           Text.Whitespace
-' '           Text.Whitespace
+'  '          Text.Whitespace
 ']'           Punctuation
 '\n'          Text.Whitespace
 


### PR DESCRIPTION
This should close #2558.

I tried to add tests but:

```
jvoisin@home 20:49 (tyspt) ~/dev/pygments tox -- --update-goldens ~/text.typ 
Traceback (most recent call last):
  File "/usr/bin/tox", line 33, in <module>
    sys.exit(load_entry_point('tox==3.21.4', 'console_scripts', 'tox')())
  File "/usr/lib/python3/dist-packages/tox/session/__init__.py", line 44, in cmdline
    main(args)
  File "/usr/lib/python3/dist-packages/tox/session/__init__.py", line 65, in main
    config = load_config(args)
  File "/usr/lib/python3/dist-packages/tox/session/__init__.py", line 81, in load_config
    config = parseconfig(args)
  File "/usr/lib/python3/dist-packages/tox/config/__init__.py", line 280, in parseconfig
    ParseIni(config, config_file, content)
  File "/usr/lib/python3/dist-packages/tox/config/__init__.py", line 1276, in __init__
    raise tox.exception.ConfigError(
tox.exception.ConfigError: ConfigError: pylint failed with ConfigError: skip_install: boolean value "True # doesn't need installing Pygments into the venv" needs to be 'True' or 'False' at Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/tox/config/__init__.py", line 1252, in run
    results[name] = cur_self.make_envconfig(name, section, subs, config)
  File "/usr/lib/python3/dist-packages/tox/config/__init__.py", line 1407, in make_envconfig
    res = meth(env_attr.name, env_attr.default, replace=replace)
  File "/usr/lib/python3/dist-packages/tox/config/__init__.py", line 1696, in getbool
    raise tox.exception.ConfigError(
tox.exception.ConfigError: ConfigError: skip_install: boolean value "True # doesn't need installing Pygments into the venv" needs to be 'True' or 'False'

[1]
jvoisin@home 20:49 (tyspt) ~/dev/pygments 
```

Also, while the lexer is working ~ok, there is still a lot of space for improvements. 