### PR TITLE
Add keywords to the Lean4 lexer

### DIFF
--- a/pygments/lexers/lean.py
+++ b/pygments/lexers/lean.py
@@ -168,7 +168,8 @@ class Lean4Lexer(RegexLexer):
     keywords2 = (
         'forall', 'fun', 'obtain', 'from', 'have', 'show', 'assume',
         'let', 'if', 'else', 'then', 'by', 'in', 'with',
-        'calc', 'match', 'nomatch', 'do', 'at',
+        'calc', 'match', 'nomatch', 'do', 'at', 'while', 'for', 'mut',
+        'return', 'unless', 'repeat', 'continue', 'break',
     )
 
     keywords3 = (


### PR DESCRIPTION
The keywords for some syntactic constructs offered by the `do` notation where not present.  The added keywords cover what is described in the language reference, [here](https://lean-lang.org/doc/reference/latest/Functors___-Monads-and--do--Notation/Syntax/#do-notation).