### PR TITLE
Use better multiline comment for Java

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -43,7 +43,7 @@ class JavaLexer(RegexLexer):
              bygroups(Whitespace, using(this), Keyword.Declaration), 'class'),
             (r'[^\S\n]+', Whitespace),
             (r'(//.*?)(\n)', bygroups(Comment.Single, Whitespace)),
-            (r'/\*.*?\*/', Comment.Multiline),
+            (r'/*(.|\n)*\*/', Comment.Multiline),
             # keywords: go before method names to avoid lexing "throw new XYZ"
             # as a method signature
             (r'(assert|break|case|catch|continue|default|do|else|finally|for|'


### PR DESCRIPTION
The old one didn't match with the following code:

```python
from re import MULTILINE, Match, compile
code: str = """/**
 * Code Multiline Comment
 */"""
match: Match[str] | None = compile(r'/\\*.*?\\*/', flags=MULTILINE).search(code)
print(match)
```