### PR TITLE
Various improvements to the BQN lexer

### DIFF
--- a/pygments/lexers/bqn.py
+++ b/pygments/lexers/bqn.py
@@ -26,6 +26,10 @@ class BQNLexer(RegexLexer):
     mimetypes = []
     version_added = '2.16'
 
+    # An inter_word_char. Necessary because \w matches all alphanumeric
+    # Unicode characters, including ones (e.g., 𝕊) that BQN treats special.
+    _iwc = r'((?=[^𝕎𝕏𝔽𝔾𝕊𝕨𝕩𝕗𝕘𝕤𝕣])\w)'
+
     tokens = {
         'root': [
             # Whitespace
@@ -66,7 +70,7 @@ class BQNLexer(RegexLexer):
             #
             # Variables
             # =========
-            (r'\b[a-z]\w*\b', Name.Variable),
+            (r'[a-z]' + _iwc + r'*', Name.Variable),
             #
             # 1-Modifiers
             # ===========
@@ -84,7 +88,7 @@ class BQNLexer(RegexLexer):
             # operands and arguments, along with function self-reference
             (r'[+\-×÷\*√⌊⌈∧∨¬|≤<>≥=≠≡≢⊣⊢⥊∾≍⋈↑↓↕«»⌽⍉/⍋⍒⊏⊑⊐⊒∊⍷⊔!𝕎𝕏𝔽𝔾𝕊]',
              Operator),
-            (r'[A-Z]\w*|•\w+\b', Operator),
+            (r'[A-Z]' + _iwc + r'*|•' + _iwc + r'+\b', Operator),
             #
             # Constant
             # ========

--- a/pygments/lexers/bqn.py
+++ b/pygments/lexers/bqn.py
@@ -66,7 +66,7 @@ class BQNLexer(RegexLexer):
             # Numbers
             # =======
             # Includes the numeric literals and the Nothing character
-            (r'¯?([0-9]+\.?[0-9]+|[0-9]+)([Ee][¯]?[0-9]+)?|¯|∞|π|·', Number),
+            (r'¯?[0-9](([0-9]|_)*\.?([0-9]|_)+|([0-9]|_)*)([Ee][¯]?([0-9]|_)+)?|¯|∞|π|·', Number),
             #
             # Variables
             # =========

--- a/pygments/lexers/bqn.py
+++ b/pygments/lexers/bqn.py
@@ -61,7 +61,7 @@ class BQNLexer(RegexLexer):
             # ===================
             # Since this token type is important in BQN, it is not included in
             # the punctuation token type but rather in the following one
-            (r'[\(\)]', String.Regex), 
+            (r'[\(\)]', String.Regex),
             #
             # Numbers
             # =======
@@ -75,12 +75,12 @@ class BQNLexer(RegexLexer):
             # 1-Modifiers
             # ===========
             (r'[˙˜˘¨⌜⁼´˝`𝕣]', Name.Attribute),
-            (r'\b_[a-zA-Z0-9]+\b', Name.Attribute),
+            (r'_[a-zA-Z0-9]+', Name.Attribute),
             #
             # 2-Modifiers
             # ===========
             (r'[∘○⊸⟜⌾⊘◶⎉⚇⍟⎊]', Name.Property),
-            (r'\b_[a-zA-Z0-9]+_\b', Name.Property),
+            (r'_[a-zA-Z0-9]+_', Name.Property),
             #
             # Functions
             # =========
@@ -88,7 +88,7 @@ class BQNLexer(RegexLexer):
             # operands and arguments, along with function self-reference
             (r'[+\-×÷\*√⌊⌈∧∨¬|≤<>≥=≠≡≢⊣⊢⥊∾≍⋈↑↓↕«»⌽⍉/⍋⍒⊏⊑⊐⊒∊⍷⊔!𝕎𝕏𝔽𝔾𝕊]',
              Operator),
-            (r'[A-Z]' + _iwc + r'*|•' + _iwc + r'+\b', Operator),
+            (r'[A-Z]' + _iwc + r'*|•' + _iwc + r'+', Operator),
             #
             # Constant
             # ========
@@ -106,8 +106,6 @@ class BQNLexer(RegexLexer):
             # ================
             (r'[;:?𝕨𝕩𝕗𝕘𝕤]', Name.Entity),
             #
-            
+
         ],
     }
-
-    

--- a/pygments/lexers/bqn.py
+++ b/pygments/lexers/bqn.py
@@ -87,7 +87,7 @@ class BQNLexer(RegexLexer):
             # =========
             # The monadic or dyadic function primitives and function
             # operands and arguments, along with function self-reference
-            (r'[+\-×÷\*√⌊⌈∧∨¬|≤<>≥=≠≡≢⊣⊢⥊∾≍⋈↑↓↕«»⌽⍉/⍋⍒⊏⊑⊐⊒∊⍷⊔!𝕎𝕏𝔽𝔾𝕊]',
+            (r'[+\-×÷\⋆√⌊⌈∧∨¬|≤<>≥=≠≡≢⊣⊢⥊∾≍⋈↑↓↕«»⌽⍉/⍋⍒⊏⊑⊐⊒∊⍷⊔!𝕎𝕏𝔽𝔾𝕊]',
              Operator),
             (r'[A-Z]' + _iwc + r'*|•' + _iwc + r'+', Operator),
             #

--- a/pygments/lexers/bqn.py
+++ b/pygments/lexers/bqn.py
@@ -72,15 +72,16 @@ class BQNLexer(RegexLexer):
             # =========
             (r'[a-z]' + _iwc + r'*', Name.Variable),
             #
+            # 2-Modifiers
+            # ===========
+            # Needs to come before the 1-modifiers due to _𝕣 and _𝕣_
+            (r'[∘○⊸⟜⌾⊘◶⎉⚇⍟⎊]', Name.Property),
+            (r'_(𝕣|[a-zA-Z0-9]+)_', Name.Property),
+            #
             # 1-Modifiers
             # ===========
             (r'[˙˜˘¨⌜⁼´˝`𝕣]', Name.Attribute),
-            (r'_[a-zA-Z0-9]+', Name.Attribute),
-            #
-            # 2-Modifiers
-            # ===========
-            (r'[∘○⊸⟜⌾⊘◶⎉⚇⍟⎊]', Name.Property),
-            (r'_[a-zA-Z0-9]+_', Name.Property),
+            (r'_(𝕣|[a-zA-Z0-9]+)', Name.Attribute),
             #
             # Functions
             # =========

--- a/tests/snippets/bqn/test_inter_word.txt
+++ b/tests/snippets/bqn/test_inter_word.txt
@@ -1,0 +1,13 @@
+---input---
+{ab𝕊is: ab}
+
+---tokens---
+'{'           Keyword.Type
+'ab'          Name.Variable
+'𝕊'           Operator
+'is'          Name.Variable
+':'           Name.Entity
+' '           Text.Whitespace
+'ab'          Name.Variable
+'}'           Keyword.Type
+'\n'          Text.Whitespace

--- a/tests/snippets/bqn/test_number_underscores.txt
+++ b/tests/snippets/bqn/test_number_underscores.txt
@@ -1,0 +1,12 @@
+---input---
+⟨1_.0__1_,10_000,_1⟩
+
+---tokens---
+'⟨'           Punctuation
+'1_.0__1_'    Literal.Number
+','           Punctuation
+'10_000'      Literal.Number
+','           Punctuation
+'_1'          Name.Attribute
+'⟩'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/bqn/test_recursive_modifier.txt
+++ b/tests/snippets/bqn/test_recursive_modifier.txt
@@ -1,0 +1,10 @@
+---input---
+_𝕣 𝕣 _𝕣_
+
+---tokens---
+'_𝕣'          Name.Attribute
+' '           Text.Whitespace
+'𝕣'           Name.Attribute
+' '           Text.Whitespace
+'_𝕣_'         Name.Property
+'\n'          Text.Whitespace


### PR DESCRIPTION
EDIT: Apologies for the somewhat messy PR; perhaps conceptually some of these should go into different PRs. However, the changes are so small that I figured it was perhaps best to include them here as well.

## Commit summary

#### Fix BQN lexer treating special characters as word chars

`\w` matches all alphanumeric Unicode characters, including ones (e.g., 𝕊) that BQN treats special. This is especially troublesome for variables; previously, something like

    𝕊i

would have returned

    (Token.Operator, '𝕊'),
    (Token.Error, 'i'),

instead of

    (Token.Operator, '𝕊'),
    (Token.Name.Variable, 'i').

This extends to special sequences like `\b`, which care about the difference between `\w` and `\W`.

---

~~There are still some `\b`'s in the code, but from what I can tell these don't produce any undesirable effects. E.g., for 2-modifiers, the BQN grammar already disallows writing something like `F_𝕣_G` instead of `F _𝕣_ G`. No guarantees that I caught everything, of course.~~

This is, of course, nonsense, there are plenty of situations where this could arise that are accepted by BQN; e.g., `_F ← {𝔽_𝕣}`, `_D ← {𝔽_F𝕩}`, etc. See the fixup commit.

#### BQN lexer: Parse _𝕣 and _𝕣_ correctly

#### BQN Lexer: Replace function * with ⋆

BQN does not actually use * (ASTERISK) anywhere, but there is a primitive function ⋆ (STAR OPERATOR).

#### BQN Lexer: Allow underscores in numbers

As per the spec.