### PR TITLE
fix: get fonts inside subdirectories on macOS

### DIFF
--- a/pygments/formatters/img.py
+++ b/pygments/formatters/img.py
@@ -132,7 +132,8 @@ class FontManager:
                          '/Library/Fonts/', '/System/Library/Fonts/'):
             font_map.update(
                 (os.path.splitext(f)[0].lower(), os.path.join(font_dir, f))
-                for f in os.listdir(font_dir)
+                for _, _, files in os.walk(font_dir)
+                for f in files
                 if f.lower().endswith(('ttf', 'ttc')))
 
         for name in STYLES['NORMAL']:


### PR DESCRIPTION
I use [Home Manager](https://github.com/nix-community/home-manager) with Nix on macOS to install new fonts, which stores the fonts in `~/Library/Fonts/HomeManager/{opentype,truetype}`. However, the `FontManager` was not able to get these fonts so I couldn’t use them when rendering as an image.

This PR fixes this by adding all the fonts inside subdirectories of `~/Library/Fonts`, `/Library/Fonts`, etc. to the font map.