### PR TITLE
Sloving issue #2293

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -2671,7 +2671,8 @@ class MatlabLexer(RegexLexer):
             include('expressions')
         ],
         'blockcomment': [
-            (r'^\s*%\}', Comment.Multiline, '#pop'),
+            (r'%\{\s*\n', Comment.Multiline, '#push'), # Enter a new blockcomment state
+            (r'%\}', Comment.Multiline, '#pop'),
             (r'^.*\n', Comment.Multiline),
             (r'.', Comment.Multiline),
         ],


### PR DESCRIPTION
The MATLAB lexer does not recognize nested multiline comments. The code provided in the issue description demonstrates that Highlight.js, the library used by GitHub, correctly handles nested comments.

This pull request modifies the MATLAB lexer to correctly handle nested multiline comments.

Changes Made:
Modified pygments/lexers/matlab.py
Changed the handling of block comments to use #push and #pop states for nested comments.
Added logic to enter a new block comment state on encountering the %{ marker and to return to the previous state on encountering the %} marker.

Justification:
When encountering the multi-line comment start marker %{, use #push to push the current state onto the stack and enter a new comment state. This allows handling nested multi-line comments. Use #pop to pop the current state from the stack and return to the previous state. This ensures that nested comments are correctly closed and the lexer returns to the appropriate state.