### PR TITLE
Remove an unnecessary apostrophe in this text

### DIFF
--- a/doc/docs/cmdline.rst
+++ b/doc/docs/cmdline.rst
@@ -183,7 +183,7 @@ will list only all installed filters.
 .. versionadded:: 2.11
 
 The ``--json`` option can be used in conjunction with the ``-L`` option to
-output it's contents as JSON. Thus, to print all the installed styles and their
+output its contents as JSON. Thus, to print all the installed styles and their
 description in JSON, use the command::
 
     $ pygmentize -L styles --json


### PR DESCRIPTION
This is possessive "its" which doesn't need an apostrophe; "it's" is a contraction of "it is" which doesn't make sense here.