### PR TITLE
TypstLexer: handle chained inline code

### DIFF
--- a/tests/snippets/typst/chained.txt
+++ b/tests/snippets/typst/chained.txt
@@ -1,0 +1,25 @@
+---input---
+#datetime.today(
+  
+).display(
+  "foo"
+)bar
+
+---tokens---
+'#datetime'   Name.Variable
+'.'           Punctuation
+'today'       Name.Function
+'('           Punctuation
+'\n  \n'      Text.Whitespace
+
+')'           Punctuation
+'.'           Punctuation
+'display'     Name.Function
+'('           Punctuation
+'\n  '        Text.Whitespace
+'"foo"'       Literal.String.Double
+'\n'          Text.Whitespace
+
+')'           Punctuation
+'bar'         Text
+'\n'          Text.Whitespace

--- a/tests/snippets/typst/chained2.txt
+++ b/tests/snippets/typst/chained2.txt
@@ -1,0 +1,35 @@
+---input---
+#let foo = 2
+#foo;$#foo;1$bar
+#baz[something()].more()text()
+
+---tokens---
+'#let'        Keyword.Declaration
+' '           Text.Whitespace
+'foo'         Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'#foo'        Name.Variable
+';'           Text
+'$'           Punctuation
+'#foo'        Name.Variable
+';'           Punctuation
+'1'           Literal.Number
+'$'           Punctuation
+'bar'         Text
+'\n'          Text.Whitespace
+
+'#baz'        Name.Function
+'['           Punctuation
+'something()' Text
+']'           Punctuation
+'.'           Punctuation
+'more'        Name.Function
+'('           Punctuation
+')'           Punctuation
+'text()'      Text
+'\n'          Text.Whitespace

--- a/tests/snippets/typst/line_code.txt
+++ b/tests/snippets/typst/line_code.txt
@@ -1,0 +1,86 @@
+---input---
+#for idx in range(10) {"foo"} {"bar"}; "e"
+"f"
+#if foo == bar.baz(
+
+).qox(x => {
+  let y = [z]
+}) {"a"}"b" "c"; "d"
+"e"
+
+---tokens---
+'#for'        Keyword.Reserved
+' '           Text.Whitespace
+'idx'         Name.Variable
+' '           Text.Whitespace
+'in'          Keyword.Reserved
+' '           Text.Whitespace
+'range'       Name.Function
+'('           Punctuation
+'10'          Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'"foo"'       Literal.String.Double
+'}'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'"bar"'       Literal.String.Double
+'}'           Punctuation
+';'           Punctuation
+' '           Text.Whitespace
+'"e"'         Text
+'\n'          Text.Whitespace
+
+'"f"'         Text
+'\n'          Text.Whitespace
+
+'#if'         Keyword.Reserved
+' '           Text.Whitespace
+'foo'         Name.Variable
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'bar'         Name.Variable
+'.'           Punctuation
+'baz'         Name.Function
+'('           Punctuation
+'\n\n'        Text.Whitespace
+
+')'           Punctuation
+'.'           Punctuation
+'qox'         Name.Function
+'('           Punctuation
+'x'           Name.Variable
+' '           Text.Whitespace
+'=>'          Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'let'         Keyword.Declaration
+' '           Text.Whitespace
+'y'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'z'           Text
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'"a"'         Literal.String.Double
+'}'           Punctuation
+'"b"'         Literal.String.Double
+' '           Text.Whitespace
+'"c"'         Literal.String.Double
+';'           Punctuation
+' '           Text.Whitespace
+'"d"'         Text
+'\n'          Text.Whitespace
+
+'"e"'         Text
+'\n'          Text.Whitespace

--- a/tests/snippets/typst/nesting_12.txt
+++ b/tests/snippets/typst/nesting_12.txt
@@ -35,8 +35,7 @@
 'singer'      Name.Variable
 ')'           Punctuation
 ' '           Text.Whitespace
-'='           Operator
-'>'           Operator
+'=>'          Operator
 ' '           Text.Whitespace
 'grid'        Name.Function
 '('           Punctuation


### PR DESCRIPTION
In Typst, inline code (initiated by `#`) can be chained:

```typst
#datetime.today().display("foo")text
//                              ^ this is regular markup again
```
(GitHub renders this incorrectly because it didn't update the grammar)

Typst code can get more complex, however. `#for a in b {"code"} {markup}` is valid Typst. Lexing this would essentially require parsing of all the inline constructs (for, if, import, include, show, etc.). Realistically, users will put a newline after the code, which is the way the end of code is detected. Alternatively, a `;` can be put after the code which is valid Typst and also exits the code state. Imo, if this is an issue for someone, they should open an issue first.

This PR fixes the lexing of the case above. Previously, only the first variable would be highlighted and everything else was markup. I split `inline_code` into `inline_code` and `line_code` (couldn't think of a good name).
`inline_code` is for constructs as above, where the switch into code happens because of `#<variable>`. Detecting the end of the segment here is relatively simple, because anything other than `.`, `(`, or `[` will be markup.
`line_code` is for constructs like `#for` that contain spaces. It's terminated by a newline (hence the name) or a semicolon.

While testing, I noticed that `=` took precedence over `==`, thus `==` would produce `=` and `=` separately.



