### PR TITLE
Add lexer for Soong (Android.bp) config files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -196,6 +196,7 @@ Other contributors, listed alphabetically, are:
 * Kashif Rasul -- CUDA lexer
 * Nathan Reed -- HLSL lexer
 * Justin Reidy -- MXML lexer
+* Jonathon Reinhart, Google LLC -- Soong lexer
 * Norman Richards -- JSON lexer
 * Corey Richardson -- Rust lexer updates
 * Fabrizio Riguzzi -- cplint leder

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -478,6 +478,7 @@ LEXERS = {
     'SnobolLexer': ('pygments.lexers.snobol', 'Snobol', ('snobol',), ('*.snobol',), ('text/x-snobol',)),
     'SnowballLexer': ('pygments.lexers.dsls', 'Snowball', ('snowball',), ('*.sbl',), ()),
     'SolidityLexer': ('pygments.lexers.solidity', 'Solidity', ('solidity',), ('*.sol',), ()),
+    'SoongLexer': ('pygments.lexers.soong', 'Soong', ('androidbp', 'bp', 'soong'), ('Android.bp',), ()),
     'SophiaLexer': ('pygments.lexers.sophia', 'Sophia', ('sophia',), ('*.aes',), ()),
     'SourcePawnLexer': ('pygments.lexers.pawn', 'SourcePawn', ('sp',), ('*.sp',), ('text/x-sourcepawn',)),
     'SourcesListLexer': ('pygments.lexers.installers', 'Debian Sourcelist', ('debsources', 'sourceslist', 'sources.list'), ('sources.list',), ()),

--- a/pygments/lexers/soong.py
+++ b/pygments/lexers/soong.py
@@ -1,0 +1,79 @@
+"""
+    pygments.lexers.soong
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for Soong (Android.bp Blueprint) files.
+
+    :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+from pygments.lexer import RegexLexer, bygroups, include
+from pygments.token import Comment, Name, Number, Operator, Punctuation, \
+        String, Whitespace
+
+__all__ = ['SoongLexer']
+
+class SoongLexer(RegexLexer):
+    name = 'Soong'
+    version_added = '2.18'
+    url = 'https://source.android.com/docs/setup/reference/androidbp'
+    aliases = ['androidbp', 'bp', 'soong']
+    filenames = [
+        'Android.bp',
+    ]
+
+    tokens = {
+        'root': [
+            # A variable assignment
+            (r'(\w*)(\s*)(\+?=)(\s*)',
+             bygroups(Name.Variable, Whitespace, Operator, Whitespace),
+             'assign-rhs'),
+
+            # A top-level module
+            (r'(\w*)(\s*)(\{)',
+             bygroups(Name.Function, Whitespace, Punctuation),
+             'in-rule'),
+
+            # Everything else
+            include('comments'),
+            (r'\s+', Whitespace),  # newlines okay
+        ],
+        'assign-rhs': [
+            include('expr'),
+            (r'\n', Whitespace, '#pop'),
+        ],
+        'in-list': [
+            include('expr'),
+            include('comments'),
+            (r'\s+', Whitespace),  # newlines okay in a list
+            (r',', Punctuation),
+            (r'\]', Punctuation, '#pop'),
+        ],
+        'in-map': [
+            # A map key
+            (r'(\w+)(:)(\s*)', bygroups(Name, Punctuation, Whitespace)),
+
+            include('expr'),
+            include('comments'),
+            (r'\s+', Whitespace),  # newlines okay in a map
+            (r',', Punctuation),
+            (r'\}', Punctuation, '#pop'),
+        ],
+        'in-rule': [
+            # Just re-use map syntax
+            include('in-map'),
+        ],
+        'comments': [
+            (r'//.*', Comment.Single),
+            (r'/(\\\n)?[*](.|\n)*?[*](\\\n)?/', Comment.Multiline),
+        ],
+        'expr': [
+            (r'(true|false)\b', Name.Builtin),
+            (r'0x[0-9a-fA-F]+', Number.Hex),
+            (r'\d+', Number.Integer),
+            (r'".*?"', String),
+            (r'\{', Punctuation, 'in-map'),
+            (r'\[', Punctuation, 'in-list'),
+            (r'\w+', Name),
+        ],
+    }

--- a/tests/snippets/soong/test_comments.txt
+++ b/tests/snippets/soong/test_comments.txt
@@ -1,0 +1,20 @@
+---input---
+// C++ Style comment
+
+/* C-style comment on one line */
+
+/**
+ * C-style comments
+ * covering multiple lines
+ * are totally cool
+ */
+
+---tokens---
+'// C++ Style comment' Comment.Single
+'\n\n'        Text.Whitespace
+
+'/* C-style comment on one line */' Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'/**\n * C-style comments\n * covering multiple lines\n * are totally cool\n */' Comment.Multiline
+'\n'          Text.Whitespace

--- a/tests/snippets/soong/test_modules.txt
+++ b/tests/snippets/soong/test_modules.txt
@@ -1,0 +1,122 @@
+---input---
+package {
+    default_applicable_licenses: ["example"],
+}
+
+module_name {
+    name: "foo",
+    // A comment inside a rule
+    shared_libs: ["libfoo"],
+    stl: "none",
+    srcs: my_srcs_var,  // A comment following a property
+    level: 42,
+    arch: {
+        arm: {
+            srcs: ["arm.cpp"],
+        },
+        x86: {
+            srcs: ["x86.cpp"],
+        },
+    },
+}
+
+---tokens---
+'package'     Name.Function
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'default_applicable_licenses' Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"example"'   Literal.String
+']'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'module_name' Name.Function
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'name'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'"foo"'       Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'// A comment inside a rule' Comment.Single
+'\n    '      Text.Whitespace
+'shared_libs' Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"libfoo"'    Literal.String
+']'           Punctuation
+','           Punctuation
+'\n    '      Text.Whitespace
+'stl'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'"none"'      Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'srcs'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'my_srcs_var' Name
+','           Punctuation
+'  '          Text.Whitespace
+'// A comment following a property' Comment.Single
+'\n    '      Text.Whitespace
+'level'       Name
+':'           Punctuation
+' '           Text.Whitespace
+'42'          Literal.Number.Integer
+','           Punctuation
+'\n    '      Text.Whitespace
+'arch'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'arm'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'srcs'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"arm.cpp"'   Literal.String
+']'           Punctuation
+','           Punctuation
+'\n        '  Text.Whitespace
+'}'           Punctuation
+','           Punctuation
+'\n        '  Text.Whitespace
+'x86'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'srcs'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"x86.cpp"'   Literal.String
+']'           Punctuation
+','           Punctuation
+'\n        '  Text.Whitespace
+'}'           Punctuation
+','           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/soong/test_variable_assignment_after_module.txt
+++ b/tests/snippets/soong/test_variable_assignment_after_module.txt
@@ -1,0 +1,51 @@
+---input---
+module_name {
+    name: "foo",
+    // A comment inside a rule
+    shared_libs: ["libfoo"],
+    stl: "none",
+}
+
+// Make sure this works
+some_var = 42
+
+---tokens---
+'module_name' Name.Function
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'name'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'"foo"'       Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'// A comment inside a rule' Comment.Single
+'\n    '      Text.Whitespace
+'shared_libs' Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"libfoo"'    Literal.String
+']'           Punctuation
+','           Punctuation
+'\n    '      Text.Whitespace
+'stl'         Name
+':'           Punctuation
+' '           Text.Whitespace
+'"none"'      Literal.String
+','           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// Make sure this works' Comment.Single
+'\n'          Text.Whitespace
+
+'some_var'    Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'42'          Literal.Number.Integer
+'\n'          Text.Whitespace

--- a/tests/snippets/soong/test_variable_assignments.txt
+++ b/tests/snippets/soong/test_variable_assignments.txt
@@ -1,0 +1,136 @@
+---input---
+an_int = 42
+
+a_hex_int = 0xC001
+
+a_string = "cool"
+
+a_list = ["put", "stuff", "here"]
+
+a_map = {key1: "value1", key2: ["value2"]}
+
+test_append = ["a", "b"]
+test_append += ["c", "d"]
+
+multiline_list = [
+    "snap",
+    // With comments
+    "crackle",
+    /* more comments */ "pop",
+]
+
+---tokens---
+'an_int'      Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'42'          Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'a_hex_int'   Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0xC001'      Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'a_string'    Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"cool"'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'a_list'      Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'"put"'       Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'"stuff"'     Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'"here"'      Literal.String
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'a_map'       Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'key1'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'"value1"'    Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'key2'        Name
+':'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'"value2"'    Literal.String
+']'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'test_append' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'"a"'         Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'"b"'         Literal.String
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'test_append' Name.Variable
+' '           Text.Whitespace
+'+='          Operator
+' '           Text.Whitespace
+'['           Punctuation
+'"c"'         Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'"d"'         Literal.String
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'multiline_list' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'\n    '      Text.Whitespace
+'"snap"'      Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'// With comments' Comment.Single
+'\n    '      Text.Whitespace
+'"crackle"'   Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'/* more comments */' Comment.Multiline
+' '           Text.Whitespace
+'"pop"'       Literal.String
+','           Punctuation
+'\n'          Text.Whitespace
+
+']'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This adds a lexer for `Android.bp` files which are used by the *Soong* Android build system.

https://source.android.com/docs/setup/build

Here is an example of a full `Android.bp` file: [`platform/frameworks/base/Android.bp`](https://android.googlesource.com/platform/frameworks/base/+/55afce9107ea882fe236acc5653aef9d6fb2185b/Android.bp).