### PR TITLE
Fix regex for triple quoted strings in Turtle lexers

### DIFF
--- a/pygments/lexers/rdf.py
+++ b/pygments/lexers/rdf.py
@@ -280,7 +280,7 @@ class TurtleLexer(RegexLexer):
         ],
         'triple-double-quoted-string': [
             (r'"""', String, 'end-of-string'),
-            (r'[^\\]+', String),
+            (r'[^\\]+(?=""")', String),
             (r'\\', String, 'string-escape'),
         ],
         'single-double-quoted-string': [
@@ -290,7 +290,7 @@ class TurtleLexer(RegexLexer):
         ],
         'triple-single-quoted-string': [
             (r"'''", String, 'end-of-string'),
-            (r'[^\\]+', String),
+            (r"[^\\]+(?=''')", String),
             (r'\\', String, 'string-escape'),
         ],
         'single-single-quoted-string': [

--- a/tests/examplefiles/turtle/example.ttl
+++ b/tests/examplefiles/turtle/example.ttl
@@ -11,6 +11,11 @@ _:BlankNode1 a _:BlankNode2 .
 
 <#doc1> a <#document>;
 	dc:creator "Smith", "Jones"; 
+    dcterms:description """Test stuff
+single line""";
+    dcterms:identifier '''Single
+Quoted [multiline] string
+'''@fr;
 	:knows <http://getopenid.com/jsmith>;
 	dcterms:hasPart [ # A comment
 		dc:title "Some title", "Some other title";

--- a/tests/examplefiles/turtle/example.ttl.output
+++ b/tests/examplefiles/turtle/example.ttl.output
@@ -101,7 +101,28 @@
 'Jones'       Literal.String
 '"'           Literal.String
 ';'           Punctuation
-' \n\t'       Text
+' \n    '     Text
+'dcterms'     Name.Namespace
+':'           Punctuation
+'description' Name.Tag
+' '           Text
+'"""'         Literal.String
+'Test stuff\nsingle line' Literal.String
+'"""'         Literal.String
+';'           Punctuation
+'\n    '      Text
+'dcterms'     Name.Namespace
+':'           Punctuation
+'identifier'  Name.Tag
+' '           Text
+"'''"         Literal.String
+'Single\nQuoted [multiline] string\n' Literal.String
+
+"'''"         Literal.String
+'@'           Operator
+'fr'          Generic.Emph
+';'           Punctuation
+'\n\t'        Text
 ':'           Punctuation
 'knows'       Name.Tag
 ' '           Text


### PR DESCRIPTION
The test cases for the turtle lexer did not include triple quoted strings (neither single nor double). The regex used to match the string contents matched every single character except escape characters, but crucially it also matched the triple quotes used to delineate the termination of such a string. The updated regex specifically excludes these characters.

Fixes #2744

Note: the same issue might also occur in the SPARQL lexer. However, I never really use SPARQL so I cannot verify if the same logic would apply.

This is my first contribution to Pygments, forgive me for any mistakes I made. I confirm I agree, am willing and am able to put my contributions under the BSD 2-clause license.

Before:
![afbeelding](https://github.com/user-attachments/assets/4aad0d9a-0f4d-426b-a34c-d62c640279b2)

After:
![afbeelding](https://github.com/user-attachments/assets/e14df088-2ffc-4056-b321-fa4d0d8626e7)
