### PR TITLE
Add val and var as xtend keywords

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -1273,7 +1273,7 @@ class XtendLexer(RegexLexer):
              Keyword),
             (r'(def|abstract|const|enum|extends|final|implements|native|private|'
              r'protected|public|static|strictfp|super|synchronized|throws|'
-             r'transient|volatile)\b', Keyword.Declaration),
+             r'transient|volatile|val|var)\b', Keyword.Declaration),
             (r'(boolean|byte|char|double|float|int|long|short|void)\b',
              Keyword.Type),
             (r'(package)(\s+)', bygroups(Keyword.Namespace, Whitespace)),


### PR DESCRIPTION
The current [Xtend](https://eclipse.dev/Xtext/xtend/) support does not highlights two important keywords of the language, namely `val` and `var`, which allow declaring variables.

Example:

```xtend
class Hello {
   def sayHello() {
      val message = "Hello world"
      println(message)
   }
}
```
When processed with Pygments, we get:

![image](https://github.com/pygments/pygments/assets/5868014/4f021aae-2f36-4e15-a49a-4c1d82e24e2f)




This PR fix this problem by adding these two keywords to the appropriate list.