### PR TITLE
Support having both a schedule and a deadline on an item in org-mode

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -688,8 +688,8 @@ class OrgLexer(RegexLexer):
             (r'\\\\$', Operator),
 
             # Deadline, Scheduled, CLOSED
-            (r'(?i)^( *(?:DEADLINE|SCHEDULED): )(<.+?> *)$',
-             bygroups(Generic.Error, Literal.Date)),
+            (r'(?i)^( *(?:DEADLINE|SCHEDULED): )(<[^>]+?> *)(?:((?:DEADLINE|SCHEDULED): )(<[^>]+?>))?$',
+             bygroups(Generic.Error, Literal.Date, Generic.Error, Literal.Date)),
             (r'(?i)^( *CLOSED: )(\[.+?\] *)$',
              bygroups(Generic.Deleted, Literal.Date)),
 

--- a/tests/examplefiles/org/example.org
+++ b/tests/examplefiles/org/example.org
@@ -68,6 +68,8 @@ something
 ** scheduled
 SCHEDULED: <2018-07-31 Tue>
 something
+** both
+DEADLINE: <2025-06-01 Sun> SCHEDULED: <2025-05-27 Tue>
 * Blocks
 #+BEGIN_QUOTE
 quote

--- a/tests/examplefiles/org/example.org.output
+++ b/tests/examplefiles/org/example.org.output
@@ -265,6 +265,15 @@
 'something'   Text
 '\n'          Text
 
+'** both'     Generic.Subheading
+'\n'          Text
+
+'DEADLINE: '  Generic.Error
+'<2025-06-01 Sun> ' Literal.Date
+'SCHEDULED: ' Generic.Error
+'<2025-05-27 Tue>' Literal.Date
+'\n'          Text
+
 '* Blocks'    Generic.Heading
 '\n'          Text
 


### PR DESCRIPTION
This is supported by org-mode, even though it is difficult to find a mention of it in the docs.

For simplicity's sake, I'm ignoring the edge cases of having two schedules or two deadlines.