### PR TITLE
Tcl lexer: \ and $ interpreted as errors fix, add string escape handling, adding test case (fixing issue #2686)

### DIFF
--- a/pygments/lexers/tcl.py
+++ b/pygments/lexers/tcl.py
@@ -61,7 +61,7 @@ class TclLexer(RegexLexer):
             include('command'),
             include('basic'),
             include('data'),
-            (r'\}', Keyword),  # HACK: somehow we miscounted our braces
+            # (r'\}', Keyword),  # HACK: somehow we miscounted our braces
         ],
         'command': _gen_command_rules(keyword_cmds_re, builtin_cmds_re),
         'command-in-brace': _gen_command_rules(keyword_cmds_re,
@@ -77,7 +77,7 @@ class TclLexer(RegexLexer):
             (r'\(', Keyword, 'paren'),
             (r'\[', Keyword, 'bracket'),
             (r'\{', Keyword, 'brace'),
-            (r'\\', Text), 
+            (r'\\(.)', String.Escape),
             (r'\$', Text),
             (r'"', String.Double, 'string'),
             (r'(eq|ne|in|ni)\b', Operator.Word),

--- a/pygments/lexers/tcl.py
+++ b/pygments/lexers/tcl.py
@@ -61,7 +61,7 @@ class TclLexer(RegexLexer):
             include('command'),
             include('basic'),
             include('data'),
-            # (r'\}', Keyword),  # HACK: somehow we miscounted our braces
+            (r'\}', Keyword),  # HACK: somehow we miscounted our braces
         ],
         'command': _gen_command_rules(keyword_cmds_re, builtin_cmds_re),
         'command-in-brace': _gen_command_rules(keyword_cmds_re,

--- a/pygments/lexers/tcl.py
+++ b/pygments/lexers/tcl.py
@@ -77,8 +77,12 @@ class TclLexer(RegexLexer):
             (r'\(', Keyword, 'paren'),
             (r'\[', Keyword, 'bracket'),
             (r'\{', Keyword, 'brace'),
-            (r'\\(.)', String.Escape),
-            (r'\$', Text),
+            (r'\\\s', String.Escape), #Handle \ at the end of line
+            (r'\$\s', Text), #Handle standalone $
+            (r'\\u[\da-fA-F]{1,4}', String.Escape),  # 16-bit Unicode escape sequences
+            (r'\\x[\da-fA-F]{1,2}', String.Escape),  # 8-bit Hexadecimal escape sequences
+            (r'\\[0-3]?[0-7]{1,2}', String.Escape),  # 8-bit Octal escape sequences
+            (r'\\.', String.Escape), 
             (r'"', String.Double, 'string'),
             (r'(eq|ne|in|ni)\b', Operator.Word),
             (r'!=|==|<<|>>|<=|>=|&&|\|\||\*\*|[-+~!*/%<>&^|?:]', Operator),

--- a/pygments/lexers/tcl.py
+++ b/pygments/lexers/tcl.py
@@ -77,6 +77,8 @@ class TclLexer(RegexLexer):
             (r'\(', Keyword, 'paren'),
             (r'\[', Keyword, 'bracket'),
             (r'\{', Keyword, 'brace'),
+            (r'\\', Text), 
+            (r'\$', Text),
             (r'"', String.Double, 'string'),
             (r'(eq|ne|in|ni)\b', Operator.Word),
             (r'!=|==|<<|>>|<=|>=|&&|\|\||\*\*|[-+~!*/%<>&^|?:]', Operator),

--- a/tests/snippets/tcl/test_string_escape.txt
+++ b/tests/snippets/tcl/test_string_escape.txt
@@ -1,0 +1,87 @@
+---input---
+set amount \$16.42
+
+puts lots\nof\n\n\n\n\n\nnewlines
+
+set somevar {
+    This is a literal $ sign, and this \} escaped
+    brace remains uninterpreted
+}
+
+puts \
+\164\x68\u1eed
+
+---tokens---
+'set'         Keyword
+' '           Text.Whitespace
+'amount'      Text
+' '           Text.Whitespace
+'\\$'         Literal.String.Escape
+'16.42'       Literal.Number.Float
+'\n'          Text
+
+'\n'          Text.Whitespace
+
+'puts'        Name.Builtin
+' '           Text.Whitespace
+'lots'        Text
+'\\n'         Literal.String.Escape
+'of'          Text
+'\\n'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'\\n'         Literal.String.Escape
+'newlines'    Text
+'\n'          Text
+
+'\n'          Text.Whitespace
+
+'set'         Keyword
+' '           Text.Whitespace
+'somevar'     Text
+' '           Text.Whitespace
+'{'           Keyword
+'\n    '      Text.Whitespace
+'This'        Name.Variable
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'literal'     Text
+' '           Text.Whitespace
+'$ '          Text
+'sign,'       Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'this'        Text
+' '           Text.Whitespace
+'\\}'         Literal.String.Escape
+' '           Text.Whitespace
+'escaped'     Text
+'\n'          Text
+
+'    '        Text.Whitespace
+'brace'       Name.Variable
+' '           Text.Whitespace
+'remains'     Text
+' '           Text.Whitespace
+'uninterpreted' Text
+'\n'          Text
+
+'}'           Keyword
+'\n'          Text
+
+'\n'          Text.Whitespace
+
+'puts'        Name.Builtin
+' '           Text.Whitespace
+'\\\n'        Literal.String.Escape
+
+'\\164'       Literal.String.Escape
+'\\x68'       Literal.String.Escape
+'\\u1eed'     Literal.String.Escape
+'\n'          Text


### PR DESCRIPTION
### Update posted in the comments!

Good day! I am proposing a fix for the issue https://github.com/pygments/pygments/issues/2686.

I have added some changes to the lexer so that it no longer considers backslashes as errors. The lexer will now consider `\` to be `String.Escape`. Standalone `$` will be considered as `Text`. 

**Details changes**
Path: pygments/lexers/tcl.py
![Change](https://github.com/pygments/pygments/assets/108263341/9544c18f-4452-4cbd-8d1e-98a4a3b393b8)

**Result:**
Before: 
![Before](https://github.com/pygments/pygments/assets/108263341/6406ca04-3553-4171-8b83-397693e60622)

After: 
![After](https://github.com/pygments/pygments/assets/108263341/82e2482c-9bcf-4305-a56a-293e22a56ab9)

Tokens: 
```
'set'         Keyword
' '           Text.Whitespace
'amount'      Text
' '           Text.Whitespace
'\\$'         Literal.String.Escape
'16.42'       Literal.Number.Float
'\n'          Text

'puts'        Name.Builtin
' '           Text.Whitespace
'lots'        Text
'\\n'         Literal.String.Escape
'of'          Text
'\\n'         Literal.String.Escape
'\\n'         Literal.String.Escape
'\\n'         Literal.String.Escape
'\\n'         Literal.String.Escape
'\\n'         Literal.String.Escape
'\\n'         Literal.String.Escape
'newlines'    Text
'\n'          Text

'set'         Keyword
' '           Text.Whitespace
'somevar'     Text
' '           Text.Whitespace
'{'           Keyword
'\n    '      Text.Whitespace
'This'        Name.Variable
' '           Text.Whitespace
'is'          Text
' '           Text.Whitespace
'a'           Text
' '           Text.Whitespace
'literal'     Text
' '           Text.Whitespace
'$ '          Text
'sign,'       Text
' '           Text.Whitespace
'and'         Text
' '           Text.Whitespace
'this'        Text
' '           Text.Whitespace
'\\}'         Literal.String.Escape
' '           Text.Whitespace
'escaped'     Text
'\n'          Text

'    '        Text.Whitespace
'brace'       Name.Variable
' '           Text.Whitespace
'remains'     Text
' '           Text.Whitespace
'uninterpreted' Text
'\n'          Text

'}'           Keyword
'\n'          Text
```

Please inform me if any alterations or modifications are necessary. I would greatly appreciate any feedback or comments!