### PR TITLE
cue: add CUE language lexer support

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -118,6 +118,7 @@ LEXERS = {
     'CssPhpLexer': ('pygments.lexers.templates', 'CSS+PHP', ('css+php',), (), ('text/css+php',)),
     'CssSmartyLexer': ('pygments.lexers.templates', 'CSS+Smarty', ('css+smarty',), (), ('text/css+smarty',)),
     'CudaLexer': ('pygments.lexers.c_like', 'CUDA', ('cuda', 'cu'), ('*.cu', '*.cuh'), ('text/x-cuda',)),
+    'CueLexer': ('pygments.lexers.cue', 'Cue', ('cue', 'cuelang', 'cue.mod'), ('*.cue',), ('text/x-cuesrc',)),
     'CypherLexer': ('pygments.lexers.graph', 'Cypher', ('cypher',), ('*.cyp', '*.cypher'), ()),
     'CythonLexer': ('pygments.lexers.python', 'Cython', ('cython', 'pyx', 'pyrex'), ('*.pyx', '*.pxd', '*.pxi'), ('text/x-cython', 'application/x-cython')),
     'DLexer': ('pygments.lexers.d', 'D', ('d',), ('*.d', '*.di'), ('text/x-dsrc',)),

--- a/pygments/lexers/cue.py
+++ b/pygments/lexers/cue.py
@@ -1,0 +1,289 @@
+"""
+    pygments.lexers.cue
+    ~~~~~~~~~~~~~~~~~~
+
+    Lexer for the Cuelang language.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Whitespace, Error
+
+__all__ = ['CueLexer']
+
+
+class CueLexer(RegexLexer):
+    """
+    For Cuelang source.
+    """
+    name = 'Cue'
+    url = 'https://cuelang.org/'
+    filenames = ['*.cue']
+    aliases = ['cue', 'cuelang', 'cue.mod']
+    mimetypes = ['text/x-cuesrc']
+    version_added = '1.0'
+
+    tokens = {
+        'root': [
+            include('comment'),
+            include('whitespace'),
+            (r'\b(package)([ \t]+)([a-zA-Z\$\#][\w\$\#]*)\b', bygroups(Keyword.Namespace, Whitespace, Name.Namespace)),
+            (r'\b(import)([ \t]+)(\()', bygroups(Keyword.Namespace, Whitespace, Punctuation.Marker), 'import'),
+            (r'\b(import)([ \t]+)(?:([a-zA-Z\$\#][\w\$\#]*)([ \t]+))?(")([^:"]+)(?:(:)([a-zA-Z\$\#][\w\$\#]*))?(")', bygroups(Keyword.Namespace, Whitespace, Name.Namespace, Whitespace, Punctuation.Marker, String, Punctuation.Marker, Name.Namespace, Punctuation.Marker)),
+            include('punctuation_comma'),
+            include('declaration'),
+            include('invalid_in_braces')
+        ],
+        'declaration': [
+            (r'(@)([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)(\()', bygroups(Punctuation.Marker, Name, Punctuation.Marker), 'parameters'),
+            (r'(?<!:)::(?!:)', Punctuation),
+            include('punctuation_colon'),
+            (r'\?', Punctuation),
+            (r'(?<![=!><])=(?![=~])', Punctuation),
+            (r'<-', Punctuation),
+            include('expression')
+        ],
+        'parameters': [
+            (r'\)', Punctuation.Marker, '#pop'),
+            include('punctuation_comma'),
+            include('whitespace'),
+            include('attribute_element'),
+        ],
+        'expression': [
+            #for - loop syntax
+            (r'\b(for)([ \t]+)([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)(?:([ \t]*)(,)([ \t]*)([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+))?([ \t]+)(in)\b',
+             bygroups(Keyword, Whitespace, Name, Whitespace, Punctuation.Marker, Whitespace, Name, Whitespace, Keyword)),
+            #for - standalone keyword
+            (r'\bfor\b', Keyword),
+            #if
+            (r'\bif\b', Keyword),
+            #in - standalone keyword 
+            (r'\bin\b', Keyword),
+            #let - assignment syntax
+            (r'\b(let)([ \t]+)([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)([ \t]*)(=)(?![=])', bygroups(Keyword, Whitespace, Name, Whitespace, Punctuation)),
+            #let - standalone keyword
+            (r'\blet\b', Keyword),
+            #Arithmetic
+            (r'[\+\-\*]|/(?![/*])', Operator),
+            #Arithmetic
+            (r'\b(?:div|mod|quo|rem)\b', Operator.Word),
+            #Comparison
+            (r'=[=~]|![=~]|<=|>=|[<](?![<-=])|[>](?![>=])', Operator),
+            #Logical
+            (r'&{2}|\|{2}|!(?![=~])', Operator),
+            #Set
+            (r'&(?!&)|\|(?!\|)', Operator),
+            #Accessor
+            (r'(?<!\.)(\.)([a-zA-Z\$][\w\$]*)\b', bygroups(Operator, Name.Property)),
+            (r'(?<!\.)(\.)(\#[\w\$\#]*)\b', bygroups(Operator, Name.Entity)),
+            (r'(?<!\.)(\.)(_[\w\$\#]+)\b', bygroups(Operator, Name.Variable.Magic)),
+            # _
+            (r'\b_(?!\|)\b', Operator),
+            # _|_
+            (r'\b_\|_\b', Operator),
+            #null
+            (r'\bnull\b', Keyword.Constant),
+            #booléen
+            (r'\b(?:true|false)\b', Keyword.Constant),
+            #float
+            (r'(?<![\w\.])[0-9](?:_?[0-9])*\.(?:[0-9](?:_?[0-9])*)?(?:[eE][\+\-]?[0-9](?:_?[0-9])*)?(?![\w\.])', Number.Float),
+            (r'(?<![\w\.])[0-9](?:_?[0-9])*[eE][\+\-]?[0-9](?:_?[0-9])*(?![\w\.])', Number.Float),
+            (r'(?<![\w\.])\.[0-9](?:_?[0-9])*(?:[eE][\+\-]?[0-9](?:_?[0-9])*)?(?![\w\.])', Number.Float),
+            #integer other
+            (r'(?<![\w\.])(?:0|[1-9](?:_?[0-9])*)(?:\.[0-9](?:_?[0-9])*)?(?:[KMGTPEYZ]i?)(?![\w\.])', Number.Integer),
+            (r'(?<![\w\.])\.[0-9](?:_?[0-9])*(?:[KMGTPEYZ]i?)(?![\w\.])', Number.Integer),
+            (r'(?<![\w\.])(?:0|[1-9](?:_?[0-9])*)(?![\w\.])', Number.Integer),
+            (r'(?<![\w\.])0b[0-1](?:_?[0-1])*(?![\w\.])', Number.Bin),
+            (r'(?<![\w\.])0[xX][0-9a-fA-F](?:_?[0-9a-fA-F])*(?![\w\.])', Number.Hex),
+            (r'(?<![\w\.])0o?[0-7](?:_?[0-7])*(?![\w\.])', Number.Oct),
+            #string
+            include('string'),
+            #types supportés
+            (r'\b(?:bool|u?int(?:8|16|32|64|128)?|float(?:32|64)?|string|bytes|number|rune)\b', Keyword.Type),
+            #functions du langage
+            (r'\b(len|close|and|or)(\()', bygroups(Name.Function, Punctuation.Marker), 'function'),
+            (r'([a-zA-Z\$\#][\w\$\#]*)(\.)([A-Z][\w\$\#]*)(\()', bygroups(Name.Namespace, Punctuation.Marker, Name.Namespace, Punctuation.Marker), 'function'),
+            #variables
+            (r'([a-zA-Z\$][\w\$]*)\b', Name.Property),
+            #definitions
+            (r'(\#[\w]+)\b', Name.Entity),
+            #hidden fields
+            (r'(_[\w]+)\b', Name.Variable.Magic),
+            #block
+            (r'\{', Punctuation.Marker, 'block'),
+            #markup entangled
+            (r'(<<)([^>]+)(>>)', bygroups(Punctuation.Marker, Name.Label, Punctuation.Marker)),
+            #brackets
+            (r'\[', Punctuation.Marker, 'bracket'),
+            #brackets
+            (r'\(', Punctuation.Marker, 'parenthesis'),
+        ],
+        'function': [
+            (r'\)', Punctuation.Marker, '#pop'),
+            include('whitespace'),
+            include('comment'),
+            include('punctuation_comma'),
+            include('expression'),
+            include('invalid_in_parens')
+        ],
+        'block': [
+            (r'\}', Punctuation.Marker, '#pop'),
+            include('whitespace'),
+            include('comment'),
+            include('punctuation_comma'),
+            include('punctuation_ellipsis'),
+            include('declaration'),
+            include('invalid_in_braces')
+        ],
+        'bracket': [
+            (r'\]', Punctuation.Marker, '#pop'),
+            include('whitespace'),
+            include('comment'),
+            include('punctuation_colon'),
+            include('punctuation_comma'),
+            include('punctuation_ellipsis'),
+            (r'([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)[ \t]*(=)', bygroups(Name.Variable, Punctuation)),
+            include('expression'),
+            (r'[^\]]+', Error)
+        ],
+        'parenthesis': [
+            (r'\)', Punctuation.Marker, '#pop'),
+            include('whitespace'),
+            include('comment'),
+            include('punctuation_comma'),
+            include('expression'),
+            include('invalid_in_parens')
+        ],
+        'attribute_element': [
+            (r'([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)(=)', bygroups(Name.Variable, Punctuation), 'attribute_element_content'),
+            (r'([a-zA-Z\$\#][\w\$\#]*|_[\w\$\#]+)(\()', bygroups(Name.Variable, Punctuation), 'attribute_element_content2'),
+            include('attribute_string')
+        ],
+        'attribute_element_content': [
+            (r'(?=[,\)])', bygroups(None), '#pop'),
+            include('attribute_string')
+        ],
+        'attribute_element_content2': [
+            (r'\)', Punctuation, '#pop'),
+            include('punctuation_comma'),
+            include('attribute_element'),
+        ],
+        'attribute_string': [
+            include('string'),
+            (r'[^\n,\"\'#=\(\)]+', String),
+            (r'[^,\)]+', Error)
+        ],
+        'whitespace': [
+            (r'[ \t\r\n]+', Whitespace),
+        ],
+        'comment': [
+            (r'//(.*?)$', Comment.Single),
+        ],
+        'invalid_in_parens': [
+            (r'[^)]+', Error),
+        ],
+        'invalid_in_braces': [
+            (r'[^}]+', Error),
+        ],
+        'punctuation_comma': [
+            (r',', Punctuation),
+        ],
+        'punctuation_colon': [
+            (r'(?<!:):(?!:)', Punctuation.Marker),
+        ],
+        'punctuation_ellipsis': [
+            (r'(?<!\.)\.{3}(?!\.)', Punctuation),
+        ],
+        'string': [
+            (r'#"""', String.Delimiter, 'string_sharp_triple_double_quote'),
+            (r'#"', String.Delimiter, 'string_sharp_double_quote'),
+            (r"#'''", String.Delimiter, 'string_sharp_triple_single_quote'),
+            (r"#'", String.Delimiter, 'string_sharp_single_quote'),
+            (r'"""', String.Delimiter, 'string_triple_double_quote'),
+            (r'"', String.Delimiter, 'string_double_quote'),
+            (r"'''", String.Delimiter, 'string_triple_single_quote'),
+            (r"'", String.Delimiter, 'string_single_quote'),
+            (r"`[^`]*`", String.Backtick),
+        ],
+        'string_sharp_triple_double_quote': [
+            (r'"""#', String.Delimiter, '#pop'),
+            (r'\\#(?:"""|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})', String.Escape),
+            (r'\\#(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\#\(', Punctuation, 'interpolation'),
+            (r'\\#.', Error),
+            (r'[^"\\]+|"(?!""#)', String.Double)
+        ],
+        'string_sharp_double_quote': [
+            (r'"#', String.Delimiter, '#pop'),
+            (r'\\#(?:"|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})', String.Escape),
+            (r'\\#(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\#\(', Punctuation, 'interpolation'),
+            (r'\\#.', Error),
+            (r'[^"\\]+|"(?!#)', String.Double)
+        ],
+        'string_sharp_triple_single_quote': [
+            (r"'''#", String.Delimiter, '#pop'),
+            (r"\\#(?:'''|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})", String.Escape),
+            (r'\\#(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\#\(', Punctuation, 'interpolation'),
+            (r'\\#.', Error),
+            (r"[^'\\]+|'(?!''#)", String.Single)
+        ],
+        'string_sharp_single_quote': [
+            (r"'#", String.Delimiter, '#pop'),
+            (r"\\#(?:'|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})", String.Escape),
+            (r'\\#(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\#\(', Punctuation, 'interpolation'),
+            (r'\\#.', Error),
+            (r'[^\'\\]+', String.Single)
+        ],
+        'string_triple_double_quote': [
+            (r'"""', String.Delimiter, '#pop'),
+            (r'\\(?:"""|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})', String.Escape),
+            (r'\\(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\\(', Punctuation, 'interpolation'),
+            (r'\\.', Error),
+            (r'[^"\\]+|"(?!"")', String.Double)
+        ],
+        'string_double_quote': [
+            (r'"', String.Delimiter, '#pop'),
+            (r'\\(?:"|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})', String.Escape),
+            (r'\\(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\\(', Punctuation, 'interpolation'),
+            (r'\\.', Error),
+            (r'[^"\\]+', String.Double)
+        ],
+        'string_triple_single_quote': [
+            (r"'''", String.Delimiter, '#pop'),
+            (r"\\(?:'''|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})", String.Escape),
+            (r'\\(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\\(', Punctuation, 'interpolation'),
+            (r'\\.', Error),
+            (r"[^'\\]+|'(?!'')", String.Single)
+        ],
+        'string_single_quote': [
+            (r"'", String.Delimiter, '#pop'),
+            (r"\\(?:'|/|\\|[abfnrtv]|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})", String.Escape),
+            (r'\\(?:[0-7]{3}|x[0-9A-Fa-f]{2})', Error),
+            (r'\\\(', Punctuation, 'interpolation'),
+            (r'\\.', Error),
+            (r"[^'\\]+", String.Single)
+        ],
+
+        'interpolation': [
+            (r'\)', Punctuation, '#pop'),
+            include('whitespace'),
+            include('expression'),
+            include('invalid_in_parens')
+        ],
+
+        'import': [
+            (r'\)', Punctuation.Marker, '#pop'),
+            include('whitespace'),
+            include('comment'),
+            include('punctuation_comma'),
+            (r'((?:[a-zA-Z\$\#][\w\$\#]*)[ \t]+)?(")([^:"]+)(?:(:)([a-zA-Z\$\#][\w\$\#]*))?(")', bygroups(Name.Namespace, Punctuation.Marker, String, Punctuation.Marker, Name.Namespace, Punctuation.Marker)),
+            (r';', Punctuation),
+            include('invalid_in_parens'),
+        ]
+    }

--- a/tests/examplefiles/cue/basic.cue
+++ b/tests/examplefiles/cue/basic.cue
@@ -1,0 +1,69 @@
+// Basic CUE example showcasing key language features
+package example
+
+import "strings"
+
+// Basic value definitions
+name:   strings.ToUpper("John")
+age:    30
+active: true
+
+// Constraints and validation
+score: >50 & <100
+score: 75
+email: =~"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+email: "cueckoo@cuelang.org"
+
+// Structs and nested structures
+#person: {
+	name!: string
+	age?:  int & >=0 & <=120
+	address?: {
+		street?: string
+		city?:   string
+		zip?:    =~"^[0-9]{5}(-[0-9]{4})?$"
+	}
+}
+
+// Lists and comprehensions
+users: [
+	{name: "Alice", role: "admin"},
+	{name: "Bob", role: "user"},
+]
+
+// For comprehension
+userNames: [for u in users {u.name}]
+
+// Conditionals
+if age > 100 {
+	status: "pending"
+}
+
+// Templates and definitions
+#User: {
+	name: string
+	age:  int & >=0
+	role: "admin" | "user" | "guest"
+}
+
+// String interpolation
+greeting: "Hello, \(name)! You are \(age) years old."
+
+// Functions
+doubleAge: age * 2
+
+// Let expressions
+let x = 10
+result: x * 2
+
+// Hidden fields
+_internal: "secret"
+
+// Optional fields
+optional?: string
+
+// Disjunctions
+status: *"active" | "inactive" | "pending"
+
+// Numbers with units
+memory: 8Gi

--- a/tests/examplefiles/cue/basic.cue.output
+++ b/tests/examplefiles/cue/basic.cue.output
@@ -1,0 +1,394 @@
+'// Basic CUE example showcasing key language features' Comment.Single
+'\n'          Text.Whitespace
+
+'package'     Keyword.Namespace
+' '           Text.Whitespace
+'example'     Name.Namespace
+'\n\n'        Text.Whitespace
+
+'import'      Keyword.Namespace
+' '           Text.Whitespace
+'"'           Punctuation.Marker
+'strings'     Literal.String
+'"'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Basic value definitions' Comment.Single
+'\n'          Text.Whitespace
+
+'name'        Name.Property
+':'           Punctuation.Marker
+'   '         Text.Whitespace
+'strings'     Name.Namespace
+'.'           Punctuation.Marker
+'ToUpper'     Name.Namespace
+'('           Punctuation.Marker
+'"'           Literal.String.Delimiter
+'John'        Literal.String.Double
+'"'           Literal.String.Delimiter
+')'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'age'         Name.Property
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'30'          Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'active'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'true'        Keyword.Constant
+'\n\n'        Text.Whitespace
+
+'// Constraints and validation' Comment.Single
+'\n'          Text.Whitespace
+
+'score'       Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'>'           Operator
+'50'          Literal.Number.Integer
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'<'           Operator
+'100'         Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'score'       Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'75'          Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'email'       Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'=~'          Operator
+'"'           Literal.String.Delimiter
+'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+' Literal.String.Double
+'\\\\'        Literal.String.Escape
+'.[a-zA-Z]{2,}$' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'email'       Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'cueckoo@cuelang.org' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Structs and nested structures' Comment.Single
+'\n'          Text.Whitespace
+
+'#person'     Name.Entity
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'name'        Name.Property
+'!'           Operator
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'string'      Keyword.Type
+'\n\t'        Text.Whitespace
+'age'         Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+'  '          Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'>='          Operator
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'<='          Operator
+'120'         Literal.Number.Integer
+'\n\t'        Text.Whitespace
+'address'     Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'street'      Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'string'      Keyword.Type
+'\n\t\t'      Text.Whitespace
+'city'        Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+'   '         Text.Whitespace
+'string'      Keyword.Type
+'\n\t\t'      Text.Whitespace
+'zip'         Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'=~'          Operator
+'"'           Literal.String.Delimiter
+'^[0-9]{5}(-[0-9]{4})?$' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t'        Text.Whitespace
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Lists and comprehensions' Comment.Single
+'\n'          Text.Whitespace
+
+'users'       Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'['           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'{'           Punctuation.Marker
+'name'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'Alice'       Literal.String.Double
+'"'           Literal.String.Delimiter
+','           Punctuation
+' '           Text.Whitespace
+'role'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'admin'       Literal.String.Double
+'"'           Literal.String.Delimiter
+'}'           Punctuation.Marker
+','           Punctuation
+'\n\t'        Text.Whitespace
+'{'           Punctuation.Marker
+'name'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'Bob'         Literal.String.Double
+'"'           Literal.String.Delimiter
+','           Punctuation
+' '           Text.Whitespace
+'role'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'user'        Literal.String.Double
+'"'           Literal.String.Delimiter
+'}'           Punctuation.Marker
+','           Punctuation
+'\n'          Text.Whitespace
+
+']'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// For comprehension' Comment.Single
+'\n'          Text.Whitespace
+
+'userNames'   Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'['           Punctuation.Marker
+'for'         Keyword
+' '           Text.Whitespace
+'u'           Name
+' '           Text.Whitespace
+'in'          Keyword
+' '           Text.Whitespace
+'users'       Name.Property
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'u'           Name.Property
+'.'           Operator
+'name'        Name.Property
+'}'           Punctuation.Marker
+']'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Conditionals' Comment.Single
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'age'         Name.Property
+' '           Text.Whitespace
+'>'           Operator
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'status'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'pending'     Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Templates and definitions' Comment.Single
+'\n'          Text.Whitespace
+
+'#User'       Name.Entity
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'name'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'string'      Keyword.Type
+'\n\t'        Text.Whitespace
+'age'         Name.Property
+':'           Punctuation.Marker
+'  '          Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'>='          Operator
+'0'           Literal.Number.Integer
+'\n\t'        Text.Whitespace
+'role'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'admin'       Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'user'        Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'guest'       Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// String interpolation' Comment.Single
+'\n'          Text.Whitespace
+
+'greeting'    Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'Hello, '     Literal.String.Double
+'\\('         Punctuation
+'name'        Name.Property
+')'           Punctuation
+'! You are '  Literal.String.Double
+'\\('         Punctuation
+'age'         Name.Property
+')'           Punctuation
+' years old.' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Functions' Comment.Single
+'\n'          Text.Whitespace
+
+'doubleAge'   Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'age'         Name.Property
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'// Let expressions' Comment.Single
+'\n'          Text.Whitespace
+
+'let'         Keyword
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'10'          Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'result'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'x'           Name.Property
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'// Hidden fields' Comment.Single
+'\n'          Text.Whitespace
+
+'_internal'   Name.Variable.Magic
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'secret'      Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Optional fields' Comment.Single
+'\n'          Text.Whitespace
+
+'optional'    Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'string'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'// Disjunctions' Comment.Single
+'\n'          Text.Whitespace
+
+'status'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'*'           Operator
+'"'           Literal.String.Delimiter
+'active'      Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'inactive'    Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'pending'     Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Numbers with units' Comment.Single
+'\n'          Text.Whitespace
+
+'memory'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'8Gi'         Literal.Number.Integer
+'\n'          Text.Whitespace

--- a/tests/examplefiles/cue/complex.cue
+++ b/tests/examplefiles/cue/complex.cue
@@ -1,0 +1,97 @@
+package kubernetes
+
+import (
+	strs "strings"
+)
+
+// Multi-line strings
+description: """
+	This is a multi-line string
+	that spans multiple lines.
+	It supports interpolation: \(name)
+	"""
+
+// Advanced number formats
+hexValue:           0xFF
+octalValue:         0o777
+binaryValue:        0b1010
+scientificNotation: 1.23e-4
+floatWithUnits:     3Ki
+
+interpolation: true
+
+// String variations
+singleQuoted:    'single quoted string'
+doubleQuoted:    "double quoted string"
+multiLineString: """
+	multi-line string with \(interpolation)
+	"""
+sharpString:     #"string with # delimiter"#
+multilineSharp:  #"""
+	Multi-line sharp string
+	with \#(interpolation)
+	"""#
+
+// Complex attribute syntax
+@tag(go="json,omitempty")
+@deprecated("use newField instead")
+field?: string
+
+name: "prod"
+
+// Advanced pattern matching
+switch: {
+	if name == "prod" {
+		replicas: 3
+	}
+	if name == "dev" {
+		replicas: 1
+	}
+}
+
+// Recursive definitions
+#Tree: {
+	value:  string
+	left?:  #Tree
+	right?: #Tree
+}
+
+// Complex comprehensions
+config: {
+	for env in ["dev", "staging", "prod"] {
+		"\(env)": {
+			resources: {
+				if env == "prod" {
+					cpu:    "2000m"
+					memory: "4Gi"
+				}
+				if env != "prod" {
+					cpu:    "500m"
+					memory: "1Gi"
+				}
+			}
+		}
+	}
+}
+
+// Nullable and bottom values
+nullable:     null
+bottomValue?: _|_
+topValue?:    _
+
+// Function calls
+userNames: ["a", "b"]
+processedData: len(userNames)
+combined:      strs.Join(userNames, ", ")
+
+// Complex validation
+#validatedConfig: {
+	name:     string & =~"^[a-z][a-z0-9-]*[a-z0-9]$"
+	port:     int & >0 & <=65535
+	protocol: *"TCP" | "UDP"
+
+	// Conditional validation
+	if protocol == "TCP" {
+		keepAlive?: bool
+	}
+}

--- a/tests/examplefiles/cue/complex.cue.output
+++ b/tests/examplefiles/cue/complex.cue.output
@@ -1,0 +1,492 @@
+'package'     Keyword.Namespace
+' '           Text.Whitespace
+'kubernetes'  Name.Namespace
+'\n\n'        Text.Whitespace
+
+'import'      Keyword.Namespace
+' '           Text.Whitespace
+'('           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'strs '       Name.Namespace
+'"'           Punctuation.Marker
+'strings'     Literal.String
+'"'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+')'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Multi-line strings' Comment.Single
+'\n'          Text.Whitespace
+
+'description' Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"""'         Literal.String.Delimiter
+'\n\tThis is a multi-line string\n\tthat spans multiple lines.\n\tIt supports interpolation: ' Literal.String.Double
+'\\('         Punctuation
+'name'        Name.Property
+')'           Punctuation
+'\n\t'        Literal.String.Double
+'"""'         Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Advanced number formats' Comment.Single
+'\n'          Text.Whitespace
+
+'hexValue'    Name.Property
+':'           Punctuation.Marker
+'           ' Text.Whitespace
+'0xFF'        Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'octalValue'  Name.Property
+':'           Punctuation.Marker
+'         '   Text.Whitespace
+'0o777'       Literal.Number.Oct
+'\n'          Text.Whitespace
+
+'binaryValue' Name.Property
+':'           Punctuation.Marker
+'        '    Text.Whitespace
+'0b1010'      Literal.Number.Bin
+'\n'          Text.Whitespace
+
+'scientificNotation' Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'1.23e-4'     Literal.Number.Float
+'\n'          Text.Whitespace
+
+'floatWithUnits' Name.Property
+':'           Punctuation.Marker
+'     '       Text.Whitespace
+'3Ki'         Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'interpolation' Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'true'        Keyword.Constant
+'\n\n'        Text.Whitespace
+
+'// String variations' Comment.Single
+'\n'          Text.Whitespace
+
+'singleQuoted' Name.Property
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+"'"           Literal.String.Delimiter
+'single quoted string' Literal.String.Single
+"'"           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'doubleQuoted' Name.Property
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'"'           Literal.String.Delimiter
+'double quoted string' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'multiLineString' Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"""'         Literal.String.Delimiter
+'\n\tmulti-line string with ' Literal.String.Double
+'\\('         Punctuation
+'interpolation' Name.Property
+')'           Punctuation
+'\n\t'        Literal.String.Double
+'"""'         Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'sharpString' Name.Property
+':'           Punctuation.Marker
+'     '       Text.Whitespace
+'#"'          Literal.String.Delimiter
+'string with # delimiter' Literal.String.Double
+'"#'          Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'multilineSharp' Name.Property
+':'           Punctuation.Marker
+'  '          Text.Whitespace
+'#"""'        Literal.String.Delimiter
+'\n\tMulti-line sharp string\n\twith ' Literal.String.Double
+'\\#('        Punctuation
+'interpolation' Name.Property
+')'           Punctuation
+'\n\t'        Literal.String.Double
+'"""#'        Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Complex attribute syntax' Comment.Single
+'\n'          Text.Whitespace
+
+'@'           Punctuation.Marker
+'tag'         Name
+'('           Punctuation.Marker
+'go'          Name.Variable
+'='           Punctuation
+'"'           Literal.String.Delimiter
+'json,omitempty' Literal.String.Double
+'"'           Literal.String.Delimiter
+')'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'@'           Punctuation.Marker
+'deprecated'  Name
+'('           Punctuation.Marker
+'"'           Literal.String.Delimiter
+'use newField instead' Literal.String.Double
+'"'           Literal.String.Delimiter
+')'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'field'       Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'string'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'name'        Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'prod'        Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n'        Text.Whitespace
+
+'// Advanced pattern matching' Comment.Single
+'\n'          Text.Whitespace
+
+'switch'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'name'        Name.Property
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'prod'        Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'replicas'    Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+'\n\t'        Text.Whitespace
+'}'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'name'        Name.Property
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'dev'         Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'replicas'    Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n\t'        Text.Whitespace
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Recursive definitions' Comment.Single
+'\n'          Text.Whitespace
+
+'#Tree'       Name.Entity
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'value'       Name.Property
+':'           Punctuation.Marker
+'  '          Text.Whitespace
+'string'      Keyword.Type
+'\n\t'        Text.Whitespace
+'left'        Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+'  '          Text.Whitespace
+'#Tree'       Name.Entity
+'\n\t'        Text.Whitespace
+'right'       Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'#Tree'       Name.Entity
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Complex comprehensions' Comment.Single
+'\n'          Text.Whitespace
+
+'config'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'for'         Keyword
+' '           Text.Whitespace
+'env'         Name
+' '           Text.Whitespace
+'in'          Keyword
+' '           Text.Whitespace
+'['           Punctuation.Marker
+'"'           Literal.String.Delimiter
+'dev'         Literal.String.Double
+'"'           Literal.String.Delimiter
+','           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'staging'     Literal.String.Double
+'"'           Literal.String.Delimiter
+','           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'prod'        Literal.String.Double
+'"'           Literal.String.Delimiter
+']'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'"'           Literal.String.Delimiter
+'\\('         Punctuation
+'env'         Name.Property
+')'           Punctuation
+'"'           Literal.String.Delimiter
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t\t'    Text.Whitespace
+'resources'   Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t\t\t'  Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'env'         Name.Property
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'prod'        Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t\t\t\t' Text.Whitespace
+'cpu'         Name.Property
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'"'           Literal.String.Delimiter
+'2000m'       Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t\t\t\t\t' Text.Whitespace
+'memory'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'4Gi'         Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t\t\t\t'  Text.Whitespace
+'}'           Punctuation.Marker
+'\n\t\t\t\t'  Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'env'         Name.Property
+' '           Text.Whitespace
+'!='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'prod'        Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t\t\t\t' Text.Whitespace
+'cpu'         Name.Property
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'"'           Literal.String.Delimiter
+'500m'        Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t\t\t\t\t' Text.Whitespace
+'memory'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'1Gi'         Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t\t\t\t'  Text.Whitespace
+'}'           Punctuation.Marker
+'\n\t\t\t'    Text.Whitespace
+'}'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'}'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Nullable and bottom values' Comment.Single
+'\n'          Text.Whitespace
+
+'nullable'    Name.Property
+':'           Punctuation.Marker
+'     '       Text.Whitespace
+'null'        Keyword.Constant
+'\n'          Text.Whitespace
+
+'bottomValue' Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'_|_'         Operator
+'\n'          Text.Whitespace
+
+'topValue'    Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+'    '        Text.Whitespace
+'_'           Operator
+'\n\n'        Text.Whitespace
+
+'// Function calls' Comment.Single
+'\n'          Text.Whitespace
+
+'userNames'   Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'['           Punctuation.Marker
+'"'           Literal.String.Delimiter
+'a'           Literal.String.Double
+'"'           Literal.String.Delimiter
+','           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'b'           Literal.String.Double
+'"'           Literal.String.Delimiter
+']'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'processedData' Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'len'         Name.Function
+'('           Punctuation.Marker
+'userNames'   Name.Property
+')'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'combined'    Name.Property
+':'           Punctuation.Marker
+'      '      Text.Whitespace
+'strs'        Name.Namespace
+'.'           Punctuation.Marker
+'Join'        Name.Namespace
+'('           Punctuation.Marker
+'userNames'   Name.Property
+','           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+', '          Literal.String.Double
+'"'           Literal.String.Delimiter
+')'           Punctuation.Marker
+'\n\n'        Text.Whitespace
+
+'// Complex validation' Comment.Single
+'\n'          Text.Whitespace
+
+'#validatedConfig' Name.Entity
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'name'        Name.Property
+':'           Punctuation.Marker
+'     '       Text.Whitespace
+'string'      Keyword.Type
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'=~'          Operator
+'"'           Literal.String.Delimiter
+'^[a-z][a-z0-9-]*[a-z0-9]$' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\t'        Text.Whitespace
+'port'        Name.Property
+':'           Punctuation.Marker
+'     '       Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'>'           Operator
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'&'           Operator
+' '           Text.Whitespace
+'<='          Operator
+'65535'       Literal.Number.Integer
+'\n\t'        Text.Whitespace
+'protocol'    Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'*'           Operator
+'"'           Literal.String.Delimiter
+'TCP'         Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'UDP'         Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n\n\t'      Text.Whitespace
+'// Conditional validation' Comment.Single
+'\n\t'        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'protocol'    Name.Property
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'TCP'         Literal.String.Double
+'"'           Literal.String.Delimiter
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t\t'      Text.Whitespace
+'keepAlive'   Name.Property
+'?'           Punctuation
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'bool'        Keyword.Type
+'\n\t'        Text.Whitespace
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace

--- a/tests/examplefiles/cue/cue.mod/module.cue
+++ b/tests/examplefiles/cue/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "cue.example"
+language: {
+	version: "v0.14.0"
+}

--- a/tests/examplefiles/cue/cue.mod/module.cue.output
+++ b/tests/examplefiles/cue/cue.mod/module.cue.output
@@ -1,0 +1,23 @@
+'module'      Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'cue.example' Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'language'    Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'{'           Punctuation.Marker
+'\n\t'        Text.Whitespace
+'version'     Name.Property
+':'           Punctuation.Marker
+' '           Text.Whitespace
+'"'           Literal.String.Delimiter
+'v0.14.0'     Literal.String.Double
+'"'           Literal.String.Delimiter
+'\n'          Text.Whitespace
+
+'}'           Punctuation.Marker
+'\n'          Text.Whitespace

--- a/tests/test_cue.py
+++ b/tests/test_cue.py
@@ -1,0 +1,185 @@
+"""
+    Basic CueLexer Test
+    ~~~~~~~~~~~~~~~~~~~
+
+    :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import pytest
+from pygments.token import (
+    Token, Keyword, Name, Number, String, Comment,
+    Operator, Punctuation, Whitespace, Error
+)
+from pygments.lexers.cue import CueLexer
+
+
+@pytest.fixture(scope='module')
+def lexer():
+    yield CueLexer()
+
+
+def test_package_declaration(lexer):
+    """Test package declaration highlighting."""
+    code = 'package example'
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Namespace, 'package') in tokens
+    assert (Name.Namespace, 'example') in tokens
+
+
+def test_import_statements(lexer):
+    """Test various import statement forms."""
+    # Simple import
+    code = 'import "strings"'
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Namespace, 'import') in tokens
+    assert (String, 'strings') in tokens
+
+    # Import with alias
+    code = 'import foo "strings"'
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Namespace, 'import') in tokens
+    assert (Name.Namespace, 'foo') in tokens
+
+    # Multi-line import block
+    code = '''import (
+    "strings"
+    "encoding/json"
+)'''
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Namespace, 'import') in tokens
+
+
+def test_basic_types(lexer):
+    """Test basic type highlighting."""
+    code = 'name: string'
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Type, 'string') in tokens
+
+    code = 'age: int'
+    tokens = list(lexer.get_tokens(code))
+    assert (Keyword.Type, 'int') in tokens
+
+
+def test_numbers(lexer):
+    """Test number format highlighting."""
+    test_cases = [
+        ('42', Number.Integer),
+        ('3.14', Number.Float),
+        ('1e10', Number.Float),
+        ('0xFF', Number.Hex),
+        ('0b1010', Number.Bin),
+        ('0o755', Number.Oct),
+        ('100Gi', Number.Integer),  # with units
+    ]
+
+    for code, expected_type in test_cases:
+        tokens = list(lexer.get_tokens(code))
+        assert any(token_type == expected_type for token_type, _ in tokens), \
+               f"Expected {expected_type} for '{code}'"
+
+
+def test_strings(lexer):
+    """Test string highlighting."""
+    test_cases = [
+        '"hello world"',
+        "'single quoted'",
+        '`raw string`',
+        '#"sharp string"#',
+        '"""\nmultiline string\n"""',
+    ]
+
+    for code in test_cases:
+        tokens = list(lexer.get_tokens(code))
+        # Check that we have string tokens
+        string_tokens = [t for t in tokens if t[0] in (String, String.Double, String.Single, String.Backtick)]
+        assert len(string_tokens) > 0, f"No string tokens found for {code}"
+
+
+def test_comments(lexer):
+    """Test comment highlighting."""
+    # Single line comment
+    code = '// This is a comment'
+    tokens = list(lexer.get_tokens(code))
+    assert (Comment.Single, '// This is a comment') in tokens
+
+
+def test_keywords(lexer):
+    """Test keyword highlighting."""
+    keywords = ['true', 'false', 'null', 'for', 'in', 'if', 'let']
+
+    for keyword in keywords:
+        tokens = list(lexer.get_tokens(keyword))
+        assert any(token_type in (Keyword, Keyword.Constant) for token_type, _ in tokens), \
+               f"Keyword '{keyword}' not highlighted correctly"
+
+
+def test_operators(lexer):
+    """Test operator highlighting."""
+    operators = ['==', '!=', '<=', '>=', '<', '>', '&&', '||', '&', '|']
+
+    for op in operators:
+        code = f'a {op} b'
+        tokens = list(lexer.get_tokens(code))
+        assert (Operator, op) in tokens, f"Operator '{op}' not highlighted"
+
+
+def test_definitions_and_fields(lexer):
+    """Test definition and field highlighting."""
+    # Regular field
+    code = 'field: value'
+    tokens = list(lexer.get_tokens(code))
+    assert (Name.Property, 'field') in tokens
+
+    # Definition (starts with #)
+    code = '#Definition: {}'
+    tokens = list(lexer.get_tokens(code))
+    assert (Name.Entity, '#Definition') in tokens
+
+    # Hidden field (starts with _)
+    code = '_hidden: "secret"'
+    tokens = list(lexer.get_tokens(code))
+    assert (Name.Variable.Magic, '_hidden') in tokens
+
+
+def test_interpolation(lexer):
+    """Test string interpolation."""
+    code = '"Hello \\(name)!"'
+    tokens = list(lexer.get_tokens(code))
+    # Should have punctuation for \( and )
+    punctuation_tokens = [t for t in tokens if t[0] == Punctuation]
+    assert len(punctuation_tokens) > 0
+
+
+def test_complex_structure(lexer):
+    """Test a more complex CUE structure."""
+    code = '''
+package config
+
+#Service: {
+    name: string
+    port: int & >0 & <=65535
+    replicas: *1 | int & >=1
+}
+
+service: #Service & {
+    name: "web-server"
+    port: 8080
+    if env == "prod" {
+        replicas: 3
+    }
+}
+'''
+    tokens = list(lexer.get_tokens(code))
+
+    # Should not have any error tokens in well-formed code
+    error_tokens = [t for t in tokens if t[0] == Error]
+    assert len(error_tokens) == 0, f"Found error tokens: {error_tokens}"
+
+    # Should have various expected token types
+    token_types = [t[0] for t in tokens]
+    assert Keyword.Namespace in token_types  # package
+    assert Name.Entity in token_types        # #Service
+    assert Keyword.Type in token_types       # string, int
+    assert Name.Property in token_types      # name, port, etc.
+    assert Number.Integer in token_types     # numbers


### PR DESCRIPTION
Adds an initial lexer for the CUE configuration language (https://cuelang.org).

Includes test suite and valid CUE example files that pass `cue export`.

Closes #2959.