### PR TITLE
Support headline tags on org-mode headlines with keywords

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -637,18 +637,18 @@ class OrgLexer(RegexLexer):
             (r'^# .*', Comment.Single),
 
             # Headings
-            (r'^(\* )(COMMENT)( .*)',
-             bygroups(Generic.Heading, Comment.Preproc, Generic.Heading)),
-            (r'^(\*\*+ )(COMMENT)( .*)',
-             bygroups(Generic.Subheading, Comment.Preproc, Generic.Subheading)),
-            (r'^(\* )(DONE)( .*)',
-             bygroups(Generic.Heading, Generic.Deleted, Generic.Heading)),
-            (r'^(\*\*+ )(DONE)( .*)',
-             bygroups(Generic.Subheading, Generic.Deleted, Generic.Subheading)),
-            (r'^(\* )(TODO)( .*)',
-             bygroups(Generic.Heading, Generic.Error, Generic.Heading)),
-            (r'^(\*\*+ )(TODO)( .*)',
-             bygroups(Generic.Subheading, Generic.Error, Generic.Subheading)),
+            (r'^(\* )(COMMENT)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Heading, Comment.Preproc, Generic.Heading, Generic.Emph)),
+            (r'^(\*\*+ )(COMMENT)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Subheading, Comment.Preproc, Generic.Subheading, Generic.Emph)),
+            (r'^(\* )(DONE)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Heading, Generic.Deleted, Generic.Heading, Generic.Emph)),
+            (r'^(\*\*+ )(DONE)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Subheading, Generic.Deleted, Generic.Subheading, Generic.Emph)),
+            (r'^(\* )(TODO)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Heading, Generic.Error, Generic.Heading, Generic.Emph)),
+            (r'^(\*\*+ )(TODO)( .*?)( *:[a-zA-Z0-9_@:]+:)?$',
+             bygroups(Generic.Subheading, Generic.Error, Generic.Subheading, Generic.Emph)),
 
             (r'^(\* .+?)( :[a-zA-Z0-9_@:]+:)?$', bygroups(Generic.Heading, Generic.Emph)),
             (r'^(\*\*+ .+?)( :[a-zA-Z0-9_@:]+:)?$', bygroups(Generic.Subheading, Generic.Emph)),
@@ -681,6 +681,7 @@ class OrgLexer(RegexLexer):
             (r'^(#\+\w+:)(.*)$', bygroups(Name.Namespace, Text)),
 
             # Properties and drawers
+            (r'(?i)^( *:\w+:\.\.\. *\n)', Name.Decorator),
             (r'(?i)^( *:\w+: *\n)((?:.|\n)*?)(^ *:end: *$)',
              bygroups(Name.Decorator, Comment.Special, Name.Decorator)),
 

--- a/tests/examplefiles/org/example.org
+++ b/tests/examplefiles/org/example.org
@@ -20,12 +20,12 @@ line two
 * First heading in this post
 ** Subheading :TAG:
 This is a under first heading. <2018-07-27 Fri>
-* COMMENT heading
-** COMMENT subheading
-* TODO heading
-** TODO subheading
-* DONE heading
-** DONE subheading
+* COMMENT heading                                                       :tag:
+** COMMENT subheading                                                   :tag:
+* TODO heading                                                          :tag:
+** TODO subheading                                                      :tag:
+* DONE heading                                                          :tag:
+** DONE subheading                                                      :tag:
 CLOSED: [2018-08-01 Wed 16:17]
 
 {{{n}}} abc {{{n(,10)}}} def {{{n(x,5)}}}

--- a/tests/examplefiles/org/example.org.output
+++ b/tests/examplefiles/org/example.org.output
@@ -84,31 +84,37 @@
 '* '          Generic.Heading
 'COMMENT'     Comment.Preproc
 ' heading'    Generic.Heading
+'                                                       :tag:' Generic.Emph
 '\n'          Text
 
 '** '         Generic.Subheading
 'COMMENT'     Comment.Preproc
 ' subheading' Generic.Subheading
+'                                                   :tag:' Generic.Emph
 '\n'          Text
 
 '* '          Generic.Heading
 'TODO'        Generic.Error
 ' heading'    Generic.Heading
+'                                                          :tag:' Generic.Emph
 '\n'          Text
 
 '** '         Generic.Subheading
 'TODO'        Generic.Error
 ' subheading' Generic.Subheading
+'                                                      :tag:' Generic.Emph
 '\n'          Text
 
 '* '          Generic.Heading
 'DONE'        Generic.Deleted
 ' heading'    Generic.Heading
+'                                                          :tag:' Generic.Emph
 '\n'          Text
 
 '** '         Generic.Subheading
 'DONE'        Generic.Deleted
 ' subheading' Generic.Subheading
+'                                                      :tag:' Generic.Emph
 '\n'          Text
 
 'CLOSED: '    Generic.Deleted


### PR DESCRIPTION
e.g. TODO.  The original regexps had left out this combination.

Also, support rendering folded drawers.  This isn't proper Org syntax per se since it is an overlay that Emacs manages for you, but it seems likely that people will want to support syntax highlighting for it (I know I certainly do).