### PR TITLE
DebianControlLexer: Fix issues related to package relations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -252,6 +252,7 @@ Other contributors, listed alphabetically, are:
 * Matthias Vallentin -- Bro lexer
 * Benoît Vinot -- AMPL lexer
 * Linh Vu Hong -- RSL lexer
+* Taavi Väänänen -- Debian control lexer
 * Immanuel Washington -- Smithy lexer
 * Nathan Weizenbaum -- Haml and Sass lexers
 * Nathan Whetsell -- Csound lexers

--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -312,7 +312,7 @@ class DebianControlLexer(RegexLexer):
              bygroups(Operator, Text, Name.Entity, Text)),
             (r'\(', Text, 'depend_vers'),
             (r'\|', Operator),
-            (r',\n', Text),
+            (r'\n\s', Text),
             (r'\n', Text, '#pop'),
             (r'[,\s]', Text),
             (r'[+.a-zA-Z0-9-]+', Name.Function),

--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -281,9 +281,9 @@ class DebianControlLexer(RegexLexer):
             (r'^(Maintainer|Uploaders)(:\s*)', bygroups(Keyword, Text),
              'maintainer'),
             (r'^((?:Build-|Pre-)?Depends(?:-Indep|-Arch)?)(:\s*)',
-             bygroups(Keyword, Text), 'depends'),
-            (r'^(Recommends|Suggests|Enhances)(:\s*)', bygroups(Keyword, Text),
-             'depends'),
+             bygroups(Keyword, Text), 'package_list'),
+            (r'^(Recommends|Suggests|Enhances|Breaks|Replaces|Provides|Conflicts)(:\s*)',
+             bygroups(Keyword, Text), 'package_list'),
             (r'^((?:Python-)?Version)(:\s*)(\S+)$',
              bygroups(Keyword, Text, Number)),
             (r'^((?:Installed-)?Size)(:\s*)(\S+)$',
@@ -307,10 +307,10 @@ class DebianControlLexer(RegexLexer):
             (r' .*\n', Text),
             default('#pop'),
         ],
-        'depends': [
+        'package_list': [
             (r'(\$)(\{)(\w+\s*:\s*\w+)(\})',
              bygroups(Operator, Text, Name.Entity, Text)),
-            (r'\(', Text, 'depend_vers'),
+            (r'\(', Text, 'package_list_vers'),
             (r'\|', Operator),
             (r'\n\s', Text),
             (r'\n', Text, '#pop'),
@@ -318,7 +318,7 @@ class DebianControlLexer(RegexLexer):
             (r'[+.a-zA-Z0-9-]+', Name.Function),
             (r'\[.*?\]', Name.Entity),
         ],
-        'depend_vers': [
+        'package_list_vers': [
             (r'\)', Text, '#pop'),
             (r'([><=]+)(\s*)([^)]+)', bygroups(Operator, Text, Number)),
         ]

--- a/tests/examplefiles/control/control
+++ b/tests/examplefiles/control/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13),
  dh-python,
  otherbuilddependancies
 Build-Depends-Indep:
- p1 | p2
+ p1 | p2,
 Build-Depends-Arch:
  p1 | p2
 Rules-Requires-Root: no

--- a/tests/examplefiles/control/control
+++ b/tests/examplefiles/control/control
@@ -33,6 +33,9 @@ Suggests:
  p1 | p2
 Enhances:
  p1 | p2
+Conflicts: p1,
+ p2,
+ p3,
 Description: title for this package
  First paragraph describing the packaged software.
  .

--- a/tests/examplefiles/control/control.output
+++ b/tests/examplefiles/control/control.output
@@ -34,13 +34,11 @@
 ' '           Text
 '13'          Literal.Number
 ')'           Text
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 'dh-python'   Name.Function
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 'otherbuilddependancies' Name.Function
 '\n'          Text
 
@@ -51,6 +49,7 @@
 '|'           Operator
 ' '           Text
 'p2'          Name.Function
+','           Text
 '\n'          Text
 
 'Build-Depends-Arch' Keyword
@@ -111,21 +110,18 @@
 'Depends'     Keyword
 ':\n '        Text
 'python3-bar' Name.Function
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 'p1'          Name.Function
 ' '           Text
 '|'           Operator
 ' '           Text
 'p2'          Name.Function
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 'otherdependancies' Name.Function
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 '$'           Operator
 '{'           Text
 'python3:Depends' Name.Entity
@@ -144,9 +140,8 @@
 '|'           Operator
 ' '           Text
 'p2'          Name.Function
-',\n'         Text
-
-' '           Text
+','           Text
+'\n '         Text
 'other-recommends' Name.Function
 '\n'          Text
 

--- a/tests/examplefiles/control/control.output
+++ b/tests/examplefiles/control/control.output
@@ -129,9 +129,9 @@
 '\n'          Text
 
 'Provides'    Keyword
-': '          Text.Whitespace
-'x-terminal-emulator' Literal.String
-'\n'          Text.Whitespace
+': '          Text
+'x-terminal-emulator' Name.Function
+'\n'          Text
 
 'Recommends'  Keyword
 ':\n '        Text
@@ -161,6 +161,18 @@
 '|'           Operator
 ' '           Text
 'p2'          Name.Function
+'\n'          Text
+
+'Conflicts'   Keyword
+': '          Text
+'p1'          Name.Function
+','           Text
+'\n '         Text
+'p2'          Name.Function
+','           Text
+'\n '         Text
+'p3'          Name.Function
+','           Text
 '\n'          Text
 
 'Description' Keyword


### PR DESCRIPTION
This PR fixes an issue related to trailing commas on lists of related packages in Debian source package control files, and adds missing types of relations a Debian package can have. See individual commits for more details.