### PR TITLE
scripts/debug_lexer.py: fix incorrect map call

### DIFF
--- a/scripts/debug_lexer.py
+++ b/scripts/debug_lexer.py
@@ -120,7 +120,7 @@ def decode_atheris(bstr):
         return chr(ch)
 
     chars = struct.unpack('%dI%dx' % divmod(len(bstr), 4), bstr)
-    return ''.join(map(valid_codepoint), chars)
+    return ''.join(map(valid_codepoint, chars))
 
 
 def main(fn, lexer=None, options={}):


### PR DESCRIPTION
This commit fixes a bug with incorrect `map()` call.

I found that when doing some tests where I cythonize pygments module and the Cython compiler found this bug:

```
[318/397] Cythonizing pygments-benchmarking/cygments/pygments/scripts/debug_lexer.py

Error compiling Cython file:
------------------------------------------------------------
...
        if ch & 0x100000:
            ch &= ~0x0f0000
        return chr(ch)

    chars = struct.unpack('%dI%dx' % divmod(len(bstr), 4), bstr)
    return ''.join(map(valid_codepoint), chars)
                  ^
------------------------------------------------------------

pygments/scripts/debug_lexer.py:123:18: Call with wrong number of arguments (expected 2, got 3)
```