### PR TITLE
Add Bicep lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -287,5 +287,6 @@ Other contributors, listed alphabetically, are:
 * Markus Meyer, Nextron Systems -- YARA lexer
 * Hannes Römer -- Mojo lexer
 * Jan Frederik Schaefer -- PDDL lexer
+* Roberto Prevato -- Bicep lexer
 
 Many thanks for all contributions!

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -53,6 +53,7 @@ LEXERS = {
     'BefungeLexer': ('pygments.lexers.esoteric', 'Befunge', ('befunge',), ('*.befunge',), ('application/x-befunge',)),
     'BerryLexer': ('pygments.lexers.berry', 'Berry', ('berry', 'be'), ('*.be',), ('text/x-berry', 'application/x-berry')),
     'BibTeXLexer': ('pygments.lexers.bibtex', 'BibTeX', ('bibtex', 'bib'), ('*.bib',), ('text/x-bibtex',)),
+    'BicepLexer': ('pygments.lexers.configs', 'Bicep', ('bicep', 'bicepparam'), ('*.bicep', '*.bicepparam'), ()),
     'BlitzBasicLexer': ('pygments.lexers.basic', 'BlitzBasic', ('blitzbasic', 'b3d', 'bplus'), ('*.bb', '*.decls'), ('text/x-bb',)),
     'BlitzMaxLexer': ('pygments.lexers.basic', 'BlitzMax', ('blitzmax', 'bmax'), ('*.bmx',), ('text/x-bmx',)),
     'BlueprintLexer': ('pygments.lexers.blueprint', 'Blueprint', ('blueprint',), ('*.blp',), ('text/x-blueprint',)),

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -22,7 +22,7 @@ __all__ = ['IniLexer', 'SystemdLexer', 'DesktopLexer', 'RegeditLexer', 'Properti
            'NginxConfLexer', 'LighttpdConfLexer', 'DockerLexer',
            'TerraformLexer', 'TermcapLexer', 'TerminfoLexer',
            'PkgConfigLexer', 'PacmanConfLexer', 'AugeasLexer', 'TOMLLexer',
-           'NestedTextLexer', 'SingularityLexer', 'UnixConfigLexer']
+           'NestedTextLexer', 'SingularityLexer', 'UnixConfigLexer', 'BicepLexer']
 
 
 class IniLexer(RegexLexer):
@@ -1429,5 +1429,75 @@ class UnixConfigLexer(RegexLexer):
             (r'[0-9]+', Number),
             (r'((?!\n)[a-zA-Z0-9\_\-\s\(\),]){2,}', Text),
             (r'[^:\n]+', String),
+        ],
+    }
+
+
+class BicepLexer(RegexLexer):
+    """
+    Lexer for Bicep ``.bicep`` files and ``.bicepparam`` files.
+    """
+    name = 'Bicep'
+    aliases = ['bicep', 'bicepparam']
+    filenames = ['*.bicep', '*.bicepparam']
+
+    declarations = ('resource', 'module', 'param', 'var', 'output', 'targetScope')
+
+    types = ('string', 'int', 'bool', 'object', 'array', 'float')
+
+    functions = (
+        'utcNow',
+        'loadJsonContent',
+        'loadYamlContent',
+        'loadTextContent',
+        'readEnvironmentVariable',
+        'resourceId',
+        'resourceGroup',
+        'subscription',
+        'tenant',
+        'reference',
+        'base64',
+        'base64ToString',
+        'concat',
+        'contains',
+        'endsWith',
+        'format',
+        'guid',
+        'indexOf',
+        'join',
+        'length',
+        'padLeft',
+        'replace',
+        'skip',
+        'split',
+        'startsWith',
+        'substring',
+        'toLower',
+        'toUpper',
+        'trim',
+        'uniqueString',
+        'uri',
+        'uriComponent',
+        'first',
+        'last',
+    )
+
+    modifiers = ('existing', 'secure', 'allowed', 'description', 'metadata', 'nullable')
+
+    tokens = {
+        'root': [
+            (r'\s+', Text),
+            (r'//.*?\n', Comment.Single),
+            (r'/\*.*?\*/', Comment.Multiline),
+            (r'\b(' + '|'.join(declarations) + r')\b', Keyword.Declaration),
+            (r'\b(' + '|'.join(types) + r')\b', Keyword.Type),
+            (r'\b(' + '|'.join(functions) + r')\b', Name.Function),
+            (r'\b(' + '|'.join(modifiers) + r')\b', Keyword.Reserved),
+            (r'\b(true|false|null)\b', Keyword.Constant),
+            (r'\b[a-zA-Z_][a-zA-Z0-9_]*\b', Name),
+            (r"'(\\\\|\\'|[^'])*'", String),
+            (r'[0-9]+', Number),
+            (r'[=;:{}()\[\],.]', Punctuation),
+            (r'[+\-*/%]', Operator),
         ],
     }


### PR DESCRIPTION
Add Lexer for [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep), for .bicep and [.bicepparam](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/parameter-files?tabs=Bicep) files.

The Lexer was added to `config.py` together with Terraform, as Bicep belongs to the same category of tools like Terraform.

Please let me know if the PR is valid.