### PR TITLE
JShell lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -236,6 +236,7 @@ LEXERS = {
     'JagsLexer': ('pygments.lexers.modeling', 'JAGS', ('jags',), ('*.jag', '*.bug'), ()),
     'JanetLexer': ('pygments.lexers.lisp', 'Janet', ('janet',), ('*.janet', '*.jdn'), ('text/x-janet', 'application/x-janet')),
     'JasminLexer': ('pygments.lexers.jvm', 'Jasmin', ('jasmin', 'jasminxt'), ('*.j',), ()),
+    'JavaConsoleLexer': ('pygments.lexers.jvm', 'JShell console session', ('jshell',), (), ('text/x-java',)),
     'JavaLexer': ('pygments.lexers.jvm', 'Java', ('java',), ('*.java',), ('text/x-java',)),
     'JavascriptDjangoLexer': ('pygments.lexers.templates', 'JavaScript+Django/Jinja', ('javascript+django', 'js+django', 'javascript+jinja', 'js+jinja'), ('*.js.j2', '*.js.jinja2'), ('application/x-javascript+django', 'application/x-javascript+jinja', 'text/x-javascript+django', 'text/x-javascript+jinja', 'text/javascript+django', 'text/javascript+jinja')),
     'JavascriptErbLexer': ('pygments.lexers.templates', 'JavaScript+Ruby', ('javascript+ruby', 'js+ruby', 'javascript+erb', 'js+erb'), (), ('application/x-javascript+ruby', 'text/x-javascript+ruby', 'text/javascript+ruby')),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -1821,7 +1821,7 @@ class _JavaConsoleLexerBase(RegexLexer):
         'root': [
             (r'(jshell> )(.*\n)', bygroups(Generic.Prompt, Other.Code), 'continuations'),
             (r'(jshell>)(\n)', bygroups(Generic.Prompt, Whitespace)),
-            (r'\|  ', Other.Traceback, 'traceback'),
+            (r'\|(\ )+(.*\n)', Other.Traceback),
             (r'.*\n', Generic.Output),
         ],
         'continuations': [
@@ -1829,11 +1829,6 @@ class _JavaConsoleLexerBase(RegexLexer):
             # See above.
             (r'(\ \ \ \.\.\.>)(\n)', bygroups(Generic.Prompt, Whitespace)),
             default('#pop'),
-        ],
-        'traceback': [
-            # As soon as we see a traceback, consume everything until the next
-            # jshell> prompt.
-            (r'(?=(jshell>)( |$))', Text, '#pop'),
         ],
     }
 

--- a/tests/examplefiles/jshell/jshell_test.jshell
+++ b/tests/examplefiles/jshell/jshell_test.jshell
@@ -1,0 +1,31 @@
+jshell> x = 2
+|  Error:
+|  cannot find symbol
+|    symbol:   variable x
+|  x =
+|  ^
+
+jshell> int x = 0;
+x ==> 0
+
+jshell> 1/x
+|  Exception java.lang.ArithmeticException: / by zero
+|        at (#2:1)
+
+jshell> x
+x ==> 0
+
+jshell> int x = -3
+x ==> -3
+
+jshell> if (x < 0) {
+   ...>     x = -x;
+   ...> } else {
+   ...>     System.out.println(x);
+   ...> }
+
+jshell> System.out.println(x)
+3
+
+jshell> 1 | 2
+3

--- a/tests/examplefiles/jshell/jshell_test.jshell.output
+++ b/tests/examplefiles/jshell/jshell_test.jshell.output
@@ -3,25 +3,20 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'2'           Literal.Number
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'Error:'      Generic.Error
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'cannot find symbol:' Generic.Error
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'  symbol:   variable x:' Generic.Error
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'x =:'        Generic.Error
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'^:'          Generic.Error
+'2'           Literal.Number.Integer
 '\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'|  Error:\n' Other.Traceback
+
+'|  cannot find symbol\n' Other.Traceback
+
+'|    symbol:   variable x\n' Other.Traceback
+
+'|  x =\n'    Other.Traceback
+
+'|  ^\n'      Other.Traceback
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
 'int'         Keyword.Type
@@ -30,49 +25,48 @@
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number
+'0'           Literal.Number.Integer
 ';'           Punctuation
 '\n'          Text.Whitespace
-'x ==&gt; 0'  Generic.Output
-'\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'x ==> 0\n'   Generic.Output
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
-'1'           Literal.Number
+'1'           Literal.Number.Integer
 '/'           Operator
 'x'           Name
 '\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'Exception java.lang.ArithmeticException: / by zero'  Generic.Error
-'\n'          Text.Whitespace
-'|  '         Generic.Traceback
-'      at (#2:1)'  Generic.Error
-'\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'|  Exception java.lang.ArithmeticException: / by zero\n' Other.Traceback
+
+'|        at (#2:1)\n' Other.Traceback
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
 'x'           Name
 '\n'          Text.Whitespace
-'x ==&gt; 0'  Generic.Output
-'\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'x ==> 0\n'   Generic.Output
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
+'int'         Keyword.Type
 ' '           Text.Whitespace
 'x'           Name
 ' '           Text.Whitespace
 '='           Operator
 ' '           Text.Whitespace
 '-'           Operator
-'3'           Literal.Number
-'\n'          Text.Whitespace
-'x ==&gt; -3' Generic.Output
+'3'           Literal.Number.Integer
 '\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'x ==> -3\n'  Generic.Output
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
 'if'          Keyword
@@ -82,11 +76,12 @@
 ' '           Text.Whitespace
 '<'           Operator
 ' '           Text.Whitespace
-'0'           Literal.Number
+'0'           Literal.Number.Integer
 ')'           Punctuation
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
+
 '   ...> '    Generic.Prompt
 '    '        Text.Whitespace
 'x'           Name
@@ -97,6 +92,7 @@
 'x'           Name
 ';'           Punctuation
 '\n'          Text.Whitespace
+
 '   ...> '    Generic.Prompt
 '}'           Punctuation
 ' '           Text.Whitespace
@@ -104,6 +100,7 @@
 ' '           Text.Whitespace
 '{'           Punctuation
 '\n'          Text.Whitespace
+
 '   ...> '    Generic.Prompt
 '    '        Text.Whitespace
 'System'      Name
@@ -113,13 +110,15 @@
 'println'     Name.Attribute
 '('           Punctuation
 'x'           Name
-');'          Punctuation
+')'           Punctuation
+';'           Punctuation
 '\n'          Text.Whitespace
+
 '   ...> '    Generic.Prompt
 '}'           Punctuation
 '\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
 'System'      Name
@@ -131,16 +130,17 @@
 'x'           Name
 ')'           Punctuation
 '\n'          Text.Whitespace
-'3'           Generic.Output
-'\n'          Text.Whitespace
 
-'\n'          Text.Whitespace
+'3\n'         Generic.Output
+
+'\n'          Generic.Output
 
 'jshell> '    Generic.Prompt
-'1'           Literal.Number
+'1'           Literal.Number.Integer
 ' '           Text.Whitespace
 '|'           Operator
 ' '           Text.Whitespace
-'2'           Literal.Number
-'3'           Generic.Output
+'2'           Literal.Number.Integer
 '\n'          Text.Whitespace
+
+'3\n'         Generic.Output

--- a/tests/examplefiles/jshell/jshell_test.jshell.output
+++ b/tests/examplefiles/jshell/jshell_test.jshell.output
@@ -1,0 +1,146 @@
+'jshell> '    Generic.Prompt
+'x'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'Error:'      Generic.Error
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'cannot find symbol:' Generic.Error
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'  symbol:   variable x:' Generic.Error
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'x =:'        Generic.Error
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'^:'          Generic.Error
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+';'           Punctuation
+'\n'          Text.Whitespace
+'x ==&gt; 0'  Generic.Output
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'1'           Literal.Number
+'/'           Operator
+'x'           Name
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'Exception java.lang.ArithmeticException: / by zero'  Generic.Error
+'\n'          Text.Whitespace
+'|  '         Generic.Traceback
+'      at (#2:1)'  Generic.Error
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'x'           Name
+'\n'          Text.Whitespace
+'x ==&gt; 0'  Generic.Output
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'-'           Operator
+'3'           Literal.Number
+'\n'          Text.Whitespace
+'x ==&gt; -3' Generic.Output
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'x'           Name
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+'   ...> '    Generic.Prompt
+'    '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'-'           Operator
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+'   ...> '    Generic.Prompt
+'}'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+'   ...> '    Generic.Prompt
+'    '        Text.Whitespace
+'System'      Name
+'.'           Punctuation
+'out'         Name.Attribute
+'.'           Punctuation
+'println'     Name.Attribute
+'('           Punctuation
+'x'           Name
+');'          Punctuation
+'\n'          Text.Whitespace
+'   ...> '    Generic.Prompt
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'System'      Name
+'.'           Punctuation
+'out'         Name.Attribute
+'.'           Punctuation
+'println'     Name.Attribute
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+'3'           Generic.Output
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'jshell> '    Generic.Prompt
+'1'           Literal.Number
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+'3'           Generic.Output
+'\n'          Text.Whitespace


### PR DESCRIPTION
This commit adds a basic lexer for Java JShell.

The design is based on `PythonConsoleLexer` but adapted for Java JShell with the prompt changed from ">>>" to "jshell" and the continuation changed from "..." to "   ...>".

There does not seem to be an easy way to separate the traceback output from output indicating creation of classes/methods.  The former looks like:

```
|  Exception ...
|         at f (...)
```

The latter looks like:

```
|  created method f()
```