### PR TITLE
add C-Shell style prompt to BashSession lexer

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -236,7 +236,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _innerLexerCls = BashLexer
     _ps1rgx = re.compile(
         r'^((?:(?:\[.*?\])|(?:\(\S+\))?(?:| |sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)' \
-        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%]\s*)(.*\n?)')
+        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%>]\s*)(.*\n?)')
     _ps2 = '> '
 
 


### PR DESCRIPTION
This is related to issue #2591: SuSE uses a C-Shell style prompt like user@host:path>
Previously only prompts ending in $#% symbols were supported.