### PR TITLE
Add Org-Mode lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -364,7 +364,7 @@ LEXERS = {
     'OpaLexer': ('pygments.lexers.ml', 'Opa', ('opa',), ('*.opa',), ('text/x-opa',)),
     'OpenEdgeLexer': ('pygments.lexers.business', 'OpenEdge ABL', ('openedge', 'abl', 'progress'), ('*.p', '*.cls'), ('text/x-openedge', 'application/x-openedge')),
     'OpenScadLexer': ('pygments.lexers.openscad', 'OpenSCAD', ('openscad',), ('*.scad',), ('application/x-openscad',)),
-    'OrgLexer': ('pygments.lexers.markup', 'Org Mode', ('org', 'orgmode'), ('*.org',), ('text/org',)),
+    'OrgLexer': ('pygments.lexers.markup', 'Org Mode', ('org', 'orgmode', 'org-mode'), ('*.org',), ('text/org',)),
     'OutputLexer': ('pygments.lexers.special', 'Text output', ('output',), (), ()),
     'PacmanConfLexer': ('pygments.lexers.configs', 'PacmanConf', ('pacmanconf',), ('pacman.conf',), ()),
     'PanLexer': ('pygments.lexers.dsls', 'Pan', ('pan',), ('*.pan',), ()),

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -364,6 +364,7 @@ LEXERS = {
     'OpaLexer': ('pygments.lexers.ml', 'Opa', ('opa',), ('*.opa',), ('text/x-opa',)),
     'OpenEdgeLexer': ('pygments.lexers.business', 'OpenEdge ABL', ('openedge', 'abl', 'progress'), ('*.p', '*.cls'), ('text/x-openedge', 'application/x-openedge')),
     'OpenScadLexer': ('pygments.lexers.openscad', 'OpenSCAD', ('openscad',), ('*.scad',), ('application/x-openscad',)),
+    'OrgLexer': ('pygments.lexers.markup', 'Org Mode', ('org', 'orgmode'), ('*.org',), ('text/org',)),
     'OutputLexer': ('pygments.lexers.special', 'Text output', ('output',), (), ()),
     'PacmanConfLexer': ('pygments.lexers.configs', 'PacmanConf', ('pacmanconf',), ('pacman.conf',), ()),
     'PanLexer': ('pygments.lexers.dsls', 'Pan', ('pan',), ('*.pan',), ()),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -626,18 +626,18 @@ class OrgLexer(RegexLexer):
     """
     name = 'Org Mode'
     url = 'https://orgmode.org'
-    aliases = ['org', 'orgmode']
+    aliases = ['org', 'orgmode', 'org-mode']
     filenames = ['*.org']
     mimetypes = ["text/org"]
-    version_added = '2.2'
+    version_added = '2.18'
     flags = re.MULTILINE
     tokens = {
         'root': [
             (r'^# .*$', Comment),
 
             # Headings
-            (r'^(\*)( COMMENT)( .*)$', bygroups(Generic.Heading, Name.Entity, Generic.Strong)),
-            (r'^(\*\*+)( COMMENT)( .*)$', bygroups(Generic.Subheading, Name.Entity, Text)),
+            (r'^(\*)( COMMENT)( .*)$', bygroups(Generic.Heading, Name.Entity, Generic.Heading)),
+            (r'^(\*\*+)( COMMENT)( .*)$', bygroups(Generic.Subheading, Name.Entity, Generic.Subheading)),
             (r'^(\*)( DONE)( .*)$', bygroups(Generic.Heading, String.Regex, Generic.Strong)),
             (r'^(\*\*+)( DONE)( .*)$', bygroups(Generic.Subheading, String.Regex, Text)),
             (r'^(\*)( TODO)( .*)$', bygroups(Generic.Heading, Generic.Error, Generic.Strong)),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -688,12 +688,12 @@ class OrgLexer(RegexLexer):
         ],
         'inline': [
             # Bold, Italics, Verbatim, Code, Strikethrough, Underline
-            (r'([ \t])*(\*[^ \n*][^*]+?[^ \n*]\*)((?=\W|\n|$))', bygroups(Text, Generic.Strong, Text)),
-            (r'([ \t])*(/[^/]+?/)((?=\W|\n|$))', bygroups(Text, Generic.Emph, Text)),
-            (r'([ \t])*(=[^\n=]+?=)((?=\W|\n|$))', bygroups(Text, Name.Class, Text)),
-            (r'([ \t])*(~[^\n~]+?~)((?=\W|\n|$))', bygroups(Text, Name.Class, Text)),
-            (r'([ \t])*(\+[^+]+?\+)((?=\W|\n|$))', bygroups(Text, Generic.Deleted, Text)),
-            (r'([ \t])*(_[^_]+?_)((?=\W|\n|$))', bygroups(Text, Generic.Underline, Text)),
+            (r'([ \t]*)(\*[^ \n*][^*]+?[^ \n*]\*)((?=\W|\n|$))', bygroups(Text, Generic.Strong, Text)),
+            (r'([ \t]*)(/[^/]+?/)((?=\W|\n|$))', bygroups(Text, Generic.Emph, Text)),
+            (r'([ \t]*)(=[^\n=]+?=)((?=\W|\n|$))', bygroups(Text, Name.Class, Text)),
+            (r'([ \t]*)(~[^\n~]+?~)((?=\W|\n|$))', bygroups(Text, Name.Class, Text)),
+            (r'([ \t]*)(\+[^+]+?\+)((?=\W|\n|$))', bygroups(Text, Generic.Deleted, Text)),
+            (r'([ \t]*)(_[^_]+?_)((?=\W|\n|$))', bygroups(Text, Generic.Underline, Text)),
 
             # Dates, Macros, Footnotes, Links
             (r'(<)([^<>]+?)(>)', bygroups(Text, String, Text)),

--- a/tests/examplefiles/org/example.org
+++ b/tests/examplefiles/org/example.org
@@ -1,0 +1,145 @@
+# -*- org -*-
+#+title: Single Post with TOML front matter
+#+author:
+#+date: 2017-07-20
+#+options: creator:t toc:2
+
+#+hugo_base_dir: ../../
+#+hugo_categories: cat1 cat2
+#+hugo_menu: :menu "foo" :weight 10 :parent main :identifier single-toml
+#+description: Some description for this post.
+
+This is a single post. You do not need to set the =EXPORT_FILE_NAME=
+property in here. But then you also lose the tag and property
+inheritance Org awesomeness.
+
+line one \\
+line two
+
+*bold* /italics/ =verbatim= ~code~ +strikethrough+ _underline_
+* First heading in this post
+This is a under first heading. <2018-07-27 Fri>
+** COMMENT comment header
+** TODO something
+** DONE anything
+CLOSED: [2018-08-01 Wed 16:17]
+
+{{{n}}} abc {{{n(,10)}}} def {{{n(x,5)}}}
+* Second heading in this post
+- unordered list item 1
+- unordered list item 2
+- Desc1 :: Description list item 1
+- Desc2 :: Description list item 2
+
+1. ordered list item 1
+2. ordered list item 2
+
+
+1) ordered list item 1
+2) ordered list item 2
+3) [@20] asdf
+
+
+- *bold*
+- /italics/
+- =verbatim=
+- ~code~
+- +strikethrough+
+- _underline_
+
+#+begin_comment
+this is a
+comment
+#+end_comment
+
+- 09 :: asdf
+- 09 :: asdf
+** Checkbox lists                                             :checkbox:list:
+- [ ] asdf
+- [X] def
+* Dates
+** deadline
+DEADLINE: <2018-07-31 Tue>
+something
+** scheduled
+SCHEDULED: <2018-07-31 Tue>
+something
+* Blocks
+#+BEGIN_QUOTE
+quote
+block
+#+END_QUOTE
+
+#+begin_example
+example
+block
+#+end_example
+
+#+begin_src emacs-lisp
+(message "hello")
+#+end_src
+
+#+begin_details
+#+begin_summary
+Why is this in *green*?
+#+end_summary
+You will learn that later below in [[#details-css][CSS]] section.
+#+end_details
+
+#+begin_export html
+<style>
+.my-table th,
+.my-table td {
+    padding: 20px;
+    text-align: left;
+}
+</style>
+#+end_export
+
+- {{{latex}}}
+- {{{xetex}}}
+#+caption: Declaring Constants
+#+name: code__decl_constants
+#+begin_src systemverilog
+const bit [7:0] R_CHARACTER = 8'b000_11100; // The /K28.0/ character
+const bit [7:0] A_CHARACTER = 8'b011_11100; // The /K28.3/ character
+const bit [7:0] Q_CHARACTER = 8'b100_11100; // The /K28.4/ character
+#+end_src
+Check out code snippet [[code__decl_constants]].
+* Links                                                            :some_tag:
+:properties:
+:CUSTOM_ID: links
+:end:
+- [[file:post-yaml.org]]
+- [[file:post-yaml.org][Post exported with YAML front-matter]].
+- <<target>>
+* Tables
+:PROPERTIES:
+:CUSTOM_ID: tables
+:END:
+| a | b |
+| c | d |
+
+|---+---|
+| a | b |
+|---+---|
+| c | d |
+|---+---|
+
+Some text [fn:2]
+
+#+BEGIN: aggregate :table "original" :cols "Color count()"
+| Color | count() |
+|-------+---------|
+| Red   |       7 |
+| Blue  |       7 |
+#+END:
+* Footnotes
+
+[fn:2] footnote 2
+[fn:1] For more detail, check out the Org manual [[http://orgmode.org/
+manual/Footnotes.html][page for footnotes]].
+* Local Variables :ARCHIVE:
+# Local Variables:
+# org-link-file-path-type: relative
+# End:

--- a/tests/examplefiles/org/example.org.output
+++ b/tests/examplefiles/org/example.org.output
@@ -1,0 +1,1263 @@
+'# -*- org -*-' Comment
+'\n'          Text
+
+'#+title'     Comment.Special
+': Single Post with TOML front matter' Comment
+'\n'          Text
+
+'#+author'    Comment.Special
+':'           Comment
+'\n'          Text
+
+'#+date'      Comment.Special
+': 2017-07-20' Comment
+'\n'          Text
+
+'#+options'   Comment.Special
+': creator:t toc:2' Comment
+'\n'          Text
+
+'\n'          Text
+
+'#+hugo_base_dir' Comment.Special
+': ../../'    Comment
+'\n'          Text
+
+'#+hugo_categories' Comment.Special
+': cat1 cat2' Comment
+'\n'          Text
+
+'#+hugo_menu' Comment.Special
+': :menu "foo" :weight 10 :parent main :identifier single-toml' Comment
+'\n'          Text
+
+'#+description' Comment.Special
+': Some description for this post.' Comment
+'\n'          Text
+
+'\n'          Text
+
+'T'           Text
+'h'           Text
+'i'           Text
+'s'           Text
+' '           Text
+'i'           Text
+'s'           Text
+' '           Text
+'a'           Text
+' '           Text
+'s'           Text
+'i'           Text
+'n'           Text
+'g'           Text
+'l'           Text
+'e'           Text
+' '           Text
+'p'           Text
+'o'           Text
+'s'           Text
+'t'           Text
+'.'           Text
+' '           Text
+'Y'           Text
+'o'           Text
+'u'           Text
+' '           Text
+'d'           Text
+'o'           Text
+' '           Text
+'n'           Text
+'o'           Text
+'t'           Text
+' '           Text
+'n'           Text
+'e'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'t'           Text
+'o'           Text
+' '           Text
+'s'           Text
+'e'           Text
+'t'           Text
+' '           Text
+'t'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'=EXPORT_FILE_NAME=' Name.Class
+'\n'          Text
+
+'p'           Text
+'r'           Text
+'o'           Text
+'p'           Text
+'e'           Text
+'r'           Text
+'t'           Text
+'y'           Text
+' '           Text
+'i'           Text
+'n'           Text
+' '           Text
+'h'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'.'           Text
+' '           Text
+'B'           Text
+'u'           Text
+'t'           Text
+' '           Text
+'t'           Text
+'h'           Text
+'e'           Text
+'n'           Text
+' '           Text
+'y'           Text
+'o'           Text
+'u'           Text
+' '           Text
+'a'           Text
+'l'           Text
+'s'           Text
+'o'           Text
+' '           Text
+'l'           Text
+'o'           Text
+'s'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'a'           Text
+'g'           Text
+' '           Text
+'a'           Text
+'n'           Text
+'d'           Text
+' '           Text
+'p'           Text
+'r'           Text
+'o'           Text
+'p'           Text
+'e'           Text
+'r'           Text
+'t'           Text
+'y'           Text
+'\n'          Text
+
+'i'           Text
+'n'           Text
+'h'           Text
+'e'           Text
+'r'           Text
+'i'           Text
+'t'           Text
+'a'           Text
+'n'           Text
+'c'           Text
+'e'           Text
+' '           Text
+'O'           Text
+'r'           Text
+'g'           Text
+' '           Text
+'a'           Text
+'w'           Text
+'e'           Text
+'s'           Text
+'o'           Text
+'m'           Text
+'e'           Text
+'n'           Text
+'e'           Text
+'s'           Text
+'s'           Text
+'.'           Text
+'\n'          Text
+
+'\n'          Text
+
+'l'           Text
+'i'           Text
+'n'           Text
+'e'           Text
+' '           Text
+'o'           Text
+'n'           Text
+'e'           Text
+' '           Text
+'\\\\'        Operator
+'\n'          Text
+
+'l'           Text
+'i'           Text
+'n'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'w'           Text
+'o'           Text
+'\n'          Text
+
+'\n'          Text
+
+'*bold*'      Generic.Strong
+' '           Text
+'/italics/'   Generic.Emph
+' '           Text
+'=verbatim='  Name.Class
+' '           Text
+'~code~'      Name.Class
+' '           Text
+'+strikethrough+' Generic.Deleted
+' '           Text
+'_underline_' Generic.Underline
+'\n'          Text
+
+'*'           Generic.Heading
+' First heading in this post' Generic.Strong
+'\n'          Text
+
+'T'           Text
+'h'           Text
+'i'           Text
+'s'           Text
+' '           Text
+'i'           Text
+'s'           Text
+' '           Text
+'a'           Text
+' '           Text
+'u'           Text
+'n'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+' '           Text
+'f'           Text
+'i'           Text
+'r'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'h'           Text
+'e'           Text
+'a'           Text
+'d'           Text
+'i'           Text
+'n'           Text
+'g'           Text
+'.'           Text
+' '           Text
+'<'           Text
+'2018-07-27 Fri' Literal.String
+'>'           Text
+'\n'          Text
+
+'**'          Generic.Subheading
+' COMMENT'    Name.Entity
+' comment header' Text
+'\n'          Text
+
+'**'          Generic.Subheading
+' TODO'       Generic.Error
+' something'  Text
+'\n'          Text
+
+'**'          Generic.Subheading
+' DONE'       Literal.String.Regex
+' anything'   Text
+'\n'          Text
+
+'CLOSED: '    Comment
+'[2018-08-01 Wed 16:17]' Comment.Special
+'\n'          Text
+
+'\n'          Text
+
+'{{{n}}}'     Name.Builtin
+' '           Text
+'a'           Text
+'b'           Text
+'c'           Text
+' '           Text
+'{{{n(,10)}}}' Name.Builtin
+' '           Text
+'d'           Text
+'e'           Text
+'f'           Text
+' '           Text
+'{{{n(x,5)}}}' Name.Builtin
+'\n'          Text
+
+'*'           Generic.Heading
+' Second heading in this post' Generic.Strong
+'\n'          Text
+
+'- '          Keyword
+'u'           Text
+'n'           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'1'           Text
+'\n'          Text
+
+'- '          Keyword
+'u'           Text
+'n'           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'2'           Text
+'\n'          Text
+
+'- '          Keyword
+'Desc1 ::'    Keyword
+' '           Text
+'D'           Text
+'e'           Text
+'s'           Text
+'c'           Text
+'r'           Text
+'i'           Text
+'p'           Text
+'t'           Text
+'i'           Text
+'o'           Text
+'n'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'1'           Text
+'\n'          Text
+
+'- '          Keyword
+'Desc2 ::'    Keyword
+' '           Text
+'D'           Text
+'e'           Text
+'s'           Text
+'c'           Text
+'r'           Text
+'i'           Text
+'p'           Text
+'t'           Text
+'i'           Text
+'o'           Text
+'n'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'2'           Text
+'\n'          Text
+
+'\n'          Text
+
+'1.'          Keyword
+' '           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'1'           Text
+'\n'          Text
+
+'2.'          Keyword
+' '           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'2'           Text
+'\n'          Text
+
+'\n'          Text
+
+'\n'          Text
+
+'1)'          Keyword
+' '           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'1'           Text
+'\n'          Text
+
+'2)'          Keyword
+' '           Text
+'o'           Text
+'r'           Text
+'d'           Text
+'e'           Text
+'r'           Text
+'e'           Text
+'d'           Text
+' '           Text
+'l'           Text
+'i'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'i'           Text
+'t'           Text
+'e'           Text
+'m'           Text
+' '           Text
+'2'           Text
+'\n'          Text
+
+'3)'          Keyword
+' [@20]'      Generic.Emph
+' '           Text
+'a'           Text
+'s'           Text
+'d'           Text
+'f'           Text
+'\n'          Text
+
+'\n'          Text
+
+'\n'          Text
+
+'- '          Keyword
+'*bold*'      Generic.Strong
+'\n'          Text
+
+'- '          Keyword
+'/italics/'   Generic.Emph
+'\n'          Text
+
+'- '          Keyword
+'=verbatim='  Name.Class
+'\n'          Text
+
+'- '          Keyword
+'~code~'      Name.Class
+'\n'          Text
+
+'- '          Keyword
+'+strikethrough+' Generic.Deleted
+'\n'          Text
+
+'- '          Keyword
+'_underline_' Generic.Underline
+'\n'          Text
+
+'\n'          Text
+
+'#+begin_comment\n' Comment
+
+'this is a\ncomment\n' Comment
+
+'#+end_comment' Comment
+'\n'          Text
+
+'\n'          Text
+
+'- '          Keyword
+'09 ::'       Keyword
+' '           Text
+'a'           Text
+'s'           Text
+'d'           Text
+'f'           Text
+'\n'          Text
+
+'- '          Keyword
+'09 ::'       Keyword
+' '           Text
+'a'           Text
+'s'           Text
+'d'           Text
+'f'           Text
+'\n'          Text
+
+'**'          Generic.Subheading
+' Checkbox lists                                            ' Text
+' :checkbox:list:' Generic.Emph
+'\n'          Text
+
+'- '          Keyword
+'[ ]'         Keyword
+' '           Text
+'a'           Text
+'s'           Text
+'d'           Text
+'f'           Text
+'\n'          Text
+
+'- '          Keyword
+'[X]'         Keyword
+' '           Text
+'d'           Text
+'e'           Text
+'f'           Text
+'\n'          Text
+
+'*'           Generic.Heading
+' Dates'      Generic.Strong
+'\n'          Text
+
+'**'          Generic.Subheading
+' deadline'   Text
+'\n'          Text
+
+'DEADLINE: '  Comment
+'<2018-07-31 Tue>' Comment.Special
+'\n'          Text
+
+'s'           Text
+'o'           Text
+'m'           Text
+'e'           Text
+'t'           Text
+'h'           Text
+'i'           Text
+'n'           Text
+'g'           Text
+'\n'          Text
+
+'**'          Generic.Subheading
+' scheduled'  Text
+'\n'          Text
+
+'SCHEDULED: ' Comment
+'<2018-07-31 Tue>' Comment.Special
+'\n'          Text
+
+'s'           Text
+'o'           Text
+'m'           Text
+'e'           Text
+'t'           Text
+'h'           Text
+'i'           Text
+'n'           Text
+'g'           Text
+'\n'          Text
+
+'*'           Generic.Heading
+' Blocks'     Generic.Strong
+'\n'          Text
+
+'#+BEGIN_'    Comment
+'QUOTE'       Comment
+'\n'          Text
+
+'quote\nblock\n' Text
+
+'#+END_QUOTE' Comment
+'\n'          Text
+
+'\n'          Text
+
+'#+begin_'    Comment
+'example'     Comment
+'\n'          Text
+
+'example\nblock\n' Text
+
+'#+end_example' Comment
+'\n'          Text
+
+'\n'          Text
+
+'#+begin_src ' Comment
+'emacs-lisp'  Comment.Special
+'\n'          Comment
+
+'('           Text
+'m'           Text
+'e'           Text
+'s'           Text
+'s'           Text
+'a'           Text
+'g'           Text
+'e'           Text
+' '           Text
+'"'           Text
+'h'           Text
+'e'           Text
+'l'           Text
+'l'           Text
+'o'           Text
+'"'           Text
+')'           Text
+'\n'          Text
+
+'#+end_src'   Comment
+'\n'          Text
+
+'\n'          Text
+
+'#+begin_'    Comment
+'details'     Comment
+'\n'          Text
+
+'#+begin_summary\nWhy is this in *green*?\n#+end_summary\nYou will learn that later below in [[#details-css][CSS]] section.\n' Text
+
+'#+end_details' Comment
+'\n'          Text
+
+'\n'          Text
+
+'#'           Text
+'+'           Text
+'b'           Text
+'e'           Text
+'g'           Text
+'i'           Text
+'n'           Text
+'_'           Text
+'e'           Text
+'x'           Text
+'p'           Text
+'o'           Text
+'r'           Text
+'t'           Text
+' '           Text
+'h'           Text
+'t'           Text
+'m'           Text
+'l'           Text
+'\n'          Text
+
+'<'           Text
+'style'       Literal.String
+'>'           Text
+'\n'          Text
+
+'.'           Text
+'m'           Text
+'y'           Text
+'-'           Text
+'t'           Text
+'a'           Text
+'b'           Text
+'l'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'h'           Text
+','           Text
+'\n'          Text
+
+'.'           Text
+'m'           Text
+'y'           Text
+'-'           Text
+'t'           Text
+'a'           Text
+'b'           Text
+'l'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'d'           Text
+' '           Text
+'{'           Text
+'\n'          Text
+
+' '           Text
+' '           Text
+' '           Text
+' '           Text
+'p'           Text
+'a'           Text
+'d'           Text
+'d'           Text
+'i'           Text
+'n'           Text
+'g'           Text
+':'           Text
+' '           Text
+'2'           Text
+'0'           Text
+'p'           Text
+'x'           Text
+';'           Text
+'\n'          Text
+
+' '           Text
+' '           Text
+' '           Text
+' '           Text
+'t'           Text
+'e'           Text
+'x'           Text
+'t'           Text
+'-'           Text
+'a'           Text
+'l'           Text
+'i'           Text
+'g'           Text
+'n'           Text
+':'           Text
+' '           Text
+'l'           Text
+'e'           Text
+'f'           Text
+'t'           Text
+';'           Text
+'\n'          Text
+
+'}'           Text
+'\n'          Text
+
+'<'           Text
+'/style'      Literal.String
+'>'           Text
+'\n'          Text
+
+'#'           Text
+'+'           Text
+'e'           Text
+'n'           Text
+'d'           Text
+'_'           Text
+'e'           Text
+'x'           Text
+'p'           Text
+'o'           Text
+'r'           Text
+'t'           Text
+'\n'          Text
+
+'\n'          Text
+
+'- '          Keyword
+'{{{latex}}}' Name.Builtin
+'\n'          Text
+
+'- '          Keyword
+'{{{xetex}}}' Name.Builtin
+'\n'          Text
+
+'#+caption'   Comment.Special
+': Declaring Constants' Comment
+'\n'          Text
+
+'#+name'      Comment.Special
+': code__decl_constants' Comment
+'\n'          Text
+
+'#+begin_src ' Comment
+'systemverilog' Comment.Special
+'\n'          Comment
+
+'c'           Text
+'o'           Text
+'n'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'b'           Text
+'i'           Text
+'t'           Text
+' '           Text
+'['           Text
+'7'           Text
+':'           Text
+'0'           Text
+']'           Text
+' '           Text
+'R'           Text
+'_'           Text
+'C'           Text
+'H'           Text
+'A'           Text
+'R'           Text
+'A'           Text
+'C'           Text
+'T'           Text
+'E'           Text
+'R'           Text
+' '           Text
+'='           Text
+' '           Text
+'8'           Text
+"'"           Text
+'b'           Text
+'0'           Text
+'0'           Text
+'0'           Text
+'_'           Text
+'1'           Text
+'1'           Text
+'1'           Text
+'0'           Text
+'0'           Text
+';'           Text
+' '           Text
+'/'           Text
+'/'           Text
+' '           Text
+'T'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'/K28.0/'     Generic.Emph
+' '           Text
+'c'           Text
+'h'           Text
+'a'           Text
+'r'           Text
+'a'           Text
+'c'           Text
+'t'           Text
+'e'           Text
+'r'           Text
+'\n'          Text
+
+'c'           Text
+'o'           Text
+'n'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'b'           Text
+'i'           Text
+'t'           Text
+' '           Text
+'['           Text
+'7'           Text
+':'           Text
+'0'           Text
+']'           Text
+' '           Text
+'A'           Text
+'_'           Text
+'C'           Text
+'H'           Text
+'A'           Text
+'R'           Text
+'A'           Text
+'C'           Text
+'T'           Text
+'E'           Text
+'R'           Text
+' '           Text
+'='           Text
+' '           Text
+'8'           Text
+"'"           Text
+'b'           Text
+'0'           Text
+'1'           Text
+'1'           Text
+'_'           Text
+'1'           Text
+'1'           Text
+'1'           Text
+'0'           Text
+'0'           Text
+';'           Text
+' '           Text
+'/'           Text
+'/'           Text
+' '           Text
+'T'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'/K28.3/'     Generic.Emph
+' '           Text
+'c'           Text
+'h'           Text
+'a'           Text
+'r'           Text
+'a'           Text
+'c'           Text
+'t'           Text
+'e'           Text
+'r'           Text
+'\n'          Text
+
+'c'           Text
+'o'           Text
+'n'           Text
+'s'           Text
+'t'           Text
+' '           Text
+'b'           Text
+'i'           Text
+'t'           Text
+' '           Text
+'['           Text
+'7'           Text
+':'           Text
+'0'           Text
+']'           Text
+' '           Text
+'Q'           Text
+'_'           Text
+'C'           Text
+'H'           Text
+'A'           Text
+'R'           Text
+'A'           Text
+'C'           Text
+'T'           Text
+'E'           Text
+'R'           Text
+' '           Text
+'='           Text
+' '           Text
+'8'           Text
+"'"           Text
+'b'           Text
+'1'           Text
+'0'           Text
+'0'           Text
+'_'           Text
+'1'           Text
+'1'           Text
+'1'           Text
+'0'           Text
+'0'           Text
+';'           Text
+' '           Text
+'/'           Text
+'/'           Text
+' '           Text
+'T'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'/K28.4/'     Generic.Emph
+' '           Text
+'c'           Text
+'h'           Text
+'a'           Text
+'r'           Text
+'a'           Text
+'c'           Text
+'t'           Text
+'e'           Text
+'r'           Text
+'\n'          Text
+
+'#+end_src'   Comment
+'\n'          Text
+
+'C'           Text
+'h'           Text
+'e'           Text
+'c'           Text
+'k'           Text
+' '           Text
+'o'           Text
+'u'           Text
+'t'           Text
+' '           Text
+'c'           Text
+'o'           Text
+'d'           Text
+'e'           Text
+' '           Text
+'s'           Text
+'n'           Text
+'i'           Text
+'p'           Text
+'p'           Text
+'e'           Text
+'t'           Text
+' '           Text
+'[['          Text
+'code__decl_constants' Name.Attribute
+']]'          Text
+'.'           Text
+'\n'          Text
+
+'*'           Generic.Heading
+' Links                                                           ' Generic.Strong
+' :some_tag:' Generic.Emph
+'\n'          Text
+
+':properties:\n' Comment
+
+':CUSTOM_ID: links\n' Comment.Special
+
+':end:'       Comment
+'\n'          Text
+
+'- '          Keyword
+'[['          Text
+'file:post-yaml.org' Name.Attribute
+']]'          Text
+'\n'          Text
+
+'- '          Keyword
+'[['          Text
+'file:post-yaml.org' Name.Attribute
+']['          Text
+'Post exported with YAML front-matter' Name.Tag
+']]'          Text
+'.'           Text
+'\n'          Text
+
+'- '          Keyword
+'<<'          Text
+'target'      Name.Attribute
+'>>'          Text
+'\n'          Text
+
+'*'           Generic.Heading
+' Tables'     Generic.Strong
+'\n'          Text
+
+':PROPERTIES:\n' Comment
+
+':CUSTOM_ID: tables\n' Comment.Special
+
+':END:'       Comment
+'\n'          Text
+
+'| a | b |'   Literal.String
+'\n'          Text
+
+'| c | d |'   Literal.String
+'\n'          Text
+
+'\n'          Text
+
+'|---+---|'   Literal.String
+'\n'          Text
+
+'| a | b |'   Literal.String
+'\n'          Text
+
+'|---+---|'   Literal.String
+'\n'          Text
+
+'| c | d |'   Literal.String
+'\n'          Text
+
+'|---+---|'   Literal.String
+'\n'          Text
+
+'\n'          Text
+
+'S'           Text
+'o'           Text
+'m'           Text
+'e'           Text
+' '           Text
+'t'           Text
+'e'           Text
+'x'           Text
+'t'           Text
+' '           Text
+'[fn:'        Name.Builtin.Pseudo
+'2'           Literal.String
+']'           Name.Builtin.Pseudo
+'\n'          Text
+
+'\n'          Text
+
+'#+BEGIN: '   Comment
+'aggregate'   Comment.Special
+' :table "original" :cols "Color count()"\n' Comment
+
+'| Color | count() |' Literal.String
+'\n'          Text
+
+'|-------+---------|' Literal.String
+'\n'          Text
+
+'| Red   |       7 |' Literal.String
+'\n'          Text
+
+'| Blue  |       7 |' Literal.String
+'\n'          Text
+
+'#+END:'      Comment
+'\n'          Text
+
+'*'           Generic.Heading
+' Footnotes'  Generic.Strong
+'\n'          Text
+
+'\n'          Text
+
+'[fn:'        Name.Builtin.Pseudo
+'2'           Literal.String
+']'           Name.Builtin.Pseudo
+' '           Text
+'f'           Text
+'o'           Text
+'o'           Text
+'t'           Text
+'n'           Text
+'o'           Text
+'t'           Text
+'e'           Text
+' '           Text
+'2'           Text
+'\n'          Text
+
+'[fn:'        Name.Builtin.Pseudo
+'1'           Literal.String
+']'           Name.Builtin.Pseudo
+' '           Text
+'F'           Text
+'o'           Text
+'r'           Text
+' '           Text
+'m'           Text
+'o'           Text
+'r'           Text
+'e'           Text
+' '           Text
+'d'           Text
+'e'           Text
+'t'           Text
+'a'           Text
+'i'           Text
+'l'           Text
+','           Text
+' '           Text
+'c'           Text
+'h'           Text
+'e'           Text
+'c'           Text
+'k'           Text
+' '           Text
+'o'           Text
+'u'           Text
+'t'           Text
+' '           Text
+'t'           Text
+'h'           Text
+'e'           Text
+' '           Text
+'O'           Text
+'r'           Text
+'g'           Text
+' '           Text
+'m'           Text
+'a'           Text
+'n'           Text
+'u'           Text
+'a'           Text
+'l'           Text
+' '           Text
+'[['          Text
+'http://orgmode.org/\nmanual/Footnotes.html' Name.Attribute
+']['          Text
+'page for footnotes' Name.Tag
+']]'          Text
+'.'           Text
+'\n'          Text
+
+'*'           Generic.Heading
+' Local Variables' Generic.Strong
+' :ARCHIVE:'  Generic.Emph
+'\n'          Text
+
+'# Local Variables:' Comment
+'\n'          Text
+
+'# org-link-file-path-type: relative' Comment
+'\n'          Text
+
+'# End:'      Comment
+'\n'          Text

--- a/tests/examplefiles/org/example.org.output
+++ b/tests/examplefiles/org/example.org.output
@@ -264,7 +264,7 @@
 
 '**'          Generic.Subheading
 ' COMMENT'    Name.Entity
-' comment header' Text
+' comment header' Generic.Subheading
 '\n'          Text
 
 '**'          Generic.Subheading


### PR DESCRIPTION
Hello,

This PR adds a new lexer for the Emacs [Org-Mode](https://orgmode.org). It is basically a direct translation of [the work](https://github.com/alecthomas/chroma/pull/156) done by @kaushalmodi for Go's Chroma library, which I came across in https://github.com/pygments/pygments/issues/426#issuecomment-526846873.

I have to say that I am familiar with neither Python nor Go; my reason for wanting this lexer is so that my forge of choice (Sourcehut) which uses `pygments` would syntax highlight my org files 😁 

~~Therefore, I would like to ask for help on this PR, and I am marking it as draft. Currently, the test for the lexer is failing (I'm adding the output below). I don't know enough about the Python ecosystem to debug it myself, and I hope someone here would be able to assist.~~

Thank you for your consideration!