### PR TITLE
Fixes issue #2710: description of the fix

### DIFF
--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -117,7 +117,7 @@ class CSharpLexer(RegexLexer):
                  r'unchecked|unsafe|virtual|void|while|'
                  r'get|set|new|partial|yield|add|remove|value|alias|ascending|'
                  r'descending|from|group|into|orderby|select|thenby|where|'
-                 r'join|equals)\b', Keyword),
+                 r'join|equals|file)\b', Keyword),   #2710 Add the keyword 'file' here
                 (r'(global)(::)', bygroups(Keyword, Punctuation)),
                 (r'(bool|byte|char|decimal|double|dynamic|float|int|long|object|'
                  r'sbyte|short|string|uint|ulong|ushort|var)\b\??', Keyword.Type),


### PR DESCRIPTION


**Before:**
![屏幕截图 2024-06-09 103112](https://github.com/pygments/pygments/assets/161684706/1d83fb1e-521f-4d51-8650-7a90b337e935)
**After:**
![后](https://github.com/pygments/pygments/assets/161684706/2315f738-a182-461c-99ad-718aae9795fb)


**Details changes：**
path: `pygments/lexers/dotnet.py`

```python
    for levelname, cs_ident in levels.items():
        tokens[levelname] = {
            'root': [
                # method names
                (r'^([ \t]*)((?:' + cs_ident + r'(?:\[\])?\s+)+?)'  # return type
                 r'(' + cs_ident + ')'                            # method name
                 r'(\s*)(\()',                               # signature start
                 bygroups(Whitespace, using(this), Name.Function, Whitespace,
                          Punctuation)),
                (r'^(\s*)(\[.*?\])', bygroups(Whitespace, Name.Attribute)),
                (r'[^\S\n]+', Whitespace),
                (r'(\\)(\n)', bygroups(Text, Whitespace)),  # line continuation
                (r'//.*?\n', Comment.Single),
                (r'/[*].*?[*]/', Comment.Multiline),
                (r'\n', Whitespace),
                (words((
                    '>>>=', '>>=', '<<=', '<=', '>=', '+=', '-=', '*=', '/=',
                    '%=', '&=', '|=', '^=', '??=', '=>', '??', '?.', '!=', '==',
                    '&&', '||', '>>>', '>>', '<<', '++', '--', '+', '-', '*',
                    '/', '%', '&', '|', '^', '<', '>', '?', '!', '~', '=',
                )), Operator),
                (r'=~|!=|==|<<|>>|[-+/*%=<>&^|]', Operator),
                (r'[()\[\];:,.]', Punctuation),
                (r'[{}]', Punctuation),
                (r'@"(""|[^"])*"', String),
                (r'\$?"(\\\\|\\[^\\]|[^"\\\n])*["\n]', String),
                (r"'\\.'|'[^\\]'", String.Char),
                (r"[0-9]+(\.[0-9]*)?([eE][+-][0-9]+)?"
                 r"[flFLdD]?|0[xX][0-9a-fA-F]+[Ll]?", Number),
                (r'(#)([ \t]*)(if|endif|else|elif|define|undef|'
                 r'line|error|warning|region|endregion|pragma)\b(.*?)(\n)',
                 bygroups(Comment.Preproc, Whitespace, Comment.Preproc,
                          Comment.Preproc, Whitespace)),
                (r'\b(extern)(\s+)(alias)\b', bygroups(Keyword, Whitespace,
                 Keyword)),
                (r'(abstract|as|async|await|base|break|by|case|catch|'
                 r'checked|const|continue|default|delegate|'
                 r'do|else|enum|event|explicit|extern|false|finally|'
                 r'fixed|for|foreach|goto|if|implicit|in|interface|'
                 r'internal|is|let|lock|new|null|on|operator|'
                 r'out|override|params|private|protected|public|readonly|'
                 r'ref|return|sealed|sizeof|stackalloc|static|'
                 r'switch|this|throw|true|try|typeof|'
                 r'unchecked|unsafe|virtual|void|while|'
                 r'get|set|new|partial|yield|add|remove|value|alias|ascending|'
                 r'descending|from|group|into|orderby|select|thenby|where|'
                 r'join|equals|file)\b', Keyword),   #2710 Add the keyword 'file' here
                (r'(global)(::)', bygroups(Keyword, Punctuation)),
                (r'(bool|byte|char|decimal|double|dynamic|float|int|long|object|'
                 r'sbyte|short|string|uint|ulong|ushort|var)\b\??', Keyword.Type),
                (r'(class|struct)(\s+)', bygroups(Keyword, Whitespace), 'class'),
                (r'(namespace|using)(\s+)', bygroups(Keyword, Whitespace), 'namespace'),
                (cs_ident, Name),
            ],
            'class': [
                (cs_ident, Name.Class, '#pop'),
                default('#pop'),
            ],
            'namespace': [
                (r'(?=\()', Text, '#pop'),  # using (resource)
                ('(' + cs_ident + r'|\.)+', Name.Namespace, '#pop'),
            ]
        }

```