### PR TITLE
Update Mathematica lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -313,7 +313,7 @@ LEXERS = {
     'MarkdownLexer': ('pygments.lexers.markup', 'Markdown', ('markdown', 'md'), ('*.md', '*.markdown'), ('text/x-markdown',)),
     'MaskLexer': ('pygments.lexers.javascript', 'Mask', ('mask',), ('*.mask',), ('text/x-mask',)),
     'MasonLexer': ('pygments.lexers.templates', 'Mason', ('mason',), ('*.m', '*.mhtml', '*.mc', '*.mi', 'autohandler', 'dhandler'), ('application/x-mason',)),
-    'MathematicaLexer': ('pygments.lexers.algebra', 'Mathematica', ('mathematica', 'mma', 'nb'), ('*.nb', '*.cdf', '*.nbp', '*.ma'), ('application/mathematica', 'application/vnd.wolfram.mathematica', 'application/vnd.wolfram.mathematica.package', 'application/vnd.wolfram.cdf')),
+    'MathematicaLexer': ('pygments.lexers.algebra', 'Mathematica', ('mathematica', 'mma', 'nb', 'wl', 'wolfram'), ('*.nb', '*.cdf', '*.nbp', '*.ma', '*.wl', '*.wls'), ('application/mathematica', 'application/vnd.wolfram.mathematica', 'application/vnd.wolfram.mathematica.package', 'application/vnd.wolfram.cdf', 'application/vnd.wolfram.wl')),
     'MatlabLexer': ('pygments.lexers.matlab', 'Matlab', ('matlab',), ('*.m',), ('text/matlab',)),
     'MatlabSessionLexer': ('pygments.lexers.matlab', 'Matlab session', ('matlabsession',), (), ()),
     'MaximaLexer': ('pygments.lexers.maxima', 'Maxima', ('maxima', 'macsyma'), ('*.mac', '*.max'), ()),

--- a/pygments/lexers/algebra.py
+++ b/pygments/lexers/algebra.py
@@ -151,16 +151,17 @@ class MathematicaLexer(RegexLexer):
     Lexer for Mathematica source code.
     """
     name = 'Mathematica'
-    url = 'http://www.wolfram.com/mathematica/'
-    aliases = ['mathematica', 'mma', 'nb']
-    filenames = ['*.nb', '*.cdf', '*.nbp', '*.ma']
+    url = 'https://www.wolfram.com/language/'
+    aliases = ['mathematica', 'mma', 'nb', 'wl', 'wolfram']
+    filenames = ['*.nb', '*.cdf', '*.nbp', '*.ma', '*.wl', '*.wls']
     mimetypes = ['application/mathematica',
                  'application/vnd.wolfram.mathematica',
                  'application/vnd.wolfram.mathematica.package',
-                 'application/vnd.wolfram.cdf']
+                 'application/vnd.wolfram.cdf',
+                 'application/vnd.wolfram.wl']
     version_added = '2.0'
 
-    # http://reference.wolfram.com/mathematica/guide/Syntax.html
+    # https://reference.wolfram.com/language/guide/Syntax.html
     operators = (
         ";;", "=", "=.", "!=" "==", ":=", "->", ":>", "/.", "+", "-", "*", "/",
         "^", "&&", "||", "!", "<>", "|", "/;", "?", "@", "//", "/@", "@@",


### PR DESCRIPTION
Add new aliases, extensions, and mime-types. 

These changes are motivated by the fact that the programming language itself is called the [Wolfram Language](https://www.wolfram.com/language/), hence the new aliases `wolfram` and `wl`. I also added the `*.wls` extension which is used for Wolfram Language scripts.