### PR TITLE
Add 'Change-By' field to Debian control lexer

### DIFF
--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -278,7 +278,7 @@ class DebianControlLexer(RegexLexer):
     tokens = {
         'root': [
             (r'^(Description)', Keyword, 'description'),
-            (r'^(Maintainer|Uploaders)(:)(\s*)',
+            (r'^(Maintainer|Uploaders|Changed-By)(:)(\s*)',
              bygroups(Keyword, Punctuation, Whitespace),
              'maintainer'),
             (r'^((?:Build-|Pre-)?Depends(?:-Indep|-Arch)?)(:)(\s*)',

--- a/tests/examplefiles/control/control
+++ b/tests/examplefiles/control/control
@@ -3,6 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Debian Python Team <team+python@domain.tld>
 Uploaders: Alice <alice@domain.tld>
+Changed-By: Bob <bob@domain.test>
 Build-Depends: debhelper-compat (= 13),
  dh-python,
  otherbuilddependancies

--- a/tests/examplefiles/control/control.output
+++ b/tests/examplefiles/control/control.output
@@ -30,6 +30,13 @@
 '<alice@domain.tld>' Generic.Strong
 '\n'          Text.Whitespace
 
+'Changed-By'  Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'Bob '        Text
+'<bob@domain.test>' Generic.Strong
+'\n'          Text.Whitespace
+
 'Build-Depends' Keyword
 ':'           Punctuation
 ' '           Text.Whitespace


### PR DESCRIPTION
The content of the 'Change-by' field has the 'Maintainer' field format: https://www.debian.org/doc/debian-policy/ch-controlfields.html#changed-by
so it should use it instead of the default parsing.

I added a test with a fake e-mail address ending with '.test' as top level domain instead of '.tld' previously because someone learn me the existence of the [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) (Reserved Top Level DNS Names). I can modify the other occurrences in the file but I'm sure it's really useful. What do you think on this point?