### PR TITLE
Fix Kotlin number literals

### DIFF
--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -1162,15 +1162,20 @@ class KotlinLexer(RegexLexer):
             # Operators
             (r'::|!!|\?[:.]', Operator),
             (r'[~^*!%&\[\]<>|+=/?-]', Operator),
-            # Punctuation
-            (r'[{}();:.,]', Punctuation),
             # Strings
             (r'"""', String, 'multiline_string'),
             (r'"', String, 'string'),
             (r"'\\.'|'[^\\]'", String.Char),
             # Numbers
-            (r"[0-9](\.[0-9]*)?([eE][+-][0-9]+)?[flFL]?|"
-             r"0[xX][0-9a-fA-F]+[Ll]?", Number),
+            (r"0[xX][0-9a-fA-F]+(_+[0-9a-fA-F]+)*[uU]?L?", Number.Hex),
+            (r"0[bB][01]+(_+[01]+)*[uU]?L?", Number.Bin),
+            (r"[0-9]+(_+[0-9]+)*\.[0-9]+(_+[0-9]+)*([eE][+-]?[0-9]+(_+[0-9]+)*)?[fF]?|"
+             r"\.[0-9]+(_+[0-9]+)*([eE][+-]?[0-9]+(_+[0-9]+)*)?[fF]?|"
+             r"[0-9]+(_+[0-9]+)*[eE][+-]?[0-9]+(_+[0-9]+)*[fF]?|"
+             r"[0-9]+(_+[0-9]+)*[fF]"    , Number.Float),
+            (r"[0-9]+(_+[0-9]+)*[uU]?L?", Number.Integer),
+            # Punctuation
+            (r'[{}();:.,]', Punctuation),
             # Identifiers
             (r'' + kt_id + r'((\?[^.])?)', Name) # additionally handle nullable types
         ],

--- a/tests/snippets/kotlin/test_can_handle_numbers.txt
+++ b/tests/snippets/kotlin/test_can_handle_numbers.txt
@@ -1,0 +1,139 @@
+---input---
+0
+1
+123
+9_000
+1__2
+123u
+123U
+123L
+123uL
+123UL
+123f
+0003f
+0b0110_10
+0B0110_10
+0xaf0__5
+0XAf0_76
+0b01L
+0xFF8800L
+0XFF8800L
+0b01uL
+0xFF8800uL
+0XFF8800uL
+0b01UL
+0xFF8800UL
+0XFF8800UL
+1.23
+.123
+1.2_3
+123.123e123
+123.123E123
+123.123e+123
+123.123E+123
+123.123e-123
+123.123E-123
+
+
+---tokens---
+'0'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'1'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123'         Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'9_000'       Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'1__2'        Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123u'        Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123U'        Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123L'        Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123uL'       Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123UL'       Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'123f'        Literal.Number.Float
+'\n'          Text.Whitespace
+
+'0003f'       Literal.Number.Float
+'\n'          Text.Whitespace
+
+'0b0110_10'   Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'0B0110_10'   Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'0xaf0__5'    Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0XAf0_76'    Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0b01L'       Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'0xFF8800L'   Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0XFF8800L'   Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0b01uL'      Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'0xFF8800uL'  Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0XFF8800uL'  Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0b01UL'      Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'0xFF8800UL'  Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'0XFF8800UL'  Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'1.23'        Literal.Number.Float
+'\n'          Text.Whitespace
+
+'.123'        Literal.Number.Float
+'\n'          Text.Whitespace
+
+'1.2_3'       Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123e123' Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123E123' Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123e+123' Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123E+123' Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123e-123' Literal.Number.Float
+'\n'          Text.Whitespace
+
+'123.123E-123' Literal.Number.Float
+'\n'          Text.Whitespace


### PR DESCRIPTION
There are some quite a few ways numbers can be expressed in Kotlin which previously pygments didn't support and with this commit conforms to the grammar described in the [Kotlin Language Specification](https://kotlinlang.org/spec/syntax-and-grammar.html#literals).

### Separators
Like Java Kotlin allows any amount of separators inside number literals, as long as they don't appear at the start or end.

```Kotlin
9_000
1__2
1_2.3_4E5_6
```

### Plus and minus in E-Notation is optional

While plus and minus _can_ occur after the `e` or `E` it's not required.

```kotlin
123.123e123
123.123E123
123.123e+123
123.123E+123
123.123e-123
123.123E-123
```

### Binary Literals
Just as in Java there are binary literals which start with the `0b` or `0B` prefix.

```Kotlin
0b011010
0B011010
```

### Suffixes
Kotlin allows the suffixes `f`, `F`, `L`, `u`, `U`, `uL`, `UL`, though notably the previously supported suffix `l` is not allowed.

```Kotlin
123u
123U
123L
123uL
123UL
123f
0003f
0b01L
0xFF8800L
0XFF8800L
0b01uL
0xFF8800uL
0XFF8800uL
0b01UL
0xFF8800UL
0XFF8800UL
```