### PR TITLE
Add OneDarkVivd style

### DIFF
--- a/pygments/styles/_mapping.py
+++ b/pygments/styles/_mapping.py
@@ -33,6 +33,7 @@ STYLES = {
     'NordDarkerStyle': ('pygments.styles.nord', 'nord-darker', ()),
     'NordStyle': ('pygments.styles.nord', 'nord', ()),
     'OneDarkStyle': ('pygments.styles.onedark', 'one-dark', ()),
+    'OneDarkVividStyle': ('pygments.styles.onedark_vivid', 'one-dark-vivid', ()),
     'ParaisoDarkStyle': ('pygments.styles.paraiso_dark', 'paraiso-dark', ()),
     'ParaisoLightStyle': ('pygments.styles.paraiso_light', 'paraiso-light', ()),
     'PastieStyle': ('pygments.styles.pastie', 'pastie', ()),

--- a/pygments/styles/onedark_vivid.py
+++ b/pygments/styles/onedark_vivid.py
@@ -1,6 +1,6 @@
 """
     pygments.styles.onedark_vivid
-    ~~~~~~~~~~~~~~~~~~~~~~~
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     One Dark Vivid Theme for Pygments by Tristan Partin (https://github.com/tristan957).
 

--- a/pygments/styles/onedark_vivid.py
+++ b/pygments/styles/onedark_vivid.py
@@ -1,0 +1,63 @@
+"""
+    pygments.styles.onedark_vivid
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    One Dark Vivid Theme for Pygments by Tristan Partin (https://github.com/tristan957).
+
+    Inspired by OneDark-Pro for the code editor Visual Studio Code
+    (https://github.com/Binaryify/OneDark-Pro).
+
+    :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.style import Style
+from pygments.token import Comment, Keyword, Name, Number, Operator, \
+    Punctuation, String, Token
+
+
+__all__ = ['OneDarkVividStyle']
+
+
+class OneDarkVividStyle(Style):
+    """
+    Theme inspired by One Dark Pro for Atom.
+
+    .. versionadded:: 2.18
+    """
+    name = 'one-dark-vivid'
+
+    background_color = '#282C34'
+
+    styles = {
+        Token:                  '#ABB2BF',
+
+        Punctuation:            '#ABB2BF',
+        Punctuation.Marker:     '#ABB2BF',
+
+        Keyword:                '#D55FDE',
+        Keyword.Constant:       '#E5C07B',
+        Keyword.Declaration:    '#D55FDE',
+        Keyword.Namespace:      '#D55FDE',
+        Keyword.Reserved:       '#D55FDE',
+        Keyword.Type:           '#E5C07B',
+
+        Name:                   '#EF596F',
+        Name.Attribute:         '#EF596F',
+        Name.Builtin:           '#E5C07B',
+        Name.Class:             '#E5C07B',
+        Name.Function:          'bold #61AFEF',
+        Name.Function.Magic:    'bold #2BBAC5',
+        Name.Other:             '#EF596F',
+        Name.Tag:               '#EF596F',
+        Name.Decorator:         '#61AFEF',
+        Name.Variable.Class:    '',
+
+        String:                 '#89CA78',
+
+        Number:                 '#D19A66',
+
+        Operator:               '#2BBAC5',
+
+        Comment:                '#7F848E'
+    }


### PR DESCRIPTION
This is inspired by the VSCode One Dark Pro vivid variant, which was originally inspired by the One Dark theme for Atom.