### PR TITLE
fixed protobuf namespace tokenization (namespaces can include .)

### DIFF
--- a/pygments/lexers/dsls.py
+++ b/pygments/lexers/dsls.py
@@ -67,7 +67,7 @@ class ProtoBufLexer(RegexLexer):
             (r'[a-zA-Z_][\w.]*', Name),
         ],
         'package': [
-            (r'[a-zA-Z_]\w*', Name.Namespace, '#pop'),
+            (r'[a-zA-Z_][\w\.]*', Name.Namespace, '#pop'),
             default('#pop'),
         ],
         'message': [


### PR DESCRIPTION
In protobuf syntax, namespace definitions are allowed to be separated by "." and actually this feature is used in many generators. It would be nice if it was implemented correctly :)