### PR TITLE
Add Odin Lang lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -154,6 +154,7 @@ Other contributors, listed alphabetically, are:
 * Valentin Lorentz -- C++ lexer improvements
 * Ben Mabey -- Gherkin lexer
 * Angus MacArthur -- QML lexer
+* Collin MacDonald -- Odin lexer
 * Louis Mandel -- X10 lexer
 * Louis Marchand -- Eiffel lexer
 * Simone Margaritelli -- Hybris lexer

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 2.20.0
 
 - New lexers:
 
+  * Odin (#2945)
   * Rell (#2914)
 
 Version 2.19.2

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -367,6 +367,7 @@ LEXERS = {
     'ObjectiveJLexer': ('pygments.lexers.javascript', 'Objective-J', ('objective-j', 'objectivej', 'obj-j', 'objj'), ('*.j',), ('text/x-objective-j',)),
     'OcamlLexer': ('pygments.lexers.ml', 'OCaml', ('ocaml',), ('*.ml', '*.mli', '*.mll', '*.mly'), ('text/x-ocaml',)),
     'OctaveLexer': ('pygments.lexers.matlab', 'Octave', ('octave',), ('*.m',), ('text/octave',)),
+    'OdinLangLexer': ('pygments.lexers.odin', 'Odin', ('odinlang',), ('*.odin',), ('text/x-odinsrc',)),
     'OdinLexer': ('pygments.lexers.archetype', 'ODIN', ('odin',), ('*.odin',), ('text/odin',)),
     'OmgIdlLexer': ('pygments.lexers.c_like', 'OMG Interface Definition Language', ('omg-idl',), ('*.idl', '*.pidl'), ()),
     'OocLexer': ('pygments.lexers.ooc', 'Ooc', ('ooc',), ('*.ooc',), ('text/x-ooc',)),

--- a/pygments/lexers/archetype.py
+++ b/pygments/lexers/archetype.py
@@ -13,6 +13,8 @@
     :license: BSD, see LICENSE for details.
 """
 
+import re
+
 from pygments.lexer import RegexLexer, include, bygroups, using, default
 from pygments.token import Text, Comment, Name, Literal, Number, String, \
     Punctuation, Keyword, Operator, Generic, Whitespace
@@ -142,6 +144,13 @@ class OdinLexer(AtomsLexer):
     mimetypes = ['text/odin']
     url = 'https://github.com/openEHR/odin'
     version_added = '2.1'
+
+    def analyse_text(text):
+        """Disambiguate from the Odin programming language, which also uses *.odin."""
+        # openEHR ODIN is a data notation built from `attribute = <...>` blocks
+        if re.search(r'^\s*[\w-]+\s*=\s*<', text, re.MULTILINE):
+            return 0.7
+        return 0.0
 
     tokens = {
         'path': [

--- a/pygments/lexers/odin.py
+++ b/pygments/lexers/odin.py
@@ -1,0 +1,119 @@
+import re
+
+from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation
+
+__all__ = ['OdinLangLexer']
+
+
+class OdinLangLexer(RegexLexer):
+    """
+    For `Odin <https://odin-lang.org>` source.
+    """
+    name = 'Odin'
+    url = 'https://odin-lang.org'
+    filenames = ['*.odin']
+    aliases = ['odinlang']
+    mimetypes = ['text/x-odinsrc']
+    version_added = '2.20' 
+
+    flags = re.MULTILINE | re.UNICODE
+
+    tokens = {
+        'root': [
+            (r'\n', Text),
+            (r'\s+', Text),
+            (r'\\\n', Text),  # line continuations
+            (r'//(.*?)\n', Comment.Single),
+            (r'/\*', Comment.Multiline, 'nested_comment'),
+            (r'(foreign|import|package)\b', Keyword.Namespace),
+            (r'(proc|struct|union|enum|bit_set|matrix|map|typeid|using)\b',
+             Keyword.Declaration),
+            (words((
+                'asm', 'auto_cast', 'bit_set', 'break', 'case', 'cast', 
+                'context', 'continue', 'defer', 'distinct', 'do', 
+                'dynamic', 'else', 'enum', 'fallthrough', 'for', 'foreign', 
+                'if', 'import', 'in', 'map', 'matrix', 'not_in', 'or_else', 
+                'or_return', 'package', 'proc', 'return', 'struct', 'switch', 
+                'transmute', 'typeid', 'union', 'using', 'when', 'where'), suffix=r'\b'),
+             Keyword),
+            (r'(true|false|nil)\b', Keyword.Constant),
+            # It seems the builtin types aren't actually keywords, but
+            # can be used as functions. So we need two declarations.
+            (words((
+                'bool', 'b8', 'b16', 'b32', 'b64', 
+                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128', 
+                'rune', 
+                'f16', 'f32', 'f64', 
+                'complex32', 'complex64', 'complex128', 
+                'quaternion64', 'quaternion128', 'quaternion256', 
+                'int', 'uint', 'uintptr', 'rawptr', 
+                'string', 'cstring', 'any', 'typeid', 
+                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le', 
+                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be', 
+                'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte', 
+
+                'len', 'cap', 'size_of', 'align_of', 'offset_of', 'offset_of_by_string', 
+                'type_of', 'type_info_of', 'typeid_of', 'swizzle', 'complex', 
+                'quaternion', 'real', 'imag', 'jmag', 'kmag', 'conj', 
+                'expand_to_tuple', 'min', 'max', 'abs', 'clamp', 
+                'soa_zip', 'soa_unzip', 'transpose', 'outer_product', 
+                'hadamard_product', 'matrix_flatten'), suffix=r'\b(\()'),
+             bygroups(Name.Builtin, Punctuation)),
+            (words((
+                'bool', 'b8', 'b16', 'b32', 'b64', 
+                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128', 
+                'rune', 
+                'f16', 'f32', 'f64', 
+                'complex32', 'complex64', 'complex128', 
+                'quaternion64', 'quaternion128', 'quaternion256', 
+                'int', 'uint', 'uintptr', 'rawptr', 
+                'string', 'cstring', 'any', 'typeid', 
+                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le', 
+                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be', 
+                'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte'), suffix=r'\b'),
+             Keyword.Type),
+            # imaginary_lit
+            (r'\d+i', Number),
+            (r'\d+\.\d*([Ee][-+]\d+)?i', Number),
+            (r'\.\d+([Ee][-+]\d+)?i', Number),
+            (r'\d+[Ee][-+]\d+i', Number),
+            # float_lit
+            (r'\d+(\.\d+[eE][+\-]?\d+|'
+             r'\.\d*|[eE][+\-]?\d+)', Number.Float),
+            (r'\.\d+([eE][+\-]?\d+)?', Number.Float),
+            # int_lit
+            # -- binary_lit
+            (r'0b[01]+', Number.Bin),
+            # -- octal_lit
+            (r'0o[0-7]+', Number.Oct),
+            # -- hex_lit
+            (r'0[x][0-9a-fA-F]+', Number.Hex),
+            # -- decimal_lit
+            (r'([0-9]+)', Number.Integer),
+            (r'(0d[0-9]+)', Number.Integer),
+            # -- dozenal_lit
+            (r'(0z[0-9abAB]+)', Number.Integer),
+            # char_lit
+            (r"""'(\\['"\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}"""
+             r"""|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|[^\\])'""",
+             String.Char),
+            # StringLiteral
+            # -- raw_string_lit
+            (r'`[^`]*`', String),
+            # -- interpreted_string_lit
+            (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
+            # Tokens
+            (r'([+-\/%~!=<>]=?|%%=?|---|\?|\|(?:=|\|=?)?|&(?:=|&=?|\~=?)?|>(?:>=?|=)?|<(?:<=?|=)?|:\s*=|:\s*:|\.\.[=<]?|->|[@#$])', Operator),
+            (r'[|^<>=!()\[\]{}.,;:]', Punctuation),
+            # identifier
+            (r'[^\W\d]\w*', Name.Other),
+        ],
+        'nested_comment': [
+            (r'[^*/]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline),
+        ],
+    }

--- a/pygments/lexers/odin.py
+++ b/pygments/lexers/odin.py
@@ -74,27 +74,31 @@ class OdinLangLexer(RegexLexer):
                 'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be', 
                 'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte'), suffix=r'\b'),
              Keyword.Type),
+
             # imaginary_lit
-            (r'\d+i', Number),
-            (r'\d+\.\d*([Ee][-+]\d+)?i', Number),
-            (r'\.\d+([Ee][-+]\d+)?i', Number),
-            (r'\d+[Ee][-+]\d+i', Number),
+            (r'\d+\.\d*([Ee][-+]\d+)?i', Number.Imaginary),
+            (r'\.\d+([Ee][-+]\d+)?i', Number.Imaginary),
+            (r'\d+[Ee][-+]\d+i', Number.Imaginary),
+            (r'\d+i', Number.Imaginary),
+            
             # float_lit
-            (r'\d+(\.\d+[eE][+\-]?\d+|'
-             r'\.\d*|[eE][+\-]?\d+)', Number.Float),
-            (r'\.\d+([eE][+\-]?\d+)?', Number.Float),
+            (r'\d+\.\d+([eE][+\-]?\d+)?', Number.Float),
+            (r'\d+[eE][+\-]?\d+', Number.Float),
+            
             # int_lit
             # -- binary_lit
             (r'0b[01]+', Number.Bin),
             # -- octal_lit
             (r'0o[0-7]+', Number.Oct),
             # -- hex_lit
-            (r'0[x][0-9a-fA-F]+', Number.Hex),
-            # -- decimal_lit
-            (r'([0-9]+)', Number.Integer),
-            (r'(0d[0-9]+)', Number.Integer),
+            (r'0[xX][0-9a-fA-F]+', Number.Hex),
             # -- dozenal_lit
-            (r'(0z[0-9abAB]+)', Number.Integer),
+            (r'0z[0-9abAB]+', Number.Integer),
+            # -- explicit decimal_lit
+            (r'0d[0-9]+', Number.Integer),
+            # -- generic decimal_lit
+            (r'[0-9]+', Number.Integer),
+            
             # char_lit
             (r"""'(\\['"\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}"""
              r"""|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|[^\\])'""",
@@ -104,9 +108,17 @@ class OdinLangLexer(RegexLexer):
             (r'`[^`]*`', String),
             # -- interpreted_string_lit
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
-            # Tokens
-            (r'([+-\/%~!=<>]=?|%%=?|---|\?|\|(?:=|\|=?)?|&(?:=|&=?|\~=?)?|>(?:>=?|=)?|<(?:<=?|=)?|:\s*=|:\s*:|\.\.[=<]?|->|[@#$])', Operator),
-            (r'[|^<>=!()\[\]{}.,;:]', Punctuation),
+            
+            # Range operators
+            (r'\.\.[=<]?', Operator),
+            # All other operators
+            (r'(::=|<<=|>>=|%%= |&&=|\|\|=|&~=|::|:=|<<|>>|&&|\|\||&~|==|!=|<=|>=|---|->|[+\-*/%~!=<>&|^?]=?)', Operator),
+            # Attribute marker
+            (r'@', Name.Decorator),
+            # Other symbols
+            (r'[#$]', Operator),
+            (r'[()[\]{}.,;:]', Punctuation),
+            
             # identifier
             (r'[^\W\d]\w*', Name.Other),
         ],

--- a/pygments/lexers/odin.py
+++ b/pygments/lexers/odin.py
@@ -4,7 +4,7 @@
 
     Lexers for the Odin programming language.
 
-    :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
 

--- a/pygments/lexers/odin.py
+++ b/pygments/lexers/odin.py
@@ -1,6 +1,16 @@
+"""
+    pygments.lexers.odin
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Lexers for the Odin programming language.
+
+    :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
 import re
 
-from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.lexer import RegexLexer, bygroups, words
 from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
     Number, Punctuation
 
@@ -9,16 +19,16 @@ __all__ = ['OdinLangLexer']
 
 class OdinLangLexer(RegexLexer):
     """
-    For `Odin <https://odin-lang.org>` source.
+    For Odin source code.
     """
     name = 'Odin'
     url = 'https://odin-lang.org'
     filenames = ['*.odin']
     aliases = ['odinlang']
     mimetypes = ['text/x-odinsrc']
-    version_added = '2.20' 
+    version_added = '2.20'
 
-    flags = re.MULTILINE | re.UNICODE
+    flags = re.MULTILINE
 
     tokens = {
         'root': [
@@ -31,47 +41,47 @@ class OdinLangLexer(RegexLexer):
             (r'(proc|struct|union|enum|bit_set|matrix|map|typeid|using)\b',
              Keyword.Declaration),
             (words((
-                'asm', 'auto_cast', 'bit_set', 'break', 'case', 'cast', 
-                'context', 'continue', 'defer', 'distinct', 'do', 
-                'dynamic', 'else', 'enum', 'fallthrough', 'for', 'foreign', 
-                'if', 'import', 'in', 'map', 'matrix', 'not_in', 'or_else', 
-                'or_return', 'package', 'proc', 'return', 'struct', 'switch', 
+                'asm', 'auto_cast', 'bit_set', 'break', 'case', 'cast',
+                'context', 'continue', 'defer', 'distinct', 'do',
+                'dynamic', 'else', 'enum', 'fallthrough', 'for', 'foreign',
+                'if', 'import', 'in', 'map', 'matrix', 'not_in', 'or_else',
+                'or_return', 'package', 'proc', 'return', 'struct', 'switch',
                 'transmute', 'typeid', 'union', 'using', 'when', 'where'), suffix=r'\b'),
              Keyword),
             (r'(true|false|nil)\b', Keyword.Constant),
             # It seems the builtin types aren't actually keywords, but
             # can be used as functions. So we need two declarations.
             (words((
-                'bool', 'b8', 'b16', 'b32', 'b64', 
-                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128', 
-                'rune', 
-                'f16', 'f32', 'f64', 
-                'complex32', 'complex64', 'complex128', 
-                'quaternion64', 'quaternion128', 'quaternion256', 
-                'int', 'uint', 'uintptr', 'rawptr', 
-                'string', 'cstring', 'any', 'typeid', 
-                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le', 
-                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be', 
-                'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte', 
+                'bool', 'b8', 'b16', 'b32', 'b64',
+                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128',
+                'rune',
+                'f16', 'f32', 'f64',
+                'complex32', 'complex64', 'complex128',
+                'quaternion64', 'quaternion128', 'quaternion256',
+                'int', 'uint', 'uintptr', 'rawptr',
+                'string', 'cstring', 'any', 'typeid',
+                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le',
+                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be',
+                'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte',
 
-                'len', 'cap', 'size_of', 'align_of', 'offset_of', 'offset_of_by_string', 
-                'type_of', 'type_info_of', 'typeid_of', 'swizzle', 'complex', 
-                'quaternion', 'real', 'imag', 'jmag', 'kmag', 'conj', 
-                'expand_to_tuple', 'min', 'max', 'abs', 'clamp', 
-                'soa_zip', 'soa_unzip', 'transpose', 'outer_product', 
+                'len', 'cap', 'size_of', 'align_of', 'offset_of', 'offset_of_by_string',
+                'type_of', 'type_info_of', 'typeid_of', 'swizzle', 'complex',
+                'quaternion', 'real', 'imag', 'jmag', 'kmag', 'conj',
+                'expand_to_tuple', 'min', 'max', 'abs', 'clamp',
+                'soa_zip', 'soa_unzip', 'transpose', 'outer_product',
                 'hadamard_product', 'matrix_flatten'), suffix=r'\b(\()'),
              bygroups(Name.Builtin, Punctuation)),
             (words((
-                'bool', 'b8', 'b16', 'b32', 'b64', 
-                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128', 
-                'rune', 
-                'f16', 'f32', 'f64', 
-                'complex32', 'complex64', 'complex128', 
-                'quaternion64', 'quaternion128', 'quaternion256', 
-                'int', 'uint', 'uintptr', 'rawptr', 
-                'string', 'cstring', 'any', 'typeid', 
-                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le', 
-                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be', 
+                'bool', 'b8', 'b16', 'b32', 'b64',
+                'i8', 'u8', 'i16', 'u16', 'i32', 'u32', 'i64', 'u64', 'i128', 'u128',
+                'rune',
+                'f16', 'f32', 'f64',
+                'complex32', 'complex64', 'complex128',
+                'quaternion64', 'quaternion128', 'quaternion256',
+                'int', 'uint', 'uintptr', 'rawptr',
+                'string', 'cstring', 'any', 'typeid',
+                'i16le', 'u16le', 'i32le', 'u32le', 'i64le', 'u64le', 'i128le', 'u128le',
+                'i16be', 'u16be', 'i32be', 'u32be', 'i64be', 'u64be', 'i128be', 'u128be',
                 'f16le', 'f32le', 'f64le', 'f16be', 'f32be', 'f64be', 'byte'), suffix=r'\b'),
              Keyword.Type),
 
@@ -80,11 +90,11 @@ class OdinLangLexer(RegexLexer):
             (r'\.\d+([Ee][-+]\d+)?i', Number.Imaginary),
             (r'\d+[Ee][-+]\d+i', Number.Imaginary),
             (r'\d+i', Number.Imaginary),
-            
+
             # float_lit
             (r'\d+\.\d+([eE][+\-]?\d+)?', Number.Float),
             (r'\d+[eE][+\-]?\d+', Number.Float),
-            
+
             # int_lit
             # -- binary_lit
             (r'0b[01]+', Number.Bin),
@@ -98,7 +108,7 @@ class OdinLangLexer(RegexLexer):
             (r'0d[0-9]+', Number.Integer),
             # -- generic decimal_lit
             (r'[0-9]+', Number.Integer),
-            
+
             # char_lit
             (r"""'(\\['"\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}"""
              r"""|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|[^\\])'""",
@@ -108,17 +118,17 @@ class OdinLangLexer(RegexLexer):
             (r'`[^`]*`', String),
             # -- interpreted_string_lit
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
-            
+
             # Range operators
             (r'\.\.[=<]?', Operator),
             # All other operators
-            (r'(::=|<<=|>>=|%%= |&&=|\|\|=|&~=|::|:=|<<|>>|&&|\|\||&~|==|!=|<=|>=|---|->|[+\-*/%~!=<>&|^?]=?)', Operator),
+            (r'(::=|<<=|>>=|%%=|&&=|\|\|=|&~=|%%|::|:=|<<|>>|&&|\|\||&~|==|!=|<=|>=|---|->|[+\-*/%~!=<>&|^?]=?)', Operator),
             # Attribute marker
             (r'@', Name.Decorator),
             # Other symbols
             (r'[#$]', Operator),
             (r'[()[\]{}.,;:]', Punctuation),
-            
+
             # identifier
             (r'[^\W\d]\w*', Name.Other),
         ],
@@ -129,3 +139,12 @@ class OdinLangLexer(RegexLexer):
             (r'[*/]', Comment.Multiline),
         ],
     }
+
+    def analyse_text(text):
+        """Disambiguate from openEHR ODIN, which also uses *.odin."""
+        # every Odin-lang file starts with a package declaration
+        if re.search(r'^\s*package\s+\w+', text, re.MULTILINE):
+            return 0.9
+        if re.search(r'\w+\s*::\s*(proc|struct|enum|union)\b', text):
+            return 0.5
+        return 0.0

--- a/pygments/lexers/odin.py
+++ b/pygments/lexers/odin.py
@@ -142,9 +142,15 @@ class OdinLangLexer(RegexLexer):
 
     def analyse_text(text):
         """Disambiguate from openEHR ODIN, which also uses *.odin."""
-        # every Odin-lang file starts with a package declaration
-        if re.search(r'^\s*package\s+\w+', text, re.MULTILINE):
-            return 0.9
+        result = 0.0
+        # Odin's collection-style imports, e.g. import "core:fmt", are distinctive.
+        if re.search(r'import\s+"\w+:', text):
+            result += 0.5
+        # `name :: proc/struct/enum/union` declarations are distinctive Odin syntax.
         if re.search(r'\w+\s*::\s*(proc|struct|enum|union)\b', text):
-            return 0.5
-        return 0.0
+            result += 0.3
+        # Odin's package declaration is just "package name", unlike similar
+        # declarations in other languages (e.g. Carbon's "package name api;").
+        if re.search(r'^\s*package\s+\w+\s*$', text, re.MULTILINE):
+            result += 0.1
+        return min(result, 1.0)

--- a/tests/examplefiles/odinlang/example.odin
+++ b/tests/examplefiles/odinlang/example.odin
@@ -20,9 +20,9 @@ Color :: enum u8 {
 
 // Union types
 Shape :: union {
-    Circle:    struct { radius: f32 },
-    Rectangle: struct { width, height: f32 },
-    Triangle:  struct { base, height: f32 },
+    bool,
+    i32,
+    f32,
 }
 
 // Generic struct
@@ -43,8 +43,7 @@ main :: proc() {
     emoji: rune = '🚀'
     
     // Maps
-    scores := map[string]int{"Alice" = 95, "Bob" = 87}
-    defer delete(scores)
+    scores: map[string]int
     
     // Bitwise operations
     bit_result := 0b1010 & 0b1100   // AND
@@ -89,23 +88,12 @@ main :: proc() {
     vec := Vec3{x = 1.0, y = 2.0, z = 3.0}
     fmt.printf("Vector: (%f, %f, %f)\n", vec.x, vec.y, vec.z)
     
-    // Union usage with pattern matching
-    shape := Shape(Circle{{radius = 5.0}})
-    switch s in shape {
-    case Circle:
-        fmt.printf("Circle with radius %f\n", s.radius)
-    case Rectangle:
-        fmt.printf("Rectangle %f x %f\n", s.width, s.height)
-    }
-    
     // Generic usage
     stack: Generic_Stack(int)
-    append(&stack.items, 42)
     
     // Memory allocation
     ptr := new(int)
     ptr^ = 100
-    defer free(ptr)
 }
 
 add_numbers :: proc(a, b: int) -> int {

--- a/tests/examplefiles/odinlang/example.odin
+++ b/tests/examplefiles/odinlang/example.odin
@@ -1,0 +1,136 @@
+// Odin Programming Language Example
+package example
+
+import "core:fmt"
+import "core:mem"
+
+// Constants and types
+BUFFER_SIZE :: 1024
+PI :: 3.14159
+
+Vec3 :: struct {
+    x, y, z: f32,
+}
+
+Color :: enum u8 {
+    RED   = 0,
+    GREEN = 1,
+    BLUE  = 2,
+}
+
+// Union types
+Shape :: union {
+    Circle:    struct { radius: f32 },
+    Rectangle: struct { width, height: f32 },
+    Triangle:  struct { base, height: f32 },
+}
+
+// Generic struct
+Generic_Stack :: struct($T: typeid) {
+    items: [dynamic]T,
+    count: int,
+}
+
+// Procedures (functions)
+main :: proc() {
+    fmt.println("Hello, Odin!")
+    
+    // Variable declarations
+    number := 42
+    floating := 3.14159
+    boolean := true
+    character := 'A'
+    emoji: rune = '🚀'
+    
+    // Maps
+    scores := map[string]int{"Alice" = 95, "Bob" = 87}
+    defer delete(scores)
+    
+    // Bitwise operations
+    bit_result := 0b1010 & 0b1100   // AND
+    bit_xor := 5 ~ 3                // XOR
+    
+    // Arrays and slices
+    array: [5]int = {1, 2, 3, 4, 5}
+    dynamic_array: [dynamic]int
+    append(&dynamic_array, 10, 20, 30)
+    
+    // String literals
+    regular_string := "This is a regular string"
+    raw_string := `This is a raw string with "quotes"`
+    
+    // Control flow
+    if number > 0 {
+        fmt.printf("Number is positive: %d\n", number)
+    } else {
+        fmt.println("Number is zero or negative")
+    }
+    
+    // Loops
+    for i in 0..<5 {
+        fmt.printf("Loop iteration: %d\n", i)
+    }
+    
+    // Switch statement
+    switch Color.RED {
+    case .RED:
+        fmt.println("Color is red")
+    case .GREEN:
+        fmt.println("Color is green")  
+    case .BLUE:
+        fmt.println("Color is blue")
+    }
+    
+    // Procedure call
+    result := add_numbers(10, 20)
+    fmt.printf("Result: %d\n", result)
+    
+    // Struct usage
+    vec := Vec3{x = 1.0, y = 2.0, z = 3.0}
+    fmt.printf("Vector: (%f, %f, %f)\n", vec.x, vec.y, vec.z)
+    
+    // Union usage with pattern matching
+    shape := Shape(Circle{{radius = 5.0}})
+    switch s in shape {
+    case Circle:
+        fmt.printf("Circle with radius %f\n", s.radius)
+    case Rectangle:
+        fmt.printf("Rectangle %f x %f\n", s.width, s.height)
+    }
+    
+    // Generic usage
+    stack: Generic_Stack(int)
+    append(&stack.items, 42)
+    
+    // Memory allocation
+    ptr := new(int)
+    ptr^ = 100
+    defer free(ptr)
+}
+
+add_numbers :: proc(a, b: int) -> int {
+    return a + b
+}
+
+// Number literals and bit operations
+test_numbers :: proc() {
+    // Different number bases
+    decimal := 255
+    hex := 0xFF
+    octal := 0o377
+    binary := 0b11111111
+    dozenal := 0z9B  // Base 12
+    
+    // Floating point literals
+    float_val := 3.14159
+    scientific := 1.23e-4
+    imaginary := 2.5i
+}
+
+// Foreign procedure declaration
+foreign import libc "system:c"
+
+@(default_calling_convention="c")
+foreign libc {
+    printf :: proc(format: cstring, #c_vararg args: ..any) -> i32 ---
+}

--- a/tests/examplefiles/odinlang/example.odin.output
+++ b/tests/examplefiles/odinlang/example.odin.output
@@ -1,0 +1,1011 @@
+'// Odin Programming Language Example\n' Comment.Single
+
+'package'     Keyword.Namespace
+' '           Text
+'example'     Name.Other
+'\n'          Text
+
+'\n'          Text
+
+'import'      Keyword.Namespace
+' '           Text
+'"core:fmt"'  Literal.String
+'\n'          Text
+
+'import'      Keyword.Namespace
+' '           Text
+'"core:mem"'  Literal.String
+'\n'          Text
+
+'\n'          Text
+
+'// Constants and types\n' Comment.Single
+
+'BUFFER_SIZE' Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'1024'        Literal.Number.Integer
+'\n'          Text
+
+'PI'          Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'3.14159'     Literal.Number.Float
+'\n'          Text
+
+'\n'          Text
+
+'Vec3'        Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'struct'      Keyword.Declaration
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'x'           Name.Other
+','           Operator
+' '           Text
+'y'           Name.Other
+','           Operator
+' '           Text
+'z'           Name.Other
+':'           Punctuation
+' '           Text
+'f32'         Keyword.Type
+','           Operator
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'Color'       Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'enum'        Keyword.Declaration
+' '           Text
+'u8'          Keyword.Type
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'RED'         Name.Other
+'   '         Text
+'='           Operator
+' '           Text
+'0'           Literal.Number.Integer
+','           Operator
+'\n'          Text
+
+'    '        Text
+'GREEN'       Name.Other
+' '           Text
+'='           Operator
+' '           Text
+'1'           Literal.Number.Integer
+','           Operator
+'\n'          Text
+
+'    '        Text
+'BLUE'        Name.Other
+'  '          Text
+'='           Operator
+' '           Text
+'2'           Literal.Number.Integer
+','           Operator
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Union types\n' Comment.Single
+
+'Shape'       Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'union'       Keyword.Declaration
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'Circle'      Name.Other
+':'           Punctuation
+'    '        Text
+'struct'      Keyword.Declaration
+' '           Text
+'{'           Punctuation
+' '           Text
+'radius'      Name.Other
+':'           Punctuation
+' '           Text
+'f32'         Keyword.Type
+' '           Text
+'}'           Punctuation
+','           Operator
+'\n'          Text
+
+'    '        Text
+'Rectangle'   Name.Other
+':'           Punctuation
+' '           Text
+'struct'      Keyword.Declaration
+' '           Text
+'{'           Punctuation
+' '           Text
+'width'       Name.Other
+','           Operator
+' '           Text
+'height'      Name.Other
+':'           Punctuation
+' '           Text
+'f32'         Keyword.Type
+' '           Text
+'}'           Punctuation
+','           Operator
+'\n'          Text
+
+'    '        Text
+'Triangle'    Name.Other
+':'           Punctuation
+'  '          Text
+'struct'      Keyword.Declaration
+' '           Text
+'{'           Punctuation
+' '           Text
+'base'        Name.Other
+','           Operator
+' '           Text
+'height'      Name.Other
+':'           Punctuation
+' '           Text
+'f32'         Keyword.Type
+' '           Text
+'}'           Punctuation
+','           Operator
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Generic struct\n' Comment.Single
+
+'Generic_Stack' Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'struct'      Keyword.Declaration
+'('           Punctuation
+'$'           Operator
+'T'           Name.Other
+':'           Punctuation
+' '           Text
+'typeid'      Keyword.Declaration
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'items'       Name.Other
+':'           Punctuation
+' '           Text
+'['           Punctuation
+'dynamic'     Keyword
+']'           Punctuation
+'T'           Name.Other
+','           Operator
+'\n'          Text
+
+'    '        Text
+'count'       Name.Other
+':'           Punctuation
+' '           Text
+'int'         Keyword.Type
+','           Operator
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Procedures (functions)\n' Comment.Single
+
+'main'        Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'proc'        Keyword.Declaration
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'fmt'         Name.Other
+'.'           Operator
+'println'     Name.Other
+'('           Punctuation
+'"Hello, Odin!"' Literal.String
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Variable declarations\n' Comment.Single
+
+'    '        Text
+'number'      Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'42'          Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'floating'    Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'3.14159'     Literal.Number.Float
+'\n'          Text
+
+'    '        Text
+'boolean'     Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'true'        Keyword.Constant
+'\n'          Text
+
+'    '        Text
+'character'   Name.Other
+' '           Text
+':='          Operator
+' '           Text
+"'A'"         Literal.String.Char
+'\n'          Text
+
+'    '        Text
+'emoji'       Name.Other
+':'           Punctuation
+' '           Text
+'rune'        Keyword.Type
+' '           Text
+'='           Operator
+' '           Text
+"'🚀'"         Literal.String.Char
+'\n'          Text
+
+'    \n    '  Text
+'// Maps\n'   Comment.Single
+
+'    '        Text
+'scores'      Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'map'         Keyword.Declaration
+'['           Punctuation
+'string'      Keyword.Type
+']'           Punctuation
+'int'         Keyword.Type
+'{'           Punctuation
+'"Alice"'     Literal.String
+' '           Text
+'='           Operator
+' '           Text
+'95'          Literal.Number.Integer
+','           Operator
+' '           Text
+'"Bob"'       Literal.String
+' '           Text
+'='           Operator
+' '           Text
+'87'          Literal.Number.Integer
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'defer'       Keyword
+' '           Text
+'delete'      Name.Other
+'('           Punctuation
+'scores'      Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Bitwise operations\n' Comment.Single
+
+'    '        Text
+'bit_result'  Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'0b1010'      Literal.Number.Bin
+' '           Text
+'&'           Operator
+' '           Text
+'0b1100'      Literal.Number.Bin
+'   '         Text
+'// AND\n'    Comment.Single
+
+'    '        Text
+'bit_xor'     Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'5'           Literal.Number.Integer
+' '           Text
+'~'           Operator
+' '           Text
+'3'           Literal.Number.Integer
+'                ' Text
+'// XOR\n'    Comment.Single
+
+'    \n    '  Text
+'// Arrays and slices\n' Comment.Single
+
+'    '        Text
+'array'       Name.Other
+':'           Punctuation
+' '           Text
+'['           Punctuation
+'5'           Literal.Number.Integer
+']'           Punctuation
+'int'         Keyword.Type
+' '           Text
+'='           Operator
+' '           Text
+'{'           Punctuation
+'1'           Literal.Number.Integer
+','           Operator
+' '           Text
+'2'           Literal.Number.Integer
+','           Operator
+' '           Text
+'3'           Literal.Number.Integer
+','           Operator
+' '           Text
+'4'           Literal.Number.Integer
+','           Operator
+' '           Text
+'5'           Literal.Number.Integer
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'dynamic_array' Name.Other
+':'           Punctuation
+' '           Text
+'['           Punctuation
+'dynamic'     Keyword
+']'           Punctuation
+'int'         Keyword.Type
+'\n'          Text
+
+'    '        Text
+'append'      Name.Other
+'('           Punctuation
+'&'           Operator
+'dynamic_array' Name.Other
+','           Operator
+' '           Text
+'10'          Literal.Number.Integer
+','           Operator
+' '           Text
+'20'          Literal.Number.Integer
+','           Operator
+' '           Text
+'30'          Literal.Number.Integer
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// String literals\n' Comment.Single
+
+'    '        Text
+'regular_string' Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'"This is a regular string"' Literal.String
+'\n'          Text
+
+'    '        Text
+'raw_string'  Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'`This is a raw string with "quotes"`' Literal.String
+'\n'          Text
+
+'    \n    '  Text
+'// Control flow\n' Comment.Single
+
+'    '        Text
+'if'          Keyword
+' '           Text
+'number'      Name.Other
+' '           Text
+'>'           Operator
+' '           Text
+'0'           Literal.Number.Integer
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Number is positive: %d\\n"' Literal.String
+','           Operator
+' '           Text
+'number'      Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+' '           Text
+'else'        Keyword
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'println'     Name.Other
+'('           Punctuation
+'"Number is zero or negative"' Literal.String
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Loops\n'  Comment.Single
+
+'    '        Text
+'for'         Keyword
+' '           Text
+'i'           Name.Other
+' '           Text
+'in'          Keyword
+' '           Text
+'0.'          Literal.Number.Float
+'.'           Operator
+'<'           Operator
+'5'           Literal.Number.Integer
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Loop iteration: %d\\n"' Literal.String
+','           Operator
+' '           Text
+'i'           Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Switch statement\n' Comment.Single
+
+'    '        Text
+'switch'      Keyword
+' '           Text
+'Color'       Name.Other
+'.'           Operator
+'RED'         Name.Other
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'.'           Operator
+'RED'         Name.Other
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'println'     Name.Other
+'('           Punctuation
+'"Color is red"' Literal.String
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'.'           Operator
+'GREEN'       Name.Other
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'println'     Name.Other
+'('           Punctuation
+'"Color is green"' Literal.String
+')'           Punctuation
+'  \n    '    Text
+'case'        Keyword
+' '           Text
+'.'           Operator
+'BLUE'        Name.Other
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'println'     Name.Other
+'('           Punctuation
+'"Color is blue"' Literal.String
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Procedure call\n' Comment.Single
+
+'    '        Text
+'result'      Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'add_numbers' Name.Other
+'('           Punctuation
+'10'          Literal.Number.Integer
+','           Operator
+' '           Text
+'20'          Literal.Number.Integer
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Result: %d\\n"' Literal.String
+','           Operator
+' '           Text
+'result'      Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Struct usage\n' Comment.Single
+
+'    '        Text
+'vec'         Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'Vec3'        Name.Other
+'{'           Punctuation
+'x'           Name.Other
+' '           Text
+'='           Operator
+' '           Text
+'1.0'         Literal.Number.Float
+','           Operator
+' '           Text
+'y'           Name.Other
+' '           Text
+'='           Operator
+' '           Text
+'2.0'         Literal.Number.Float
+','           Operator
+' '           Text
+'z'           Name.Other
+' '           Text
+'='           Operator
+' '           Text
+'3.0'         Literal.Number.Float
+'}'           Punctuation
+'\n'          Text
+
+'    '        Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Vector: (%f, %f, %f)\\n"' Literal.String
+','           Operator
+' '           Text
+'vec'         Name.Other
+'.'           Operator
+'x'           Name.Other
+','           Operator
+' '           Text
+'vec'         Name.Other
+'.'           Operator
+'y'           Name.Other
+','           Operator
+' '           Text
+'vec'         Name.Other
+'.'           Operator
+'z'           Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Union usage with pattern matching\n' Comment.Single
+
+'    '        Text
+'shape'       Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'Shape'       Name.Other
+'('           Punctuation
+'Circle'      Name.Other
+'{'           Punctuation
+'{'           Punctuation
+'radius'      Name.Other
+' '           Text
+'='           Operator
+' '           Text
+'5.0'         Literal.Number.Float
+'}'           Punctuation
+'}'           Punctuation
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'switch'      Keyword
+' '           Text
+'s'           Name.Other
+' '           Text
+'in'          Keyword
+' '           Text
+'shape'       Name.Other
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'Circle'      Name.Other
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Circle with radius %f\\n"' Literal.String
+','           Operator
+' '           Text
+'s'           Name.Other
+'.'           Operator
+'radius'      Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'case'        Keyword
+' '           Text
+'Rectangle'   Name.Other
+':'           Punctuation
+'\n'          Text
+
+'        '    Text
+'fmt'         Name.Other
+'.'           Operator
+'printf'      Name.Other
+'('           Punctuation
+'"Rectangle %f x %f\\n"' Literal.String
+','           Operator
+' '           Text
+'s'           Name.Other
+'.'           Operator
+'width'       Name.Other
+','           Operator
+' '           Text
+'s'           Name.Other
+'.'           Operator
+'height'      Name.Other
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'}'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Generic usage\n' Comment.Single
+
+'    '        Text
+'stack'       Name.Other
+':'           Punctuation
+' '           Text
+'Generic_Stack' Name.Other
+'('           Punctuation
+'int'         Keyword.Type
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'append'      Name.Other
+'('           Punctuation
+'&'           Operator
+'stack'       Name.Other
+'.'           Operator
+'items'       Name.Other
+','           Operator
+' '           Text
+'42'          Literal.Number.Integer
+')'           Punctuation
+'\n'          Text
+
+'    \n    '  Text
+'// Memory allocation\n' Comment.Single
+
+'    '        Text
+'ptr'         Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'new'         Name.Other
+'('           Punctuation
+'int'         Keyword.Type
+')'           Punctuation
+'\n'          Text
+
+'    '        Text
+'ptr'         Name.Other
+'^'           Punctuation
+' '           Text
+'='           Operator
+' '           Text
+'100'         Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'defer'       Keyword
+' '           Text
+'free'        Name.Other
+'('           Punctuation
+'ptr'         Name.Other
+')'           Punctuation
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'add_numbers' Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'proc'        Keyword.Declaration
+'('           Punctuation
+'a'           Name.Other
+','           Operator
+' '           Text
+'b'           Name.Other
+':'           Punctuation
+' '           Text
+'int'         Keyword.Type
+')'           Punctuation
+' '           Text
+'-'           Operator
+'>'           Operator
+' '           Text
+'int'         Keyword.Type
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'a'           Name.Other
+' '           Text
+'+'           Operator
+' '           Text
+'b'           Name.Other
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Number literals and bit operations\n' Comment.Single
+
+'test_numbers' Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'proc'        Keyword.Declaration
+'('           Punctuation
+')'           Punctuation
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'// Different number bases\n' Comment.Single
+
+'    '        Text
+'decimal'     Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'255'         Literal.Number.Integer
+'\n'          Text
+
+'    '        Text
+'hex'         Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'0xFF'        Literal.Number.Hex
+'\n'          Text
+
+'    '        Text
+'octal'       Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'0o377'       Literal.Number.Oct
+'\n'          Text
+
+'    '        Text
+'binary'      Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'0b11111111'  Literal.Number.Bin
+'\n'          Text
+
+'    '        Text
+'dozenal'     Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'0'           Literal.Number.Integer
+'z9B'         Name.Other
+'  '          Text
+'// Base 12\n' Comment.Single
+
+'    \n    '  Text
+'// Floating point literals\n' Comment.Single
+
+'    '        Text
+'float_val'   Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'3.14159'     Literal.Number.Float
+'\n'          Text
+
+'    '        Text
+'scientific'  Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'1.23e-4'     Literal.Number.Float
+'\n'          Text
+
+'    '        Text
+'imaginary'   Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'2.5i'        Literal.Number
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text
+
+'\n'          Text
+
+'// Foreign procedure declaration\n' Comment.Single
+
+'foreign'     Keyword.Namespace
+' '           Text
+'import'      Keyword.Namespace
+' '           Text
+'libc'        Name.Other
+' '           Text
+'"system:c"'  Literal.String
+'\n'          Text
+
+'\n'          Text
+
+'@'           Operator
+'('           Punctuation
+'default_calling_convention' Name.Other
+'='           Operator
+'"c"'         Literal.String
+')'           Punctuation
+'\n'          Text
+
+'foreign'     Keyword.Namespace
+' '           Text
+'libc'        Name.Other
+' '           Text
+'{'           Punctuation
+'\n'          Text
+
+'    '        Text
+'printf'      Name.Other
+' '           Text
+'::'          Operator
+' '           Text
+'proc'        Keyword.Declaration
+'('           Punctuation
+'format'      Name.Other
+':'           Punctuation
+' '           Text
+'cstring'     Keyword.Type
+','           Operator
+' '           Text
+'#'           Operator
+'c_vararg'    Name.Other
+' '           Text
+'args'        Name.Other
+':'           Punctuation
+' '           Text
+'.'           Operator
+'.'           Operator
+'any'         Keyword.Type
+')'           Punctuation
+' '           Text
+'-'           Operator
+'>'           Operator
+' '           Text
+'i32'         Keyword.Type
+' '           Text
+'-'           Operator
+'-'           Operator
+'-'           Operator
+'\n'          Text
+
+'}'           Punctuation
+'\n'          Text

--- a/tests/examplefiles/odinlang/example.odin.output
+++ b/tests/examplefiles/odinlang/example.odin.output
@@ -48,16 +48,16 @@
 
 '    '        Text
 'x'           Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 'y'           Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 'z'           Name.Other
 ':'           Punctuation
 ' '           Text
 'f32'         Keyword.Type
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '}'           Punctuation
@@ -82,7 +82,7 @@
 '='           Operator
 ' '           Text
 '0'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '    '        Text
@@ -91,7 +91,7 @@
 '='           Operator
 ' '           Text
 '1'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '    '        Text
@@ -100,7 +100,7 @@
 '='           Operator
 ' '           Text
 '2'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '}'           Punctuation
@@ -121,17 +121,17 @@
 
 '    '        Text
 'bool'        Keyword.Type
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '    '        Text
 'i32'         Keyword.Type
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '    '        Text
 'f32'         Keyword.Type
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '}'           Punctuation
@@ -165,7 +165,7 @@
 'dynamic'     Keyword
 ']'           Punctuation
 'T'           Name.Other
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '    '        Text
@@ -173,7 +173,7 @@
 ':'           Punctuation
 ' '           Text
 'int'         Keyword.Type
-','           Operator
+','           Punctuation
 '\n'          Text
 
 '}'           Punctuation
@@ -196,7 +196,7 @@
 
 '    '        Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'println'     Name.Other
 '('           Punctuation
 '"Hello, Odin!"' Literal.String
@@ -308,16 +308,16 @@
 ' '           Text
 '{'           Punctuation
 '1'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '2'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '3'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '4'           Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '5'           Literal.Number.Integer
 '}'           Punctuation
@@ -338,13 +338,13 @@
 '('           Punctuation
 '&'           Operator
 'dynamic_array' Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 '10'          Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '20'          Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '30'          Literal.Number.Integer
 ')'           Punctuation
@@ -386,11 +386,11 @@
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'printf'      Name.Other
 '('           Punctuation
 '"Number is positive: %d\\n"' Literal.String
-','           Operator
+','           Punctuation
 ' '           Text
 'number'      Name.Other
 ')'           Punctuation
@@ -406,7 +406,7 @@
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'println'     Name.Other
 '('           Punctuation
 '"Number is zero or negative"' Literal.String
@@ -427,9 +427,8 @@
 ' '           Text
 'in'          Keyword
 ' '           Text
-'0.'          Literal.Number.Float
-'.'           Operator
-'<'           Operator
+'0'           Literal.Number.Integer
+'..<'         Operator
 '5'           Literal.Number.Integer
 ' '           Text
 '{'           Punctuation
@@ -437,11 +436,11 @@
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'printf'      Name.Other
 '('           Punctuation
 '"Loop iteration: %d\\n"' Literal.String
-','           Operator
+','           Punctuation
 ' '           Text
 'i'           Name.Other
 ')'           Punctuation
@@ -458,7 +457,7 @@
 'switch'      Keyword
 ' '           Text
 'Color'       Name.Other
-'.'           Operator
+'.'           Punctuation
 'RED'         Name.Other
 ' '           Text
 '{'           Punctuation
@@ -467,14 +466,14 @@
 '    '        Text
 'case'        Keyword
 ' '           Text
-'.'           Operator
+'.'           Punctuation
 'RED'         Name.Other
 ':'           Punctuation
 '\n'          Text
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'println'     Name.Other
 '('           Punctuation
 '"Color is red"' Literal.String
@@ -484,14 +483,14 @@
 '    '        Text
 'case'        Keyword
 ' '           Text
-'.'           Operator
+'.'           Punctuation
 'GREEN'       Name.Other
 ':'           Punctuation
 '\n'          Text
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'println'     Name.Other
 '('           Punctuation
 '"Color is green"' Literal.String
@@ -499,14 +498,14 @@
 '  \n    '    Text
 'case'        Keyword
 ' '           Text
-'.'           Operator
+'.'           Punctuation
 'BLUE'        Name.Other
 ':'           Punctuation
 '\n'          Text
 
 '        '    Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'println'     Name.Other
 '('           Punctuation
 '"Color is blue"' Literal.String
@@ -528,7 +527,7 @@
 'add_numbers' Name.Other
 '('           Punctuation
 '10'          Literal.Number.Integer
-','           Operator
+','           Punctuation
 ' '           Text
 '20'          Literal.Number.Integer
 ')'           Punctuation
@@ -536,11 +535,11 @@
 
 '    '        Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'printf'      Name.Other
 '('           Punctuation
 '"Result: %d\\n"' Literal.String
-','           Operator
+','           Punctuation
 ' '           Text
 'result'      Name.Other
 ')'           Punctuation
@@ -561,14 +560,14 @@
 '='           Operator
 ' '           Text
 '1.0'         Literal.Number.Float
-','           Operator
+','           Punctuation
 ' '           Text
 'y'           Name.Other
 ' '           Text
 '='           Operator
 ' '           Text
 '2.0'         Literal.Number.Float
-','           Operator
+','           Punctuation
 ' '           Text
 'z'           Name.Other
 ' '           Text
@@ -580,24 +579,24 @@
 
 '    '        Text
 'fmt'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'printf'      Name.Other
 '('           Punctuation
 '"Vector: (%f, %f, %f)\\n"' Literal.String
-','           Operator
+','           Punctuation
 ' '           Text
 'vec'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'x'           Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 'vec'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'y'           Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 'vec'         Name.Other
-'.'           Operator
+'.'           Punctuation
 'z'           Name.Other
 ')'           Punctuation
 '\n'          Text
@@ -631,7 +630,7 @@
 
 '    '        Text
 'ptr'         Name.Other
-'^'           Punctuation
+'^'           Operator
 ' '           Text
 '='           Operator
 ' '           Text
@@ -650,7 +649,7 @@
 'proc'        Keyword.Declaration
 '('           Punctuation
 'a'           Name.Other
-','           Operator
+','           Punctuation
 ' '           Text
 'b'           Name.Other
 ':'           Punctuation
@@ -658,8 +657,7 @@
 'int'         Keyword.Type
 ')'           Punctuation
 ' '           Text
-'-'           Operator
-'>'           Operator
+'->'          Operator
 ' '           Text
 'int'         Keyword.Type
 ' '           Text
@@ -734,8 +732,7 @@
 ' '           Text
 ':='          Operator
 ' '           Text
-'0'           Literal.Number.Integer
-'z9B'         Name.Other
+'0z9B'        Literal.Number.Integer
 '  '          Text
 '// Base 12\n' Comment.Single
 
@@ -763,7 +760,7 @@
 ' '           Text
 ':='          Operator
 ' '           Text
-'2.5i'        Literal.Number
+'2.5i'        Literal.Number.Imaginary
 '\n'          Text
 
 '}'           Punctuation
@@ -784,7 +781,7 @@
 
 '\n'          Text
 
-'@'           Operator
+'@'           Name.Decorator
 '('           Punctuation
 'default_calling_convention' Name.Other
 '='           Operator
@@ -810,7 +807,7 @@
 ':'           Punctuation
 ' '           Text
 'cstring'     Keyword.Type
-','           Operator
+','           Punctuation
 ' '           Text
 '#'           Operator
 'c_vararg'    Name.Other
@@ -818,19 +815,15 @@
 'args'        Name.Other
 ':'           Punctuation
 ' '           Text
-'.'           Operator
-'.'           Operator
+'..'          Operator
 'any'         Keyword.Type
 ')'           Punctuation
 ' '           Text
-'-'           Operator
-'>'           Operator
+'->'          Operator
 ' '           Text
 'i32'         Keyword.Type
 ' '           Text
-'-'           Operator
-'-'           Operator
-'-'           Operator
+'---'         Operator
 '\n'          Text
 
 '}'           Punctuation

--- a/tests/examplefiles/odinlang/example.odin.output
+++ b/tests/examplefiles/odinlang/example.odin.output
@@ -120,59 +120,17 @@
 '\n'          Text
 
 '    '        Text
-'Circle'      Name.Other
-':'           Punctuation
-'    '        Text
-'struct'      Keyword.Declaration
-' '           Text
-'{'           Punctuation
-' '           Text
-'radius'      Name.Other
-':'           Punctuation
-' '           Text
-'f32'         Keyword.Type
-' '           Text
-'}'           Punctuation
+'bool'        Keyword.Type
 ','           Operator
 '\n'          Text
 
 '    '        Text
-'Rectangle'   Name.Other
-':'           Punctuation
-' '           Text
-'struct'      Keyword.Declaration
-' '           Text
-'{'           Punctuation
-' '           Text
-'width'       Name.Other
-','           Operator
-' '           Text
-'height'      Name.Other
-':'           Punctuation
-' '           Text
-'f32'         Keyword.Type
-' '           Text
-'}'           Punctuation
+'i32'         Keyword.Type
 ','           Operator
 '\n'          Text
 
 '    '        Text
-'Triangle'    Name.Other
-':'           Punctuation
-'  '          Text
-'struct'      Keyword.Declaration
-' '           Text
-'{'           Punctuation
-' '           Text
-'base'        Name.Other
-','           Operator
-' '           Text
-'height'      Name.Other
-':'           Punctuation
-' '           Text
 'f32'         Keyword.Type
-' '           Text
-'}'           Punctuation
 ','           Operator
 '\n'          Text
 
@@ -296,37 +254,13 @@
 
 '    '        Text
 'scores'      Name.Other
-' '           Text
-':='          Operator
+':'           Punctuation
 ' '           Text
 'map'         Keyword.Declaration
 '['           Punctuation
 'string'      Keyword.Type
 ']'           Punctuation
 'int'         Keyword.Type
-'{'           Punctuation
-'"Alice"'     Literal.String
-' '           Text
-'='           Operator
-' '           Text
-'95'          Literal.Number.Integer
-','           Operator
-' '           Text
-'"Bob"'       Literal.String
-' '           Text
-'='           Operator
-' '           Text
-'87'          Literal.Number.Integer
-'}'           Punctuation
-'\n'          Text
-
-'    '        Text
-'defer'       Keyword
-' '           Text
-'delete'      Name.Other
-'('           Punctuation
-'scores'      Name.Other
-')'           Punctuation
 '\n'          Text
 
 '    \n    '  Text
@@ -669,92 +603,6 @@
 '\n'          Text
 
 '    \n    '  Text
-'// Union usage with pattern matching\n' Comment.Single
-
-'    '        Text
-'shape'       Name.Other
-' '           Text
-':='          Operator
-' '           Text
-'Shape'       Name.Other
-'('           Punctuation
-'Circle'      Name.Other
-'{'           Punctuation
-'{'           Punctuation
-'radius'      Name.Other
-' '           Text
-'='           Operator
-' '           Text
-'5.0'         Literal.Number.Float
-'}'           Punctuation
-'}'           Punctuation
-')'           Punctuation
-'\n'          Text
-
-'    '        Text
-'switch'      Keyword
-' '           Text
-'s'           Name.Other
-' '           Text
-'in'          Keyword
-' '           Text
-'shape'       Name.Other
-' '           Text
-'{'           Punctuation
-'\n'          Text
-
-'    '        Text
-'case'        Keyword
-' '           Text
-'Circle'      Name.Other
-':'           Punctuation
-'\n'          Text
-
-'        '    Text
-'fmt'         Name.Other
-'.'           Operator
-'printf'      Name.Other
-'('           Punctuation
-'"Circle with radius %f\\n"' Literal.String
-','           Operator
-' '           Text
-'s'           Name.Other
-'.'           Operator
-'radius'      Name.Other
-')'           Punctuation
-'\n'          Text
-
-'    '        Text
-'case'        Keyword
-' '           Text
-'Rectangle'   Name.Other
-':'           Punctuation
-'\n'          Text
-
-'        '    Text
-'fmt'         Name.Other
-'.'           Operator
-'printf'      Name.Other
-'('           Punctuation
-'"Rectangle %f x %f\\n"' Literal.String
-','           Operator
-' '           Text
-'s'           Name.Other
-'.'           Operator
-'width'       Name.Other
-','           Operator
-' '           Text
-'s'           Name.Other
-'.'           Operator
-'height'      Name.Other
-')'           Punctuation
-'\n'          Text
-
-'    '        Text
-'}'           Punctuation
-'\n'          Text
-
-'    \n    '  Text
 '// Generic usage\n' Comment.Single
 
 '    '        Text
@@ -764,19 +612,6 @@
 'Generic_Stack' Name.Other
 '('           Punctuation
 'int'         Keyword.Type
-')'           Punctuation
-'\n'          Text
-
-'    '        Text
-'append'      Name.Other
-'('           Punctuation
-'&'           Operator
-'stack'       Name.Other
-'.'           Operator
-'items'       Name.Other
-','           Operator
-' '           Text
-'42'          Literal.Number.Integer
 ')'           Punctuation
 '\n'          Text
 
@@ -801,15 +636,6 @@
 '='           Operator
 ' '           Text
 '100'         Literal.Number.Integer
-'\n'          Text
-
-'    '        Text
-'defer'       Keyword
-' '           Text
-'free'        Name.Other
-'('           Punctuation
-'ptr'         Name.Other
-')'           Punctuation
 '\n'          Text
 
 '}'           Punctuation

--- a/tests/snippets/odinlang/test_nested_comments.txt
+++ b/tests/snippets/odinlang/test_nested_comments.txt
@@ -1,0 +1,52 @@
+---input---
+/* outer comment /* inner comment */ still in outer */
+code_after_comment := true
+
+/* multiple levels
+   /* level 2
+      /* level 3 */ 
+      back to level 2 
+   */ 
+   back to level 1 
+*/
+more_code := 42
+
+---tokens---
+'/*'          Comment.Multiline
+' outer comment ' Comment.Multiline
+'/*'          Comment.Multiline
+' inner comment ' Comment.Multiline
+'*/'          Comment.Multiline
+' still in outer ' Comment.Multiline
+'*/'          Comment.Multiline
+'\n'          Text
+
+'code_after_comment' Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'true'        Keyword.Constant
+'\n'          Text
+
+'\n'          Text
+
+'/*'          Comment.Multiline
+' multiple levels\n   ' Comment.Multiline
+'/*'          Comment.Multiline
+' level 2\n      ' Comment.Multiline
+'/*'          Comment.Multiline
+' level 3 '   Comment.Multiline
+'*/'          Comment.Multiline
+' \n      back to level 2 \n   ' Comment.Multiline
+'*/'          Comment.Multiline
+' \n   back to level 1 \n' Comment.Multiline
+
+'*/'          Comment.Multiline
+'\n'          Text
+
+'more_code'   Name.Other
+' '           Text
+':='          Operator
+' '           Text
+'42'          Literal.Number.Integer
+'\n'          Text

--- a/tests/test_guess.py
+++ b/tests/test_guess.py
@@ -15,6 +15,7 @@ from pygments.lexers import (
     find_lexer_class_by_name,
     get_lexer_by_name,
     guess_lexer,
+    guess_lexer_for_filename,
 )
 from pygments.lexers.basic import CbmBasicV2Lexer
 from pygments.lexers.ecl import ECLLexer
@@ -264,3 +265,10 @@ def test_filename_matching(example_file):
             matches.append(pattern)
 
     assert matches, f"No {klass.filenames} patterns matches {example_file.name!r}"
+
+
+def test_guess_odin_lexers():
+    odinlang = 'package main\n\nmain :: proc() {\n}\n'
+    openehr_odin = 'original_author = <\n    ["name"] = <"J Joyce">\n>\n'
+    assert guess_lexer_for_filename('t.odin', odinlang).__class__.__name__ == 'OdinLangLexer'
+    assert guess_lexer_for_filename('t.odin', openehr_odin).__class__.__name__ == 'OdinLexer'


### PR DESCRIPTION
This PR adds a lexer for the [Odin language](https://odin-lang.org). 

Most of the actual lexer was already defined already in the related issue (https://github.com/pygments/pygments/issues/1969). I only made one small change around nested multi-line comments and created the tests.

**NOTE**: One weird thing you might notice is that there already exists an `ODIN` directory and references to `odin` in the project.  `ODIN` is actually a [different, much less popular, project ](https://github.com/openEHR/odin). For this reason I've added _this_ `Odin`, as `odinlang` where necessary. 