### PR TITLE
Update expired domains link

### DIFF
--- a/pygments/lexers/ooc.py
+++ b/pygments/lexers/ooc.py
@@ -20,7 +20,7 @@ class OocLexer(RegexLexer):
     For Ooc source code
     """
     name = 'Ooc'
-    url = 'http://ooc-lang.org/'
+    url = 'https://ooc-lang.github.io/'
     aliases = ['ooc']
     filenames = ['*.ooc']
     mimetypes = ['text/x-ooc']
@@ -42,7 +42,7 @@ class OocLexer(RegexLexer):
             (r'(func)((?:[ \t]|\\\n)+)(~[a-z_]\w*)',
              bygroups(Keyword, Text, Name.Function)),
             (r'\bfunc\b', Keyword),
-            # Note: %= and ^= not listed on http://ooc-lang.org/syntax
+            # Note: %= not listed on https://ooc-lang.github.io/docs/lang/operators/
             (r'//.*', Comment),
             (r'(?s)/\*.*?\*/', Comment.Multiline),
             (r'(==?|\+=?|-[=>]?|\*=?|/=?|:=|!=?|%=?|\?|>{1,3}=?|<{1,3}=?|\.\.|'


### PR DESCRIPTION
ooc-lang.org - outdated link now links to unwanted websites (online casino).
ooc-lang.org -> ooc-lang.github.io