### PR TITLE
Wikitext lexer: remove kk-* in variant_langs

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -945,8 +945,6 @@ class WikitextLexer(RegexLexer):
         'sh-latn', 'sh-cyrl',
         # KuConverter.php
         'ku', 'ku-arab', 'ku-latn',
-        # KkConverter.php
-        'kk', 'kk-cyrl', 'kk-latn', 'kk-arab', 'kk-kz', 'kk-tr', 'kk-cn',
         # IuConverter.php
         'iu', 'ike-cans', 'ike-latn',
         # GanConverter.php


### PR DESCRIPTION
Reason: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/972472