### PR TITLE
Add a TableGen lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Other contributors, listed alphabetically, are:
 * Ian Cooper -- VGL lexer
 * David Corbett -- Inform, Jasmin, JSGF, Snowball, and TADS 3 lexers
 * Leaf Corcoran -- MoonScript lexer
+* Fraser Cormack -- TableGen lexer
 * Gabriel Corona -- ASN.1 lexer
 * Christopher Creutzig -- MuPAD lexer
 * Daniël W. Crompton -- Pike lexer

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -501,6 +501,7 @@ LEXERS = {
     'TAPLexer': ('pygments.lexers.testing', 'TAP', ('tap',), ('*.tap',), ()),
     'TNTLexer': ('pygments.lexers.tnt', 'Typographic Number Theory', ('tnt',), ('*.tnt',), ()),
     'TOMLLexer': ('pygments.lexers.configs', 'TOML', ('toml',), ('*.toml', 'Pipfile', 'poetry.lock'), ('application/toml',)),
+    'TableGenLexer': ('pygments.lexers.tablegen', 'TableGen', ('tablegen', 'td'), ('*.td',), ()),
     'TactLexer': ('pygments.lexers.tact', 'Tact', ('tact',), ('*.tact',), ()),
     'Tads3Lexer': ('pygments.lexers.int_fiction', 'TADS 3', ('tads3',), ('*.t',), ()),
     'TalLexer': ('pygments.lexers.tal', 'Tal', ('tal', 'uxntal'), ('*.tal',), ('text/x-uxntal',)),

--- a/pygments/lexers/tablegen.py
+++ b/pygments/lexers/tablegen.py
@@ -1,3 +1,13 @@
+"""
+    pygments.lexers.tablegen
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for LLVM's TableGen DSL.
+
+    :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
 from pygments.lexer import RegexLexer, include, words, using
 from pygments.lexers.c_cpp import CppLexer
 from pygments.token import Comment, Keyword, Name, Number, Operator, \

--- a/pygments/lexers/tablegen.py
+++ b/pygments/lexers/tablegen.py
@@ -2,7 +2,7 @@
     pygments.lexers.tablegen
     ~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Lexers for LLVM's TableGen DSL.
+    Lexer for LLVM's TableGen DSL.
 
     :copyright: Copyright 2006-2024 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.

--- a/pygments/lexers/tablegen.py
+++ b/pygments/lexers/tablegen.py
@@ -1,0 +1,169 @@
+import re
+
+from pygments.lexer import RegexLexer, include, words, using
+from pygments.lexers.c_cpp import CppLexer
+from pygments.token import Comment, Keyword, Name, Number, Operator, \
+    Punctuation, String, Text, Whitespace, Error
+
+__all__ = ['TableGenLexer']
+
+KEYWORDS = (
+    'assert',
+    'class',
+    'code',
+    'def',
+    'dump',
+    'else',
+    'foreach',
+    'defm',
+    'defset',
+    'defvar',
+    'field',
+    'if',
+    'in',
+    'include',
+    'let',
+    'multiclass',
+    'then',
+)
+
+KEYWORDS_CONST = (
+    'false',
+    'true',
+)
+KEYWORDS_TYPE = (
+    'bit',
+    'bits',
+    'dag',
+    'int',
+    'list',
+    'string',
+)
+
+BANG_OPERATORS = (
+    'add',
+    'and',
+    'cast',
+    'con',
+    'cond',
+    'dag',
+    'div',
+    'empty',
+    'eq',
+    'exists',
+    'filter',
+    'find',
+    'foldl',
+    'foreach',
+    'ge',
+    'getdagarg',
+    'getdagname',
+    'getdagop',
+    'gt',
+    'head',
+    'if',
+    'interleave',
+    'isa',
+    'le',
+    'listconcat',
+    'listremove',
+    'listsplat',
+    'logtwo',
+    'lt',
+    'mul',
+    'ne',
+    'not',
+    'or',
+    'range',
+    'repr',
+    'setdagarg',
+    'setdagname',
+    'setdagop',
+    'shl',
+    'size',
+    'sra',
+    'srl',
+    'strconcat',
+    'sub',
+    'subst',
+    'substr',
+    'tail',
+    'tolower',
+    'toupper',
+    'xor',
+)
+
+class TableGenLexer(RegexLexer):
+    """
+    Lexer for TableGen
+    """
+
+    name = 'TableGen'
+    url = 'https://llvm.org/docs/TableGen/ProgRef.html'
+    aliases = ['tablegen', 'td']
+    filenames = ['*.td']
+
+    version_added = '2.19'
+
+    tokens = {
+        'root': [
+            (r'\s+', Whitespace),
+
+            (r'/\*', Comment.Multiline, 'comment'),
+            (r'//.*?$', Comment.SingleLine),
+            (r'#(define|ifdef|ifndef|else|endif)', Comment.Preproc),
+
+            # Binary/hex numbers. Note that these take priority over names,
+            # which may begin with numbers.
+            (r'0b[10]+', Number.Bin),
+            (r'0x[0-9a-fA-F]+', Number.Hex),
+
+            # Keywords
+            (words(KEYWORDS, suffix=r'\b'), Keyword),
+            (words(KEYWORDS_CONST, suffix=r'\b'), Keyword.Constant),
+            (words(KEYWORDS_TYPE, suffix=r'\b'), Keyword.Type),
+
+            # Bang operators
+            (words(BANG_OPERATORS, prefix=r'\!', suffix=r'\b'), Operator),
+            # Unknown bang operators are an error
+            (r'![a-zA-Z]+', Error),
+
+            # Names and identifiers
+            (r'[0-9]*[a-zA-Z_][a-zA-Z_0-9]*', Name),
+            (r'\$[a-zA-Z_][a-zA-Z_0-9]*', Name.Variable),
+
+            # Place numbers after keywords. Names/identifiers may begin with
+            # numbers, and we want to parse 1X as one name token as opposed to
+            # a number and a name.
+            (r'[-\+]?[0-9]+', Number.Integer),
+
+            # String literals
+            (r'"', String, 'dqs'),
+            (r'\[\{', Text, 'codeblock'),
+
+            # Misc. punctuation
+            (r'[-+\[\]{}()<>\.,;:=?#]', Punctuation),
+        ],
+        'comment': [
+            (r'[^*/]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline)
+        ],
+        'strings': [
+            (r'\\[\\\'"tn]', String.Escape),
+            (r'[^\\"]+', String),
+        ],
+        # Double-quoted string, a la C
+        'dqs': [
+            (r'"', String, '#pop'),
+            include('strings'),
+        ],
+        # No escaping inside a code block - everything is literal
+        # Assume that the code inside a code block is C++. This isn't always
+        # true in TableGen, but is the far most common scenario.
+        'codeblock': [
+            (r'\}\]', Text, '#pop'),
+            (r'([^}]+|}[^]])*', using(CppLexer)),
+        ],
+    }

--- a/pygments/lexers/tablegen.py
+++ b/pygments/lexers/tablegen.py
@@ -1,5 +1,3 @@
-import re
-
 from pygments.lexer import RegexLexer, include, words, using
 from pygments.lexers.c_cpp import CppLexer
 from pygments.token import Comment, Keyword, Name, Number, Operator, \
@@ -164,6 +162,6 @@ class TableGenLexer(RegexLexer):
         # true in TableGen, but is the far most common scenario.
         'codeblock': [
             (r'\}\]', Text, '#pop'),
-            (r'([^}]+|}[^]])*', using(CppLexer)),
+            (r'([^}]+|\}[^]])*', using(CppLexer)),
         ],
     }

--- a/tests/snippets/tablegen/test_bang_operators.txt
+++ b/tests/snippets/tablegen/test_bang_operators.txt
@@ -1,0 +1,19 @@
+---input---
+!add(), !eq(!cond()), !unknown
+
+---tokens---
+'!add'        Operator
+'('           Punctuation
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'!eq'         Operator
+'('           Punctuation
+'!cond'       Operator
+'('           Punctuation
+')'           Punctuation
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'!unknown'    Error
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_code_blocks.txt
+++ b/tests/snippets/tablegen/test_code_blocks.txt
@@ -1,0 +1,34 @@
+---input---
+let c = [{
+  return I && A != 0;
+}]
+
+---tokens---
+'let'         Keyword
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'[{'          Text
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'I'           Name
+' '           Text.Whitespace
+'&'           Operator
+'&'           Operator
+' '           Text.Whitespace
+'A'           Name
+' '           Text.Whitespace
+'!'           Operator
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}]'          Text
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_identifiers.txt
+++ b/tests/snippets/tablegen/test_identifiers.txt
@@ -1,0 +1,20 @@
+---input---
+0x00 0xab 0abc 1abc abc9_9 $a $a_b $_A0Z
+
+---tokens---
+'0x00'        Literal.Number.Hex
+' '           Text.Whitespace
+'0xab'        Literal.Number.Hex
+' '           Text.Whitespace
+'0abc'        Name
+' '           Text.Whitespace
+'1abc'        Name
+' '           Text.Whitespace
+'abc9_9'      Name
+' '           Text.Whitespace
+'$a'          Name.Variable
+' '           Text.Whitespace
+'$a_b'        Name.Variable
+' '           Text.Whitespace
+'$_A0Z'       Name.Variable
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_keywords.txt
+++ b/tests/snippets/tablegen/test_keywords.txt
@@ -1,0 +1,57 @@
+---input---
+assert bit bits class code dag def dump else false foreach defm defset defvar field if in include int let list multiclass string then true truex
+
+
+---tokens---
+'assert'      Keyword
+' '           Text.Whitespace
+'bit'         Keyword.Type
+' '           Text.Whitespace
+'bits'        Keyword.Type
+' '           Text.Whitespace
+'class'       Keyword
+' '           Text.Whitespace
+'code'        Keyword
+' '           Text.Whitespace
+'dag'         Keyword.Type
+' '           Text.Whitespace
+'def'         Keyword
+' '           Text.Whitespace
+'dump'        Keyword
+' '           Text.Whitespace
+'else'        Keyword
+' '           Text.Whitespace
+'false'       Keyword.Constant
+' '           Text.Whitespace
+'foreach'     Keyword
+' '           Text.Whitespace
+'defm'        Keyword
+' '           Text.Whitespace
+'defset'      Keyword
+' '           Text.Whitespace
+'defvar'      Keyword
+' '           Text.Whitespace
+'field'       Keyword
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'in'          Keyword
+' '           Text.Whitespace
+'include'     Keyword
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'let'         Keyword
+' '           Text.Whitespace
+'list'        Keyword.Type
+' '           Text.Whitespace
+'multiclass'  Keyword
+' '           Text.Whitespace
+'string'      Keyword.Type
+' '           Text.Whitespace
+'then'        Keyword
+' '           Text.Whitespace
+'true'        Keyword.Constant
+' '           Text.Whitespace
+'truex'       Name
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_numeric_literals.txt
+++ b/tests/snippets/tablegen/test_numeric_literals.txt
@@ -1,0 +1,26 @@
+---input---
+42 -1 +2 0123 0x0 0xA 0xb 0xaB1 0b0 0b1 0b1010
+
+---tokens---
+'42'          Literal.Number.Integer
+' '           Text.Whitespace
+'-1'          Literal.Number.Integer
+' '           Text.Whitespace
+'+2'          Literal.Number.Integer
+' '           Text.Whitespace
+'0123'        Literal.Number.Integer
+' '           Text.Whitespace
+'0x0'         Literal.Number.Hex
+' '           Text.Whitespace
+'0xA'         Literal.Number.Hex
+' '           Text.Whitespace
+'0xb'         Literal.Number.Hex
+' '           Text.Whitespace
+'0xaB1'       Literal.Number.Hex
+' '           Text.Whitespace
+'0b0'         Literal.Number.Bin
+' '           Text.Whitespace
+'0b1'         Literal.Number.Bin
+' '           Text.Whitespace
+'0b1010'      Literal.Number.Bin
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_punctuation.txt
+++ b/tests/snippets/tablegen/test_punctuation.txt
@@ -1,0 +1,22 @@
+---input---
+. .. ... () {} []
+
+---tokens---
+'.'           Punctuation
+' '           Text.Whitespace
+'.'           Punctuation
+'.'           Punctuation
+' '           Text.Whitespace
+'.'           Punctuation
+'.'           Punctuation
+'.'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+']'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/tablegen/test_strings.txt
+++ b/tests/snippets/tablegen/test_strings.txt
@@ -1,0 +1,53 @@
+---input---
+string woof = "woof";
+string escaped = "a \"woof\" and \'woof\',a \\, and a \tand not a \b...\n";
+let s = "
+
+---tokens---
+'string'      Keyword.Type
+' '           Text.Whitespace
+'woof'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'woof'        Literal.String
+'"'           Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'string'      Keyword.Type
+' '           Text.Whitespace
+'escaped'     Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'a '          Literal.String
+'\\"'         Literal.String.Escape
+'woof'        Literal.String
+'\\"'         Literal.String.Escape
+' and '       Literal.String
+"\\'"         Literal.String.Escape
+'woof'        Literal.String
+"\\'"         Literal.String.Escape
+',a '         Literal.String
+'\\\\'        Literal.String.Escape
+', and a '    Literal.String
+'\\t'         Literal.String.Escape
+'and not a '  Literal.String
+'\\'          Error
+'b...'        Literal.String
+'\\n'         Literal.String.Escape
+'"'           Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'let'         Keyword
+' '           Text.Whitespace
+'s'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'\n'          Literal.String


### PR DESCRIPTION
This commit adds a basic lexer for LLVM's TableGen DSL[1][2].

The major design decision is about how to tokenize "code blocks" since those are, at a TableGen language level, string literals. In practice, however, in LLVM 99% of the time they are snippets of C++ which are processed by a TableGen backend. This would ideally be a configurable property of the lexer. For the initial implementation, it is assumed that code blocks contain C++ code and so the CppLexer is invoked on their contents.

[1] https://llvm.org/docs/TableGen/index.html
[2] https://llvm.org/docs/TableGen/ProgRef.html