### PR TITLE
Add operator ^ to Matlab, Octave and Scilab lexers

### DIFF
--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -31,7 +31,7 @@ class MatlabLexer(RegexLexer):
     url = 'https://www.mathworks.com/products/matlab.html'
     version_added = '0.10'
 
-    _operators = r'-|==|~=|<=|>=|<|>|&&|&|~|\|\|?|\.\*|\*|\+|\.\^|\.\\|\./|/|\\'
+    _operators = r'-|==|~=|<=|>=|<|>|&&|&|~|\|\|?|\.\*|\*|\+|\.\^|\^|\.\\|\./|/|\\'
 
     tokens = {
         'expressions': [
@@ -3175,7 +3175,7 @@ class OctaveLexer(RegexLexer):
             # operators in Octave but not Matlab requiring escape for re:
             (r'\*=|\+=|\^=|\/=|\\=|\*\*|\+\+|\.\*\*', Operator),
             # operators requiring escape for re:
-            (r'\.\*|\*|\+|\.\^|\.\\|\.\/|\/|\\', Operator),
+            (r'\.\*|\*|\+|\.\^|\^|\.\\|\.\/|\/|\\', Operator),
 
 
             # punctuation:
@@ -3260,7 +3260,7 @@ class ScilabLexer(RegexLexer):
             # operators:
             (r'-|==|~=|<|>|<=|>=|&&|&|~|\|\|?', Operator),
             # operators requiring escape for re:
-            (r'\.\*|\*|\+|\.\^|\.\\|\.\/|\/|\\', Operator),
+            (r'\.\*|\*|\+|\.\^|\^|\.\\|\.\/|\/|\\', Operator),
 
             # punctuation:
             (r'[\[\](){}@.,=:;]+', Punctuation),

--- a/tests/examplefiles/matlab/matlab_sample.m
+++ b/tests/examplefiles/matlab/matlab_sample.m
@@ -14,7 +14,7 @@ a = rand(30);
 b = rand(30);
 
 c = a .* b ./ a \ ... comment at end of line and continuation
-    (b .* a + b - a);
+    (b .* a + b - a) ^ 2;
 
 c = a' * b';  % note: these ticks are for transpose, not quotes.
 

--- a/tests/examplefiles/matlab/matlab_sample.m.output
+++ b/tests/examplefiles/matlab/matlab_sample.m.output
@@ -115,6 +115,10 @@
 ' '           Text.Whitespace
 'a'           Name
 ')'           Punctuation
+' '           Text.Whitespace
+'^'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
 ';'           Punctuation
 '\n\n'        Text.Whitespace
 


### PR DESCRIPTION
Currently the Matlab (including octave and SciLab) lexers do not recognize the `^` operator. Only the element-wise operator `.^` is recognized. Although most of the time the element-wise operator is used, there are some cases for the normal operator to be used, like for example scalar power operation (`2^16`).

I also added a test case for this operator in the matlab sample code.