### PR TITLE
Improve SLexer

### DIFF
--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -88,6 +88,9 @@ class SLexer(RegexLexer):
         'valid_name': [
             (valid_name, Name),
         ],
+        'function_name': [
+            (rf'({valid_name})\s*(?=\()', Name.Function),
+        ],
         'punctuation': [
             (r'\[{1,2}|\]{1,2}|\(|\)|;|,', Punctuation),
         ],
@@ -121,15 +124,15 @@ class SLexer(RegexLexer):
             (r'\'', String, 'string_squote'),
             (r'\"', String, 'string_dquote'),
             include('builtin_symbols'),
+            include('keywords'),
+            include('function_name'),
             include('valid_name'),
             include('numbers'),
-            include('keywords'),
             include('punctuation'),
             include('operators'),
         ],
         'root': [
             # calls:
-            (rf'({valid_name})\s*(?=\()', Name.Function),
             include('statements'),
             # blocks:
             (r'\{|\}', Punctuation),

--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -100,7 +100,7 @@ class SLexer(RegexLexer):
              Keyword.Reserved),
         ],
         'operators': [
-            (r'<<?-|->>?|-|==|<=|>=|<|>|&&?|!=|\|\|?|\?', Operator),
+            (r'<<?-|->>?|-|==|<=|>=|\|>|<|>|&&?|!=|\|\|?|\?', Operator),
             (r'\*|\+|\^|/|!|%[^%]*%|=|~|\$|@|:{1,3}', Operator),
         ],
         'builtin_symbols': [

--- a/tests/examplefiles/rconsole/r-console-transcript.Rout.output
+++ b/tests/examplefiles/rconsole/r-console-transcript.Rout.output
@@ -43,7 +43,7 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name
+'function'    Keyword.Reserved
 ' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
@@ -56,7 +56,7 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name.Function
+'function'    Keyword.Reserved
 '('           Punctuation
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -69,7 +69,7 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name.Function
+'function'    Keyword.Reserved
 '('           Punctuation
 ')'           Punctuation
 ' '           Text.Whitespace

--- a/tests/examplefiles/splus/test.R
+++ b/tests/examplefiles/splus/test.R
@@ -137,6 +137,8 @@ foo <<- 2 + 2
 2 + 2 ->> foo
 base:::sum
 base::sum
+## Forward pipe operator (since R version 4.1)
+mtcars |> head()
 
 ## Strings
 foo <- "hello, world!"

--- a/tests/examplefiles/splus/test.R
+++ b/tests/examplefiles/splus/test.R
@@ -153,7 +153,7 @@ world!'
 ## Backtick strings
 `foo123 +!"bar'baz` <- 2 + 2
 
-## Builtin funcitons
+## Builtin functions
 file.create()
 gamma()
 grep()

--- a/tests/examplefiles/splus/test.R.output
+++ b/tests/examplefiles/splus/test.R.output
@@ -262,7 +262,7 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name.Function
+'function'    Keyword.Reserved
 '('           Punctuation
 'x'           Name
 ','           Punctuation
@@ -290,7 +290,8 @@
 '## if, else' Comment.Single
 '\n'          Text.Whitespace
 
-'if '         Name.Function
+'if'          Keyword.Reserved
+' '           Text.Whitespace
 '('           Punctuation
 'TRUE'        Keyword.Constant
 ')'           Punctuation
@@ -301,7 +302,7 @@
 'foo"'        Literal.String
 ')'           Punctuation
 ' '           Text.Whitespace
-'else'        Name
+'else'        Keyword.Reserved
 ' '           Text.Whitespace
 'print'       Name.Function
 '('           Punctuation
@@ -313,11 +314,11 @@
 '## For, in'  Comment.Single
 '\n'          Text.Whitespace
 
-'for'         Name.Function
+'for'         Keyword.Reserved
 '('           Punctuation
 'i'           Name
 ' '           Text.Whitespace
-'in'          Name
+'in'          Keyword.Reserved
 ' '           Text.Whitespace
 '1'           Literal.Number
 ':'           Operator
@@ -345,7 +346,8 @@
 '1'           Literal.Number
 '\n'          Text.Whitespace
 
-'while '      Name.Function
+'while'       Keyword.Reserved
+' '           Text.Whitespace
 '('           Punctuation
 'TRUE'        Keyword.Constant
 ')'           Punctuation
@@ -362,7 +364,8 @@
 ' '           Text.Whitespace
 '1'           Literal.Number
 '\n    '      Text.Whitespace
-'if '         Name.Function
+'if'          Keyword.Reserved
+' '           Text.Whitespace
 '('           Punctuation
 'i'           Name
 ' '           Text.Whitespace
@@ -371,7 +374,7 @@
 '3'           Literal.Number
 ')'           Punctuation
 ' '           Text.Whitespace
-'break'       Name
+'break'       Keyword.Reserved
 '\n'          Text.Whitespace
 
 '}'           Punctuation
@@ -380,7 +383,7 @@
 '## Repeat'   Comment.Single
 '\n'          Text.Whitespace
 
-'repeat'      Name
+'repeat'      Keyword.Reserved
 ' '           Text.Whitespace
 '{'           Punctuation
 '1'           Literal.Number
@@ -398,7 +401,7 @@
 '3'           Literal.Number
 '\n'          Text.Whitespace
 
-'switch'      Name.Function
+'switch'      Keyword.Reserved
 '('           Punctuation
 'x'           Name
 ','           Punctuation
@@ -429,14 +432,14 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name.Function
+'function'    Keyword.Reserved
 '('           Punctuation
 '...'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n    '      Text.Whitespace
-'return'      Name.Function
+'return'      Keyword.Reserved
 '('           Punctuation
 'sum'         Name.Function
 '('           Punctuation
@@ -510,7 +513,7 @@
 ' '           Text.Whitespace
 '<-'          Operator
 ' '           Text.Whitespace
-'function'    Name.Function
+'function'    Keyword.Reserved
 '('           Punctuation
 'a'           Name
 ')'           Punctuation
@@ -868,7 +871,7 @@
 '2'           Literal.Number
 '\n\n'        Text.Whitespace
 
-'## Builtin funcitons' Comment.Single
+'## Builtin functions' Comment.Single
 '\n'          Text.Whitespace
 
 'file.create' Name.Function

--- a/tests/examplefiles/splus/test.R.output
+++ b/tests/examplefiles/splus/test.R.output
@@ -788,6 +788,18 @@
 'base'        Name
 '::'          Operator
 'sum'         Name
+'\n'          Text.Whitespace
+
+'## Forward pipe operator (since R version 4.1)' Comment.Single
+'\n'          Text.Whitespace
+
+'mtcars'      Name
+' '           Text.Whitespace
+'|>'          Operator
+' '           Text.Whitespace
+'head'        Name.Function
+'('           Punctuation
+')'           Punctuation
 '\n\n'        Text.Whitespace
 
 '## Strings'  Comment.Single


### PR DESCRIPTION
This fixes the issue with keywords never being highlighted as such, because they were recognized as (regular) functions. See #2082.

Also adds the "new" forward pipe operator ('|>') which was introduced in R version 4.1