### PR TITLE
Improve the Rust lexer

### DIFF
--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -105,7 +105,7 @@ class RustLexer(RegexLexer):
             builtin_funcs_types,
             builtin_macros,
             # Path separators, so types don't catch them.
-            (r'::\b', Operator),
+            (r'::\b', Punctuation),
             # Types in positions.
             (r'(?::|->)', Punctuation, 'typename'),
             # Labels

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -98,7 +98,7 @@ class RustLexer(RegexLexer):
             (r'let\b', Keyword.Declaration),
             (r'fn\b', Keyword, 'funcname'),
             (r'(struct|enum|type|union)\b', Keyword, 'typename'),
-            (r'(default)(\s+)(type|fn)\b', bygroups(Keyword, Text, Keyword)),
+            (r'(default)(\s+)(type|fn)\b', bygroups(Keyword, Whitespace, Keyword)),
             keyword_types,
             (r'[sS]elf\b', Name.Builtin.Pseudo),
             # Prelude (taken from Rust's src/libstd/prelude.rs)
@@ -171,17 +171,17 @@ class RustLexer(RegexLexer):
             (r'[*/]', String.Doc),
         ],
         'modname': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'[a-zA-Z_]\w*', Name.Namespace, '#pop'),
             default('#pop'),
         ],
         'funcname': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'[a-zA-Z_]\w*', Name.Function, '#pop'),
             default('#pop'),
         ],
         'typename': [
-            (r'\s+', Text),
+            (r'\s+', Whitespace),
             (r'&', Keyword.Pseudo),
             (r"'", Operator, 'lifetime'),
             builtin_funcs_types,

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -107,7 +107,7 @@ class RustLexer(RegexLexer):
             # Path separators, so types don't catch them.
             (r'::\b', Operator),
             # Types in positions.
-            (r'(?::|->)', Text, 'typename'),
+            (r'(?::|->)', Punctuation, 'typename'),
             # Labels
             (r'(break|continue)(\b\s*)(\'[A-Za-z_]\w*)?',
              bygroups(Keyword, Text.Whitespace, Name.Label)),
@@ -156,7 +156,7 @@ class RustLexer(RegexLexer):
             # Misc
             # Lone hashes: not used in Rust syntax, but allowed in macro
             # arguments, most famously for quote::quote!()
-            (r'#', Text),
+            (r'#', Punctuation),
         ],
         'comment': [
             (r'[^*/]+', Comment.Multiline),

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -105,7 +105,7 @@ class RustLexer(RegexLexer):
             builtin_funcs_types,
             builtin_macros,
             # Path separators, so types don't catch them.
-            (r'::\b', Text),
+            (r'::\b', Operator),
             # Types in positions.
             (r'(?::|->)', Text, 'typename'),
             # Labels

--- a/tests/examplefiles/rust/eval.rs.output
+++ b/tests/examplefiles/rust/eval.rs.output
@@ -45,10 +45,10 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'std'         Name
-'::'          Text
+'::'          Punctuation
 'fmt'         Name
-':'           Text
-':'           Text
+':'           Punctuation
+':'           Punctuation
 '{'           Punctuation
 ' '           Text.Whitespace
 'Debug'       Name
@@ -63,9 +63,9 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'std'         Name
-'::'          Text
+'::'          Punctuation
 'io'          Name
-'::'          Text
+'::'          Punctuation
 'Write'       Name
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -73,7 +73,7 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'std'         Name
-'::'          Text
+'::'          Punctuation
 'u16'         Keyword.Type
 ';'           Punctuation
 '\n'          Text.Whitespace
@@ -83,8 +83,8 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'err'         Name
-':'           Text
-':'           Text
+':'           Punctuation
+':'           Punctuation
 '{'           Punctuation
 ' '           Text.Whitespace
 'Res'         Name
@@ -120,8 +120,8 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'ast'         Name
-':'           Text
-':'           Text
+':'           Punctuation
+':'           Punctuation
 '{'           Punctuation
 ' '           Text.Whitespace
 'self'        Name.Builtin.Pseudo
@@ -154,8 +154,8 @@
 'use'         Keyword
 ' '           Text.Whitespace
 'stdops'      Name
-':'           Text
-':'           Text
+':'           Punctuation
+':'           Punctuation
 '{'           Punctuation
 ' '           Text.Whitespace
 'Bind'        Name
@@ -225,7 +225,7 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'enum'        Keyword
-' '           Text
+' '           Text.Whitespace
 'Val'         Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -266,15 +266,15 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'as_u16'      Name.Function
 '('           Punctuation
 '&'           Operator
 'self'        Name.Builtin.Pseudo
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'u16'         Keyword.Type
@@ -294,7 +294,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'v'           Name
@@ -312,7 +312,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -333,7 +333,7 @@
 ' '           Text.Whitespace
 '('           Punctuation
 'u16'         Keyword.Type
-'::'          Text
+'::'          Punctuation
 'MAX'         Name
 ' '           Text.Whitespace
 'as'          Keyword
@@ -391,17 +391,17 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'as_u32'      Name.Function
 '('           Punctuation
 '&'           Operator
 'self'        Name.Builtin.Pseudo
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -416,7 +416,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'v'           Name
@@ -435,7 +435,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -464,17 +464,17 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'as_usize'    Name.Function
 '('           Punctuation
 '&'           Operator
 'self'        Name.Builtin.Pseudo
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'usize'       Keyword.Type
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
 
@@ -503,17 +503,17 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'from_u32'    Name.Function
 '('           Punctuation
 'v'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Val'         Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -538,7 +538,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'v'           Name
@@ -559,7 +559,7 @@
 
 '            ' Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -584,7 +584,7 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'struct'      Keyword
-' '           Text
+' '           Text.Whitespace
 'Eval'        Name.Class
 '<'           Operator
 "'"           Operator
@@ -599,12 +599,12 @@
 
 '    '        Text.Whitespace
 'program'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 "'"           Operator
 'a'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 'Program'     Name.Class
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -614,12 +614,12 @@
 
 '    '        Text.Whitespace
 'stdout'      Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 "'"           Operator
 'a'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 'mut'         Name.Class
 ' '           Text.Whitespace
 'Write'       Name
@@ -631,8 +631,8 @@
 
 '    '        Text.Whitespace
 'debug'       Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'bool'        Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -642,8 +642,8 @@
 
 '    '        Text.Whitespace
 'spot'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'Bind'        Name
@@ -656,8 +656,8 @@
 
 '    '        Text.Whitespace
 'twospot'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'Bind'        Name
@@ -670,8 +670,8 @@
 
 '    '        Text.Whitespace
 'tail'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'Bind'        Name
@@ -687,8 +687,8 @@
 
 '    '        Text.Whitespace
 'hybrid'      Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'Bind'        Name
@@ -707,12 +707,12 @@
 
 '    '        Text.Whitespace
 'jumps'       Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'ast'         Name
-'::'          Text
+'::'          Punctuation
 'LogLine'     Name
 '>'           Operator
 ','           Punctuation
@@ -723,8 +723,8 @@
 
 '    '        Text.Whitespace
 'abstain'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Vec'         Name.Builtin
 '<'           Operator
 'u32'         Keyword.Type
@@ -737,16 +737,16 @@
 
 '    '        Text.Whitespace
 'last_in'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u8'          Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '    '        Text.Whitespace
 'last_out'    Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u8'          Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -756,8 +756,8 @@
 
 '    '        Text.Whitespace
 'rand_st'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -767,8 +767,8 @@
 
 '    '        Text.Whitespace
 'stmt_ctr'    Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'usize'       Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -781,7 +781,7 @@
 '/// Represents the control flow effect of an executed statement.\n' Literal.String.Doc
 
 'enum'        Keyword
-' '           Text
+' '           Text.Whitespace
 'StmtRes'     Name.Class
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -860,47 +860,47 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'new'         Name.Function
 '('           Punctuation
 'program'     Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 "'"           Operator
 'a'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 'Program'     Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'stdout'      Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 "'"           Operator
 'a'           Name.Attribute
-' '           Text
+' '           Text.Whitespace
 'mut'         Name.Class
 ' '           Text.Whitespace
 'Write'       Name
 ','           Punctuation
 ' '           Text.Whitespace
 'debug'       Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'bool'        Keyword.Type
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '               ' Text.Whitespace
 'random'      Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'bool'        Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Eval'        Name.Class
 '<'           Operator
 "'"           Operator
@@ -1012,37 +1012,37 @@
 
 '            ' Text.Whitespace
 'program'     Name
-':'           Text
-'  '          Text
+':'           Punctuation
+'  '          Text.Whitespace
 'program'     Name.Class
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'stdout'      Name
-':'           Text
-'   '         Text
+':'           Punctuation
+'   '         Text.Whitespace
 'stdout'      Name.Class
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'debug'       Name
-':'           Text
-'    '        Text
+':'           Punctuation
+'    '        Text.Whitespace
 'debug'       Name.Class
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'spot'        Name
-':'           Text
-'     '       Text
+':'           Punctuation
+'     '       Text.Whitespace
 'vec'         Name.Class
 '!'           Operator
 '['           Punctuation
 'Bind'        Name
-'::'          Text
+'::'          Punctuation
 'new'         Name
 '('           Punctuation
 '0'           Literal.Number.Integer
@@ -1058,13 +1058,13 @@
 
 '            ' Text.Whitespace
 'twospot'     Name
-':'           Text
-'  '          Text
+':'           Punctuation
+'  '          Text.Whitespace
 'vec'         Name.Class
 '!'           Operator
 '['           Punctuation
 'Bind'        Name
-'::'          Text
+'::'          Punctuation
 'new'         Name
 '('           Punctuation
 '0'           Literal.Number.Integer
@@ -1080,17 +1080,17 @@
 
 '            ' Text.Whitespace
 'tail'        Name
-':'           Text
-'     '       Text
+':'           Punctuation
+'     '       Text.Whitespace
 'vec'         Name.Class
 '!'           Operator
 '['           Punctuation
 'Bind'        Name
-'::'          Text
+'::'          Punctuation
 'new'         Name
 '('           Punctuation
 'Array'       Name
-'::'          Text
+'::'          Punctuation
 'empty'       Name
 '('           Punctuation
 ')'           Punctuation
@@ -1106,17 +1106,17 @@
 
 '            ' Text.Whitespace
 'hybrid'      Name
-':'           Text
-'   '         Text
+':'           Punctuation
+'   '         Text.Whitespace
 'vec'         Name.Class
 '!'           Operator
 '['           Punctuation
 'Bind'        Name
-'::'          Text
+'::'          Punctuation
 'new'         Name
 '('           Punctuation
 'Array'       Name
-'::'          Text
+'::'          Punctuation
 'empty'       Name
 '('           Punctuation
 ')'           Punctuation
@@ -1132,10 +1132,10 @@
 
 '            ' Text.Whitespace
 'jumps'       Name
-':'           Text
-'    '        Text
+':'           Punctuation
+'    '        Text.Whitespace
 'Vec'         Name.Builtin
-'::'          Text
+'::'          Punctuation
 'with_capacity' Name
 '('           Punctuation
 '80'          Literal.Number.Integer
@@ -1145,8 +1145,8 @@
 
 '            ' Text.Whitespace
 'rand_st'     Name
-':'           Text
-'  '          Text
+':'           Punctuation
+'  '          Text.Whitespace
 'if'          Name.Class
 ' '           Text.Whitespace
 'random'      Name
@@ -1171,32 +1171,32 @@
 
 '            ' Text.Whitespace
 'abstain'     Name
-':'           Text
-'  '          Text
+':'           Punctuation
+'  '          Text.Whitespace
 'abs'         Name.Class
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'last_in'     Name
-':'           Text
-'  '          Text
+':'           Punctuation
+'  '          Text.Whitespace
 '0'           Literal.Number.Integer
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'last_out'    Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '0'           Literal.Number.Integer
 ','           Punctuation
 '\n'          Text.Whitespace
 
 '            ' Text.Whitespace
 'stmt_ctr'    Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '0'           Literal.Number.Integer
 ','           Punctuation
 '\n'          Text.Whitespace
@@ -1221,7 +1221,7 @@
 'pub'         Keyword
 ' '           Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'eval'        Name.Function
 '('           Punctuation
 '&'           Operator
@@ -1230,8 +1230,8 @@
 'self'        Name.Builtin.Pseudo
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'usize'       Keyword.Type
@@ -1319,7 +1319,7 @@
 'let'         Keyword.Declaration
 ' '           Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'TryAgain'    Name
 ' '           Text.Whitespace
 '='           Operator
@@ -1532,7 +1532,7 @@
 'let'         Keyword.Declaration
 ' '           Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'DoNext'      Name
 '('           Punctuation
 'n'           Name
@@ -1648,7 +1648,7 @@
 
 '                        ' Text.Whitespace
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 '    '        Text.Whitespace
 '='           Operator
@@ -1661,7 +1661,7 @@
 
 '                        ' Text.Whitespace
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Jump'        Name
 '('           Punctuation
 'n'           Name
@@ -1711,7 +1711,7 @@
 
 '                        ' Text.Whitespace
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Back'        Name
 '('           Punctuation
 'n'           Name
@@ -1739,7 +1739,7 @@
 
 '                        ' Text.Whitespace
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'FromTop'     Name
 ' '           Text.Whitespace
 '='           Operator
@@ -1769,7 +1769,7 @@
 
 '                        ' Text.Whitespace
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'End'         Name
 '     '       Text.Whitespace
 '='           Operator
@@ -1945,11 +1945,11 @@
 'let'         Keyword.Declaration
 ' '           Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'ComeFrom'    Name
 '('           Punctuation
 'ComeFrom'    Name
-'::'          Text
+'::'          Punctuation
 'Expr'        Name
 '('           Punctuation
 'ref'         Keyword
@@ -2246,7 +2246,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'eval_stmt'   Name.Function
 '('           Punctuation
 '&'           Operator
@@ -2256,14 +2256,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'stmt'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Stmt'        Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'StmtRes'     Name
@@ -2336,7 +2336,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Calc'        Name
 '('           Punctuation
 'ref'         Keyword
@@ -2396,7 +2396,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2407,7 +2407,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Dim'         Name
 '('           Punctuation
 'ref'         Keyword
@@ -2447,7 +2447,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2458,7 +2458,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'DoNext'      Name
 '('           Punctuation
 'n'           Name
@@ -2535,7 +2535,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Jump'        Name
 '('           Punctuation
 '*'           Operator
@@ -2573,7 +2573,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'ComeFrom'    Name
 '('           Punctuation
 '_'           Name
@@ -2592,7 +2592,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2603,7 +2603,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Resume'      Name
 '('           Punctuation
 'ref'         Keyword
@@ -2693,7 +2693,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Back'        Name
 '('           Punctuation
 'next'        Name
@@ -2711,7 +2711,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Forget'      Name
 '('           Punctuation
 'ref'         Keyword
@@ -2779,7 +2779,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2790,7 +2790,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Ignore'      Name
 '('           Punctuation
 'ref'         Keyword
@@ -2837,7 +2837,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2848,7 +2848,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Remember'    Name
 '('           Punctuation
 'ref'         Keyword
@@ -2895,7 +2895,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2906,7 +2906,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Stash'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -2950,7 +2950,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -2961,7 +2961,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Retrieve'    Name
 '('           Punctuation
 'ref'         Keyword
@@ -3009,7 +3009,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3020,7 +3020,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Abstain'     Name
 '('           Punctuation
 'ref'         Keyword
@@ -3043,8 +3043,8 @@
 'let'         Keyword.Declaration
 ' '           Text.Whitespace
 'f'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Box'         Name.Builtin
 '<'           Operator
 'Fn'          Name.Builtin
@@ -3052,8 +3052,8 @@
 'u32'         Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 '>'           Operator
 ' '           Text.Whitespace
@@ -3109,8 +3109,8 @@
 ' '           Text.Whitespace
 '|'           Operator
 'v'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 '|'           Operator
 ' '           Text.Whitespace
@@ -3180,7 +3180,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3191,7 +3191,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Reinstate'   Name
 '('           Punctuation
 'ref'         Keyword
@@ -3228,8 +3228,8 @@
 '&'           Operator
 '|'           Operator
 'v'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 '|'           Operator
 ' '           Text.Whitespace
@@ -3251,7 +3251,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3262,7 +3262,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'ReadOut'     Name
 '('           Punctuation
 'ref'         Keyword
@@ -3302,7 +3302,7 @@
 
 '                        ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Var'         Name
 '('           Punctuation
 'ref'         Keyword
@@ -3347,7 +3347,7 @@
 
 '                        ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Var'         Name
 '('           Punctuation
 'ref'         Keyword
@@ -3414,7 +3414,7 @@
 
 '                        ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Num'         Name
 '('           Punctuation
 '_'           Name
@@ -3477,7 +3477,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3488,7 +3488,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'WriteIn'     Name
 '('           Punctuation
 'ref'         Keyword
@@ -3584,7 +3584,7 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'from_u32'    Name
 '('           Punctuation
 'n'           Name
@@ -3606,7 +3606,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3620,7 +3620,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Print'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -3678,7 +3678,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'Next'        Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -3689,7 +3689,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'TryAgain'    Name
 ' '           Text.Whitespace
 '='           Operator
@@ -3698,7 +3698,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'FromTop'     Name
 ')'           Punctuation
 ','           Punctuation
@@ -3706,7 +3706,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'GiveUp'      Name
 ' '           Text.Whitespace
 '='           Operator
@@ -3715,7 +3715,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'StmtRes'     Name
-'::'          Text
+'::'          Punctuation
 'End'         Name
 ')'           Punctuation
 ','           Punctuation
@@ -3723,7 +3723,7 @@
 
 '            ' Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'Error'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -3763,7 +3763,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'eval_expr'   Name.Function
 '('           Punctuation
 '&'           Operator
@@ -3771,14 +3771,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'expr'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Expr'        Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'Val'         Name
@@ -3798,7 +3798,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Num'         Name
 '('           Punctuation
 'vtype'       Name
@@ -3819,7 +3819,7 @@
 
 '                ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -3828,7 +3828,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'v'           Name
@@ -3843,7 +3843,7 @@
 
 '                ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -3852,7 +3852,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -3868,7 +3868,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Var'         Name
 '('           Punctuation
 'ref'         Keyword
@@ -3890,7 +3890,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Mingle'      Name
 '('           Punctuation
 'ref'         Keyword
@@ -4003,7 +4003,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'mingle'      Name
@@ -4023,7 +4023,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Select'      Name
 '('           Punctuation
 'vtype'       Name
@@ -4094,7 +4094,7 @@
 '='           Operator
 ' '           Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -4104,7 +4104,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'select'      Name
@@ -4150,7 +4150,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'select'      Name
@@ -4182,7 +4182,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'And'         Name
 '('           Punctuation
 'vtype'       Name
@@ -4229,7 +4229,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4238,7 +4238,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'and_16'      Name
@@ -4268,7 +4268,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4277,7 +4277,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'and_32'      Name
@@ -4303,7 +4303,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Or'          Name
 '('           Punctuation
 'vtype'       Name
@@ -4350,7 +4350,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4359,7 +4359,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'or_16'       Name
@@ -4389,7 +4389,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4398,7 +4398,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'or_32'       Name
@@ -4424,7 +4424,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'Xor'         Name
 '('           Punctuation
 'vtype'       Name
@@ -4471,7 +4471,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4480,7 +4480,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'xor_16'      Name
@@ -4510,7 +4510,7 @@
 
 '                    ' Text.Whitespace
 'VType'       Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 ' '           Text.Whitespace
 '='           Operator
@@ -4519,7 +4519,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'xor_32'      Name
@@ -4545,7 +4545,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsNot'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -4583,7 +4583,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 '!'           Operator
@@ -4602,7 +4602,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsAnd'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -4665,7 +4665,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -4691,7 +4691,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsOr'        Name
 '('           Punctuation
 'ref'         Keyword
@@ -4754,7 +4754,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -4780,7 +4780,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsXor'       Name
 '('           Punctuation
 'ref'         Keyword
@@ -4843,7 +4843,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -4869,7 +4869,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsRshift'    Name
 '('           Punctuation
 'ref'         Keyword
@@ -4932,7 +4932,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -4959,7 +4959,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsLshift'    Name
 '('           Punctuation
 'ref'         Keyword
@@ -5022,7 +5022,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -5064,7 +5064,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsNotEqual'  Name
 '('           Punctuation
 'ref'         Keyword
@@ -5127,7 +5127,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 '('           Punctuation
@@ -5160,7 +5160,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsPlus'      Name
 '('           Punctuation
 'ref'         Keyword
@@ -5223,7 +5223,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -5249,7 +5249,7 @@
 
 '            ' Text.Whitespace
 'Expr'        Name
-'::'          Text
+'::'          Punctuation
 'RsMinus'     Name
 '('           Punctuation
 'ref'         Keyword
@@ -5312,7 +5312,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'v'           Name
@@ -5354,7 +5354,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'eval_subs'   Name.Function
 '('           Punctuation
 '&'           Operator
@@ -5362,8 +5362,8 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'subs'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Vec'         Name.Builtin
 '<'           Operator
@@ -5371,8 +5371,8 @@
 '>'           Operator
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'Vec'         Name.Builtin
@@ -5434,7 +5434,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'array_dim'   Name.Function
 '('           Punctuation
 '&'           Operator
@@ -5444,15 +5444,15 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'dims'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Vec'         Name.Builtin
 '<'           Operator
@@ -5460,8 +5460,8 @@
 '>'           Operator
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 '('           Punctuation
@@ -5502,7 +5502,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -5533,7 +5533,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -5593,7 +5593,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'assign'      Name.Function
 '('           Punctuation
 '&'           Operator
@@ -5603,20 +5603,20 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'val'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Val'         Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 '('           Punctuation
@@ -5637,7 +5637,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'n'           Name
@@ -5673,7 +5673,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'n'           Name
@@ -5705,7 +5705,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -5776,7 +5776,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -5856,7 +5856,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'lookup'      Name.Function
 '('           Punctuation
 '&'           Operator
@@ -5864,14 +5864,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 'Val'         Name
@@ -5891,7 +5891,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'n'           Name
@@ -5903,7 +5903,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'self'        Name.Builtin.Pseudo
@@ -5921,7 +5921,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'n'           Name
@@ -5933,7 +5933,7 @@
 'Ok'          Name.Builtin
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'self'        Name.Builtin.Pseudo
@@ -5951,7 +5951,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -6007,7 +6007,7 @@
 'map'         Name
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -6018,7 +6018,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -6074,7 +6074,7 @@
 'map'         Name
 '('           Punctuation
 'Val'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 ')'           Punctuation
 '\n'          Text.Whitespace
@@ -6098,7 +6098,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'stash'       Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6108,8 +6108,8 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ')'           Punctuation
@@ -6128,7 +6128,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'n'           Name
@@ -6152,7 +6152,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'n'           Name
@@ -6176,7 +6176,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -6203,7 +6203,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -6243,7 +6243,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'retrieve'    Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6253,14 +6253,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 '('           Punctuation
@@ -6281,7 +6281,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'n'           Name
@@ -6306,7 +6306,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'n'           Name
@@ -6331,7 +6331,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -6359,7 +6359,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -6400,7 +6400,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'set_rw'      Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6410,15 +6410,15 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ','           Punctuation
 ' '           Text.Whitespace
 'rw'          Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'bool'        Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -6436,7 +6436,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I16'         Name
 '('           Punctuation
 'n'           Name
@@ -6462,7 +6462,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'I32'         Name
 '('           Punctuation
 'n'           Name
@@ -6488,7 +6488,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -6517,7 +6517,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -6559,7 +6559,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'abstain'     Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6569,25 +6569,25 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'what'        Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'ast'         Name.Class
-'::'          Text
+'::'          Punctuation
 'Abstain'     Name
 ','           Punctuation
 ' '           Text.Whitespace
 'f'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Fn'          Name.Builtin
 '('           Punctuation
 'u32'         Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'u32'         Keyword.Type
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -6601,9 +6601,9 @@
 ' '           Text.Whitespace
 '&'           Operator
 'ast'         Name
-'::'          Text
+'::'          Punctuation
 'Abstain'     Name
-'::'          Text
+'::'          Punctuation
 'Label'       Name
 '('           Punctuation
 'lbl'         Name
@@ -6657,7 +6657,7 @@
 '='           Operator
 ' '           Text.Whitespace
 'StmtBody'    Name
-'::'          Text
+'::'          Punctuation
 'GiveUp'      Name
 ' '           Text.Whitespace
 '{'           Punctuation
@@ -6784,7 +6784,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'array_readout' Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6794,14 +6794,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 '('           Punctuation
@@ -6838,7 +6838,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -6874,7 +6874,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -6939,7 +6939,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'array_writein' Name.Function
 '('           Punctuation
 '&'           Operator
@@ -6949,14 +6949,14 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'var'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Var'         Name.Class
 ')'           Punctuation
 ' '           Text.Whitespace
-'->'          Text
-' '           Text
+'->'          Punctuation
+' '           Text.Whitespace
 'Res'         Name.Class
 '<'           Operator
 '('           Punctuation
@@ -6993,7 +6993,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A16'         Name
 '('           Punctuation
 'n'           Name
@@ -7024,7 +7024,7 @@
 
 '            ' Text.Whitespace
 'Var'         Name
-'::'          Text
+'::'          Punctuation
 'A32'         Name
 '('           Punctuation
 'n'           Name
@@ -7084,7 +7084,7 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'dump_state'  Name.Function
 '('           Punctuation
 '&'           Operator
@@ -7214,12 +7214,12 @@
 
 '    '        Text.Whitespace
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'dump_state_one' Name.Function
 '<'           Operator
 'T'           Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 'Debug'       Name.Class
 ' '           Text.Whitespace
 '+'           Operator
@@ -7232,8 +7232,8 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'vec'         Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'Vec'         Name.Builtin
 '<'           Operator
@@ -7245,8 +7245,8 @@
 ','           Punctuation
 ' '           Text.Whitespace
 'sigil'       Name
-':'           Text
-' '           Text
+':'           Punctuation
+' '           Text.Whitespace
 '&'           Keyword.Pseudo
 'str'         Keyword.Type
 ')'           Punctuation

--- a/tests/snippets/rust/test_func.txt
+++ b/tests/snippets/rust/test_func.txt
@@ -1,0 +1,21 @@
+---input---
+fn func(x: u32) -> None {}
+
+---tokens---
+'fn'          Keyword
+' '           Text.Whitespace
+'func'        Name.Function
+'('           Punctuation
+'x'           Name
+':'           Punctuation
+' '           Text.Whitespace
+'u32'         Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Punctuation
+' '           Text.Whitespace
+'None'        Name.Builtin
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/rust/test_rawstrings.txt
+++ b/tests/snippets/rust/test_rawstrings.txt
@@ -20,7 +20,7 @@ fn main() {
 
 ---tokens---
 'fn'          Keyword
-' '           Text
+' '           Text.Whitespace
 'main'        Name.Function
 '('           Punctuation
 ')'           Punctuation

--- a/tests/snippets/rust/test_struct.txt
+++ b/tests/snippets/rust/test_struct.txt
@@ -9,7 +9,7 @@ struct X { x: u32 }
 '{'           Punctuation
 ' '           Text.Whitespace
 'x'           Name
-':'           Text
+':'           Punctuation
 ' '           Text.Whitespace
 'u32'         Keyword.Type
 ' '           Text.Whitespace

--- a/tests/snippets/rust/test_struct.txt
+++ b/tests/snippets/rust/test_struct.txt
@@ -1,0 +1,17 @@
+---input---
+struct X { x: u32 }
+
+---tokens---
+'struct'      Keyword
+' '           Text.Whitespace
+'X'           Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'x'           Name
+':'           Text
+' '           Text.Whitespace
+'u32'         Keyword.Type
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/rust/test_use.txt
+++ b/tests/snippets/rust/test_use.txt
@@ -1,0 +1,13 @@
+---input---
+use std::collections::BtreeMap;
+
+---tokens---
+'use'         Keyword
+' '           Text.Whitespace
+'std'         Name
+'::'          Operator
+'collections' Name
+'::'          Operator
+'BtreeMap'    Name
+';'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/rust/test_use.txt
+++ b/tests/snippets/rust/test_use.txt
@@ -5,9 +5,9 @@ use std::collections::BtreeMap;
 'use'         Keyword
 ' '           Text.Whitespace
 'std'         Name
-'::'          Operator
+'::'          Punctuation
 'collections' Name
-'::'          Operator
+'::'          Punctuation
 'BtreeMap'    Name
 ';'           Punctuation
 '\n'          Text.Whitespace


### PR DESCRIPTION
This changes the Rust lexer to handle `::`, `:`, and `->` better. Previously, all of these tokens would labeled as text, which leads to poor rendering on certain styles. For instance, using a `monokai` HTML style w/ inline CSS, I get

![image](https://github.com/pygments/pygments/assets/1914111/65efbcc8-1bfc-4a4d-bcea-1fcd6bb3aab6)

where the tokens are rendered using the default (black) text which is not really visible against the background.

This changes the lexer so that:
* `:` and `->` are considered punctuation
* `::` is considered an operator -- I am not entirely sure that's the correct thing to do, but it seems like a resaonable choice
* I went through and used `Text.Whitespace` instead of plain `Text` a little more thoroughly. 