### PR TITLE
Fixed issue with single-line comments in TransactSqlLexer

### DIFF
--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -713,7 +713,7 @@ class TransactSqlLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Whitespace),
-            (r'--.*?$\n?', Comment.Single),
+            (r'--.*[$|\n]?', Comment.Single),
             (r'/\*', Comment.Multiline, 'multiline-comments'),
             (words(_tsql_builtins.OPERATORS), Operator),
             (words(_tsql_builtins.OPERATOR_WORDS, suffix=r'\b'), Operator.Word),

--- a/tests/examplefiles/tsql/tsql_example.sql.output
+++ b/tests/examplefiles/tsql/tsql_example.sql.output
@@ -1,25 +1,8 @@
-'-'           Operator
-'-'           Operator
-' '           Text.Whitespace
-'Example'     Name
-' '           Text.Whitespace
-'Transact'    Name
-'-'           Operator
-'SQL'         Keyword
-' '           Text.Whitespace
-'file'        Keyword
-'.'           Punctuation
-'\n\n'        Text.Whitespace
+'-- Example Transact-SQL file.\n' Comment.Single
 
-'-'           Operator
-'-'           Operator
-' '           Text.Whitespace
-'Single'      Name
-' '           Text.Whitespace
-'line'        Name
-' '           Text.Whitespace
-'comment'     Name
 '\n'          Text.Whitespace
+
+'-- Single line comment\n' Comment.Single
 
 '/*'          Comment.Multiline
 ' A comment \n ' Comment.Multiline
@@ -373,13 +356,7 @@
 ';'           Punctuation
 '\n\n'        Text.Whitespace
 
-'-'           Operator
-'-'           Operator
-' '           Text.Whitespace
-'Example'     Name
-' '           Text.Whitespace
-'transaction' Keyword
-'\n'          Text.Whitespace
+'-- Example transaction\n' Comment.Single
 
 'BEGIN'       Keyword
 ' '           Text.Whitespace

--- a/tests/snippets/tsql/test_single_line_comment.txt
+++ b/tests/snippets/tsql/test_single_line_comment.txt
@@ -1,0 +1,9 @@
+---input---
+-- this is a single line comment
+select
+
+---tokens---
+'-- this is a single line comment\n' Comment.Single
+
+'select'      Keyword
+'\n'          Text.Whitespace


### PR DESCRIPTION
This pull request fixes an issue with the regex for the `Comment.Single` token type in the `TransactSqlLexer` class.

In the current version of `pygments` (2.18.0), the existing regex causes single-line comments to be lexed incorrectly whenever they are immediately followed by a non-comment token on the next line. For example, consider the following code:
```python
from pygments.lexers.sql import TransactSqlLexer
for token_type, token_contents in list(
    TransactSqlLexer().get_tokens(
        """
        -- this is a single line comment
        select
        """
    )
):
    print(token_type, repr(token_contents))
```

When run, this results in the following stream of tokens: (Note that the comment is lexed as various other tokens)
```
Token.Text.Whitespace '        '
Token.Operator '-'
Token.Operator '-'
Token.Text.Whitespace ' '
Token.Name 'this'
Token.Text.Whitespace ' '
Token.Keyword 'is'
Token.Text.Whitespace ' '
Token.Name 'a'
Token.Text.Whitespace ' '
Token.Name 'single'
Token.Text.Whitespace ' '
Token.Name 'line'
Token.Text.Whitespace ' '
Token.Name 'comment'
Token.Text.Whitespace '\n        '
Token.Keyword 'select'
Token.Text.Whitespace '\n        \n'
```

Lexing with the modified regex for the token `Comment.Single` in this commit results in the following stream of tokens: (Note that the comment is now lexed correctly.)

```
Token.Text.Whitespace '        '
Token.Comment.Single '-- this is a single line comment\n'
Token.Text.Whitespace '        '
Token.Keyword 'select'
Token.Text.Whitespace '\n        \n'
```