### PR TITLE
add staticcall and extcall keywords for vyper

### DIFF
--- a/pygments/lexers/vyper.py
+++ b/pygments/lexers/vyper.py
@@ -61,7 +61,7 @@ class VyperLexer(RegexLexer):
             # Keywords
             (words(('def', 'event', 'pass', 'return', 'for', 'while', 'if', 'elif',
                     'else', 'assert', 'raise', 'import', 'in', 'struct', 'implements',
-                    'interface', 'from', 'indexed', 'log'),
+                    'interface', 'from', 'indexed', 'log', 'extcall', 'staticcall'),
                    prefix=r'\b', suffix=r'\b'), Keyword),
 
             # Visibility and State Mutability


### PR DESCRIPTION
`staticcall` and `extcall` were added in vyper 0.4.0, see https://github.com/vyperlang/vyper/commit/2d232eb32677f142e7f98bbe9b667497610b2378