### PR TITLE
Add aliases to Rocq in Coq lexer

### DIFF
--- a/pygments/lexers/theorem.py
+++ b/pygments/lexers/theorem.py
@@ -25,10 +25,10 @@ class CoqLexer(RegexLexer):
     """
 
     name = 'Coq'
-    url = 'http://coq.inria.fr/'
-    aliases = ['coq']
+    url = 'https://rocq-prover.org/'
+    aliases = ['coq', 'rocq-prover', 'rocq', 'Rocq']
     filenames = ['*.v']
-    mimetypes = ['text/x-coq']
+    mimetypes = ['text/x-coq', 'text/x-rocq']
     version_added = '1.5'
 
     flags = 0 # no re.MULTILINE


### PR DESCRIPTION
Hello,

The Coq proof assistant has recently been renamed Rocq (or rocq-prover).
See https://rocq-prover.org/about

I'm not sure I did this right but the goal of this PR is to add aliases in the Coq lexer to the new name and change the url to the new website.