### PR TITLE
hide lineanchors from accessibility API

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -779,7 +779,8 @@ class HtmlFormatter(Formatter):
             if t:
                 i += 1
                 href = "" if self.linenos else ' href="#%s-%d"' % (s, i)
-                yield 1, '<a id="%s-%d" name="%s-%d"%s></a>' % (s, i, s, i, href) + line
+                yield 1, '<a id="%s-%d" name="%s-%d"%s aria-hidden="true"></a>' % \
+                         (s, i, s, i, href) + line
             else:
                 yield 0, line
 


### PR DESCRIPTION
This modification is to increase accessibility of generated HTML files.
It adds `aria-hidden="true"` to the empty lineanchors.

E.g. this is a page created via current Nikola/pygments and opened in Edge:
![grafik](https://github.com/user-attachments/assets/f294d46a-52f9-41e7-9367-d39b7ba79f03)
The "Speech Viewer" is showing what a user with a screen reader would hear. Everything is cluttered due to the lineanchors.

Fixes https://github.com/wxWidgets/Phoenix/issues/2677