### PR TITLE
Update SourcesListLexer, fix #2695

### DIFF
--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -234,25 +234,24 @@ class SourcesListLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'#.*?$', Comment),
             (r'^(deb(?:-src)?)(\s+)',
-             bygroups(Keyword, Whitespace), 'distribution')
+             bygroups(Keyword, Whitespace), 'uri')
         ],
-        'distribution': [
-            (r'#.*?$', Comment, '#pop'),
+        'uri': [
+            (r'(\[[^]]*\])(\s+)', bygroups(String.Other, Whitespace)),
             (r'\$\(ARCH\)', Name.Variable),
-            (r'[^\s$[]+', String),
-            (r'\[', String.Other, 'escaped-distribution'),
+            (r'[^\s$]+', String),
             (r'\$', String),
-            (r'\s+', Whitespace, 'components')
+            (r'\s+', Whitespace, 'suites')
         ],
-        'escaped-distribution': [
-            (r'\]', String.Other, '#pop'),
-            (r'\$\(ARCH\)', Name.Variable),
-            (r'[^\]$]+', String.Other),
-            (r'\$', String.Other)
-        ],
-        'components': [
+        'suites': [
             (r'#.*?$', Comment, '#pop:2'),
             (r'$', Text, '#pop:2'),
+            (r'\s+', Whitespace, 'components'),
+            (r'\S+', Keyword),
+        ],
+        'components': [
+            (r'#.*?$', Comment, '#pop:3'),
+            (r'$', Text, '#pop:3'),
             (r'\s+', Whitespace),
             (r'\S+', Keyword.Pseudo),
         ]


### PR DESCRIPTION
For valid inputs, this new set of states is working as intended.

Input:

```shell
deb http://deb.debian.org/debian bookworm main contrib
deb [arch=amd64 trusted=yes] http://deb.debian.org/debian bookworm main contrib
```

Output:

```shell
# Line 1
Token.Keyword   'deb'
Token.Text.Whitespace   ' '
Token.Literal.String    'http://deb.debian.org/debian'
Token.Text.Whitespace   ' '
Token.Keyword   'bookworm'
Token.Text.Whitespace   ' '
Token.Keyword.Pseudo    'main'
Token.Text.Whitespace   ' '
Token.Keyword.Pseudo    'contrib'
Token.Text      ''
Token.Text.Whitespace   '\n'

# Line 2
Token.Keyword   'deb'
Token.Text.Whitespace   ' '
Token.Literal.String.Other      '[arch=amd64 trusted=yes]'
Token.Text.Whitespace   ' '
Token.Literal.String    'http://deb.debian.org/debian'
Token.Text.Whitespace   ' '
Token.Keyword   'bookworm'
Token.Text.Whitespace   ' '
Token.Keyword.Pseudo    'main'
Token.Text.Whitespace   ' '
Token.Keyword.Pseudo    'contrib'
Token.Text      ''
Token.Text.Whitespace   '\n'

```