### PR TITLE
fixes #2811: exit from bad utf-8 in check_sources

### DIFF
--- a/scripts/check_sources.py
+++ b/scripts/check_sources.py
@@ -179,6 +179,10 @@ def main(argv):
                 print(f"{fn}: cannot open: {err}")
                 num += 1
                 continue
+            except UnicodeDecodeError as err:
+                print(f"{fn}: error decoding: {err}")
+                num += 1
+                continue
 
             for checker in checkerlist:
                 if not in_pygments_pkg and checker.only_pkg:

--- a/scripts/check_sources.py
+++ b/scripts/check_sources.py
@@ -146,7 +146,7 @@ def main(argv):
     out = io.StringIO()
 
     for root, dirs, files in os.walk(path):
-        for excl in ['.tox', '.git', 'examplefiles']:
+        for excl in ['.tox', '.git', '.venv', 'examplefiles']:
             if excl in dirs:
                 dirs.remove(excl)
         if '-i' in opts and abspath(root) in opts['-i']:


### PR DESCRIPTION
Came across a case where running "tox -e check" resulted in the script "test/check_sources.py" exiting due to an uncaught exception rather than reporting an error in the file being checked.  This adds an exception handler almost identical to the one right above it that deals with unopenable  files.  Still an apparent problem with scanning files in ".venv".