### PR TITLE
Agda: add `opaque` and `unfolding` keywords

### DIFF
--- a/pygments/lexers/haskell.py
+++ b/pygments/lexers/haskell.py
@@ -302,9 +302,9 @@ class AgdaLexer(RegexLexer):
         'abstract', 'codata', 'coinductive', 'constructor', 'data', 'do',
         'eta-equality', 'field', 'forall', 'hiding', 'in', 'inductive', 'infix',
         'infixl', 'infixr', 'instance', 'interleaved', 'let', 'macro', 'mutual',
-        'no-eta-equality', 'open', 'overlap', 'pattern', 'postulate', 'primitive',
+        'no-eta-equality', 'opaque', 'open', 'overlap', 'pattern', 'postulate', 'primitive',
         'private', 'quote', 'quoteTerm', 'record', 'renaming', 'rewrite',
-        'syntax', 'tactic', 'unquote', 'unquoteDecl', 'unquoteDef', 'using',
+        'syntax', 'tactic', 'unfolding', 'unquote', 'unquoteDecl', 'unquoteDef', 'using',
         'variable', 'where', 'with',
     )
 


### PR DESCRIPTION
The keywords were added in Agda 2.6.4, see https://agda.readthedocs.io/en/v2.6.4/language/opaque-definitions.html

The current list of keywords is at https://github.com/agda/agda/blob/84b0c60b418476d63d5287a5751da43ceab33735/src/full/Agda/Syntax/Parser/Lexer.x#L159-L200