### PR TITLE
Add rules for interpolated strings in MoonScript lexer

### DIFF
--- a/pygments/lexers/scripting.py
+++ b/pygments/lexers/scripting.py
@@ -546,13 +546,26 @@ class MoonScriptLexer(LuaLexer):
         'stringescape': [
             (r'''\\([abfnrtv\\"']|\d{1,3})''', String.Escape)
         ],
-        'sqs': [
-            ("'", String.Single, '#pop'),
-            ("[^']+", String)
+        'strings': [
+            (r'[^#\\\'"]+', String),
+            # note that strings are multi-line.
+            # hashmarks, quotes and backslashes must be parsed one at a time
+        ],
+        'interpoling_string': [
+            (r'\}', String.Interpol, "#pop"),
+            include('base')
         ],
         'dqs': [
-            ('"', String.Double, '#pop'),
-            ('[^"]+', String)
+            (r'"', String.Double, '#pop'),
+            (r'\\.|\'', String),  # double-quoted string don't need ' escapes
+            (r'#\{', String.Interpol, "interpoling_string"),
+            (r'#', String),
+            include('strings')
+        ],
+        'sqs': [
+            (r"'", String.Single, '#pop'),
+            (r'#|\\.|"', String),  # single quoted strings don't need " escapses
+            include('strings')
         ]
     }
 

--- a/tests/snippets/moon/test_string_interpolation.txt
+++ b/tests/snippets/moon/test_string_interpolation.txt
@@ -1,0 +1,82 @@
+---input---
+"#{wow}"
+"w#{wow}w"
+"#wow"
+"wow#"
+"w#ow"
+
+'#{wow}'
+'w#{wow}w'
+'#wow'
+'wow#'
+'w#ow'
+
+---tokens---
+'"'           Literal.String.Double
+'#{'          Literal.String.Interpol
+'wow'         Name
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'"'           Literal.String.Double
+'w'           Literal.String
+'#{'          Literal.String.Interpol
+'wow'         Name
+'}'           Literal.String.Interpol
+'w'           Literal.String
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'"'           Literal.String.Double
+'#'           Literal.String
+'wow'         Literal.String
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'"'           Literal.String.Double
+'wow'         Literal.String
+'#'           Literal.String
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'"'           Literal.String.Double
+'w'           Literal.String
+'#'           Literal.String
+'ow'          Literal.String
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Single
+'#'           Literal.String
+'{wow}'       Literal.String
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Single
+'w'           Literal.String
+'#'           Literal.String
+'{wow}w'      Literal.String
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Single
+'#'           Literal.String
+'wow'         Literal.String
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Single
+'wow'         Literal.String
+'#'           Literal.String
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Single
+'w'           Literal.String
+'#'           Literal.String
+'ow'          Literal.String
+"'"           Literal.String.Single
+'\n'          Text.Whitespace


### PR DESCRIPTION
This change updates the MoonScript lexer with rules for interpolated strings (eg `"the #{color} car"`).