### PR TITLE
[elpi] matching parens of same color + nested quotations

### DIFF
--- a/pygments/lexers/elpi.py
+++ b/pygments/lexers/elpi.py
@@ -8,12 +8,13 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pygments.lexer import RegexLexer, bygroups, include
+from pygments.lexer import RegexLexer, bygroups, include, using
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Number, Punctuation
 
 __all__ = ['ElpiLexer']
 
+from pygments.lexers.theorem import CoqLexer
 
 class ElpiLexer(RegexLexer):
     """
@@ -155,7 +156,7 @@ class ElpiLexer(RegexLexer):
             (r"\s+", Text.Whitespace),
             (r"(lp:)(\{\{)", bygroups(Number, Punctuation), 'elpi-quote-exit'),
             (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Number, Name.Variable)),
-            (r"((?!lp:|\s|\}\}).)+", Text),
+            (r"((?!lp:|\}\}).)+", using(CoqLexer)),
         ],
         'elpi-quote-exit': [
             include('elpi'),

--- a/pygments/lexers/elpi.py
+++ b/pygments/lexers/elpi.py
@@ -153,10 +153,10 @@ class ElpiLexer(RegexLexer):
         ],
         'elpi-quote': [
             (r'\}\}', Punctuation, '#pop'),
-            (r"\s", Text.Whitespace),
-            (r"(lp:)({})".format("{{"), bygroups(Number, Punctuation), 'elpi-quote-exit'),
-            (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Number, Name.Variable)),
-            (r".", Text),
+            (r"\s+", Text.Whitespace),
+            (r"(lp:)(\{\{)", bygroups(Number, Punctuation), 'elpi-quote-exit'),
+            (r"(lp:)((?=[A-Z_]){})".format(constant_re), bygroups(Number, Name.Variable)),
+            (r"((?!lp:|\s|\}\}).)+", Text),
         ],
         'elpi-quote-exit': [
             include('elpi'),

--- a/pygments/lexers/elpi.py
+++ b/pygments/lexers/elpi.py
@@ -51,7 +51,7 @@ class ElpiLexer(RegexLexer):
             (r"(:before|:after|:if|:name)(\s*)(\")",
              bygroups(Keyword.Mode, Text.Whitespace, String.Double),
              'elpi-string'),
-            (r"(:index)(\s*)", bygroups(Keyword.Mode, Text.Whitespace),
+            (r"(:index)(\s*)(\()", bygroups(Keyword.Mode, Text.Whitespace, Punctuation),
              'elpi-indexing-expr'),
             (rf"\b(external pred|pred)(\s+)({const_sym_re})",
              bygroups(Keyword.Declaration, Text.Whitespace, Name.Function),
@@ -79,7 +79,7 @@ class ElpiLexer(RegexLexer):
              'elpi-chr-rule-start'),
 
             (rf"(?=[A-Z_]){constant_re}", Name.Variable),
-            (rf"(?=[a-z_]){constant_re}\\", Name.Variable),
+            (rf"(?=[a-z_])({constant_re}|_)\\", Name.Variable),
             (r"_", Name.Variable),
             (rf"({symbol_re}|!|=>|;)", Keyword.Declaration),
             (constant_re, Text),
@@ -87,9 +87,9 @@ class ElpiLexer(RegexLexer):
             (r'"', String.Double, 'elpi-string'),
             (r'`', String.Double, 'elpi-btick'),
             (r'\'', String.Double, 'elpi-tick'),
-            (r'\{\{', Text, 'elpi-quote'),
+            (r'\{\{', Punctuation, 'elpi-quote'),
             (r'\{[^\{]', Text, 'elpi-spill'),
-            (r"\(", Text, 'elpi-in-parens'),
+            (r"\(", Punctuation, 'elpi-in-parens'),
             (r'\d[\d_]*', Number.Integer),
             (r'-?\d[\d_]*(.[\d_]*)?([eE][+\-]?\d[\d_]*)', Number.Float),
             (r"[\+\*\-/\^\.]", Operator),
@@ -104,7 +104,6 @@ class ElpiLexer(RegexLexer):
             (r'.', Comment)
         ],
         'elpi-indexing-expr':[
-            (r'\(', Punctuation, '#push'),
             (r'[0-9 _]+', Number.Integer),
             (r'\)', Punctuation, '#pop'),
         ],
@@ -117,13 +116,13 @@ class ElpiLexer(RegexLexer):
             include('_elpi-comment'),
         ],
         'elpi-chr-rule-start': [
-            (r"\{", Text, 'elpi-chr-rule'),
+            (r"\{", Punctuation, 'elpi-chr-rule'),
             include('_elpi-comment'),
         ],
         'elpi-chr-rule': [
            (r"\brule\b", Keyword.Declaration),
            (r"\\", Keyword.Declaration),
-           (r"\}", Text, '#pop:2'),
+           (r"\}", Punctuation, '#pop:2'),
            include('elpi'),
         ],
         'elpi-pred-item': [
@@ -153,11 +152,15 @@ class ElpiLexer(RegexLexer):
             (r'"', String.Double, '#pop'),
         ],
         'elpi-quote': [
-            (r'\{\{', Text, '#push'),
-            (r'\}\}', Text, '#pop'),
+            (r'\}\}', Punctuation, '#pop'),
             (r"\s", Text.Whitespace),
-            (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Keyword, Name.Variable)),
-            (r".", Text.Comment),
+            (r"(lp:)({})".format("{{"), bygroups(Number, Punctuation), 'elpi-quote-exit'),
+            (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Number, Name.Variable)),
+            (r".", Text),
+        ],
+        'elpi-quote-exit': [
+            include('elpi'),
+            (r'\}\}', Punctuation, '#pop'),
         ],
         'elpi-spill': [
             (r'\{[^\{]', Text, '#push'),
@@ -169,6 +172,4 @@ class ElpiLexer(RegexLexer):
             include('elpi'),
             (r"\)", Punctuation, '#pop'),
         ],
-
-
     }

--- a/pygments/lexers/elpi.py
+++ b/pygments/lexers/elpi.py
@@ -65,6 +65,9 @@ class ElpiLexer(RegexLexer):
             (rf"\b(typeabbrev)(\s+)({const_sym_re})",
              bygroups(Keyword.Declaration, Text.Whitespace, Name.Function),
              'elpi-type'),
+            (r"\b(typeabbrev)(\s+)(\([^)]+\))",
+             bygroups(Keyword.Declaration, Text.Whitespace, Name.Function),
+             'elpi-type'),
             (r"\b(accumulate)(\s+)(\")",
              bygroups(Keyword.Declaration, Text.Whitespace, String.Double),
              'elpi-string'),
@@ -96,12 +99,8 @@ class ElpiLexer(RegexLexer):
         ],
         '_elpi-comment': [
             (r'%[^\n]*\n', Comment),
-            (r'/\*', Comment, 'elpi-multiline-comment'),
+            (r'/(?:\\\n)?[*](?:[^*]|[*](?!(?:\\\n)?/))*[*](?:\\\n)?/', Comment),
             (r"\s+", Text.Whitespace),
-        ],
-        'elpi-multiline-comment': [
-            (r'\*/', Comment, '#pop'),
-            (r'.', Comment)
         ],
         'elpi-indexing-expr':[
             (r'[0-9 _]+', Number.Integer),
@@ -155,7 +154,7 @@ class ElpiLexer(RegexLexer):
             (r'\}\}', Punctuation, '#pop'),
             (r"\s+", Text.Whitespace),
             (r"(lp:)(\{\{)", bygroups(Number, Punctuation), 'elpi-quote-exit'),
-            (r"(lp:)((?=[A-Z_]){})".format(constant_re), bygroups(Number, Name.Variable)),
+            (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Number, Name.Variable)),
             (r"((?!lp:|\s|\}\}).)+", Text),
         ],
         'elpi-quote-exit': [

--- a/pygments/lexers/elpi.py
+++ b/pygments/lexers/elpi.py
@@ -51,7 +51,7 @@ class ElpiLexer(RegexLexer):
             (r"(:before|:after|:if|:name)(\s*)(\")",
              bygroups(Keyword.Mode, Text.Whitespace, String.Double),
              'elpi-string'),
-            (r"(:index)(\s*\()", bygroups(Keyword.Mode, Text.Whitespace),
+            (r"(:index)(\s*)", bygroups(Keyword.Mode, Text.Whitespace),
              'elpi-indexing-expr'),
             (rf"\b(external pred|pred)(\s+)({const_sym_re})",
              bygroups(Keyword.Declaration, Text.Whitespace, Name.Function),
@@ -87,7 +87,7 @@ class ElpiLexer(RegexLexer):
             (r'"', String.Double, 'elpi-string'),
             (r'`', String.Double, 'elpi-btick'),
             (r'\'', String.Double, 'elpi-tick'),
-            (r'\{\{', Punctuation, 'elpi-quote'),
+            (r'\{\{', Text, 'elpi-quote'),
             (r'\{[^\{]', Text, 'elpi-spill'),
             (r"\(", Text, 'elpi-in-parens'),
             (r'\d[\d_]*', Number.Integer),
@@ -104,8 +104,9 @@ class ElpiLexer(RegexLexer):
             (r'.', Comment)
         ],
         'elpi-indexing-expr':[
+            (r'\(', Punctuation, '#push'),
             (r'[0-9 _]+', Number.Integer),
-            (r'\)', Text, '#pop'),
+            (r'\)', Punctuation, '#pop'),
         ],
         'elpi-type': [
             (r"(ctype\s+)(\")", bygroups(Keyword.Type, String.Double), 'elpi-string'),
@@ -152,11 +153,11 @@ class ElpiLexer(RegexLexer):
             (r'"', String.Double, '#pop'),
         ],
         'elpi-quote': [
-            (r'\{\{', Punctuation, '#push'),
-            (r'\}\}', Punctuation, '#pop'),
+            (r'\{\{', Text, '#push'),
+            (r'\}\}', Text, '#pop'),
+            (r"\s", Text.Whitespace),
             (rf"(lp:)((?=[A-Z_]){constant_re})", bygroups(Keyword, Name.Variable)),
-            (r"[^l\}]+", Text),
-            (r"l|\}", Text),
+            (r".", Text.Comment),
         ],
         'elpi-spill': [
             (r'\{[^\{]', Text, '#push'),
@@ -164,9 +165,10 @@ class ElpiLexer(RegexLexer):
             include('elpi'),
         ],
         'elpi-in-parens': [
-            (r"\(", Operator, '#push'),
-            (r"\)", Operator, '#pop'),
+            (r"\(", Punctuation, '#push'),
             include('elpi'),
+            (r"\)", Punctuation, '#pop'),
         ],
+
 
     }

--- a/tests/snippets/elpi/test_chr.txt
+++ b/tests/snippets/elpi/test_chr.txt
@@ -11,7 +11,7 @@ rule. % not a kwd
 'constraint'  Keyword.Declaration
 ' '           Text.Whitespace
 'foo, bar '   Name.Function
-'{'           Text
+'{'           Punctuation
 '\n\n  '      Text.Whitespace
 ':name'       Keyword.Mode
 ' '           Text.Whitespace
@@ -21,19 +21,19 @@ rule. % not a kwd
 '\n  '        Text.Whitespace
 'rule'        Keyword.Declaration
 ' '           Text.Whitespace
-'('           Text
+'('           Punctuation
 'odd'         Text
 ' '           Text.Whitespace
 'X'           Name.Variable
-')'           Operator
+')'           Punctuation
 ' '           Text.Whitespace
 '\\'          Keyword.Declaration
 ' '           Text.Whitespace
-'('           Text
+'('           Punctuation
 'even'        Text
 ' '           Text.Whitespace
 'X'           Name.Variable
-')'           Operator
+')'           Punctuation
 ' '           Text.Whitespace
 '|'           Keyword.Declaration
 ' '           Text.Whitespace
@@ -45,7 +45,7 @@ rule. % not a kwd
 '.'           Operator
 '\n\n'        Text.Whitespace
 
-'}'           Text
+'}'           Punctuation
 '\n'          Text.Whitespace
 
 'rule'        Text

--- a/tests/snippets/elpi/test_clause.txt
+++ b/tests/snippets/elpi/test_clause.txt
@@ -3,6 +3,7 @@ true.
 stop :- !.
 of (fun F) :- pi x\ of x => of (F x).
 match (uvar as Y) :- print Y.
+f :- forall (_\ true) []. 
 
 ---tokens---
 'true'        Text
@@ -19,11 +20,11 @@ match (uvar as Y) :- print Y.
 
 'of'          Text
 ' '           Text.Whitespace
-'('           Text
+'('           Punctuation
 'fun'         Text
 ' '           Text.Whitespace
 'F'           Name.Variable
-')'           Operator
+')'           Punctuation
 ' '           Text.Whitespace
 ':-'          Keyword.Declaration
 ' '           Text.Whitespace
@@ -40,23 +41,23 @@ match (uvar as Y) :- print Y.
 ' '           Text.Whitespace
 'of'          Text
 ' '           Text.Whitespace
-'('           Text
+'('           Punctuation
 'F'           Name.Variable
 ' '           Text.Whitespace
 'x'           Text
-')'           Operator
+')'           Punctuation
 '.'           Operator
 '\n'          Text.Whitespace
 
 'match'       Text
 ' '           Text.Whitespace
-'('           Text
+'('           Punctuation
 'uvar'        Keyword.Declaration
 ' '           Text.Whitespace
 'as'          Keyword.Declaration
 ' '           Text.Whitespace
 'Y'           Name.Variable
-')'           Operator
+')'           Punctuation
 ' '           Text.Whitespace
 ':-'          Keyword.Declaration
 ' '           Text.Whitespace
@@ -65,3 +66,19 @@ match (uvar as Y) :- print Y.
 'Y'           Name.Variable
 '.'           Operator
 '\n'          Text.Whitespace
+
+'f'           Text
+' '           Text.Whitespace
+':-'          Keyword.Declaration
+' '           Text.Whitespace
+'forall'      Text
+' '           Text.Whitespace
+'('           Punctuation
+'_\\'         Name.Variable
+' '           Text.Whitespace
+'true'        Text
+')'           Punctuation
+' '           Text.Whitespace
+'[]'          Keyword.Declaration
+'.'           Operator
+' \n'         Text.Whitespace

--- a/tests/snippets/elpi/test_comment.txt
+++ b/tests/snippets/elpi/test_comment.txt
@@ -1,0 +1,18 @@
+---input---
+/* 
+  test !
+*/
+pred x  i:nat.
+
+---tokens---
+'/* \n  test !\n*/' Comment
+'\n'          Text.Whitespace
+
+'pred'        Keyword.Declaration
+' '           Text.Whitespace
+'x'           Name.Function
+'  '          Text.Whitespace
+'i:'          Keyword.Mode
+'nat'         Keyword.Type
+'.'           Text
+'\n'          Text.Whitespace

--- a/tests/snippets/elpi/test_pred.txt
+++ b/tests/snippets/elpi/test_pred.txt
@@ -42,9 +42,9 @@ pred p3 i:(bool -> prop).
 '\n'          Text.Whitespace
 
 ':index'      Keyword.Mode
-'('           Text.Whitespace
+'('           Punctuation
 '_ 2'         Literal.Number.Integer
-')'           Text
+')'           Punctuation
 ' '           Text.Whitespace
 'pred'        Keyword.Declaration
 ' '           Text.Whitespace

--- a/tests/snippets/elpi/test_quotations.txt
+++ b/tests/snippets/elpi/test_quotations.txt
@@ -1,14 +1,29 @@
 ---input---
-tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
+tc {{ Eq (fun x => 3) lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
 tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
+pred int->nat i:int, o:term.
+int->nat 0 {{ 0 }}.
+int->nat N {{ S lp:X }} :- M is N - 1, int->nat M X.
+dummy :- {{Record coqWorld (T : Type) := 
+  {myFun : T -> nat -> bool}. lp:{{pred elpiAgain i:term, o:nat -> nat.}}}}.
 
 ---tokens---
 'tc'          Text
 ' '           Text.Whitespace
 '{{'          Punctuation
 ' '           Text.Whitespace
-'Eq'          Text
-' '           Text.Whitespace
+'Eq'          Name
+' '           Text
+'('           Operator
+'fun'         Keyword
+' '           Text
+'x'           Name
+' '           Text
+'=>'          Operator
+' '           Text
+'3'           Literal.Number.Integer
+')'           Operator
+' '           Text
 'lp:'         Literal.Number
 'A'           Name.Variable
 ' '           Text.Whitespace
@@ -16,13 +31,13 @@ tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 ' '           Text.Whitespace
 '{{'          Punctuation
 ' '           Text.Whitespace
-'f'           Text
-' '           Text.Whitespace
+'f'           Name
+' '           Text
 'lp:'         Literal.Number
 'B'           Name.Variable
 ' '           Text.Whitespace
-'l'           Text
-' '           Text.Whitespace
+'l'           Name
+' '           Text
 'lp:'         Literal.Number
 '{{'          Punctuation
 'f'           Text
@@ -30,7 +45,7 @@ tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 'Elpi'        Name.Variable
 ' '           Text.Whitespace
 '{{'          Punctuation
-'Coq'         Text
+'Coq'         Name
 '}}'          Punctuation
 '}}'          Punctuation
 '}}'          Punctuation
@@ -49,8 +64,8 @@ tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 ' '           Text.Whitespace
 '{{'          Punctuation
 ' '           Text.Whitespace
-'x'           Text
-' '           Text.Whitespace
+'x'           Name
+' '           Text
 'lp:'         Literal.Number
 '{{'          Punctuation
 'f'           Text
@@ -64,7 +79,7 @@ tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 '3'           Literal.Number.Integer
 ' '           Text.Whitespace
 '{{'          Punctuation
-'Coq'         Text
+'Coq'         Name
 '}}'          Punctuation
 '}}'          Punctuation
 '}}'          Punctuation
@@ -76,5 +91,123 @@ tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 'A'           Name.Variable
 ' '           Text.Whitespace
 'B'           Name.Variable
+'.'           Operator
+'\n'          Text.Whitespace
+
+'pred'        Keyword.Declaration
+' '           Text.Whitespace
+'int->nat'    Name.Function
+' '           Text.Whitespace
+'i:'          Keyword.Mode
+'int'         Keyword.Type
+','           Text
+' '           Text.Whitespace
+'o:'          Keyword.Mode
+'term'        Keyword.Type
+'.'           Text
+'\n'          Text.Whitespace
+
+'int->nat'    Text
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'{{'          Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text
+'}}'          Punctuation
+'.'           Operator
+'\n'          Text.Whitespace
+
+'int->nat'    Text
+' '           Text.Whitespace
+'N'           Name.Variable
+' '           Text.Whitespace
+'{{'          Punctuation
+' '           Text.Whitespace
+'S'           Name
+' '           Text
+'lp:'         Literal.Number
+'X'           Name.Variable
+' '           Text.Whitespace
+'}}'          Punctuation
+' '           Text.Whitespace
+':-'          Keyword.Declaration
+' '           Text.Whitespace
+'M'           Name.Variable
+' '           Text.Whitespace
+'is'          Keyword.Declaration
+' '           Text.Whitespace
+'N'           Name.Variable
+' '           Text.Whitespace
+'-'           Keyword.Declaration
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+','           Keyword.Declaration
+' '           Text.Whitespace
+'int->nat'    Text
+' '           Text.Whitespace
+'M'           Name.Variable
+' '           Text.Whitespace
+'X'           Name.Variable
+'.'           Operator
+'\n'          Text.Whitespace
+
+'dummy'       Text
+' '           Text.Whitespace
+':-'          Keyword.Declaration
+' '           Text.Whitespace
+'{{'          Punctuation
+'Record'      Keyword.Namespace
+' '           Text
+'coqWorld'    Name
+' '           Text
+'('           Operator
+'T'           Name
+' '           Text
+':'           Operator
+' '           Text
+'Type'        Keyword.Type
+')'           Operator
+' '           Text
+':='          Operator
+' '           Text
+'\n  '        Text.Whitespace
+'{'           Operator
+'myFun'       Name
+' '           Text
+':'           Operator
+' '           Text
+'T'           Name
+' '           Text
+'->'          Operator
+' '           Text
+'nat'         Name
+' '           Text
+'->'          Operator
+' '           Text
+'bool'        Name
+'}'           Operator
+'.'           Operator
+' '           Text
+'lp:'         Literal.Number
+'{{'          Punctuation
+'pred'        Keyword.Declaration
+' '           Text.Whitespace
+'elpiAgain'   Name.Function
+' '           Text.Whitespace
+'i:'          Keyword.Mode
+'term'        Keyword.Type
+','           Text
+' '           Text.Whitespace
+'o:'          Keyword.Mode
+'nat'         Keyword.Type
+' '           Text.Whitespace
+'->'          Keyword.Type
+' '           Text.Whitespace
+'nat'         Keyword.Type
+'.'           Text
+'}}'          Punctuation
+'}}'          Punctuation
 '.'           Operator
 '\n'          Text.Whitespace

--- a/tests/snippets/elpi/test_quotations.txt
+++ b/tests/snippets/elpi/test_quotations.txt
@@ -6,8 +6,7 @@ tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
 ' '           Text.Whitespace
 '{{'          Punctuation
 ' '           Text.Whitespace
-'E'           Text
-'q'           Text
+'Eq'          Text
 ' '           Text.Whitespace
 'lp:'         Literal.Number
 'A'           Name.Variable
@@ -30,9 +29,7 @@ tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
 'Elpi'        Name.Variable
 ' '           Text.Whitespace
 '{{'          Punctuation
-'C'           Text
-'o'           Text
-'q'           Text
+'Coq'         Text
 '}}'          Punctuation
 '}}'          Punctuation
 '}}'          Punctuation

--- a/tests/snippets/elpi/test_quotations.txt
+++ b/tests/snippets/elpi/test_quotations.txt
@@ -1,25 +1,40 @@
 ---input---
-tc {{ Eq lp:A }} {{ f lp:B l } }} :- foo A B.
+tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
 
 ---tokens---
 'tc'          Text
 ' '           Text.Whitespace
 '{{'          Punctuation
-' Eq '        Text
-'lp:'         Keyword
+' '           Text.Whitespace
+'E'           Text
+'q'           Text
+' '           Text.Whitespace
+'lp:'         Literal.Number
 'A'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '}}'          Punctuation
 ' '           Text.Whitespace
 '{{'          Punctuation
-' f '         Text
-'lp:'         Keyword
+' '           Text.Whitespace
+'f'           Text
+' '           Text.Whitespace
+'lp:'         Literal.Number
 'B'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 'l'           Text
-' '           Text
-'}'           Text
-' '           Text
+' '           Text.Whitespace
+'lp:'         Literal.Number
+'{{'          Punctuation
+'f'           Text
+' '           Text.Whitespace
+'Elpi'        Name.Variable
+' '           Text.Whitespace
+'{{'          Punctuation
+'C'           Text
+'o'           Text
+'q'           Text
+'}}'          Punctuation
+'}}'          Punctuation
 '}}'          Punctuation
 ' '           Text.Whitespace
 ':-'          Keyword.Declaration

--- a/tests/snippets/elpi/test_quotations.txt
+++ b/tests/snippets/elpi/test_quotations.txt
@@ -1,5 +1,6 @@
 ---input---
 tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
+tc {{ x lp:{{f Elpi "STRING" 3 {{Coq}}}}}} :- foo A B.
 
 ---tokens---
 'tc'          Text
@@ -27,6 +28,40 @@ tc {{ Eq lp:A }} {{ f lp:B l lp:{{f Elpi {{Coq}}}}}} :- foo A B.
 'f'           Text
 ' '           Text.Whitespace
 'Elpi'        Name.Variable
+' '           Text.Whitespace
+'{{'          Punctuation
+'Coq'         Text
+'}}'          Punctuation
+'}}'          Punctuation
+'}}'          Punctuation
+' '           Text.Whitespace
+':-'          Keyword.Declaration
+' '           Text.Whitespace
+'foo'         Text
+' '           Text.Whitespace
+'A'           Name.Variable
+' '           Text.Whitespace
+'B'           Name.Variable
+'.'           Operator
+'\n'          Text.Whitespace
+
+'tc'          Text
+' '           Text.Whitespace
+'{{'          Punctuation
+' '           Text.Whitespace
+'x'           Text
+' '           Text.Whitespace
+'lp:'         Literal.Number
+'{{'          Punctuation
+'f'           Text
+' '           Text.Whitespace
+'Elpi'        Name.Variable
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'STRING'      Literal.String.Double
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
 ' '           Text.Whitespace
 '{{'          Punctuation
 'Coq'         Text


### PR DESCRIPTION
Original (matching parens of different color)
![image](https://github.com/pygments/pygments/assets/79260701/132513b7-0698-40e0-a0f7-ef4c9b6e38b1)

Fixed
![image](https://github.com/pygments/pygments/assets/79260701/51f2a52c-cafd-48ca-a3fe-295035bc134d)
---
Original (nested quotations):
![image](https://github.com/pygments/pygments/assets/79260701/46c9334e-9a4d-4a11-aa1e-81bbea65c71d)

Fixed:
![image](https://github.com/pygments/pygments/assets/79260701/f3d97ab5-594e-485a-862f-fcbdad099458)



CC @gares 