### PR TITLE
Fixes #2803 - broken link in contributing

### DIFF
--- a/doc/docs/contributing.rst
+++ b/doc/docs/contributing.rst
@@ -39,12 +39,12 @@ Python support
 --------------
 
 Pygments supports all supported Python versions as per the `Python
-Developer's Guide <devguide>`_. Additionally, the default Python
+Developer's Guide`_. Additionally, the default Python
 version of the latest stable version of RHEL, Ubuntu LTS, and Debian
 are supported, even if they're officially EOL. Supporting other
 end-of-life versions is a non-goal of Pygments.
 
-.. _devguide: https://devguide.python.org/versions/
+.. _Python Developer's Guide: https://devguide.python.org/versions/
 
 
 Validation


### PR DESCRIPTION
There was a broken link from the Contributing to Pygments page in the documentation to the the supported versions page on the Python Developer's Guide site.  The changes in this PR fix the link, and resolve #2803.