### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         # Run macOS CI only when pushing tags, not on every push/PR.
         # There seems not to be a prettier solution than this trick ...
         exclude:

--- a/doc/docs/plugins.rst
+++ b/doc/docs/plugins.rst
@@ -17,35 +17,6 @@ This will allow you to use your custom lexers/... with the
 tools such as Sphinx, mkdocs, ...
 
 
-Plugin discovery
-================
-
-At runtime, discovering plugins is preferentially done using Python's
-standard library module `importlib.metadata`_, available in Python 3.8
-and higher. In earlier Python versions, Pygments attempts to use the
-`importlib_metadata`_ backport, if available. If not available, a
-fallback is attempted on the older `pkg_resources`_ module. Finally, if
-``pkg_resources`` is not available, no plugins will be loaded at
-all. Note that ``pkg_resources`` is distributed with setuptools, and
-thus available on most Python environments. However, ``pkg_resources``
-is considerably slower than ``importlib.metadata`` or its
-``importlib_metadata`` backport. For this reason, if you run Pygments
-under Python older than 3.8, it is recommended to install
-``importlib-metadata``. Pygments defines a ``plugins`` packaging extra,
-so you can ensure it is installed with best plugin support (i.e., that
-``importlib-metadata`` is also installed in case you are running Python
-earlier than 3.8) by specifying ``pygments[plugins]`` as the
-requirement, for example, with ``pip``:
-
-.. sourcecode:: shell
-
-   $ python -m pip install --user pygments[plugins]
-
-.. _importlib.metadata: https://docs.python.org/3.10/library/importlib.metadata.html
-.. _importlib_metadata: https://pypi.org/project/importlib-metadata
-.. _pkg_resources: https://setuptools.pypa.io/en/latest/pkg_resources.html
-
-
 Defining plugins through entry points
 =====================================
 

--- a/pygments/plugin.py
+++ b/pygments/plugin.py
@@ -2,12 +2,7 @@
     pygments.plugin
     ~~~~~~~~~~~~~~~
 
-    Pygments plugin interface. By default, this tries to use
-    ``importlib.metadata``, which is in the Python standard
-    library since Python 3.8, or its ``importlib_metadata``
-    backport for earlier versions of Python. It falls back on
-    ``pkg_resources`` if not found. Finally, if ``pkg_resources``
-    is not found either, no plugins are loaded at all.
+    Pygments plugin interface.
 
     lexer plugins::
 
@@ -37,6 +32,7 @@
     :copyright: Copyright 2006-2023 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from importlib.metadata import entry_points
 
 LEXER_ENTRY_POINT = 'pygments.lexers'
 FORMATTER_ENTRY_POINT = 'pygments.formatters'
@@ -45,18 +41,6 @@ FILTER_ENTRY_POINT = 'pygments.filters'
 
 
 def iter_entry_points(group_name):
-    try:
-        from importlib.metadata import entry_points
-    except ImportError:
-        try:
-            from importlib_metadata import entry_points
-        except ImportError:
-            try:
-                from pkg_resources import iter_entry_points
-            except (ImportError, OSError):
-                return []
-            else:
-                return iter_entry_points(group_name)
     groups = entry_points()
     if hasattr(groups, 'select'):
         # New interface in Python 3.10 and newer versions of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "Pygments"
 dynamic = ["version"]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "BSD-2-Clause"}
 authors = [
   {name = "Georg Brandl", email = "georg@python.org"}
@@ -28,7 +28,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -41,7 +40,6 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-plugins = ["importlib-metadata;python_version<'3.8'"]
 windows-terminal = ["colorama >= 0.4.6"]
 
 [project.urls]


### PR DESCRIPTION
Dropping 3.7 means the https://pypi.org/project/importlib-metadata and `pkg_resources` fallbacks can be removed.

