### PR TITLE
Add lexer for Vue SFC (*.vue)

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -561,6 +561,7 @@ LEXERS = {
     'VimLexer': ('pygments.lexers.textedit', 'VimL', ('vim',), ('*.vim', '.vimrc', '.exrc', '.gvimrc', '_vimrc', '_exrc', '_gvimrc', 'vimrc', 'gvimrc'), ('text/x-vim',)),
     'VisualPrologGrammarLexer': ('pygments.lexers.vip', 'Visual Prolog Grammar', ('visualprologgrammar',), ('*.vipgrm',), ()),
     'VisualPrologLexer': ('pygments.lexers.vip', 'Visual Prolog', ('visualprolog',), ('*.pro', '*.cl', '*.i', '*.pack', '*.ph'), ()),
+    'VueLexer': ('pygments.lexers.html', 'Vue', ('vue',), ('*.vue',), ()),
     'VyperLexer': ('pygments.lexers.vyper', 'Vyper', ('vyper',), ('*.vy',), ()),
     'WDiffLexer': ('pygments.lexers.diff', 'WDiff', ('wdiff',), ('*.wdiff',), ()),
     'WatLexer': ('pygments.lexers.webassembly', 'WebAssembly', ('wast', 'wat'), ('*.wat', '*.wast'), ()),

--- a/pygments/lexers/html.py
+++ b/pygments/lexers/html.py
@@ -664,6 +664,6 @@ class VueLexer(HtmlLexer):
         'attr-directive': [
             (r'(["\'])(.*?)(\1)', bygroups(String,
              using(JavascriptLexer), String), '#pop'),
-            (r'[^\s>]+', bygroups(using(JavascriptLexer)), '#pop'),
+            (r'[^\s>]+', using(JavascriptLexer), '#pop'),
         ],
     }

--- a/pygments/lexers/html.py
+++ b/pygments/lexers/html.py
@@ -11,7 +11,7 @@
 import re
 
 from pygments.lexer import RegexLexer, ExtendedRegexLexer, include, bygroups, \
-    default, using
+    default, using, inherit, this
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Punctuation, Whitespace
 from pygments.util import looks_like_xml, html_doctype_matches
@@ -22,7 +22,7 @@ from pygments.lexers.css import CssLexer, _indentation, _starts_block
 from pygments.lexers.ruby import RubyLexer
 
 __all__ = ['HtmlLexer', 'DtdLexer', 'XmlLexer', 'XsltLexer', 'HamlLexer',
-           'ScamlLexer', 'PugLexer', 'UrlEncodedLexer']
+           'ScamlLexer', 'PugLexer', 'VueLexer', 'UrlEncodedLexer']
 
 
 class HtmlLexer(RegexLexer):
@@ -622,5 +622,48 @@ class UrlEncodedLexer(RegexLexer):
     tokens = {
         'root': [
             ('([^&=]*)(=)([^=&]*)(&?)', bygroups(Name.Tag, Operator, String, Punctuation)),
+        ],
+    }
+    
+
+class VueLexer(HtmlLexer):
+    """
+    For Vue Single-File Component.
+    """
+
+    name = 'Vue'
+    url = 'https://vuejs.org/api/sfc-spec.html'
+    aliases = ['vue']
+    filenames = ['*.vue']
+    mimetypes = []
+
+    flags = re.IGNORECASE | re.DOTALL
+    tokens = {
+        'root': [
+            (r'(\{\{)(.*?)(\}\})', bygroups(Comment.Preproc,
+             using(JavascriptLexer), Comment.Preproc)),
+            ('[^<&{]+', Text),
+            inherit,
+        ],
+        'tag': [
+            (r'\s+', Text),
+            (r'((?:[@:]|v-)(?:[.\w:-]|\[[^\]]*?\])+\s*)(=)(\s*)',
+             bygroups(using(this, state=['name']), Operator, Text),
+             'attr-directive'),
+            (r'([\w:-]+\s*)(=)(\s*)', bygroups(Name.Attribute, Operator, Text),
+             'attr'),
+            (r'[\w:-]+', Name.Attribute),
+            (r'(/?)(\s*)(>)', bygroups(Punctuation, Text, Punctuation), '#pop'),
+        ],
+        'name': [
+            (r'[\w-]+', Name.Attribute),
+            (r'[:@.]', Punctuation),
+            (r'(\[)([^\]]*?)(\])', bygroups(Comment.Preproc,
+             using(JavascriptLexer), Comment.Preproc)),
+        ],
+        'attr-directive': [
+            (r'(["\'])(.*?)(\1)', bygroups(String,
+             using(JavascriptLexer), String), '#pop'),
+            (r'[^\s>]+', bygroups(using(JavascriptLexer)), '#pop'),
         ],
     }

--- a/tests/examplefiles/vue/test.vue
+++ b/tests/examplefiles/vue/test.vue
@@ -1,0 +1,58 @@
+<script>
+export default {
+    data() {
+        return {
+            greeting: 'Hello World!'
+        }
+    }
+}
+</script>
+
+<template>
+    <p class="greeting">{{ greeting }}</p>
+    <div v-bind="objectOfAttrs"></div>
+    {{ number + 1 }}
+    {{ ok ? 'YES' : 'NO' }}
+    {{ message.split('').reverse().join('') }}
+    <div :id="`list-${id}`"></div>
+    <span :title="toTitleDate(date)">
+        {{ formatDate(date) }}
+    </span>
+    <p v-if="seen">Now you see me</p>
+    <a v-bind:href="url"> ... </a>
+    <!-- shorthand -->
+    <a :href="url"> ... </a>
+    <a v-on:click="doSomething"> ... </a>
+    <!-- shorthand -->
+    <a @click="doSomething"> ... </a>
+    <a v-bind:[attributeName]="url"> ... </a>
+    <a :[attributeName]="url"> ... </a>
+    <a v-on:[eventName]="doSomething"> ... </a>
+    <a @[eventName]="doSomething"></a>
+    <form @submit.prevent="onSubmit">...</form>
+    <li v-for="item in items">
+        {{ item.message }}
+    </li>
+    <li v-for="(item, index) in items">
+        {{ parentMessage }} - {{ index }} - {{ item.message }}
+    </li>
+    <li v-for="{ message } in items">
+        {{ message }}
+    </li>
+    <li v-for="({ message }, index) in items">
+        {{ message }} {{ index }}
+    </li>
+    <li v-for="item in items">
+        <span v-for="childItem in item.children">
+            {{ item.message }} {{ childItem }}
+        </span>
+    </li>
+    <div v-for="item of items"></div>
+</template>
+
+<style>
+.greeting {
+    color: red;
+    font-weight: bold;
+}
+</style>

--- a/tests/examplefiles/vue/test.vue.output
+++ b/tests/examplefiles/vue/test.vue.output
@@ -1,0 +1,608 @@
+'<'           Punctuation
+'script'      Name.Tag
+'>'           Punctuation
+''            Text
+'\n'          Text.Whitespace
+
+'export'      Keyword
+' '           Text.Whitespace
+'default'     Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'data'        Name.Other
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'\n            ' Text.Whitespace
+'greeting'    Name.Other
+':'           Operator
+' '           Text.Whitespace
+"'Hello World!'" Literal.String.Single
+'\n        '  Text.Whitespace
+'}'           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'<'           Punctuation
+'/'           Punctuation
+'script'      Name.Tag
+'>'           Punctuation
+'\n\n'        Text
+
+'<'           Punctuation
+'template'    Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'p'           Name.Tag
+' '           Text
+'class'       Name.Attribute
+'='           Operator
+'"greeting"'  Literal.String
+'>'           Punctuation
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'greeting'    Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'<'           Punctuation
+'/'           Punctuation
+'p'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'div'         Name.Tag
+' '           Text
+'v-bind'      Name.Attribute
+'='           Operator
+'"'           Literal.String
+'objectOfAttrs' Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'<'           Punctuation
+'/'           Punctuation
+'div'         Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'number'      Name.Other
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Float
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'ok'          Name.Other
+' '           Text.Whitespace
+'?'           Operator
+' '           Text.Whitespace
+"'YES'"       Literal.String.Single
+' '           Text.Whitespace
+':'           Operator
+' '           Text.Whitespace
+"'NO'"        Literal.String.Single
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'message'     Name.Other
+'.'           Punctuation
+'split'       Name.Other
+'('           Punctuation
+"''"          Literal.String.Single
+')'           Punctuation
+'.'           Punctuation
+'reverse'     Name.Other
+'('           Punctuation
+')'           Punctuation
+'.'           Punctuation
+'join'        Name.Other
+'('           Punctuation
+"''"          Literal.String.Single
+')'           Punctuation
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'div'         Name.Tag
+' '           Text
+':'           Punctuation
+'id'          Name.Attribute
+'='           Operator
+'"'           Literal.String
+'`'           Literal.String.Backtick
+'list-'       Literal.String.Backtick
+'${'          Literal.String.Interpol
+'id'          Name.Other
+'}'           Literal.String.Interpol
+'`'           Literal.String.Backtick
+'"'           Literal.String
+'>'           Punctuation
+'<'           Punctuation
+'/'           Punctuation
+'div'         Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'span'        Name.Tag
+' '           Text
+':'           Punctuation
+'title'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'toTitleDate' Name.Other
+'('           Punctuation
+'date'        Name.Other
+')'           Punctuation
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'formatDate'  Name.Other
+'('           Punctuation
+'date'        Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'span'        Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'p'           Name.Tag
+' '           Text
+'v-if'        Name.Attribute
+'='           Operator
+'"'           Literal.String
+'seen'        Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'Now you see me' Text
+'<'           Punctuation
+'/'           Punctuation
+'p'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'v-bind'      Name.Attribute
+':'           Punctuation
+'href'        Name.Attribute
+'='           Operator
+'"'           Literal.String
+'url'         Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<!-- shorthand -->' Comment.Multiline
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+':'           Punctuation
+'href'        Name.Attribute
+'='           Operator
+'"'           Literal.String
+'url'         Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'v-on'        Name.Attribute
+':'           Punctuation
+'click'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'doSomething' Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<!-- shorthand -->' Comment.Multiline
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'@'           Punctuation
+'click'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'doSomething' Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'v-bind'      Name.Attribute
+':'           Punctuation
+'['           Comment.Preproc
+'attributeName' Name.Other
+']'           Comment.Preproc
+'='           Operator
+'"'           Literal.String
+'url'         Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+':'           Punctuation
+'['           Comment.Preproc
+'attributeName' Name.Other
+']'           Comment.Preproc
+'='           Operator
+'"'           Literal.String
+'url'         Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'v-on'        Name.Attribute
+':'           Punctuation
+'['           Comment.Preproc
+'eventName'   Name.Other
+']'           Comment.Preproc
+'='           Operator
+'"'           Literal.String
+'doSomething' Name.Other
+'"'           Literal.String
+'>'           Punctuation
+' ... '       Text
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'a'           Name.Tag
+' '           Text
+'@'           Punctuation
+'['           Comment.Preproc
+'eventName'   Name.Other
+']'           Comment.Preproc
+'='           Operator
+'"'           Literal.String
+'doSomething' Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'<'           Punctuation
+'/'           Punctuation
+'a'           Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'form'        Name.Tag
+' '           Text
+'@'           Punctuation
+'submit'      Name.Attribute
+'.'           Punctuation
+'prevent'     Name.Attribute
+'='           Operator
+'"'           Literal.String
+'onSubmit'    Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'...'         Text
+'<'           Punctuation
+'/'           Punctuation
+'form'        Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'li'          Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'item'        Name.Other
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'item'        Name.Other
+'.'           Punctuation
+'message'     Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'li'          Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'li'          Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'('           Punctuation
+'item'        Name.Other
+','           Punctuation
+' '           Text.Whitespace
+'index'       Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'parentMessage' Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+' - '         Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'index'       Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+' - '         Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'item'        Name.Other
+'.'           Punctuation
+'message'     Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'li'          Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'li'          Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'{'           Punctuation
+' '           Text.Whitespace
+'message'     Name.Other
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'message'     Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'li'          Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'li'          Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'('           Punctuation
+'{'           Punctuation
+' '           Text.Whitespace
+'message'     Name.Other
+' '           Text.Whitespace
+'}'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'index'       Name.Other
+')'           Punctuation
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'message'     Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+' '           Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'index'       Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'li'          Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'li'          Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'item'        Name.Other
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n        '  Text
+'<'           Punctuation
+'span'        Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'childItem'   Name.Other
+' '           Text.Whitespace
+'in'          Operator.Word
+' '           Text.Whitespace
+'item'        Name.Other
+'.'           Punctuation
+'children'    Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'\n            ' Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'item'        Name.Other
+'.'           Punctuation
+'message'     Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+' '           Text
+'{{'          Comment.Preproc
+''            Text
+' '           Text.Whitespace
+'childItem'   Name.Other
+' '           Text.Whitespace
+'}}'          Comment.Preproc
+'\n        '  Text
+'<'           Punctuation
+'/'           Punctuation
+'span'        Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'/'           Punctuation
+'li'          Name.Tag
+'>'           Punctuation
+'\n    '      Text
+'<'           Punctuation
+'div'         Name.Tag
+' '           Text
+'v-for'       Name.Attribute
+'='           Operator
+'"'           Literal.String
+'item'        Name.Other
+' '           Text.Whitespace
+'of'          Keyword
+' '           Text.Whitespace
+'items'       Name.Other
+'"'           Literal.String
+'>'           Punctuation
+'<'           Punctuation
+'/'           Punctuation
+'div'         Name.Tag
+'>'           Punctuation
+'\n'          Text
+
+'<'           Punctuation
+'/'           Punctuation
+'template'    Name.Tag
+'>'           Punctuation
+'\n\n'        Text
+
+'<'           Punctuation
+'style'       Name.Tag
+'>'           Punctuation
+'\n'          Text.Whitespace
+
+'.'           Punctuation
+'greeting'    Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'color'       Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'red'         Keyword.Constant
+';'           Punctuation
+'\n    '      Text.Whitespace
+'font-weight' Keyword
+':'           Punctuation
+' '           Text.Whitespace
+'bold'        Keyword.Constant
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'<'           Punctuation
+'/'           Punctuation
+'style'       Name.Tag
+'>'           Punctuation
+'\n'          Text


### PR DESCRIPTION
Closes #2111.

Note that <script> and <style> always use JavaScript and CSS lexer accordingly because it's inherited from HtmlLexer. If there are any requirements to support lang detection (TypeScript, Pug, LESS etc.) this can be improved in the future.