### PR TITLE
Update lexer for Fennel.

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -168,7 +168,7 @@ LEXERS = {
     'FancyLexer': ('pygments.lexers.ruby', 'Fancy', ('fancy', 'fy'), ('*.fy', '*.fancypack'), ('text/x-fancysrc',)),
     'FantomLexer': ('pygments.lexers.fantom', 'Fantom', ('fan',), ('*.fan',), ('application/x-fantom',)),
     'FelixLexer': ('pygments.lexers.felix', 'Felix', ('felix', 'flx'), ('*.flx', '*.flxh'), ('text/x-felix',)),
-    'FennelLexer': ('pygments.lexers.lisp', 'Fennel', ('fennel', 'fnl'), ('*.fnl',), ()),
+    'FennelLexer': ('pygments.lexers.lisp', 'Fennel', ('fennel', 'fnl'), ('*.fnl', '*.fnlm'), ('text/x-fennel',)),
     'FiftLexer': ('pygments.lexers.fift', 'Fift', ('fift', 'fif'), ('*.fif',), ()),
     'FishShellLexer': ('pygments.lexers.shell', 'Fish', ('fish', 'fishshell'), ('*.fish', '*.load'), ('application/x-fish',)),
     'FlatlineLexer': ('pygments.lexers.dsls', 'Flatline', ('flatline',), (), ('text/x-flatline',)),

--- a/pygments/lexers/lisp.py
+++ b/pygments/lexers/lisp.py
@@ -2756,19 +2756,22 @@ class FennelLexer(RegexLexer):
     name = 'Fennel'
     url = 'https://fennel-lang.org'
     aliases = ['fennel', 'fnl']
-    filenames = ['*.fnl']
+    filenames = ['*.fnl', '*.fnlm']
+    mimetypes = ['text/x-fennel']
     version_added = '2.3'
 
-    # this list is current as of Fennel version 0.10.0.
+    # this list is current as of Fennel version 1.5.3
     special_forms = (
-        '#', '%', '*', '+', '-', '->', '->>', '-?>', '-?>>', '.', '..',
-        '/', '//', ':', '<', '<=', '=', '>', '>=', '?.', '^', 'accumulate',
-        'and', 'band', 'bnot', 'bor', 'bxor', 'collect', 'comment', 'do', 'doc',
-        'doto', 'each', 'eval-compiler', 'for', 'hashfn', 'icollect', 'if',
-        'import-macros', 'include', 'length', 'let', 'lshift', 'lua',
-        'macrodebug', 'match', 'not', 'not=', 'or', 'partial', 'pick-args',
-        'pick-values', 'quote', 'require-macros', 'rshift', 'set',
-        'set-forcibly!', 'tset', 'values', 'when', 'while', 'with-open', '~='
+        '#', '%', '*', '+', '-', '->', '->>', '-?>', '-?>>', '.', '..', '/',
+        '//', ':', '<', '<=', '=', '>', '>=', '?.', '^', 'accumulate', 'and',
+        'assert-repl', 'band', 'bnot', 'bor', 'bxor', 'case', 'case-try',
+        'collect', 'comment', 'do', 'doto', 'each', 'eval-compiler',
+        'faccumulate', 'fcollect', 'for', 'hashfn', 'icollect',
+        'if', 'import-macros', 'include', 'length', 'let',
+        'lshift', 'lua', 'macrodebug', 'match', 'match-try',
+        'not', 'not=', 'or', 'partial', 'pick-args', 'pick-values', 'quote',
+        'require-macros', 'rshift', 'set', 'set-forcibly!', 'tail!', 'tset',
+        'unquote', 'values', 'when', 'while', 'with-open', '~='
     )
 
     declarations = (
@@ -2826,6 +2829,9 @@ class FennelLexer(RegexLexer):
 
             # the # symbol is shorthand for a lambda function
             (r'#', Punctuation),
+
+            # backtick is used for quoting macros
+            (r'`', Punctuation),
         ]
     }
 


### PR DESCRIPTION
* Add new filename pattern for macro modules.
* Add a mime type (Trac ignores languages that lack this for some reason).
* Update list of special forms for the latest Fennel version.
* Add backtick as a punctuation character.