### PR TITLE
Add lexer for Promela

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -391,7 +391,7 @@ LEXERS = {
     'ProcfileLexer': ('pygments.lexers.procfile', 'Procfile', ('procfile',), ('Procfile',), ()),
     'PrologLexer': ('pygments.lexers.prolog', 'Prolog', ('prolog',), ('*.ecl', '*.prolog', '*.pro', '*.pl'), ('text/x-prolog',)),
     'PromQLLexer': ('pygments.lexers.promql', 'PromQL', ('promql',), ('*.promql',), ()),
-    'PromelaLexer': ('pygments.lexers.c_like', 'Promela', ('promela',), ('*.pml', '*.prom', '*.prm', '*.promela', '*pr', '*.pm'), ('text/x-promela',)),
+    'PromelaLexer': ('pygments.lexers.c_like', 'Promela', ('promela',), ('*.pml', '*.prom', '*.prm', '*.promela', '*.pr', '*.pm'), ('text/x-promela',)),
     'PropertiesLexer': ('pygments.lexers.configs', 'Properties', ('properties', 'jproperties'), ('*.properties',), ('text/x-java-properties',)),
     'ProtoBufLexer': ('pygments.lexers.dsls', 'Protocol Buffer', ('protobuf', 'proto'), ('*.proto',), ()),
     'PrqlLexer': ('pygments.lexers.prql', 'PRQL', ('prql',), ('*.prql',), ('application/prql', 'application/x-prql')),

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -391,6 +391,7 @@ LEXERS = {
     'ProcfileLexer': ('pygments.lexers.procfile', 'Procfile', ('procfile',), ('Procfile',), ()),
     'PrologLexer': ('pygments.lexers.prolog', 'Prolog', ('prolog',), ('*.ecl', '*.prolog', '*.pro', '*.pl'), ('text/x-prolog',)),
     'PromQLLexer': ('pygments.lexers.promql', 'PromQL', ('promql',), ('*.promql',), ()),
+    'PromelaLexer': ('pygments.lexers.c_like', 'Promela', ('promela',), ('*.pml', '*.prom', '*.prm', '*.promela', '*pr', '*.pm'), ('text/x-promela',)),
     'PropertiesLexer': ('pygments.lexers.configs', 'Properties', ('properties', 'jproperties'), ('*.properties',), ('text/x-java-properties',)),
     'ProtoBufLexer': ('pygments.lexers.dsls', 'Protocol Buffer', ('protobuf', 'proto'), ('*.proto',), ()),
     'PrqlLexer': ('pygments.lexers.prql', 'PRQL', ('prql',), ('*.prql',), ('application/prql', 'application/x-prql')),

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -20,7 +20,7 @@ from pygments.lexers import _mql_builtins
 
 __all__ = ['PikeLexer', 'NesCLexer', 'ClayLexer', 'ECLexer', 'ValaLexer',
            'CudaLexer', 'SwigLexer', 'MqlLexer', 'ArduinoLexer', 'CharmciLexer',
-           'OmgIdlLexer']
+           'OmgIdlLexer', 'PromelaLexer']
 
 
 class PikeLexer(CppLexer):
@@ -655,5 +655,83 @@ class OmgIdlLexer(CLexer):
             (r'[\(\)]', Punctuation),
             include('values'),
             include('annotation_appl'),
+        ],
+    }
+
+
+class PromelaLexer(CLexer):
+    """
+    For the Promela language used with SPIN.
+    """
+    name = 'Promela'
+    aliases = ['promela']
+    filenames = ['*.pml', '*.prom', '*.prm', '*.promela', '*pr', '*.pm']
+    mimetypes = ['text/x-promela']
+    url = 'https://spinroot.com/spin/whatispin.html'
+    version_added = '2.18'
+
+    # Promela's language reference:
+    # https://spinroot.com/spin/Man/promela.html
+    # Promela's grammar definition:
+    # https://spinroot.com/spin/Man/grammar.html
+
+    tokens = {
+        'statements': [
+            (r'(\[\]|<>|/\\|\\/)|(U|W|V)\b', Operator), # LTL Operators
+            (r'[@]', Punctuation), #remoterefs
+            (r'(\.)([a-zA-Z_]\w*)', bygroups(Operator, Name.Attribute)),
+            inherit
+        ],
+        'types': [
+            # Predefined (data types)
+            (words((
+                'bit', 'bool', 'byte', 'pid', 'short', 'int', 'unsigned'),
+                suffix=r'\b'),
+             Keyword.Type),
+        ],
+        'keywords': [
+            # ControlFlow
+            (words((
+                'atomic', 'break', 'd_step', 'do', 'od', 'for', 'in', 'goto',
+                'if', 'fi', 'unless'), suffix=r'\b'),
+             Keyword),
+            # BasicStatements
+            (words((
+                'assert', 'get_priority', 'printf', 'printm', 'set_priority'),
+                suffix=r'\b'),
+             Name.Function),
+            # Embedded C Code
+            (words((
+                'c_code', 'c_decl', 'c_expr', 'c_state', 'c_track'),
+                suffix=r'\b'),
+             Keyword),
+            # Predefined (local/global variables)
+            (words((
+                '_', '_last', '_nr_pr', '_pid', '_priority', 'else', 'np_',
+                'STDIN'), suffix=r'\b'),
+             Name.Builtin),
+            # Predefined (functions)
+            (words((
+                'empty', 'enabled', 'eval', 'full', 'len', 'nempty', 'nfull',
+                'pc_value'), suffix=r'\b'),
+             Name.Function),
+            # Predefined (operators)
+            (r'(run)\b', Operator.Word),
+            # Declarators
+            (words((
+                'active', 'chan', 'D_proctype', 'hidden', 'init', 'local',
+                'mtype', 'never', 'notrace', 'proctype', 'show', 'trace',
+                'typedef', 'xr', 'xs'), suffix=r'\b'),
+             Keyword.Declaration),
+            # Declarators (suffixes)
+            (words((
+                'priority', 'provided'), suffix=r'\b'),
+             Keyword),
+            # MetaTerms (declarators)
+            (words((
+                'inline', 'ltl', 'select'), suffix=r'\b'),
+             Keyword.Declaration),
+            # MetaTerms (keywords)
+            (r'(skip)\b', Keyword),
         ],
     }

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -679,7 +679,7 @@ class PromelaLexer(CLexer):
     tokens = {
         'statements': [
             (r'(\[\]|<>|/\\|\\/)|(U|W|V)\b', Operator), # LTL Operators
-            (r'[@]', Punctuation), #remoterefs
+            (r'@', Punctuation), #remoterefs
             (r'(\.)([a-zA-Z_]\w*)', bygroups(Operator, Name.Attribute)),
             inherit
         ],

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -666,7 +666,7 @@ class PromelaLexer(CLexer):
     
     name = 'Promela'
     aliases = ['promela']
-    filenames = ['*.pml', '*.prom', '*.prm', '*.promela', '*pr', '*.pm']
+    filenames = ['*.pml', '*.prom', '*.prm', '*.promela', '*.pr', '*.pm']
     mimetypes = ['text/x-promela']
     url = 'https://spinroot.com/spin/whatispin.html'
     version_added = '2.18'

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -663,6 +663,7 @@ class PromelaLexer(CLexer):
     """
     For the Promela language used with SPIN.
     """
+    
     name = 'Promela'
     aliases = ['promela']
     filenames = ['*.pml', '*.prom', '*.prm', '*.promela', '*pr', '*.pm']

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -717,7 +717,7 @@ class PromelaLexer(CLexer):
                 'pc_value'), suffix=r'\b'),
              Name.Function),
             # Predefined (operators)
-            (r'(run)\b', Operator.Word),
+            (r'run\b', Operator.Word),
             # Declarators
             (words((
                 'active', 'chan', 'D_proctype', 'hidden', 'init', 'local',

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -733,6 +733,6 @@ class PromelaLexer(CLexer):
                 'inline', 'ltl', 'select'), suffix=r'\b'),
              Keyword.Declaration),
             # MetaTerms (keywords)
-            (r'(skip)\b', Keyword),
+            (r'skip\b', Keyword),
         ],
     }

--- a/tests/examplefiles/promela/calc.pml
+++ b/tests/examplefiles/promela/calc.pml
@@ -1,0 +1,20 @@
+// reverse polish
+
+mtype = { operator, value }
+
+chan f = [12] of { mtype, int }
+
+proctype calc(chan you)
+{	int s, lft, rgt
+	chan me = [0] of { int }
+
+	if
+	:: f?operator(s)
+		run calc(me); me?lft
+		run calc(me); me?rgt
+		if
+		:: s == '+' -> you!(lft+rgt)
+		fi
+	:: f?value(s) -> you!s
+	fi
+}

--- a/tests/examplefiles/promela/calc.pml.output
+++ b/tests/examplefiles/promela/calc.pml.output
@@ -1,0 +1,191 @@
+'// reverse polish\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'operator'    Name
+','           Punctuation
+' '           Text.Whitespace
+'value'       Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'chan'        Keyword.Declaration
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'12'          Literal.Number.Integer
+']'           Punctuation
+' '           Text.Whitespace
+'of'          Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'mtype'       Keyword.Declaration
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'proctype'    Keyword.Declaration
+' '           Text.Whitespace
+'calc'        Name
+'('           Punctuation
+'chan'        Keyword.Declaration
+' '           Text.Whitespace
+'you'         Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'{'           Punctuation
+'\t'          Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'s'           Name
+','           Punctuation
+' '           Text.Whitespace
+'lft'         Name
+','           Punctuation
+' '           Text.Whitespace
+'rgt'         Name
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'chan'        Keyword.Declaration
+' '           Text.Whitespace
+'me'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'0'           Literal.Number.Integer
+']'           Punctuation
+' '           Text.Whitespace
+'of'          Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'f'           Name
+'?'           Operator
+'operator'    Name
+'('           Punctuation
+'s'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'run'         Operator.Word
+' '           Text.Whitespace
+'calc'        Name
+'('           Punctuation
+'me'          Name
+')'           Punctuation
+';'           Punctuation
+' '           Text.Whitespace
+'me'          Name
+'?'           Operator
+'lft'         Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'run'         Operator.Word
+' '           Text.Whitespace
+'calc'        Name
+'('           Punctuation
+'me'          Name
+')'           Punctuation
+';'           Punctuation
+' '           Text.Whitespace
+'me'          Name
+'?'           Operator
+'rgt'         Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'if'          Keyword
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'s'           Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'+'           Literal.String.Char
+"'"           Literal.String.Char
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'you'         Name
+'!'           Operator
+'('           Punctuation
+'lft'         Name
+'+'           Operator
+'rgt'         Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'fi'          Keyword
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'f'           Name
+'?'           Operator
+'value'       Name
+'('           Punctuation
+'s'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'you'         Name
+'!'           Operator
+'s'           Name
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/examplefiles/promela/sample.pml
+++ b/tests/examplefiles/promela/sample.pml
@@ -1,0 +1,275 @@
+/**
+	Needham-Schroeder message passing protocol (patched). 
+	|	msg1:	agentA -> agentB	(keyB, agentA, nonceA, 0)
+	|	msg2:	agentB -> agentA	(keyA, agentB, nonceA, nonceB)
+	|	msg3:	agentA -> agentB	(keyB, nonceB, 0, 0)
+
+	Note that sending (keyB, agentA, nonceA) from agentA to agentB 
+	over the network (chan)nel models agentA encrypting the message 
+	"[agentA, nonceB]" with agentB's public key.
+*/
+
+mtype = {
+	/* Status Codes */
+	ok, 
+	err, 
+
+	/* Message Codes */
+	msg1, 
+	msg2, 
+	msg3, 
+
+	/*	Agent (A)lice */
+	keyA,
+	agentA, 
+	nonceA,
+
+	/*	Agent (B)ob */
+	keyB, 
+	agentB,
+	nonceB,
+
+	/*	Agent (I)ntruder */
+	keyI, 
+	agentI, 
+	nonceI 
+};
+
+
+/**
+	Declare a structured data type to model our encrypted messages.
+	Messages will contain either 2 or 3 content fields.
+*/
+typedef Crypt { 
+	mtype key, 
+	content1, 
+	content2,
+	content3 
+};
+
+
+/**
+	Model network between agents via a rendezvous channel. 
+	Send and recieve operations are performed synchronously. 
+*/
+chan network = [0] of {mtype, mtype, Crypt};
+
+
+/* global variables for verification*/
+mtype partnerA; 
+mtype partnerB;
+mtype statusA = err;
+mtype statusB = err;
+bool knows_nonceA; 
+bool knows_nonceB;
+
+/* Agent (A)lice */
+active proctype Alice() {
+
+	/* local variables */
+	mtype pkey;			/* reciever's public key */
+	mtype pnonce;		/* reciever's nonce	 */
+	Crypt messageAB;	/* sent messages			 */
+	Crypt data;			/* recieved messages	 */
+
+	/* 
+		Initialization: In this example we non-deterministically choose between 
+		agents (B)ob and (I)ntruder
+	*/
+	if 
+	:: partnerA = agentB; pkey = keyB;
+	:: partnerA = agentI; pkey = keyI;
+	fi;
+
+	/* prepare (msg1) */
+	messageAB.key = pkey;
+	messageAB.content1 = agentA;
+	messageAB.content2 = nonceA;
+	messageAB.content3 = 0;
+
+	/* send (msg1) */
+	network ! msg1 (partnerA, messageAB);
+
+	/* recv (msg2) : blocking */
+	network ? (msg2, agentA, data);
+
+	/* verify (msg2) : blocking	*/
+	(data.key == keyA) && (data.content1 == partnerA) && (data.content2 == nonceA);
+
+	/* obtain (msg2) sender's nonce */
+	pnonce = data.content3;
+
+	/* prepare (msg3) */
+	messageAB.key = pkey;
+	messageAB.content1 = pnonce;
+	messageAB.content2 = 0;
+	messageAB.content3 = 0;
+
+	/* send (msg3) */
+	network ! msg3 (partnerA, messageAB);
+
+	/* update status */
+	statusA = ok;
+}
+
+/* Agent (B)ob */
+active proctype Bob() {
+		
+	/* local variables */
+	mtype pkey;			/* reciever's public key */
+	mtype pnonce;		/* reciever's nonce	 */
+	Crypt messageBA;	/* sent messages			 */
+	Crypt data;			/* recieved messages	 */
+
+	/* Initialization	*/
+	partnerB = agentA;
+	pkey	 = keyA;
+
+	/* recv (msg1) : blocking */
+	network ? (msg1, agentB, data)
+
+	/* verify (msg1) : blocking */
+	(data.key == keyB) && (data.content1 == agentA);
+
+	/* obtain (msg1) sender's nonce */
+	pnonce = data.content2;	
+
+	/* prepare (msg2) */
+	messageBA.key = pkey;
+	messageBA.content1 = agentB;
+	messageBA.content2 = pnonce;
+	messageBA.content3 = nonceB;
+
+	/* send (msg2) */
+	network ! msg2 (partnerB, messageBA);
+
+	/* recv (msg3) : blocking */
+	network ? (msg3, agentB, data);
+
+	/* verify (msg3) : blocking */
+	(data.key == keyB) && (data.content1 == nonceB);
+
+	statusB = ok;
+}
+
+/* Agent (I)ntruder */
+active proctype Intruder() {
+
+	mtype msg, recpt;
+	Crypt data, intercepted;
+
+	/* Initialize knows_nonce variables to false */
+	knows_nonceA = false;
+	knows_nonceB = false;
+
+	do
+	:: network ? (msg, _, data) -> 
+	if /* perhaps store the message */
+			
+		::	intercepted.key		 = data.key;
+			intercepted.content1 = data.content1;
+			intercepted.content2 = data.content2;
+			
+			/*	
+				Message contains (I)ntruder's (public) key, the intruder can 
+				decrypt the message. Note that we can learn nonce values from 
+				either content1 or content2
+				|	msg1:	(keyB, agentA, nonceA, 0)
+				|	msg2:	(keyA, agentB, nonceA, nonceB)
+				|	msg3: 	(keyB, nonceB, 0, 0)
+			*/
+			if 
+			::  (intercepted.key == keyI) -> if 
+				:: intercepted.content1 == nonceA -> knows_nonceA = true; 
+				:: intercepted.content1 == nonceB -> knows_nonceB = true; 
+				:: intercepted.content2 == nonceA -> knows_nonceA = true; 
+				:: intercepted.content2 == nonceB -> knows_nonceB = true; 
+				:: intercepted.content3 == nonceA -> knows_nonceA = true; 
+				:: intercepted.content3 == nonceB -> knows_nonceB = true;
+				fi 
+
+			:: skip;
+			fi 
+
+		:: skip;
+	fi;
+
+	:: /* Replay or send a message */
+	if /* choose message type */
+		:: msg = msg1;
+		:: msg = msg2;
+		:: msg = msg3;
+	fi;
+		
+	if /* choose a recepient */
+		:: recpt = agentA;
+		:: recpt = agentB;
+	fi;
+			 
+	if /* replay intercepted message or assemble it */
+		::	data.key		= intercepted.key;
+			data.content1	= intercepted.content1;
+			data.content2	= intercepted.content2;
+			data.content3	= intercepted.content3;
+		
+		:: 
+		if /* assemble content1 */
+			:: data.content1 = agentA;
+			:: data.content1 = agentB;
+			:: data.content1 = agentI;
+			:: (knows_nonceA) -> data.content1 = nonceA
+			:: (knows_nonceB) -> data.content1 = nonceB
+			:: (!knows_nonceA && !knows_nonceB) -> data.content1 = nonceI;
+		fi;
+		
+		if /* assemble key */
+			:: data.key = keyA;
+			:: data.key = keyB;
+			:: data.key = keyI;
+		fi;
+		
+		if 
+		:: (knows_nonceA) -> data.content2 = nonceA
+		:: (knows_nonceB) -> data.content2 = nonceB
+		:: (!knows_nonceA && !knows_nonceB) -> data.content2 = nonceI;
+		fi 
+
+		if 
+		:: (knows_nonceA) -> data.content3 = nonceA
+		:: (knows_nonceB) -> data.content3 = nonceB
+		:: (!knows_nonceA && !knows_nonceB) -> data.content3 = nonceI;
+		fi 
+		
+	fi;
+
+	network ! msg (recpt, data);
+	od
+}
+
+/**
+	Always, one process will terminate in error
+*/
+ltl alwaysErr { [] ( (statusA == err) || (statusB == err) ) }
+
+/**
+	Eventually the protocol will complete without error
+*/
+ltl eventuallyOk { <> ( (statusA == ok) && (statusB == ok) ) }
+
+/*
+	propAB: If both Alice and Bob reach the end of their runs (i.e. both statusA and statusB are ok) 
+	then Alice's communication partner is Bob, and Bob's communication partner is Alice.
+*/
+ltl propAB { [] ( ( (statusA == ok) && (statusB == ok) ) -> ( (partnerB == agentA) && (partnerA == agentB) ) ) }
+
+/*
+	propA: If agent A reaches the end of its run (statusA is ok) and A believes it is talking to B 
+	(partnerA is agentB) then the intruder does not know A's nonce (!knows_nonceA).
+*/
+ltl propA { [] ( ( (statusA == ok)  && (partnerA == agentB) ) ->  ( knows_nonceA == false ) ) }
+
+/*
+	propB: If agent B reaches the end of its run (statusB is ok) and it believes it is talking to A 
+	(partnerB is agentA) then the intruder does not know B's nonce (!knows_nonceB)
+*/
+ltl propB { [] ( ( (statusB == ok)  && (partnerB == agentA) ) ->  ( knows_nonceB == false ) ) }

--- a/tests/examplefiles/promela/sample.pml.output
+++ b/tests/examplefiles/promela/sample.pml.output
@@ -1,0 +1,2082 @@
+'/**\n\tNeedham-Schroeder message passing protocol (patched). \n\t|\tmsg1:\tagentA -> agentB\t(keyB, agentA, nonceA, 0)\n\t|\tmsg2:\tagentB -> agentA\t(keyA, agentB, nonceA, nonceB)\n\t|\tmsg3:\tagentA -> agentB\t(keyB, nonceB, 0, 0)\n\n\tNote that sending (keyB, agentA, nonceA) from agentA to agentB \n\tover the network (chan)nel models agentA encrypting the message \n\t"[agentA, nonceB]" with agentB\'s public key.\n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* Status Codes */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'ok'          Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'err'         Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* Message Codes */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'msg1'        Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'msg2'        Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'msg3'        Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/*\tAgent (A)lice */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'keyA'        Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'agentA'      Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'nonceA'      Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/*\tAgent (B)ob */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'keyB'        Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'agentB'      Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'nonceB'      Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/*\tAgent (I)ntruder */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'keyI'        Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'agentI'      Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'nonceI'      Name
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/**\n\tDeclare a structured data type to model our encrypted messages.\n\tMessages will contain either 2 or 3 content fields.\n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'typedef'     Keyword.Declaration
+' '           Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'key'         Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'content1'    Name
+','           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'content2'    Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'content3'    Name
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/**\n\tModel network between agents via a rendezvous channel. \n\tSend and recieve operations are performed synchronously. \n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'chan'        Keyword.Declaration
+' '           Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'0'           Literal.Number.Integer
+']'           Punctuation
+' '           Text.Whitespace
+'of'          Name
+' '           Text.Whitespace
+'{'           Punctuation
+'mtype'       Keyword.Declaration
+','           Punctuation
+' '           Text.Whitespace
+'mtype'       Keyword.Declaration
+','           Punctuation
+' '           Text.Whitespace
+'Crypt'       Name
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* global variables for verification*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'partnerA'    Name
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'partnerB'    Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'knows_nonceA' Name
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'bool'        Keyword.Type
+' '           Text.Whitespace
+'knows_nonceB' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* Agent (A)lice */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'active'      Keyword.Declaration
+' '           Text.Whitespace
+'proctype'    Keyword.Declaration
+' '           Text.Whitespace
+'Alice'       Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* local variables */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'pkey'        Name
+';'           Punctuation
+'\t\t\t'      Text.Whitespace
+"/* reciever's public key */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'pnonce'      Name
+';'           Punctuation
+'\t\t'        Text.Whitespace
+"/* reciever's nonce\t */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'messageAB'   Name
+';'           Punctuation
+'\t'          Text.Whitespace
+'/* sent messages\t\t\t */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'data'        Name
+';'           Punctuation
+'\t\t\t'      Text.Whitespace
+'/* recieved messages\t */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* \n\t\tInitialization: In this example we non-deterministically choose between \n\t\tagents (B)ob and (I)ntruder\n\t*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'partnerA'    Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+';'           Punctuation
+' '           Text.Whitespace
+'pkey'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyB'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'partnerA'    Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentI'      Name
+';'           Punctuation
+' '           Text.Whitespace
+'pkey'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyI'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* prepare (msg1) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'pkey'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* send (msg1) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'!'           Operator
+' '           Text.Whitespace
+'msg1'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'partnerA'    Name
+','           Punctuation
+' '           Text.Whitespace
+'messageAB'   Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* recv (msg2) : blocking */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'msg2'        Name
+','           Punctuation
+' '           Text.Whitespace
+'agentA'      Name
+','           Punctuation
+' '           Text.Whitespace
+'data'        Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* verify (msg2) : blocking\t*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'keyA'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'partnerA'    Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+"/* obtain (msg2) sender's nonce */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'pnonce'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content3'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* prepare (msg3) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'pkey'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'pnonce'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageAB'   Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* send (msg3) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'!'           Operator
+' '           Text.Whitespace
+'msg3'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'partnerA'    Name
+','           Punctuation
+' '           Text.Whitespace
+'messageAB'   Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* update status */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* Agent (B)ob */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'active'      Keyword.Declaration
+' '           Text.Whitespace
+'proctype'    Keyword.Declaration
+' '           Text.Whitespace
+'Bob'         Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* local variables */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'pkey'        Name
+';'           Punctuation
+'\t\t\t'      Text.Whitespace
+"/* reciever's public key */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'pnonce'      Name
+';'           Punctuation
+'\t\t'        Text.Whitespace
+"/* reciever's nonce\t */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'messageBA'   Name
+';'           Punctuation
+'\t'          Text.Whitespace
+'/* sent messages\t\t\t */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'data'        Name
+';'           Punctuation
+'\t\t\t'      Text.Whitespace
+'/* recieved messages\t */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* Initialization\t*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'partnerB'    Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'pkey'        Name
+'\t '         Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyA'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* recv (msg1) : blocking */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'msg1'        Name
+','           Punctuation
+' '           Text.Whitespace
+'agentB'      Name
+','           Punctuation
+' '           Text.Whitespace
+'data'        Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* verify (msg1) : blocking */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'keyB'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+"/* obtain (msg1) sender's nonce */" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'pnonce'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+';'           Punctuation
+'\t'          Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* prepare (msg2) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageBA'   Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'pkey'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageBA'   Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageBA'   Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'pnonce'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'messageBA'   Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* send (msg2) */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'!'           Operator
+' '           Text.Whitespace
+'msg2'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'partnerB'    Name
+','           Punctuation
+' '           Text.Whitespace
+'messageBA'   Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* recv (msg3) : blocking */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'msg3'        Name
+','           Punctuation
+' '           Text.Whitespace
+'agentB'      Name
+','           Punctuation
+' '           Text.Whitespace
+'data'        Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* verify (msg3) : blocking */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'keyB'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/* Agent (I)ntruder */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'active'      Keyword.Declaration
+' '           Text.Whitespace
+'proctype'    Keyword.Declaration
+' '           Text.Whitespace
+'Intruder'    Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'mtype'       Keyword.Declaration
+' '           Text.Whitespace
+'msg'         Name
+','           Punctuation
+' '           Text.Whitespace
+'recpt'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'data'        Name
+','           Punctuation
+' '           Text.Whitespace
+'intercepted' Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'/* Initialize knows_nonce variables to false */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'knows_nonceA' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'false'       Name.Builtin
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'knows_nonceB' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'false'       Name.Builtin
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'do'          Keyword
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'msg'         Name
+','           Punctuation
+' '           Text.Whitespace
+'_'           Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'data'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* perhaps store the message */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+'\t'          Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'key'         Name.Attribute
+'\t\t '       Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+"/*\t\n\t\t\t\tMessage contains (I)ntruder's (public) key, the intruder can \n\t\t\t\tdecrypt the message. Note that we can learn nonce values from \n\t\t\t\teither content1 or content2\n\t\t\t\t|\tmsg1:\t(keyB, agentA, nonceA, 0)\n\t\t\t\t|\tmsg2:\t(keyA, agentB, nonceA, nonceB)\n\t\t\t\t|\tmsg3: \t(keyB, nonceB, 0, 0)\n\t\t\t*/" Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+'  '          Text.Whitespace
+'('           Punctuation
+'intercepted' Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'keyI'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceA' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceB' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceA' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceB' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceA' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'knows_nonceB' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Name.Builtin
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t\t'    Text.Whitespace
+'fi'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'skip'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'fi'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'skip'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'/* Replay or send a message */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* choose message type */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'msg'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'msg1'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'msg'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'msg2'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'msg'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'msg3'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* choose a recepient */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'recpt'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'recpt'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t '     Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* replay intercepted message or assemble it */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+'\t'          Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+'\t\t'        Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'key'         Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+'\t'          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content1'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+'\t'          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content2'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+'data'        Name
+'.'           Operator
+'content3'    Name.Attribute
+'\t'          Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'content3'    Name.Attribute
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* assemble content1 */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'agentI'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceA' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'!'           Operator
+'knows_nonceA' Name
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'!'           Operator
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content1'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceI'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'/* assemble key */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyA'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyB'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t\t'      Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'keyI'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceA' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'!'           Operator
+'knows_nonceA' Name
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'!'           Operator
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content2'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceI'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'fi'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceA' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceA'      Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceB'      Name
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'!'           Operator
+'knows_nonceA' Name
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'!'           Operator
+'knows_nonceB' Name
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'content3'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nonceI'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'fi'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'network'     Name
+' '           Text.Whitespace
+'!'           Operator
+' '           Text.Whitespace
+'msg'         Name
+' '           Text.Whitespace
+'('           Punctuation
+'recpt'       Name
+','           Punctuation
+' '           Text.Whitespace
+'data'        Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'od'          Keyword
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/**\n\tAlways, one process will terminate in error\n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'alwaysErr'   Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'[]'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Operator
+'|'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/**\n\tEventually the protocol will complete without error\n*/' Comment.Multiline
+'\n'          Text.Whitespace
+
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'eventuallyOk' Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'<>'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"/*\n\tpropAB: If both Alice and Bob reach the end of their runs (i.e. both statusA and statusB are ok) \n\tthen Alice's communication partner is Bob, and Bob's communication partner is Alice.\n*/" Comment.Multiline
+'\n'          Text.Whitespace
+
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'propAB'      Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'[]'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'partnerB'    Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'partnerA'    Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"/*\n\tpropA: If agent A reaches the end of its run (statusA is ok) and A believes it is talking to B \n\t(partnerA is agentB) then the intruder does not know A's nonce (!knows_nonceA).\n*/" Comment.Multiline
+'\n'          Text.Whitespace
+
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'propA'       Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'[]'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'statusA'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+'  '          Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'partnerA'    Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'agentB'      Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+'  '          Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'knows_nonceA' Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'false'       Name.Builtin
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"/*\n\tpropB: If agent B reaches the end of its run (statusB is ok) and it believes it is talking to A \n\t(partnerB is agentA) then the intruder does not know B's nonce (!knows_nonceB)\n*/" Comment.Multiline
+'\n'          Text.Whitespace
+
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'propB'       Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'[]'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'statusB'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'ok'          Name
+')'           Punctuation
+'  '          Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'partnerB'    Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'agentA'      Name
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+'  '          Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'knows_nonceB' Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'false'       Name.Builtin
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/do.txt
+++ b/tests/snippets/promela/do.txt
@@ -1,0 +1,31 @@
+---input---
+init {
+  a ? b -> a ! b;
+}
+
+---tokens---
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'!'           Operator
+' '           Text.Whitespace
+'b'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/dotted-assign.txt
+++ b/tests/snippets/promela/dotted-assign.txt
@@ -1,0 +1,48 @@
+---input---
+init {
+  intercepted.key = data.key
+  r.b[a] = a * 4 + 7;
+}
+
+---tokens---
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'intercepted' Name
+'.'           Operator
+'key'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'data'        Name
+'.'           Operator
+'key'         Name.Attribute
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'r'           Name
+'.'           Operator
+'b'           Name.Attribute
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'4'           Literal.Number.Integer
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'7'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/if.txt
+++ b/tests/snippets/promela/if.txt
@@ -1,0 +1,38 @@
+---input---
+init {
+    if 
+    :: skip;
+    fi;
+    skip
+}
+
+---tokens---
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+':'           Operator
+':'           Operator
+' '           Text.Whitespace
+'skip'        Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'fi'          Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'skip'        Keyword
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/intruder.txt
+++ b/tests/snippets/promela/intruder.txt
@@ -1,0 +1,27 @@
+---input---
+Crypt x;
+init {
+  Crypt x;
+}
+
+---tokens---
+'Crypt'       Name
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'Crypt'       Name
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/ltl.txt
+++ b/tests/snippets/promela/ltl.txt
@@ -1,0 +1,37 @@
+---input---
+ltl alwayserr { [] ((statusa == err) || (statusb == err)) }
+
+---tokens---
+'ltl'         Keyword.Declaration
+' '           Text.Whitespace
+'alwayserr'   Name
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'[]'          Operator
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+'statusa'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Operator
+'|'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'statusb'     Name
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'err'         Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/msg.txt
+++ b/tests/snippets/promela/msg.txt
@@ -1,0 +1,28 @@
+---input---
+
+init {
+  1 == 1 -> 3
+}
+
+---tokens---
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+'='           Operator
+'='           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+'-'           Operator
+'>'           Operator
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/skip.txt
+++ b/tests/snippets/promela/skip.txt
@@ -1,0 +1,12 @@
+---input---
+init { skip }
+
+---tokens---
+'init'        Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'skip'        Keyword
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/promela/welfare.txt
+++ b/tests/snippets/promela/welfare.txt
@@ -1,0 +1,15 @@
+---input---
+active proctype cr() {}
+
+---tokens---
+'active'      Keyword.Declaration
+' '           Text.Whitespace
+'proctype'    Keyword.Declaration
+' '           Text.Whitespace
+'cr'          Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This pull request adds a lexer for Promela. (https://spinroot.com/spin/whatispin.html)

Promela (**Pro**cess **Me**ta **La**nguage) is a C-like language used by SPIN to formally model software and hardware systems. SPIN (**Si**mple **Pr**omela **I**nterpreter) was originally developed in the 1980s at Bell Labs and since 1991 has been open-source and is a popular formal methods tool.

Pygments already supports other popular formal methods languages, including Isabelle, Coq, and NuSmv. Promela would be a fitting addition.

~~I have not included test snippets since PromelaLexer is derived from CLexer, though I have tested that it produces correct highlighting on a few of my own Promela files.~~ Edit: I added snippets and examplefiles and ran `tox -e check` and `tox -e mapfiles` which both succeeded.