### PR TITLE
Terraform: Add support for provider-defined functions

### DIFF
--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -745,9 +745,11 @@ class TerraformLexer(ExtendedRegexLexer):
     type_conversion_functions = ('can', 'defaults', 'tobool', 'tolist', 'tomap',
                                  'tonumber', 'toset', 'tostring', 'try')
 
+    provider_functions = (r'provider::\w+::\w+',)
+
     builtins = numeric_functions + string_functions + collection_functions + encoding_functions +\
         filesystem_functions + date_time_functions + hash_crypto_functions + ip_network_functions +\
-        type_conversion_functions
+        type_conversion_functions + provider_functions
     builtins_re = "({})".format(('|').join(builtins))
 
     def heredoc_callback(self, match, ctx):

--- a/tests/snippets/terraform/test_functions.txt
+++ b/tests/snippets/terraform/test_functions.txt
@@ -7,6 +7,10 @@ provider "aws" {
   value = jsonencode(element("value"))
 }
 
+provider "aws" {
+  value = provider::exampletime::rfc3339_parse("2023-07-25T23:43:16Z")
+}
+
 ---tokens---
 'provider'    Keyword.Reserved
 ' '           Text.Whitespace
@@ -49,6 +53,29 @@ provider "aws" {
 '('           Punctuation
 '"value"'     Literal.String.Double
 ')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'provider'    Keyword.Reserved
+' '           Text.Whitespace
+'"aws"'       Name.Variable
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'value'       Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'provider::exampletime::rfc3339_parse' Name.Function
+'('           Punctuation
+'"2023-07-25T23:43:16Z"' Literal.String.Double
 ')'           Punctuation
 '\n'          Text.Whitespace
 


### PR DESCRIPTION
Terraform supports calling provider-defined functions via `provider::providername::functionname(...)`. This PR adds Pygment support for that syntax.

The test case is lifted from their example provider function: https://github.com/hashicorp/terraform-provider-time/blob/main/docs/functions/rfc3339_parse.md#example-usage