### PR TITLE
count_token_references script: Remove thousands separators from line numbers

### DIFF
--- a/scripts/count_token_references.py
+++ b/scripts/count_token_references.py
@@ -105,10 +105,10 @@ class FileCount:
 
     def __str__(self):
         if len(self.lines) > 3:
-            lines = ", ".join(f"{line:,}" for line in self.lines[:5])
+            lines = ", ".join(f"{line}" for line in self.lines[:5])
             lines = f"{lines}, ... ({len(lines):,} lines)"
         else:
-            lines = ", ".join(f"{line:,}" for line in self.lines)
+            lines = ", ".join(f"{line}" for line in self.lines)
         return f"{self.filename.name}[{lines}]"
 
     def add(self, linenumber):


### PR DESCRIPTION
Line numbers are rarely seen with thousands separators — a statement's location is referred to as "line 1304" ("line thirteen-oh-four"), much more often than "line 1,304" ("line one thousand, three hundred four").

More importantly, multiple line numbers are displayed in a comma- separated list. While it's not _technically_ ambiguous because each list item is separated by a comma and a space, a small amount of extra effort is required to parse "foo.py[2, 1,537, 1,822]".

So, make that "foo.py[2, 1537, 1822]" which is immediately clear.