### PR TITLE
Fix GetElem in Lean 4

### DIFF
--- a/pygments/lexers/lean.py
+++ b/pygments/lexers/lean.py
@@ -136,7 +136,7 @@ class Lean4Lexer(RegexLexer):
     """
     For the Lean 4 theorem prover.
     """
-    
+
     name = 'Lean4'
     url = 'https://github.com/leanprover/lean4'
     aliases = ['lean4']
@@ -186,7 +186,7 @@ class Lean4Lexer(RegexLexer):
     )
 
     punctuation = ('(', ')', ':', '{', '}', '[', ']', '⦃', '⦄',
-                   ':=', ',')
+                   ':=', ',', ']\'', ']?', ']!')
 
     tokens = {
         'expression': [


### PR DESCRIPTION
I have added `]'`, `]?`, and `]!` as operators, since they are used as [Data Lookups](https://lean-lang.org/doc/reference/latest/Type-Classes/Basic-Classes/#GetElem___mk).