### PR TITLE
[styles/coffee] Improve the colour of `builtin` & `PreProc`

### DIFF
--- a/pygments/styles/coffee.py
+++ b/pygments/styles/coffee.py
@@ -31,7 +31,7 @@ class CoffeeStyle(Style):
     styles = {
         Comment: "#70757A",
         Comment.Hashbang: "#8f9f9f",
-        Comment.Preproc: "#fdd0c0",
+        Comment.Preproc: "#dfaf87",
         Comment.PreprocFile: "#c9b98f",
         Comment.Special: "#af5f5f",
         Error: "#af5f5f",


### PR DESCRIPTION
Before the colour of built-ins was plain. Now it is changed to be highlighted and reflected in the source code.

Previously added at https://github.com/pygments/pygments/pull/2609 :)

Before:

![image](https://github.com/user-attachments/assets/9391fd4e-9783-4e1b-ab09-f638a4b38236)

After:

![image](https://github.com/user-attachments/assets/4da727d8-344c-4a8e-ac12-03fe198c396e)

It's essentially a change of one colour.
