### PR TITLE
fix lua regex causing runaway backtracking.

### DIFF
--- a/pygments/lexers/scripting.py
+++ b/pygments/lexers/scripting.py
@@ -57,7 +57,7 @@ class LuaLexer(RegexLexer):
 
     _comment_multiline = r'(?:--\[(?P<level>=*)\[[\w\W]*?\](?P=level)\])'
     _comment_single = r'(?:--.*$)'
-    _space = r'(?:\s+)'
+    _space = r'(?:\s+(?!\s))'
     _s = rf'(?:{_comment_multiline}|{_comment_single}|{_space})'
     _name = r'(?:[^\W\d]\w*)'
 


### PR DESCRIPTION
Use possessive quantifier if possible, otherwise fallback to old, buggy regex.

Fixes #2839

For reference, see: 
*  https://www.regular-expressions.info/catastrophic.html 
* https://www.regular-expressions.info/possessive.html
