### PR TITLE
Change deprecated .textsize into .textlength

### DIFF
--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -633,7 +633,7 @@ class ImageFormatter(Formatter):
                                fill=self.hl_color)
         for pos, value, font, text_fg, text_bg in self.drawables:
             if text_bg:
-                text_size = draw.textsize(text=value, font=font)
+                text_size = draw.textlength(text=value, font=font)
                 draw.rectangle([pos[0], pos[1], pos[0] + text_size[0], pos[1] + text_size[1]], fill=text_bg)
             draw.text(pos, value, font=font, fill=text_fg)
         im.save(outfile, self.image_format.upper())

--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -7,6 +7,7 @@
     :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+from packaging import version
 import os
 import sys
 
@@ -19,6 +20,7 @@ import subprocess
 # Import this carefully
 try:
     from PIL import Image, ImageDraw, ImageFont
+    import PIL
     pil_available = True
 except ImportError:
     pil_available = False
@@ -633,7 +635,11 @@ class ImageFormatter(Formatter):
                                fill=self.hl_color)
         for pos, value, font, text_fg, text_bg in self.drawables:
             if text_bg:
-                text_size = draw.textlength(text=value, font=font)
+                # see deprecations https://pillow.readthedocs.io/en/stable/releasenotes/9.2.0.html#font-size-and-offset-methods
+                if version.parse(PIL.__version__) < version.Version('9.2.0'):
+                    text_size = draw.textsize(text=value, font=font)
+                else:
+                    text_size = draw.textlength(text=value, font=font)
                 draw.rectangle([pos[0], pos[1], pos[0] + text_size[0], pos[1] + text_size[1]], fill=text_bg)
             draw.text(pos, value, font=font, fill=text_fg)
         im.save(outfile, self.image_format.upper())

--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -639,7 +639,7 @@ class ImageFormatter(Formatter):
                 if version.parse(PIL.__version__) < version.Version('9.2.0'):
                     text_size = draw.textsize(text=value, font=font)
                 else:
-                    text_size = draw.textlength(text=value, font=font)
+                    text_size = font.getbbox(value)[2:]
                 draw.rectangle([pos[0], pos[1], pos[0] + text_size[0], pos[1] + text_size[1]], fill=text_bg)
             draw.text(pos, value, font=font, fill=text_fg)
         im.save(outfile, self.image_format.upper())

--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -7,7 +7,6 @@
     :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
-from packaging import version
 import os
 import sys
 
@@ -636,7 +635,7 @@ class ImageFormatter(Formatter):
         for pos, value, font, text_fg, text_bg in self.drawables:
             if text_bg:
                 # see deprecations https://pillow.readthedocs.io/en/stable/releasenotes/9.2.0.html#font-size-and-offset-methods
-                if version.parse(PIL.__version__) < version.Version('9.2.0'):
+                if hasattr(draw, 'textsize'):
                     text_size = draw.textsize(text=value, font=font)
                 else:
                     text_size = font.getbbox(value)[2:]

--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -19,7 +19,6 @@ import subprocess
 # Import this carefully
 try:
     from PIL import Image, ImageDraw, ImageFont
-    import PIL
     pil_available = True
 except ImportError:
     pil_available = False


### PR DESCRIPTION
See https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods

Changed in pillow 10, `textsize` method no longer exists