### PR TITLE
feat(lexer): unicode "box drawings" characters

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Other contributors, listed alphabetically, are:
 * Bryan Davis -- EBNF lexer
 * Bruno Deferrari -- Shen lexer
 * Walter Dörwald -- UL4 lexer
+* Johann Dreo -- Box Drawing lexr
 * Luke Drummond -- Meson lexer
 * Giedrius Dubinskas -- HTML formatter improvements
 * Owen Durni -- Haxe lexer

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -60,6 +60,7 @@ LEXERS = {
     'BoaLexer': ('pygments.lexers.boa', 'Boa', ('boa',), ('*.boa',), ()),
     'BooLexer': ('pygments.lexers.dotnet', 'Boo', ('boo',), ('*.boo',), ('text/x-boo',)),
     'BoogieLexer': ('pygments.lexers.verification', 'Boogie', ('boogie',), ('*.bpl',), ()),
+    'BoxDrawingLexer': ('pygments.lexers.boxdrawing', 'boxdrawing', ('box', 'boxdrawing', 'boxdrawings', 'box-drawing', 'box-drawings', 'box_drawing', 'box_drawings'), ('*.txt',), ()),
     'BrainfuckLexer': ('pygments.lexers.esoteric', 'Brainfuck', ('brainfuck', 'bf'), ('*.bf', '*.b'), ('application/x-brainfuck',)),
     'BugsLexer': ('pygments.lexers.modeling', 'BUGS', ('bugs', 'winbugs', 'openbugs'), ('*.bug',), ()),
     'CAmkESLexer': ('pygments.lexers.esoteric', 'CAmkES', ('camkes', 'idl4'), ('*.camkes', '*.idl4'), ()),

--- a/pygments/lexers/boxdrawing.py
+++ b/pygments/lexers/boxdrawing.py
@@ -1,0 +1,45 @@
+"""
+    pygments.lexers.boxdrawing
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for unicode box drawings characters.
+
+    :copyright: Institut Pasteur (2025), author: Johann Dreo <johann.dreo@pasteur.fr>
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer
+from pygments.token import Comment, Text
+
+__all__ = ['BoxDrawingLexer']
+
+
+class BoxDrawingLexer(RegexLexer):
+    """
+    Highlight any unicode "box drawings" characters as Comment,
+    remaining characters as Text or Text.Whitespace.
+
+    Example:
+    .. sourcecode:: boxdrawing
+
+        ╭─────────╮            ╭─────────╮
+        │My_source├──┤toward├──┤My_target│
+        ╰┬────────╯     ┊      ╰─────┬───╯
+         ┊              ┊            ┊
+         ╰my_prop:this  ╳            ╽
+    """
+
+    name = 'boxdrawing'
+    aliases = ['box', 'boxdrawing', 'boxdrawings', 'box-drawing', 'box-drawings', 'box_drawing', 'box_drawings']
+    filenames = ['*.txt']
+    url = 'https://en.wikipedia.org/wiki/Box-drawing_characters'
+    version_added = '2.19.2'
+
+    tokens = {
+        'root': [
+            # Unicode characters tagged as "BOX DRAWINGS .*"
+            (r'[\u2500-\u257F]+', Comment),
+            (r'\s+', Text.Whitespace),
+            (r'[^\s\u2500-\u257F]+', Text),
+        ]
+    }

--- a/tests/snippets/boxdrawing/boxdrawing.txt
+++ b/tests/snippets/boxdrawing/boxdrawing.txt
@@ -1,0 +1,363 @@
+---input---
+            Named pipes
+         ┌───────┴───────┐
+┌──────┐ ┌─────┐   ┌─────┐ ┌──────┐
+│Client│ │reply│   │query│ │Server│
+└───┬──┘ └─┬───┘   └─┬───┘ └───┬──┘
+    │      │         │         │
+    │      │         │  ┌──────╢
+    │      │    block│  │ wait ║
+    │query │         │  └─────>║
+    ├───────────────>│         │
+    ╟─────┐│         ├────────>│
+    ║wait ││block    │         ║process
+    ║<────┘│         │         ║
+    │      │<──────────────────┤
+    │<─────┤         │    reply│
+    │      │         │         │
+    ┊      ┊         ┊         ┊
+
+
+        ←  genes  →
+     ┌────────────────┐
+     │ var:"id",[…]   │
+     └────────────────┘
+     ┏━━━━━━━━━━━━━━━━┓  ┌────────────────┐
+     ┃ X:             ┃  │ obs:           │  ↑
+     ┃ counts         ┃┓ │ "sample",[…]   │ cells
+     ┃                ┃┃ │                │  ↓
+     ┗━━━━━━━━━━━━━━━━┛┃┓└────────────────┘
+      ┃layers["ranks"] ┃┃
+      ┗━━━━━━━━━━━━━━━━┛┃
+       ┃layers["zscore"]┃
+       ┗━━━━━━━━━━━━━━━━┛
+        ←  genes  →
+     ┌────────────────┐
+     │ varp:          │┐
+     │ "correlations" ││  ↑
+     │                ││ genes
+     │                ││  ↓
+     │                ││
+     └────────────────┘│
+      │ "p-values"     │
+      └────────────────┘
+         ←  genes  →
+
+
+ ╭─────────╮                 ╭───────╮                 ╭─────────╮
+ │My_source├──┤edge_source├──┤My_edge├──┤edge_target├──┤My_target│
+ ╰┬────────╯                 ╰┬──────╯                 ╰────┬────╯
+  ┊                           ┊                             ┊
+  ╰my_prop:this               ╰my_edge_prop:that            ╽
+
+
+---tokens---
+'            ' Text.Whitespace
+'Named'       Text
+' '           Text.Whitespace
+'pipes'       Text
+'\n         ' Text.Whitespace
+'┌───────┴───────┐' Comment
+'\n'          Text.Whitespace
+
+'┌──────┐'    Comment
+' '           Text.Whitespace
+'┌─────┐'     Comment
+'   '         Text.Whitespace
+'┌─────┐'     Comment
+' '           Text.Whitespace
+'┌──────┐'    Comment
+'\n'          Text.Whitespace
+
+'│'           Comment
+'Client'      Text
+'│'           Comment
+' '           Text.Whitespace
+'│'           Comment
+'reply'       Text
+'│'           Comment
+'   '         Text.Whitespace
+'│'           Comment
+'query'       Text
+'│'           Comment
+' '           Text.Whitespace
+'│'           Comment
+'Server'      Text
+'│'           Comment
+'\n'          Text.Whitespace
+
+'└───┬──┘'    Comment
+' '           Text.Whitespace
+'└─┬───┘'     Comment
+'   '         Text.Whitespace
+'└─┬───┘'     Comment
+' '           Text.Whitespace
+'└───┬──┘'    Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'      '      Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'      '      Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'  '          Text.Whitespace
+'┌──────╢'    Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'      '      Text.Whitespace
+'│'           Comment
+'    '        Text.Whitespace
+'block'       Text
+'│'           Comment
+'  '          Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'wait'        Text
+' '           Text.Whitespace
+'║'           Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'query'       Text
+' '           Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'  '          Text.Whitespace
+'└─────'      Comment
+'>'           Text
+'║'           Comment
+'\n    '      Text.Whitespace
+'├───────────────' Comment
+'>'           Text
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'\n    '      Text.Whitespace
+'╟─────┐│'    Comment
+'         '   Text.Whitespace
+'├────────'   Comment
+'>'           Text
+'│'           Comment
+'\n    '      Text.Whitespace
+'║'           Comment
+'wait'        Text
+' '           Text.Whitespace
+'││'          Comment
+'block'       Text
+'    '        Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'║'           Comment
+'process'     Text
+'\n    '      Text.Whitespace
+'║'           Comment
+'<'           Text
+'────┘│'      Comment
+'         '   Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'║'           Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'      '      Text.Whitespace
+'│'           Comment
+'<'           Text
+'──────────────────┤' Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'<'           Text
+'─────┤'      Comment
+'         '   Text.Whitespace
+'│'           Comment
+'    '        Text.Whitespace
+'reply'       Text
+'│'           Comment
+'\n    '      Text.Whitespace
+'│'           Comment
+'      '      Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'         '   Text.Whitespace
+'│'           Comment
+'\n    '      Text.Whitespace
+'┊'           Comment
+'      '      Text.Whitespace
+'┊'           Comment
+'         '   Text.Whitespace
+'┊'           Comment
+'         '   Text.Whitespace
+'┊'           Comment
+'\n\n\n        ' Text.Whitespace
+'←'           Text
+'  '          Text.Whitespace
+'genes'       Text
+'  '          Text.Whitespace
+'→'           Text
+'\n     '     Text.Whitespace
+'┌────────────────┐' Comment
+'\n     '     Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'var:"id",[…]' Text
+'   '         Text.Whitespace
+'│'           Comment
+'\n     '     Text.Whitespace
+'└────────────────┘' Comment
+'\n     '     Text.Whitespace
+'┏━━━━━━━━━━━━━━━━┓' Comment
+'  '          Text.Whitespace
+'┌────────────────┐' Comment
+'\n     '     Text.Whitespace
+'┃'           Comment
+' '           Text.Whitespace
+'X:'          Text
+'             ' Text.Whitespace
+'┃'           Comment
+'  '          Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'obs:'        Text
+'           ' Text.Whitespace
+'│'           Comment
+'  '          Text.Whitespace
+'↑'           Text
+'\n     '     Text.Whitespace
+'┃'           Comment
+' '           Text.Whitespace
+'counts'      Text
+'         '   Text.Whitespace
+'┃┓'          Comment
+' '           Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'"sample",[…]' Text
+'   '         Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'cells'       Text
+'\n     '     Text.Whitespace
+'┃'           Comment
+'                ' Text.Whitespace
+'┃┃'          Comment
+' '           Text.Whitespace
+'│'           Comment
+'                ' Text.Whitespace
+'│'           Comment
+'  '          Text.Whitespace
+'↓'           Text
+'\n     '     Text.Whitespace
+'┗━━━━━━━━━━━━━━━━┛┃┓└────────────────┘' Comment
+'\n      '    Text.Whitespace
+'┃'           Comment
+'layers["ranks"]' Text
+' '           Text.Whitespace
+'┃┃'          Comment
+'\n      '    Text.Whitespace
+'┗━━━━━━━━━━━━━━━━┛┃' Comment
+'\n       '   Text.Whitespace
+'┃'           Comment
+'layers["zscore"]' Text
+'┃'           Comment
+'\n       '   Text.Whitespace
+'┗━━━━━━━━━━━━━━━━┛' Comment
+'\n        '  Text.Whitespace
+'←'           Text
+'  '          Text.Whitespace
+'genes'       Text
+'  '          Text.Whitespace
+'→'           Text
+'\n     '     Text.Whitespace
+'┌────────────────┐' Comment
+'\n     '     Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'varp:'       Text
+'          '  Text.Whitespace
+'│┐'          Comment
+'\n     '     Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'"correlations"' Text
+' '           Text.Whitespace
+'││'          Comment
+'  '          Text.Whitespace
+'↑'           Text
+'\n     '     Text.Whitespace
+'│'           Comment
+'                ' Text.Whitespace
+'││'          Comment
+' '           Text.Whitespace
+'genes'       Text
+'\n     '     Text.Whitespace
+'│'           Comment
+'                ' Text.Whitespace
+'││'          Comment
+'  '          Text.Whitespace
+'↓'           Text
+'\n     '     Text.Whitespace
+'│'           Comment
+'                ' Text.Whitespace
+'││'          Comment
+'\n     '     Text.Whitespace
+'└────────────────┘│' Comment
+'\n      '    Text.Whitespace
+'│'           Comment
+' '           Text.Whitespace
+'"p-values"'  Text
+'     '       Text.Whitespace
+'│'           Comment
+'\n      '    Text.Whitespace
+'└────────────────┘' Comment
+'\n         ' Text.Whitespace
+'←'           Text
+'  '          Text.Whitespace
+'genes'       Text
+'  '          Text.Whitespace
+'→'           Text
+'\n\n\n '     Text.Whitespace
+'╭─────────╮' Comment
+'                 ' Text.Whitespace
+'╭───────╮'   Comment
+'                 ' Text.Whitespace
+'╭─────────╮' Comment
+'\n '         Text.Whitespace
+'│'           Comment
+'My_source'   Text
+'├──┤'        Comment
+'edge_source' Text
+'├──┤'        Comment
+'My_edge'     Text
+'├──┤'        Comment
+'edge_target' Text
+'├──┤'        Comment
+'My_target'   Text
+'│'           Comment
+'\n '         Text.Whitespace
+'╰┬────────╯' Comment
+'                 ' Text.Whitespace
+'╰┬──────╯'   Comment
+'                 ' Text.Whitespace
+'╰────┬────╯' Comment
+'\n  '        Text.Whitespace
+'┊'           Comment
+'                           ' Text.Whitespace
+'┊'           Comment
+'                             ' Text.Whitespace
+'┊'           Comment
+'\n  '        Text.Whitespace
+'╰'           Comment
+'my_prop:this' Text
+'               ' Text.Whitespace
+'╰'           Comment
+'my_edge_prop:that' Text
+'            ' Text.Whitespace
+'╽'           Comment
+'\n'          Text.Whitespace


### PR DESCRIPTION
Adds the "boxdrawing" lexer.

Highlight any Unicode character in the u2500—u257F range as comments, the remaining characters as either spaces or text.

This is particularly useful for pygmenting documentations showing diagrams that can be read right in the source text file (in the spirit of Markdown or Sphinx). Having a different color for the borders of the diagrams helps readability of the processed documentation.

As a side effect, having the <pre> block tagged by pygments with the related lexer class also helps setting up a CSS with line-height:100%, which is needed to get a good display of the diagram (the majority of use cases use a larger line spacing, which hinder readability).