### PR TITLE
Fixes #2491: adds "--strip-escapes" as suggested in discussion of PR #2492.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 venv/
 .venv/
 .DS_Store
+
+.fake

--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -463,7 +463,8 @@ def main_inner(parser, argns):
             fmter.encoding = terminal_encoding(sys.stdout)
 
     # provide coloring under Windows, if possible
-    if not outfn and sys.platform in ('win32', 'cygwin') and \
+    if not outfn and not argns.color and \
+       sys.platform in ('win32', 'cygwin') and \
        fmter.name in ('Terminal', 'Terminal256'):  # pragma: no cover
         # unfortunately colorama doesn't support binary streams on Py3
         outfile = UnclosingTextIOWrapper(outfile, encoding=fmter.encoding)
@@ -596,6 +597,12 @@ def main(args=sys.argv):
         'be only used in conjunction with -L.',
         default=False,
         action='store_true')
+    flags.add_argument(
+        '--color', action='store_true', default=False,
+        help=(
+            'Turn off fixes for Windows terminal, and use ANSI color '
+            'sequences.'
+        ))
 
     special_modes_group = parser.add_argument_group(
         'Special modes - do not do any highlighting')

--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -463,9 +463,22 @@ def main_inner(parser, argns):
             fmter.encoding = terminal_encoding(sys.stdout)
 
     # provide coloring under Windows, if possible
-    if not outfn and not argns.color and \
-       sys.platform in ('win32', 'cygwin') and \
-       fmter.name in ('Terminal', 'Terminal256'):  # pragma: no cover
+    # extend to all OSes if argsn.strip_escapes == 'on'
+
+    strip_escapes = argns.strip_escapes
+    if isinstance(strip_escapes, list):
+        strip_escapes = strip_escapes[-1]
+    use_colorama = (
+            strip_escapes != 'raw' and
+            sys.platform in ('win32', 'cygwin') and
+            fmter.name in ('Terminal', 'Terminal256')
+        ) or (
+            strip_escapes == 'on' and
+            fmter.name in (
+                'Terminal', 'Terminal256', 'TerminalTrueColor')
+        )
+
+    if use_colorama and not outfn:  # pragma: no cover
         # unfortunately colorama doesn't support binary streams on Py3
         outfile = UnclosingTextIOWrapper(outfile, encoding=fmter.encoding)
         fmter.encoding = None
@@ -474,8 +487,17 @@ def main_inner(parser, argns):
         except ImportError:
             pass
         else:
+            strip = convert = None
+            if strip_escapes == 'off':
+                strip = False
+            elif strip_escapes == 'on':
+                strip = True
+            elif strip_escapes == 'semi-raw':
+                # should have same effect as "raw", but doesn't?
+                convert = strip = False
             outfile = colorama.initialise.wrap_stream(
-                outfile, convert=None, strip=None, autoreset=False, wrap=True)
+                outfile, convert=convert, strip=strip, autoreset=False,
+                wrap=True)
 
     # When using the LaTeX formatter and the option `escapeinside` is
     # specified, we need a special lexer which collects escaped text
@@ -598,10 +620,23 @@ def main(args=sys.argv):
         default=False,
         action='store_true')
     flags.add_argument(
-        '--color', action='store_true', default=False,
+        '--color', 
+        dest='strip_escapes',
+        action='store_const',
+        const='raw',
+        help='Alias for "--strip-escapes=raw".')
+    flags.add_argument(
+        '--strip-escapes',
+        dest='strip_escapes',
+        choices=['off', 'on', 'auto', 'raw', 'semi-raw'],
+        default='auto',  # default from before adding option
+        nargs=1,
         help=(
-            'Turn off fixes for Windows terminal, and use ANSI color '
-            'sequences.'
+            'Specifies how the output is processed so that what is written '
+            'is appropriate for the platform and destination (on = always '
+            'strip; off = no stripping, but convert as needed on Windows; '
+            'raw = leave output as produced by formatter'
+            ').'
         ))
 
     special_modes_group = parser.add_argument_group(

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -231,18 +231,18 @@ def test_C_opt():
     assert 'text' == o.strip()
 
 
-def _nl_to_crnl(text):
-    """Converts *text* to have DOS line endings."""
-    return text.replace('\n', '\r\n')
+def _fix_line_endings(text):
+    """Converts *text* to have the correct line endings for os."""
+    return text.replace('\n', os.linesep)
 
 
 @pytest.mark.parametrize('opts,transform', [
     (('--color',), None),
     (('--strip-escapes=raw',), None),
-    (('--strip-escapes=semi-raw',), _nl_to_crnl),
-    (('--strip-escapes=off',), _nl_to_crnl),
+    (('--strip-escapes=semi-raw',), _fix_line_endings),
+    (('--strip-escapes=off',), _fix_line_endings),
 ])
-def test_color_opt(opts, transform):
+def test_strip_escapes_opt(opts, transform):
     # tests output of main using the --color option to the result of using the api
     # near copy of test_normal
     from pygments.lexers import PythonLexer

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -231,6 +231,22 @@ def test_C_opt():
     assert 'text' == o.strip()
 
 
+def test_color_opt():
+    # tests output of main using the --color option to the result of using the api
+    # near copy of test_normal
+    from pygments.lexers import PythonLexer
+    from pygments.formatters import TerminalFormatter
+
+    filename = TESTFILE
+    cmdline_output = check_success('--color', '-lpython', '-fterminal', filename)
+
+    with open(filename, 'rb') as fp:
+        code = fp.read()
+
+    highlight_output = highlight(code, PythonLexer(), TerminalFormatter())
+    assert cmdline_output == highlight_output
+
+
 @pytest.mark.parametrize('opts', [
     ('-X',),
     ('-L', '-lpy'),


### PR DESCRIPTION
This was intended to fix the issue of ANSI escape sequences being stripped when the output of `pygmentize` is piped to commands like `less`.  Following some discussion on the topic, I implemented something based on the discussion in PR #2492.  This involved adding support for a "--strip-escapes" option that can take values of "off", "on", and "auto".  The "auto" option is the default and gives the current behaviour.  The "on" option causes `colorama` to be used to strip escape sequences on all platforms.  The "off" option still uses `colorama` under Windows, but sets an option to turn off stripping escape sequences.  To these, I have added the "raw" and "semi-raw" options.  The "raw" option disables the use of `colorama` to wrap `outfile`, producing output under Windows that is identical to that produced on other platforms.  The "--semi-raw" sets both `convert` and `strip` options to `False`, which still ends up converting line endings.  I have added "--color" as an alias for "--strip-escapes=raw", since this is what I had originally, based on its use in commands like `ls`.

It should be noted that the new unit tests covering "--strip-escaped=off" and "--strip-escapes=semi-raw" fail on Windows.  The output of the command gets truncated after 32808 characters when I run them on Windows, but not under linux.  The output up to that point matches what is produced by the library.  The output obtained by running `pygmentize` with the appropriate options is also fine, with no truncation; it's just the unit test that fails.