### PR TITLE
[Waiting for #2654] add the `\sa0` keyword to the rtf formatter

### DIFF
--- a/pygments/formatters/rtf.py
+++ b/pygments/formatters/rtf.py
@@ -113,7 +113,7 @@ class RtfFormatter(Formatter):
                         int(color[4:6], 16)
                     ))
                     offset += 1
-        outfile.write('}\\f0 ')
+        outfile.write('}\\f0\\sa0 ')
         if self.fontsize:
             outfile.write('\\fs%d' % self.fontsize)
 


### PR DESCRIPTION
This sets a default explicitly, which is set differently by some rtf displayers, e.g. MS PowerPoint. Here, \sa200 is assumed which adds a 10pt spacing after every newline, thus making the code very spaced out. For further discussion, see #1111. This issue is solved by this PR.

Edit: I referenced the wrong issue...