### PR TITLE
Vala: Handle identifiers starting with `@`

### DIFF
--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -240,7 +240,7 @@ class ValaLexer(RegexLexer):
                 'ulong', 'unichar', 'ushort'), suffix=r'\b'),
              Keyword.Type),
             (r'(true|false|null)\b', Name.Builtin),
-            (r'[a-zA-Z_]\w*', Name),
+            (r'@?[a-zA-Z_]\w*', Name),
         ],
         'root': [
             include('whitespace'),


### PR DESCRIPTION
Closes: #2859