### PR TITLE
Add support for tsx to jsx lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -251,7 +251,7 @@ LEXERS = {
     'JsonLexer': ('pygments.lexers.data', 'JSON', ('json', 'json-object'), ('*.json', '*.jsonl', '*.ndjson', 'Pipfile.lock'), ('application/json', 'application/json-object', 'application/x-ndjson', 'application/jsonl', 'application/json-seq')),
     'JsonnetLexer': ('pygments.lexers.jsonnet', 'Jsonnet', ('jsonnet',), ('*.jsonnet', '*.libsonnet'), ()),
     'JspLexer': ('pygments.lexers.templates', 'Java Server Page', ('jsp',), ('*.jsp',), ('application/x-jsp',)),
-    'JsxLexer': ('pygments.lexers.jsx', 'JSX', ('jsx', 'react'), ('*.jsx', '*.react'), ('text/jsx', 'text/typescript-jsx')),
+    'JsxLexer': ('pygments.lexers.jsx', 'JSX', ('jsx', 'react', 'tsx'), ('*.jsx', '*.react', '*.tsx'), ('text/jsx', 'text/typescript-jsx', 'text/tsx')),
     'JuliaConsoleLexer': ('pygments.lexers.julia', 'Julia console', ('jlcon', 'julia-repl'), (), ()),
     'JuliaLexer': ('pygments.lexers.julia', 'Julia', ('julia', 'jl'), ('*.jl',), ('text/x-julia', 'application/x-julia')),
     'JuttleLexer': ('pygments.lexers.javascript', 'Juttle', ('juttle',), ('*.juttle',), ('application/juttle', 'application/x-juttle', 'text/x-juttle', 'text/juttle')),

--- a/pygments/lexers/jsx.py
+++ b/pygments/lexers/jsx.py
@@ -23,9 +23,9 @@ class JsxLexer(JavascriptLexer):
     """
 
     name = "JSX"
-    aliases = ["jsx", "react"]
-    filenames = ["*.jsx", "*.react"]
-    mimetypes = ["text/jsx", "text/typescript-jsx"]
+    aliases = ["jsx", "react", "tsx"]
+    filenames = ["*.jsx", "*.react", "*.tsx"]
+    mimetypes = ["text/jsx", "text/typescript-jsx", "text/tsx"]
     url = "https://facebook.github.io/jsx/"
     version_added = '2.17'
 


### PR DESCRIPTION
I noticed that my `.tsx` files are not supported by Pygments currently. Adding the file type to the `jsx` lexer works well, at least for my purposes!

<img width="813" alt="image" src="https://github.com/user-attachments/assets/1ec84578-7321-4cfb-b713-99fd056c5e08">

ran `tox` and everything seems to pass okay!

Should address #1815