### PR TITLE
fixes #1882: parens show as error in css calc

### DIFF
--- a/pygments/lexers/css.py
+++ b/pygments/lexers/css.py
@@ -262,6 +262,7 @@ class CssLexer(RegexLexer):
              bygroups(Name.Builtin, Punctuation), 'function-start'),
             (r'([a-zA-Z_][\w-]+)(\()',
              bygroups(Name.Function, Punctuation), 'function-start'),
+            (r'\(', Punctuation, 'function-start'),
 
             (r'/\*(?:.|\n)*?\*/', Comment),
             include('numeric-values'),

--- a/tests/examplefiles/css/1882-parens-in-calc.css.output
+++ b/tests/examplefiles/css/1882-parens-in-calc.css.output
@@ -1,0 +1,28 @@
+'html'        Name.Tag
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'scroll-padding-top' Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'calc'        Name.Builtin
+'('           Punctuation
+'2'           Literal.Number.Integer
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'1'           Literal.Number.Integer
+'rem'         Keyword.Type
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+'px'          Keyword.Type
+')'           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
This is a 1-line fix for the problem of opening parentheses being tagged as errors in CSS "calc(...)" expressions; it has no impact on existing test cases, and fixes the problem described in #1882.