### PR TITLE
LuaLexer: Lex variables, properties, and function calls

### DIFF
--- a/pygments/lexers/scripting.py
+++ b/pygments/lexers/scripting.py
@@ -70,7 +70,7 @@ class LuaLexer(RegexLexer):
         'ws': [
             (_comment_multiline, Comment.Multiline),
             (_comment_single, Comment.Single),
-            (_space, Text),
+            (_space, Whitespace),
         ],
         'base': [
             include('ws'),

--- a/pygments/lexers/scripting.py
+++ b/pygments/lexers/scripting.py
@@ -98,10 +98,20 @@ class LuaLexer(RegexLexer):
             (r'(function)\b', Keyword.Reserved, 'funcname'),
 
             (words(all_lua_builtins(), suffix=r"\b"), Name.Builtin),
-            (r'[A-Za-z_]\w*', Name),
+            (fr'[A-Za-z_]\w*(?={_s}*[.:])', Name.Variable, 'varname'),
+            (fr'[A-Za-z_]\w*(?={_s}*\()', Name.Function),
+            (r'[A-Za-z_]\w*', Name.Variable),
 
             ("'", String.Single, combined('stringescape', 'sqs')),
             ('"', String.Double, combined('stringescape', 'dqs'))
+        ],
+
+        'varname': [
+            include('ws'),
+            (r'[.:]', Punctuation),
+            (rf'{_name}(?={_s}*[.:])', Name.Property),
+            (rf'{_name}(?={_s}*\()', Name.Function, '#pop'),
+            (_name, Name.Property, '#pop'),
         ],
 
         'funcname': [

--- a/tests/examplefiles/csound/test.orc.output
+++ b/tests/examplefiles/csound/test.orc.output
@@ -385,10 +385,10 @@
 'lua_exec'    Name.Builtin
 ' '           Text.Whitespace
 '{{'          Literal.String
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- Lua'      Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '}}'          Literal.String
 '\n'          Text.Whitespace

--- a/tests/examplefiles/lua/example.lua.output
+++ b/tests/examplefiles/lua/example.lua.output
@@ -1,88 +1,88 @@
 "--[[\n\tAuctioneer Advanced\n\tVersion: <%version%> (<%codename%>)\n\tRevision: $Id: CoreMain.lua 2233 2007-09-25 03:57:33Z norganna $\n\tURL: http://auctioneeraddon.com/\n\n\tThis is an addon for World of Warcraft that adds statistical history to the auction data that is collected\n\twhen the auction is scanned, so that you can easily determine what price\n\tyou will be able to sell an item for at auction or at a vendor whenever you\n\tmouse-over an item in the game\n\n\tLicense:\n\t\tThis program is free software; you can redistribute it and/or\n\t\tmodify it under the terms of the GNU General Public License\n\t\tas published by the Free Software Foundation; either version 2\n\t\tof the License, or (at your option) any later version.\n\n\t\tThis program is distributed in the hope that it will be useful,\n\t\tbut WITHOUT ANY WARRANTY; without even the implied warranty of\n\t\tMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n\t\tGNU General Public License for more details.\n\n\t\tYou should have received a copy of the GNU General Public License\n\t\talong with this program(see GPL.txt); if not, write to the Free Software\n\t\tFoundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.\n\n\tNote:\n\t\tThis AddOn's source code is specifically designed to work with\n\t\tWorld of Warcraft's interpreted AddOn system.\n\t\tYou have an implicit licence to use this AddOn with these facilities\n\t\tsince that is its designated purpose as per:\n\t\thttp://www.fsf.org/licensing/licenses/gpl-faq.html#InterpreterIncompat\n]]" Comment.Multiline
-'\n\n\n'      Text
+'\n\n\n'      Text.Whitespace
 
 '--[[\n\tSee CoreAPI.lua for a description of the modules API\n]]' Comment.Multiline
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedData' Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedData' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedLocal' Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedLocal' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedConfig' Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedConfig' Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'AucAdvanced' Name.Variable
 '.'           Punctuation
@@ -92,17 +92,17 @@
 '<%version%>' Literal.String.Double
 '"'           Literal.String.Double
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Version'     Name.Property
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 '<'           Literal.String.Double
 '"'           Literal.String.Double
@@ -111,61 +111,61 @@
 '%version%>'  Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Version'     Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 '5.0.DEV'     Literal.String.Double
 '"'           Literal.String.Double
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-- For our modular stats system, each stats engine should add their' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- subclass to AucAdvanced.Modules.<type>.<name> and store their data into their own' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- data table in AucAdvancedData.Stats.<type><name>' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 'Stat'        Name.Variable
 '='           Operator
@@ -182,130 +182,130 @@
 '{'           Punctuation
 '}'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedData' Name.Variable
 '.'           Punctuation
 'Stats'       Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedData' Name.Variable
 '.'           Punctuation
 'Stats'       Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'not'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedLocal' Name.Variable
 '.'           Punctuation
 'Stats'       Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvancedLocal' Name.Variable
 '.'           Punctuation
 'Stats'       Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'TooltipHook' Name.Function
 '('           Punctuation
 'vars'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'ret'         Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'frame'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'name'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'hyperlink'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'quality'     Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'quantity'    Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'cost'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'additional'  Name.Variable
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'EnhTooltip'  Name.Variable
 '.'           Punctuation
 'LinkType'    Name.Function
 '('           Punctuation
 'hyperlink'   Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '~='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'item'        Literal.String.Double
 '"'           Literal.String.Double
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'return'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '-- Auctioneer hooks into item tooltips only' Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 '-- Check to see if we need to force load scandata' Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'getter'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Settings'    Name.Property
 '.'           Punctuation
 'GetSetting'  Name.Property
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'getter'      Name.Function
 '('           Punctuation
@@ -313,9 +313,9 @@
 'scandata.tooltip.display' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'getter'      Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
@@ -323,9 +323,9 @@
 '"'           Literal.String.Double
 ')'           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Scan'        Name.Property
@@ -333,53 +333,53 @@
 'GetImage'    Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Function
@@ -388,104 +388,104 @@
 'tooltip'     Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'frame'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'name'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'hyperlink'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'quality'     Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'quantity'    Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'cost'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'additional'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'HookAH'      Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'hooksecurefunc' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'AuctionFrameBrowse_Update' Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'API'         Name.Property
 '.'           Punctuation
 'ListUpdate'  Name.Property
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Function
@@ -494,52 +494,52 @@
 'auctionui'   Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'addon'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'addon'       Name.Variable
 ':'           Punctuation
 'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 '-- Check if the actual addon itself is loading' Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'addon'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'auc-advanced' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'Stubby'      Name.Variable
 '.'           Punctuation
 'RegisterAddOnHook' Name.Function
@@ -548,17 +548,17 @@
 'Blizzard_AuctionUi' Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'Auc-Advanced' Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'HookAH'      Name.Property
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'Stubby'      Name.Variable
 '.'           Punctuation
 'RegisterFunctionHook' Name.Function
@@ -567,226 +567,226 @@
 'EnhTooltip.AddTooltip' Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '600'         Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'TooltipHook' Name.Property
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pos'         Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'module'      Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'ipairs'      Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'EmbeddedModules' Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 '-- These embedded modules have also just been loaded' Comment.Single
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
 'module'      Name.Variable
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 '-- Notify the actual module if it exists' Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'auc'         Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'sys'         Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'eng'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'strsplit'    Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 '-'           Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'auc'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'auc'         Literal.String.Double
 '"'           Literal.String.Double
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'sys'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'eng'         Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'sys'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ':'           Punctuation
 'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t\t\t' Text
+'\n\t\t\t\t\t' Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'eng'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ':'           Punctuation
 'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t\t\t' Text
+'\n\t\t\t\t\t\t' Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t\t\t\t\t' Text
+'\n\t\t\t\t\t' Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 "-- Check all modules' load triggers and pass event to processors" Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'LoadTriggers' Name.Property
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'LoadTriggers' Name.Property
@@ -794,58 +794,58 @@
 'addon'       Name.Variable
 ']'           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t\t' Text
+'\n\t\t\t\t\t' Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Property
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'auc'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'auc'         Literal.String.Double
 '"'           Literal.String.Double
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'sys'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 'and'         Operator.Word
-' '           Text
+' '           Text.Whitespace
 'eng'         Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Function
@@ -854,151 +854,151 @@
 'load'        Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'OnUnload'    Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnUnload'    Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'OnUnload'    Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
 'Schedule'    Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'OnEvent'     Name.Function
 '('           Punctuation
 '...'         Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'arg'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'select'      Name.Builtin
 '('           Punctuation
 '2'           Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '...'         Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'ADDON_LOADED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'addon'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'string.lower' Name.Builtin
 '('           Punctuation
 'arg'         Name.Variable
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'addon'       Name.Variable
 ':'           Punctuation
@@ -1008,55 +1008,55 @@
 ','           Punctuation
 '4'           Literal.Number.Integer
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'auc-'        Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
 'addon'       Name.Variable
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'elseif'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'AUCTION_HOUSE_SHOW' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 '-- Do Nothing for now' Comment.Single
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'elseif'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'AUCTION_HOUSE_CLOSED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Scan'        Name.Property
@@ -1064,21 +1064,21 @@
 'Interrupt'   Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'elseif'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'PLAYER_LOGOUT' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Scan'        Name.Property
@@ -1087,55 +1087,55 @@
 '('           Punctuation
 'true'        Keyword.Constant
 ')'           Punctuation
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'OnUnload'    Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'elseif'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'UNIT_INVENTORY_CHANGED' Literal.String.Double
 '"'           Literal.String.Double
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'or'          Operator.Word
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'ITEM_LOCK_CHANGED' Literal.String.Double
 '"'           Literal.String.Double
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'or'          Operator.Word
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'CURSOR_UPDATE' Literal.String.Double
 '"'           Literal.String.Double
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'or'          Operator.Word
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'BAG_UPDATE'  Literal.String.Double
 '"'           Literal.String.Double
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'Schedule'    Name.Property
@@ -1144,44 +1144,44 @@
 'inventory'   Literal.String.Double
 '"'           Literal.String.Double
 ']'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'GetTime'     Name.Function
 '('           Punctuation
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '+'           Operator
-' '           Text
+' '           Text.Whitespace
 '0.15'        Literal.Number.Float
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Class
 '.'           Punctuation
 'OnUpdate'    Name.Function
 '('           Punctuation
 '...'         Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
-' '           Text
+' '           Text.Whitespace
 '=='          Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'inventory'   Literal.String.Double
 '"'           Literal.String.Double
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Post'        Name.Property
@@ -1189,137 +1189,137 @@
 'AlertBagsChanged' Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n\n\t'      Text
+'\n\n\t'      Text.Whitespace
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'now'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'GetTime'     Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'event'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'time'        Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'private'     Name.Variable
 '.'           Punctuation
 'Schedule'    Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'time'        Name.Variable
-' '           Text
+' '           Text.Whitespace
 '>'           Operator
-' '           Text
+' '           Text.Whitespace
 'now'         Name.Variable
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'system'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'systemMods'  Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Modules'     Name.Property
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'for'         Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engine'      Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 'in'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'pairs'       Name.Builtin
 '('           Punctuation
 'systemMods'  Name.Variable
 ')'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'do'          Keyword.Reserved
-'\n\t\t\t\t\t' Text
+'\n\t\t\t\t\t' Text.Whitespace
 'if'          Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Property
-' '           Text
+' '           Text.Whitespace
 'then'        Keyword.Reserved
-'\n\t\t\t\t\t\t' Text
+'\n\t\t\t\t\t\t' Text.Whitespace
 'engineLib'   Name.Variable
 '.'           Punctuation
 'Processor'   Name.Function
 '('           Punctuation
 'event'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'time'        Name.Variable
 ')'           Punctuation
-'\n\t\t\t\t\t' Text
+'\n\t\t\t\t\t' Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t\t'  Text
+'\n\t\t\t\t'  Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t\t'    Text
+'\n\t\t\t'    Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'end'         Keyword.Reserved
-'\n\t\t'      Text
+'\n\t\t'      Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'Schedule'    Name.Property
 '['           Punctuation
 'event'       Name.Variable
 ']'           Punctuation
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'nil'         Keyword.Constant
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
 'Frame'       Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 'CreateFrame' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'Frame'       Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1331,7 +1331,7 @@
 'ADDON_LOADED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1343,7 +1343,7 @@
 'AUCTION_HOUSE_SHOW' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1355,7 +1355,7 @@
 'AUCTION_HOUSE_CLOSED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1367,7 +1367,7 @@
 'UNIT_INVENTORY_CHANGED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1379,7 +1379,7 @@
 'ITEM_LOCK_CHANGED' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1391,7 +1391,7 @@
 'CURSOR_UPDATE' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1403,7 +1403,7 @@
 'BAG_UPDATE'  Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1415,7 +1415,7 @@
 'PLAYER_LOGOUT' Literal.String.Double
 '"'           Literal.String.Double
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1427,12 +1427,12 @@
 'OnEvent'     Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'OnEvent'     Name.Property
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'private'     Name.Variable
 '.'           Punctuation
@@ -1444,118 +1444,118 @@
 'OnUpdate'    Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'private'     Name.Variable
 '.'           Punctuation
 'OnUpdate'    Name.Property
 ')'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 "-- Auctioneer's debug functions" Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'AucAdvanced' Name.Variable
 '.'           Punctuation
 'Debug'       Name.Property
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
 '}'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 'addonName'   Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '"'           Literal.String.Double
 'Auctioneer'  Literal.String.Double
 '"'           Literal.String.Double
-' '           Text
+' '           Text.Whitespace
 "-- the addon's name as it will be displayed in" Comment.Single
-'\n                               ' Text
+'\n                               ' Text.Whitespace
 '-- the debug messages' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-------------------------------------------------------------------------------' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- Prints the specified message to nLog.' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- syntax:'  Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    errorCode, message = debugPrint([message][, category][, title][, errorCode][, level])' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- parameters:' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    message   - (string) the error message' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, no error message specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    category  - (string) the category of the debug message' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, no category specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    title     - (string) the title for the debug message' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, no title specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    errorCode - (number) the error code' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, no error code specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    level     - (string) nLog message level' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                         Any nLog.levels string is valid.' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, no level specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- returns:' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    errorCode - (number) errorCode, if one is specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, otherwise' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    message   - (string) message, if one is specified' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                nil, otherwise' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-------------------------------------------------------------------------------' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Class
 '.'           Punctuation
 'Debug'       Name.Class
@@ -1564,100 +1564,100 @@
 '('           Punctuation
 'message'     Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'category'    Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'errorCode'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'level'       Name.Variable
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'return'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'DebugLib'    Name.Variable
 '.'           Punctuation
 'DebugPrint'  Name.Function
 '('           Punctuation
 'addonName'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'message'     Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'category'    Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'title'       Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'errorCode'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'level'       Name.Variable
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '-------------------------------------------------------------------------------' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- Used to make sure that conditions are met within functions.' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 "-- If test is false, the error message will be written to nLog and the user's" Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- default chat channel.' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- syntax:'  Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    assertion = assert(test, message)' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- parameters:' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    test    - (any)     false/nil, if the assertion failed' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                        anything else, otherwise' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    message - (string)  the message which will be output to the user' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- returns:' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--    assertion - (boolean) true, if the test passed' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '--                          false, otherwise' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-------------------------------------------------------------------------------' Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'AucAdvanced' Name.Class
 '.'           Punctuation
 'Debug'       Name.Class
@@ -1666,45 +1666,45 @@
 '('           Punctuation
 'test'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'message'     Name.Variable
 ')'           Punctuation
-'\n\t'        Text
+'\n\t'        Text.Whitespace
 'return'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'DebugLib'    Name.Variable
 '.'           Punctuation
 'Assert'      Name.Function
 '('           Punctuation
 'addonName'   Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'test'        Name.Variable
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 'message'     Name.Variable
 ')'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 '--[==[\nHere follow further tests of Lua syntax.\n]]==]' Comment.Multiline
-'\n'          Text
+'\n'          Text.Whitespace
 
 '---[['       Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'local'       Keyword.Declaration
-' '           Text
+' '           Text.Whitespace
 't'           Name.Variable
-' '           Text
+' '           Text.Whitespace
 '='           Operator
-' '           Text
+' '           Text.Whitespace
 '{'           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 '['           Punctuation
-' '           Text
+' '           Text.Whitespace
 '[[\nx\n]==] \\]]' Literal.String
 ']'           Punctuation
 '='           Operator
@@ -1712,7 +1712,7 @@
 '|'           Operator
 '2'           Literal.Number.Integer
 ';'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'a'           Name.Variable
 '='           Operator
 '{'           Punctuation
@@ -1726,125 +1726,125 @@
 '}'           Punctuation
 '}'           Punctuation
 ','           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 '1'           Literal.Number.Integer
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.'          Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.2'         Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '.2'          Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1e3'         Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.e3'        Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.2e3'       Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '.2e3'        Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.2e+3'      Literal.Number.Float
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '1.2E-3'      Literal.Number.Float
 ';'           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 '0xA'         Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0Xa'         Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0xA.'        Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0x.F'        Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0xA.F'       Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0xA.Fp1'     Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0xA.FP+1'    Literal.Number.Hex
 ','           Punctuation
-' '           Text
+' '           Text.Whitespace
 '0Xa.fp-1'    Literal.Number.Hex
 ';'           Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 '}'           Punctuation
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 't'           Name.Class
 '.'           Punctuation
 'f'           Name.Function
 '('           Punctuation
 ')'           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 'goto'        Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 'eof'         Name.Label
-'\n        '  Text
+'\n        '  Text.Whitespace
 'os.exit'     Name.Builtin
 '('           Punctuation
 ')'           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 '::'          Punctuation
-' '           Text
+' '           Text.Whitespace
 'eof'         Name.Label
-' '           Text
+' '           Text.Whitespace
 '::'          Punctuation
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n\n'        Text
+'\n\n'        Text.Whitespace
 
 'function'    Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 't'           Name.Class
-' '           Text
+' '           Text.Whitespace
 '.'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'a'           Name.Class
-' '           Text
+' '           Text.Whitespace
 '--[==[x]==]' Comment.Multiline
-' '           Text
+' '           Text.Whitespace
 '.'           Punctuation
 'b'           Name.Class
-' '           Text
+' '           Text.Whitespace
 '--[==[y]==]' Comment.Multiline
-' '           Text
+' '           Text.Whitespace
 '--'          Comment.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 '-- () end'   Comment.Single
-'\n           ' Text
+'\n           ' Text.Whitespace
 '.'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'c'           Name.Class
-' '           Text
+' '           Text.Whitespace
 ':'           Punctuation
-' '           Text
+' '           Text.Whitespace
 'd'           Name.Function
-' '           Text
+' '           Text.Whitespace
 '('           Punctuation
 'file'        Name.Variable
 ')'           Punctuation
-'\n        '  Text
+'\n        '  Text.Whitespace
 'return'      Keyword.Reserved
-' '           Text
+' '           Text.Whitespace
 "'"           Literal.String.Single
 '.'           Literal.String.Single
 '\\a'         Literal.String.Escape
@@ -1886,7 +1886,7 @@
 '.'           Literal.String.Single
 '\\u{1234}'   Literal.String.Escape
 "'"           Literal.String.Single
-'\n'          Text
+'\n'          Text.Whitespace
 
 'end'         Keyword.Reserved
-'\n'          Text
+'\n'          Text.Whitespace

--- a/tests/examplefiles/lua/example.lua.output
+++ b/tests/examplefiles/lua/example.lua.output
@@ -9,12 +9,12 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -29,12 +29,12 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvancedData' Name
+'AucAdvancedData' Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvancedData' Name
+'AucAdvancedData' Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -49,12 +49,12 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvancedLocal' Name
+'AucAdvancedLocal' Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvancedLocal' Name
+'AucAdvancedLocal' Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -69,12 +69,12 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvancedConfig' Name
+'AucAdvancedConfig' Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvancedConfig' Name
+'AucAdvancedConfig' Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -84,9 +84,9 @@
 'end'         Keyword.Reserved
 '\n\n'        Text
 
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Version'     Name
+'Version'     Name.Property
 '='           Operator
 '"'           Literal.String.Double
 '<%version%>' Literal.String.Double
@@ -97,9 +97,9 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Version'     Name
+'Version'     Name.Property
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -114,9 +114,9 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t'        Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Version'     Name
+'Version'     Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
@@ -131,7 +131,7 @@
 
 'local'       Keyword.Declaration
 ' '           Text
-'private'     Name
+'private'     Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -153,31 +153,31 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
 '{'           Punctuation
-'Stat'        Name
+'Stat'        Name.Variable
 '='           Operator
 '{'           Punctuation
 '}'           Punctuation
 ','           Punctuation
-'Util'        Name
+'Util'        Name.Variable
 '='           Operator
 '{'           Punctuation
 '}'           Punctuation
 ','           Punctuation
-'Filter'      Name
+'Filter'      Name.Variable
 '='           Operator
 '{'           Punctuation
 '}'           Punctuation
@@ -191,16 +191,16 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvancedData' Name
+'AucAdvancedData' Name.Variable
 '.'           Punctuation
-'Stats'       Name
+'Stats'       Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvancedData' Name
+'AucAdvancedData' Name.Variable
 '.'           Punctuation
-'Stats'       Name
+'Stats'       Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
@@ -215,16 +215,16 @@
 '('           Punctuation
 'not'         Operator.Word
 ' '           Text
-'AucAdvancedLocal' Name
+'AucAdvancedLocal' Name.Variable
 '.'           Punctuation
-'Stats'       Name
+'Stats'       Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'AucAdvancedLocal' Name
+'AucAdvancedLocal' Name.Variable
 '.'           Punctuation
-'Stats'       Name
+'Stats'       Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
@@ -240,40 +240,40 @@
 '.'           Punctuation
 'TooltipHook' Name.Function
 '('           Punctuation
-'vars'        Name
+'vars'        Name.Variable
 ','           Punctuation
 ' '           Text
-'ret'         Name
+'ret'         Name.Variable
 ','           Punctuation
 ' '           Text
-'frame'       Name
+'frame'       Name.Variable
 ','           Punctuation
 ' '           Text
-'name'        Name
+'name'        Name.Variable
 ','           Punctuation
 ' '           Text
-'hyperlink'   Name
+'hyperlink'   Name.Variable
 ','           Punctuation
 ' '           Text
-'quality'     Name
+'quality'     Name.Variable
 ','           Punctuation
 ' '           Text
-'quantity'    Name
+'quantity'    Name.Variable
 ','           Punctuation
 ' '           Text
-'cost'        Name
+'cost'        Name.Variable
 ','           Punctuation
 ' '           Text
-'additional'  Name
+'additional'  Name.Variable
 ')'           Punctuation
 '\n\t'        Text
 'if'          Keyword.Reserved
 ' '           Text
-'EnhTooltip'  Name
+'EnhTooltip'  Name.Variable
 '.'           Punctuation
-'LinkType'    Name
+'LinkType'    Name.Function
 '('           Punctuation
-'hyperlink'   Name
+'hyperlink'   Name.Variable
 ')'           Punctuation
 ' '           Text
 '~='          Operator
@@ -294,20 +294,20 @@
 '\n\t'        Text
 'local'       Keyword.Declaration
 ' '           Text
-'getter'      Name
+'getter'      Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Settings'    Name
+'Settings'    Name.Property
 '.'           Punctuation
-'GetSetting'  Name
+'GetSetting'  Name.Property
 '\n\t'        Text
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'getter'      Name
+'getter'      Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'scandata.tooltip.display' Literal.String.Double
@@ -316,7 +316,7 @@
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'getter'      Name
+'getter'      Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'scandata.force' Literal.String.Double
@@ -326,11 +326,11 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Scan'        Name
+'Scan'        Name.Property
 '.'           Punctuation
-'GetImage'    Name
+'GetImage'    Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
@@ -338,34 +338,34 @@
 '\n\n\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -373,41 +373,41 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'tooltip'     Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'frame'       Name
+'frame'       Name.Variable
 ','           Punctuation
 ' '           Text
-'name'        Name
+'name'        Name.Variable
 ','           Punctuation
 ' '           Text
-'hyperlink'   Name
+'hyperlink'   Name.Variable
 ','           Punctuation
 ' '           Text
-'quality'     Name
+'quality'     Name.Variable
 ','           Punctuation
 ' '           Text
-'quantity'    Name
+'quantity'    Name.Variable
 ','           Punctuation
 ' '           Text
-'cost'        Name
+'cost'        Name.Variable
 ','           Punctuation
 ' '           Text
-'additional'  Name
+'additional'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'end'         Keyword.Reserved
@@ -428,50 +428,50 @@
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
-'hooksecurefunc' Name
+'hooksecurefunc' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'AuctionFrameBrowse_Update' Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'API'         Name
+'API'         Name.Property
 '.'           Punctuation
-'ListUpdate'  Name
+'ListUpdate'  Name.Property
 ')'           Punctuation
 '\n\t'        Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -479,16 +479,16 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t'  Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'auctionui'   Literal.String.Double
@@ -511,16 +511,16 @@
 '.'           Punctuation
 'OnLoad'      Name.Function
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t'        Text
-'addon'       Name
+'addon'       Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
-'addon'       Name
+'addon'       Name.Variable
 ':'           Punctuation
-'lower'       Name
+'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\n\t'      Text
@@ -529,7 +529,7 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -540,9 +540,9 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'Stubby'      Name
+'Stubby'      Name.Variable
 '.'           Punctuation
-'RegisterAddOnHook' Name
+'RegisterAddOnHook' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'Blizzard_AuctionUi' Literal.String.Double
@@ -554,14 +554,14 @@
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'HookAH'      Name
+'HookAH'      Name.Property
 ')'           Punctuation
 '\n\t\t'      Text
-'Stubby'      Name
+'Stubby'      Name.Variable
 '.'           Punctuation
-'RegisterFunctionHook' Name
+'RegisterFunctionHook' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'EnhTooltip.AddTooltip' Literal.String.Double
@@ -571,36 +571,36 @@
 '600'         Literal.Number.Integer
 ','           Punctuation
 ' '           Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'TooltipHook' Name
+'TooltipHook' Name.Property
 ')'           Punctuation
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'pos'         Name
+'pos'         Name.Variable
 ','           Punctuation
 ' '           Text
-'module'      Name
+'module'      Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'ipairs'      Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'EmbeddedModules' Name
+'EmbeddedModules' Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t\t'    Text
 '-- These embedded modules have also just been loaded' Comment.Single
 '\n\t\t\t'    Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Function
 '('           Punctuation
-'module'      Name
+'module'      Name.Variable
 ')'           Punctuation
 '\n\t\t'      Text
 'end'         Keyword.Reserved
@@ -611,30 +611,30 @@
 '\n\t'        Text
 'local'       Keyword.Declaration
 ' '           Text
-'auc'         Name
+'auc'         Name.Variable
 ','           Punctuation
 ' '           Text
-'sys'         Name
+'sys'         Name.Variable
 ','           Punctuation
 ' '           Text
-'eng'         Name
+'eng'         Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
-'strsplit'    Name
+'strsplit'    Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 '-'           Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t'        Text
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'auc'         Name
+'auc'         Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -644,29 +644,29 @@
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'sys'         Name
+'sys'         Name.Variable
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'eng'         Name
+'eng'         Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -674,13 +674,13 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'sys'         Name
+'sys'         Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ':'           Punctuation
-'lower'       Name
+'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
 ')'           Punctuation
@@ -689,16 +689,16 @@
 '\n\t\t\t\t'  Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -706,30 +706,30 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'eng'         Name
+'eng'         Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ':'           Punctuation
-'lower'       Name
+'lower'       Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t\t\t' Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Function
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t\t\t\t\t' Text
 'end'         Keyword.Reserved
@@ -746,34 +746,34 @@
 '\n\t'        Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -781,17 +781,17 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'LoadTriggers' Name
+'LoadTriggers' Name.Property
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'LoadTriggers' Name
+'LoadTriggers' Name.Property
 '['           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ']'           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -800,18 +800,18 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t\t' Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Function
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t\t\t\t'  Text
 'end'         Keyword.Reserved
@@ -821,13 +821,13 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Property
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'auc'         Name
+'auc'         Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -837,25 +837,25 @@
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'sys'         Name
+'sys'         Name.Variable
 ' '           Text
 'and'         Operator.Word
 ' '           Text
-'eng'         Name
+'eng'         Name.Variable
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t'  Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'load'        Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t\t\t'    Text
 'end'         Keyword.Reserved
@@ -878,34 +878,34 @@
 '\n\t'        Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t'      Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
@@ -913,16 +913,16 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnUnload'    Name
+'OnUnload'    Name.Property
 ')'           Punctuation
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t'  Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'OnUnload'    Name
+'OnUnload'    Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t\t\t'    Text
@@ -936,9 +936,9 @@
 'end'         Keyword.Reserved
 '\n\n'        Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Schedule'    Name
+'Schedule'    Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
@@ -957,10 +957,10 @@
 '\n\t'        Text
 'local'       Keyword.Declaration
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ','           Punctuation
 ' '           Text
-'arg'         Name
+'arg'         Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -975,7 +975,7 @@
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -988,21 +988,21 @@
 '\n\t\t'      Text
 'local'       Keyword.Declaration
 ' '           Text
-'addon'       Name
+'addon'       Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
 'string.lower' Name.Builtin
 '('           Punctuation
-'arg'         Name
+'arg'         Name.Variable
 ')'           Punctuation
 '\n\t\t'      Text
 'if'          Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ':'           Punctuation
-'sub'         Name
+'sub'         Name.Function
 '('           Punctuation
 '1'           Literal.Number.Integer
 ','           Punctuation
@@ -1018,11 +1018,11 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t'    Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'OnLoad'      Name
+'OnLoad'      Name.Function
 '('           Punctuation
-'addon'       Name
+'addon'       Name.Variable
 ')'           Punctuation
 '\n\t\t'      Text
 'end'         Keyword.Reserved
@@ -1030,7 +1030,7 @@
 'elseif'      Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1046,7 +1046,7 @@
 'elseif'      Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1057,18 +1057,18 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Scan'        Name
+'Scan'        Name.Property
 '.'           Punctuation
-'Interrupt'   Name
+'Interrupt'   Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
 'elseif'      Keyword.Reserved
 ' '           Text
 '('           Punctuation
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1079,24 +1079,24 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Scan'        Name
+'Scan'        Name.Property
 '.'           Punctuation
-'Commit'      Name
+'Commit'      Name.Function
 '('           Punctuation
 'true'        Keyword.Constant
 ')'           Punctuation
 '\n\t\t'      Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'OnUnload'    Name
+'OnUnload'    Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
 'elseif'      Keyword.Reserved
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1106,7 +1106,7 @@
 '\n\t'        Text
 'or'          Operator.Word
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1116,7 +1116,7 @@
 '\n\t'        Text
 'or'          Operator.Word
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1126,7 +1126,7 @@
 '\n\t'        Text
 'or'          Operator.Word
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1136,9 +1136,9 @@
 '\n\t'        Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Schedule'    Name
+'Schedule'    Name.Property
 '['           Punctuation
 '"'           Literal.String.Double
 'inventory'   Literal.String.Double
@@ -1147,7 +1147,7 @@
 ' '           Text
 '='           Operator
 ' '           Text
-'GetTime'     Name
+'GetTime'     Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text
@@ -1172,7 +1172,7 @@
 '\n\t'        Text
 'if'          Keyword.Reserved
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ' '           Text
 '=='          Operator
 ' '           Text
@@ -1182,11 +1182,11 @@
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t'      Text
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Post'        Name
+'Post'        Name.Property
 '.'           Punctuation
-'AlertBagsChanged' Name
+'AlertBagsChanged' Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
@@ -1194,92 +1194,92 @@
 '\n\n\t'      Text
 'local'       Keyword.Declaration
 ' '           Text
-'now'         Name
+'now'         Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
-'GetTime'     Name
+'GetTime'     Name.Function
 '('           Punctuation
 ')'           Punctuation
 '\n\t'        Text
 'for'         Keyword.Reserved
 ' '           Text
-'event'       Name
+'event'       Name.Variable
 ','           Punctuation
 ' '           Text
-'time'        Name
+'time'        Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Schedule'    Name
+'Schedule'    Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t'      Text
 'if'          Keyword.Reserved
 ' '           Text
-'time'        Name
+'time'        Name.Variable
 ' '           Text
 '>'           Operator
 ' '           Text
-'now'         Name
+'now'         Name.Variable
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t'    Text
 'for'         Keyword.Reserved
 ' '           Text
-'system'      Name
+'system'      Name.Variable
 ','           Punctuation
 ' '           Text
-'systemMods'  Name
+'systemMods'  Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Modules'     Name
+'Modules'     Name.Property
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t\t\t'  Text
 'for'         Keyword.Reserved
 ' '           Text
-'engine'      Name
+'engine'      Name.Variable
 ','           Punctuation
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 ' '           Text
 'in'          Keyword.Reserved
 ' '           Text
 'pairs'       Name.Builtin
 '('           Punctuation
-'systemMods'  Name
+'systemMods'  Name.Variable
 ')'           Punctuation
 ' '           Text
 'do'          Keyword.Reserved
 '\n\t\t\t\t\t' Text
 'if'          Keyword.Reserved
 ' '           Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Property
 ' '           Text
 'then'        Keyword.Reserved
 '\n\t\t\t\t\t\t' Text
-'engineLib'   Name
+'engineLib'   Name.Variable
 '.'           Punctuation
-'Processor'   Name
+'Processor'   Name.Function
 '('           Punctuation
-'event'       Name
+'event'       Name.Variable
 ','           Punctuation
 ' '           Text
-'time'        Name
+'time'        Name.Variable
 ')'           Punctuation
 '\n\t\t\t\t\t' Text
 'end'         Keyword.Reserved
@@ -1290,11 +1290,11 @@
 '\n\t\t'      Text
 'end'         Keyword.Reserved
 '\n\t\t'      Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Schedule'    Name
+'Schedule'    Name.Property
 '['           Punctuation
-'event'       Name
+'event'       Name.Variable
 ']'           Punctuation
 ' '           Text
 '='           Operator
@@ -1307,13 +1307,13 @@
 'end'         Keyword.Reserved
 '\n\n'        Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
-'CreateFrame' Name
+'CreateFrame' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'Frame'       Literal.String.Double
@@ -1321,11 +1321,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'ADDON_LOADED' Literal.String.Double
@@ -1333,11 +1333,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'AUCTION_HOUSE_SHOW' Literal.String.Double
@@ -1345,11 +1345,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'AUCTION_HOUSE_CLOSED' Literal.String.Double
@@ -1357,11 +1357,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'UNIT_INVENTORY_CHANGED' Literal.String.Double
@@ -1369,11 +1369,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'ITEM_LOCK_CHANGED' Literal.String.Double
@@ -1381,11 +1381,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'CURSOR_UPDATE' Literal.String.Double
@@ -1393,11 +1393,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'BAG_UPDATE'  Literal.String.Double
@@ -1405,11 +1405,11 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'RegisterEvent' Name
+'RegisterEvent' Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'PLAYER_LOGOUT' Literal.String.Double
@@ -1417,46 +1417,46 @@
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'SetScript'   Name
+'SetScript'   Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'OnEvent'     Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'OnEvent'     Name
+'OnEvent'     Name.Property
 ')'           Punctuation
 '\n'          Text
 
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'Frame'       Name
+'Frame'       Name.Property
 ':'           Punctuation
-'SetScript'   Name
+'SetScript'   Name.Function
 '('           Punctuation
 '"'           Literal.String.Double
 'OnUpdate'    Literal.String.Double
 '"'           Literal.String.Double
 ','           Punctuation
 ' '           Text
-'private'     Name
+'private'     Name.Variable
 '.'           Punctuation
-'OnUpdate'    Name
+'OnUpdate'    Name.Property
 ')'           Punctuation
 '\n\n'        Text
 
 "-- Auctioneer's debug functions" Comment.Single
 '\n'          Text
 
-'AucAdvanced' Name
+'AucAdvanced' Name.Variable
 '.'           Punctuation
-'Debug'       Name
+'Debug'       Name.Property
 ' '           Text
 '='           Operator
 ' '           Text
@@ -1466,7 +1466,7 @@
 
 'local'       Keyword.Declaration
 ' '           Text
-'addonName'   Name
+'addonName'   Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -1562,43 +1562,43 @@
 '.'           Punctuation
 'DebugPrint'  Name.Function
 '('           Punctuation
-'message'     Name
+'message'     Name.Variable
 ','           Punctuation
 ' '           Text
-'category'    Name
+'category'    Name.Variable
 ','           Punctuation
 ' '           Text
-'title'       Name
+'title'       Name.Variable
 ','           Punctuation
 ' '           Text
-'errorCode'   Name
+'errorCode'   Name.Variable
 ','           Punctuation
 ' '           Text
-'level'       Name
+'level'       Name.Variable
 ')'           Punctuation
 '\n\t'        Text
 'return'      Keyword.Reserved
 ' '           Text
-'DebugLib'    Name
+'DebugLib'    Name.Variable
 '.'           Punctuation
-'DebugPrint'  Name
+'DebugPrint'  Name.Function
 '('           Punctuation
-'addonName'   Name
+'addonName'   Name.Variable
 ','           Punctuation
 ' '           Text
-'message'     Name
+'message'     Name.Variable
 ','           Punctuation
 ' '           Text
-'category'    Name
+'category'    Name.Variable
 ','           Punctuation
 ' '           Text
-'title'       Name
+'title'       Name.Variable
 ','           Punctuation
 ' '           Text
-'errorCode'   Name
+'errorCode'   Name.Variable
 ','           Punctuation
 ' '           Text
-'level'       Name
+'level'       Name.Variable
 ')'           Punctuation
 '\n'          Text
 
@@ -1664,25 +1664,25 @@
 '.'           Punctuation
 'Assert'      Name.Function
 '('           Punctuation
-'test'        Name
+'test'        Name.Variable
 ','           Punctuation
 ' '           Text
-'message'     Name
+'message'     Name.Variable
 ')'           Punctuation
 '\n\t'        Text
 'return'      Keyword.Reserved
 ' '           Text
-'DebugLib'    Name
+'DebugLib'    Name.Variable
 '.'           Punctuation
-'Assert'      Name
+'Assert'      Name.Function
 '('           Punctuation
-'addonName'   Name
+'addonName'   Name.Variable
 ','           Punctuation
 ' '           Text
-'test'        Name
+'test'        Name.Variable
 ','           Punctuation
 ' '           Text
-'message'     Name
+'message'     Name.Variable
 ')'           Punctuation
 '\n'          Text
 
@@ -1697,7 +1697,7 @@
 
 'local'       Keyword.Declaration
 ' '           Text
-'t'           Name
+'t'           Name.Variable
 ' '           Text
 '='           Operator
 ' '           Text
@@ -1713,13 +1713,13 @@
 '2'           Literal.Number.Integer
 ';'           Punctuation
 ' '           Text
-'a'           Name
+'a'           Name.Variable
 '='           Operator
 '{'           Punctuation
-'b'           Name
+'b'           Name.Variable
 '='           Operator
 '{'           Punctuation
-'c'           Name
+'c'           Name.Variable
 '='           Operator
 '{'           Punctuation
 '}'           Punctuation
@@ -1840,7 +1840,7 @@
 'd'           Name.Function
 ' '           Text
 '('           Punctuation
-'file'        Name
+'file'        Name.Variable
 ')'           Punctuation
 '\n        '  Text
 'return'      Keyword.Reserved


### PR DESCRIPTION
This PR improves the `LuaLexer` in that it can now detect variables, properties, and function calls. Accesses and/or calls like `foo.bar:baz()` now yield (excluding punctuation) variable, property, function. This required refactoring the detection of builtins (first commit).

One thing the lexer gets slightly wrong is that it will yield "variable" for table properties (`{ foo = 1 }`). Detecting this would require much more state (essentially for every scope).

The lexer now also makes use of `Text.Whitespace`.