### PR TITLE
Fix quoted string containing comment character

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -44,6 +44,9 @@ class IniLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'[;#].*', Comment.Single),
             (r'(\[.*?\])([ \t]*)$', bygroups(Keyword, Whitespace)),
+            (r'''(.*?)([  \t]*)([=:])([ \t]*)(["'])''',
+             bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String),
+             "quoted_value"),
             (r'(.*?)([  \t]*)([=:])([ \t]*)([^;#\n]*)(\\)(\s+)',
              bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String,
                       Text, Whitespace),
@@ -52,6 +55,12 @@ class IniLexer(RegexLexer):
              bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String)),
             # standalone option, supported by some INI parsers
             (r'(.+?)$', Name.Attribute),
+        ],
+        'quoted_value': [
+            (r'''([^"'\n]*)(["'])(\s*)''',
+             bygroups(String, String, Whitespace)),
+            (r'[;#].*', Comment.Single),
+            (r'$', String, "#pop"),
         ],
         'value': [     # line continuation
             (r'\s+', Whitespace),

--- a/tests/snippets/ini/test_quoted_entries.txt
+++ b/tests/snippets/ini/test_quoted_entries.txt
@@ -1,0 +1,36 @@
+---input---
+[section]
+    key 1 = "value1"
+    key 2 = "value2" # comment
+    key 3 = "value3 ; value 3bis" ; comment
+
+---tokens---
+'[section]'   Keyword
+'\n    '      Text.Whitespace
+'key 1'       Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'value1'      Literal.String
+'"'           Literal.String
+'\n    '      Text.Whitespace
+'key 2 = '    Literal.String
+'"'           Literal.String
+'value2'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'# comment'   Comment.Single
+''            Literal.String
+'\n    '      Text.Whitespace
+'key 3'       Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'value3 ; value 3bis' Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'; comment'   Comment.Single
+''            Literal.String
+'\n'          Text.Whitespace


### PR DESCRIPTION
The comment character ('#' or ';') included in a quoted value does not be interpreted as beginning of comment but as a character of the quoted value.

This PR fixes #2720.