### PR TITLE
Add a __class_getitem__ to Formatter

### DIFF
--- a/pygments/formatter.py
+++ b/pygments/formatter.py
@@ -122,3 +122,8 @@ class Formatter:
             # wrap the outfile in a StreamWriter
             outfile = codecs.lookup(self.encoding)[3](outfile)
         return self.format_unencoded(tokensource, outfile)
+
+    # Allow writing Formatter[str] or Formatter[bytes]. That's equivalent to
+    # Formatter. This helps when using third-party type stubs from typeshed.
+    def __class_getitem__(cls, name):
+        return cls


### PR DESCRIPTION
This is a simpler and less disruptive alternative to #2081.

The type stubs in typeshed distinguish between formatters that output strings and bytes. In type annotations, these are distinguished with `Formatter[str]` and `Formatter[bytes]`. For the most part, this works fine without any changes in pygments: users just tell Python to not evaluate type annotations at runtime (with `from __future__ import annotations`), and then a `Formatter[str]` type annotation won't cause an error even though subscripting the `Formatter` class wouldn't work.

But one special case happens when you try to subclass a `Formatter`. For that, you actually need to specify a class, not a type annotation. So users end up with:

```python
from typing import TYPE_CHECKING
from pygments.formatter import Formatter

if TYPE_CHECKING:
    StringFormatter = Formatter[str]
else:
    StringFormatter = Formatter

class MyFormatter(StringFormatter):
   ...
```

With this PR, this simplifies to:

```python
from pygments.formatter import Formatter

class MyFormatter(Formatter[str]):
   ...
```
