### PR TITLE
uz and zu Integer Literal Suffixes in C and C++

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -36,7 +36,7 @@ class CFamilyLexer(RegexLexer):
     # This includes decimal separators matching.
     _decpart = r'\d(\'?\d)*'
     # Integer literal suffix (e.g. 'ull' or 'll').
-    _intsuffix = r'(([uU][lL]{0,2})|[lL]{1,2}[uU]?)?'
+    _intsuffix = r'(([uU]?[zZ])|([zZ][uU])|([uU][lL]{0,2})|([lL]{1,2}[uU]?))?'
 
     # Identifier regex with C and C++ Universal Character Name (UCN) support.
     _ident = r'(?!\d)(?:[\w$]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})+'


### PR DESCRIPTION
In C++23, the `uz` literal suffix was added to allow making `size_t` typed integers. See [P0330R8](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0330r8.html). There's a similar change proposed but not yet accepted for the C standard. See [N3485](https://thephd.dev/_vendor/future_cxx/papers/C%20-%20Literal%20Suffixes%20for%20size_t.html). This updates the lexer here to recognize that suffix for integer literals.