### PR TITLE
Support new SNBT format for minecraft lexer

### DIFF
--- a/tests/snippets/snbt/literals.txt
+++ b/tests/snippets/snbt/literals.txt
@@ -1,5 +1,5 @@
 ---input---
-{int: 1, byte: 0b, short: 1s, long: 10000L, float: 10.0f, double: 20.0}
+{int: 1, byte: 0b, short: 1s, long: +10000L, float: 1.1e-23f, double: 20.000_001, binary: 0b10us, hex: 0x0d_721sl}
 
 ---tokens---
 '{'           Punctuation
@@ -24,18 +24,30 @@
 'long'        Name.Attribute
 ':'           Punctuation
 ' '           Text.Whitespace
-'10000L'      Literal.Number.Integer
+'+10000L'     Literal.Number.Integer
 ','           Punctuation
 ' '           Text.Whitespace
 'float'       Name.Attribute
 ':'           Punctuation
 ' '           Text.Whitespace
-'10.0f'       Literal.Number.Float
+'1.1e-23f'    Literal.Number.Float
 ','           Punctuation
 ' '           Text.Whitespace
 'double'      Name.Attribute
 ':'           Punctuation
 ' '           Text.Whitespace
-'20.0'        Literal.Number.Float
+'20.000_001'  Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'binary'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'0b10us'      Literal.Number.Bin
+','           Punctuation
+' '           Text.Whitespace
+'hex'         Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'0x0d_721sl'  Literal.Number.Hex
 '}'           Punctuation
 '\n'          Text

--- a/tests/snippets/snbt/multiline.txt
+++ b/tests/snippets/snbt/multiline.txt
@@ -24,7 +24,7 @@
 ':'           Punctuation
 ' '           Text.Whitespace
 '['           Punctuation
-'I'           Name.Attribute
+'I'           Keyword.Pseudo
 ';'           Punctuation
 '459130179'   Literal.Number.Integer
 ','           Punctuation

--- a/tests/snippets/snbt/nesting.txt
+++ b/tests/snippets/snbt/nesting.txt
@@ -1,7 +1,8 @@
 ---input---
-{root: [{compound: 1b}, {compound: 2b, tag: {key: "value"}}]}
+[{root: [{compound: 1b}, {compound: 2b, tag: {key: "value"}}]}]
 
 ---tokens---
+'['           Punctuation
 '{'           Punctuation
 'root'        Name.Attribute
 ':'           Punctuation
@@ -36,4 +37,5 @@
 '}'           Punctuation
 ']'           Punctuation
 '}'           Punctuation
+']'           Punctuation
 '\n'          Text

--- a/tests/snippets/snbt/quoted_keys.txt
+++ b/tests/snippets/snbt/quoted_keys.txt
@@ -14,7 +14,7 @@
 'normal_key'  Name.Attribute
 ':'           Punctuation
 ' '           Text.Whitespace
-'false'       Name.Attribute
+'false'       Keyword.Constant
 ','           Punctuation
 ' '           Text.Whitespace
 '"'           Literal.String.Double

--- a/tests/snippets/snbt/strings.txt
+++ b/tests/snippets/snbt/strings.txt
@@ -1,0 +1,52 @@
+---input---
+{
+    quoted: 'This is a special character "\N{Snowman}".',
+    quoted_2: "The character can also be represented by \"\u2603\".",
+    unquoted: This_is_a_valid_string,
+    operation: uuid(f81d4fae-7dec-11d0-a765-00a0c91e6bf6)
+}
+
+---tokens---
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'quoted'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'This is a special character "' Literal.String.Single
+'\\N{'        Literal.String.Escape
+'Snowman'     Literal.String.Interpol
+'}'           Literal.String.Escape
+'".'          Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+'\n    '      Text.Whitespace
+'quoted_2'    Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'The character can also be represented by ' Literal.String.Double
+'\\"'         Literal.String.Escape
+'\\u2603'     Literal.String.Escape
+'\\"'         Literal.String.Escape
+'.'           Literal.String.Double
+'"'           Literal.String.Double
+','           Punctuation
+'\n    '      Text.Whitespace
+'unquoted'    Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'This_is_a_valid_string' Literal.String
+','           Punctuation
+'\n    '      Text.Whitespace
+'operation'   Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'uuid'        Keyword.Pseudo
+'('           Punctuation
+'f81d4fae-7dec-11d0-a765-00a0c91e6bf6' Literal.String
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text


### PR DESCRIPTION
Minecraft Java Edition introduced new SNBT format in [25w10a](https://minecraft.wiki/w/Java_Edition_25w10a) (March 5, 2025).

This PR implements the new format, such as:
- unquoted strings
- string escape sequences
- hex and binary numbers
- signed and unsigned suffix for integers
- float point numbers with exponent
- builtin operations

This PR also improves compound keys and array prefix.