### PR TITLE
Include C++26 keywords and Java module keywords

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -347,7 +347,8 @@ class CppLexer(CFamilyLexer):
     aliases = ['cpp', 'c++']
     filenames = ['*.cpp', '*.hpp', '*.c++', '*.h++',
                  '*.cc', '*.hh', '*.cxx', '*.hxx',
-                 '*.C', '*.H', '*.cp', '*.CPP', '*.tpp']
+                 '*.C', '*.H', '*.cp', '*.CPP', '*.tpp',
+                 '*.cppm', '*.ixx', '*.mxx']
     mimetypes = ['text/x-c++hdr', 'text/x-c++src']
     version_added = ''
     priority = 0.1
@@ -363,8 +364,8 @@ class CppLexer(CFamilyLexer):
         'root': [
             inherit,
             # C++ Microsoft-isms
-            (words(('virtual_inheritance', 'uuidof', 'super', 'single_inheritance',
-                    'multiple_inheritance', 'interface', 'event'),
+            (words(('virtual_inheritance', 'uuidof', 'super', 'extends', 'single_inheritance',
+                    'multiple_inheritance', 'interface', 'implements', 'event'),
                    prefix=r'__', suffix=r'\b'), Keyword.Reserved),
             # Offload C++ extensions, http://offload.codeplay.com/
             (r'__(offload|blockingoffload|outer)\b', Keyword.Pseudo),
@@ -389,7 +390,8 @@ class CppLexer(CFamilyLexer):
                 'decltype', 'noexcept', 'override', 'final', 'constinit', 'consteval',
                 'co_await', 'co_return', 'co_yield', 'requires', 'import', 'module',
                 'typename', 'and', 'and_eq', 'bitand', 'bitor', 'compl', 'not',
-                'not_eq', 'or', 'or_eq', 'xor', 'xor_eq'),
+                'not_eq', 'or', 'or_eq', 'xor', 'xor_eq', 'contract_assert', 'pre', 'post', 
+                'trivially_relocatable_if_eligible', 'replaceable_if_eligible'),
                suffix=r'\b'), Keyword),
             (r'namespace\b', Keyword, 'namespace'),
             (r'(enum)(\s+)', bygroups(Keyword, Whitespace), 'enumname'),

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -55,16 +55,17 @@ class JavaLexer(RegexLexer):
              r'(\s*)(\()',                              # signature start
              bygroups(using(this), Name.Function, Whitespace, Punctuation)),
             (r'@[^\W\d][\w.]*', Name.Decorator),
-            (r'(abstract|const|enum|extends|final|implements|native|private|'
-             r'protected|public|sealed|static|strictfp|super|synchronized|throws|'
-             r'transient|volatile|yield)\b', Keyword.Declaration),
+            (r'(abstract|const|enum|exports|extends|final|implements|native|non-sealed|'
+             r'open|opens|permits|private|protected|provides|public|sealed|static|strictfp|'
+             r'super|synchronized|throws|to|transient|transitive|uses|volatile|with|yield)\b', Keyword.Declaration),
             (r'(boolean|byte|char|double|float|int|long|short|void)\b',
              Keyword.Type),
             (r'(package)(\s+)', bygroups(Keyword.Namespace, Whitespace), 'import'),
             (r'(true|false|null)\b', Keyword.Constant),
             (r'(class|interface)\b', Keyword.Declaration, 'class'),
+            (r'(module)\b', Keyword.Declaration, 'class'),
             (r'(var)(\s+)', bygroups(Keyword.Declaration, Whitespace), 'var'),
-            (r'(import(?:\s+static)?)(\s+)', bygroups(Keyword.Namespace, Whitespace),
+            (r'(import(?:\s+(?:static|module))?)(\s+)', bygroups(Keyword.Namespace, Whitespace),
              'import'),
             (r'"""\n', String, 'multiline_string'),
             (r'"', String, 'string'),
@@ -92,6 +93,10 @@ class JavaLexer(RegexLexer):
             (r'\n', Whitespace)
         ],
         'class': [
+            (r'\s+', Text),
+            (r'([^\W\d]|\$)[\w$]*', Name.Class, '#pop')
+        ],
+        'module': [
             (r'\s+', Text),
             (r'([^\W\d]|\$)[\w$]*', Name.Class, '#pop')
         ],


### PR DESCRIPTION
Pygments does not highlight C++26 keywords or module-related keywords for Java. This pull-request adds support for these keywords in these languages.