### PR TITLE
formatters/irc.py: remove unreachable return statement

### DIFF
--- a/pygments/formatters/irc.py
+++ b/pygments/formatters/irc.py
@@ -91,7 +91,6 @@ def ircformat(color, text):
         add += '\x03' + str(IRC_COLOR_MAP[color]).zfill(2)
         sub = '\x03' + sub
     return add + text + sub
-    return '<'+add+'>'+text+'</'+sub+'>'
 
 
 class IRCFormatter(Formatter):


### PR DESCRIPTION
Removing a return statement that was unreachable.

Full context: I don't know if this statement should be used instead of the previous return or not. I remove it simply as its last and I guess nobody bothered for ~9 years (since that's how old this line of code that I remove is).

I found it when I was cythonizing pygments module for the sake of some benchmarks: [ 16/353] Cythonizing pygments-benchmarking/cygments/pygments/pygments/formatters/irc.py warning: pygments/pygments/formatters/irc.py:94:4: Unreachable code