### PR TITLE
Add DebianSourcesLexer lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -127,6 +127,7 @@ LEXERS = {
     'Dasm16Lexer': ('pygments.lexers.asm', 'DASM16', ('dasm16',), ('*.dasm16', '*.dasm'), ('text/x-dasm16',)),
     'DaxLexer': ('pygments.lexers.dax', 'Dax', ('dax',), ('*.dax',), ()),
     'DebianControlLexer': ('pygments.lexers.installers', 'Debian Control file', ('debcontrol', 'control'), ('control',), ()),
+    'DebianSourcesLexer': ('pygments.lexers.installers', 'Debian Sources file', ('debian.sources',), ('*.sources',), ()),
     'DelphiLexer': ('pygments.lexers.pascal', 'Delphi', ('delphi', 'pas', 'pascal', 'objectpascal'), ('*.pas', '*.dpr'), ('text/x-pascal',)),
     'DesktopLexer': ('pygments.lexers.configs', 'Desktop file', ('desktop',), ('*.desktop',), ('application/x-desktop',)),
     'DevicetreeLexer': ('pygments.lexers.devicetree', 'Devicetree', ('devicetree', 'dts'), ('*.dts', '*.dtsi'), ('text/x-c',)),

--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -14,7 +14,8 @@ from pygments.lexer import RegexLexer, include, bygroups, using, this, default
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Punctuation, Generic, Number, Whitespace
 
-__all__ = ['NSISLexer', 'RPMSpecLexer', 'SourcesListLexer',
+__all__ = ['NSISLexer', 'RPMSpecLexer',
+           'DebianSourcesLexer', 'SourcesListLexer',
            'DebianControlLexer']
 
 
@@ -214,6 +215,30 @@ class RPMSpecLexer(RegexLexer):
             (r'\$\{?RPM_[A-Z0-9_]+\}?', Name.Variable.Global),
             (r'%\{[a-zA-Z]\w+\}', Keyword.Constant),
         ]
+    }
+
+
+class DebianSourcesLexer(RegexLexer):
+    """
+    Lexer that highlights debian.sources files.
+    """
+
+    name = 'Debian Sources file'
+    aliases = ['debian.sources']
+    filenames = ['*.sources']
+    version_added = '2.19'
+    url = 'https://manpages.debian.org/bookworm/apt/sources.list.5.en.html#THE_DEB_AND_DEB-SRC_TYPES:_GENERAL_FORMAT'
+
+    tokens = {
+        'root': [
+            (r'^(Signed-By)(:)(\s*)', bygroups(Keyword, Punctuation, Whitespace), 'signed-by'),
+            (r'^([a-zA-Z\-0-9\.]*?)(:)(\s*)(.*?)$',
+             bygroups(Keyword, Punctuation, Whitespace, String)),
+        ],
+        'signed-by': [
+            (r' -----END PGP PUBLIC KEY BLOCK-----\n', Text, '#pop'),
+            (r'.+\n', Text),
+        ],        
     }
 
 

--- a/pygments/lexers/text.py
+++ b/pygments/lexers/text.py
@@ -16,7 +16,7 @@ from pygments.lexers.console import PyPyLogLexer
 from pygments.lexers.textedit import VimLexer
 from pygments.lexers.markup import BBCodeLexer, MoinWikiLexer, RstLexer, \
     TexLexer, GroffLexer
-from pygments.lexers.installers import DebianControlLexer, SourcesListLexer
+from pygments.lexers.installers import DebianControlLexer, DebianSourcesLexer, SourcesListLexer
 from pygments.lexers.make import MakefileLexer, BaseMakefileLexer, CMakeLexer
 from pygments.lexers.haxe import HxmlLexer
 from pygments.lexers.sgf import SmartGameFormatLexer

--- a/tests/snippets/debian.sources/debian.sources.txt
+++ b/tests/snippets/debian.sources/debian.sources.txt
@@ -1,0 +1,46 @@
+---input---
+Types: deb
+URIs: https://deb.test
+Suites: stable
+Components: main contrib non-free non-free-firmware
+Signed-By:
+ -----BEGIN PGP PUBLIC KEY BLOCK-----
+ mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+ snippedpgppublickey123456789
+ -----END PGP PUBLIC KEY BLOCK-----
+
+---tokens---
+'Types'       Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'deb'         Literal.String
+'\n'          Text.Whitespace
+
+'URIs'        Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'https://deb.test' Literal.String
+'\n'          Text.Whitespace
+
+'Suites'      Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'stable'      Literal.String
+'\n'          Text.Whitespace
+
+'Components'  Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'main contrib non-free non-free-firmware' Literal.String
+'\n'          Text.Whitespace
+
+'Signed-By'   Keyword
+':'           Punctuation
+'\n '         Text.Whitespace
+'-----BEGIN PGP PUBLIC KEY BLOCK-----\n' Text
+
+' mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY\n' Text
+
+' snippedpgppublickey123456789\n' Text
+
+' -----END PGP PUBLIC KEY BLOCK-----\n' Text


### PR DESCRIPTION
Debian and derivatives have a new *.sources file based on deb822 format to set up system-wide packages repositories.
Ubuntu uses already it since [24.04 release](https://discourse.ubuntu.com/t/spec-apt-deb822-sources-by-default/29333).
This format will replace the sources.list format in the future.

I added the next release (2.19) in `version_added` but, of course, it should be changed if it will be release in another release. I can remove it too if a maintainer wants to manage it.

closes: #2747