### PR TITLE
Set value of version_added for Macaulay2 lexer

### DIFF
--- a/pygments/lexers/macaulay2.py
+++ b/pygments/lexers/macaulay2.py
@@ -1722,7 +1722,7 @@ class Macaulay2Lexer(RegexLexer):
     url = 'https://macaulay2.com/'
     aliases = ['macaulay2']
     filenames = ['*.m2']
-    version_added = ''
+    version_added = '2.12'
 
     tokens = {
         'root': [


### PR DESCRIPTION
It was added in 2.12.  From https://pygments.org/docs/changelog/:

> Version 2.12.0
> (released April 24th, 2022)
>
> * Added lexers:
>
>    * Berry (#&#x2060;2070)
>
>    * Cplint (#&#x2060;2045)
>
>    * Macaulay2 (#&#x2060;1791)
>
> ...
