### PR TITLE
Add generic styles for onedark

### DIFF
--- a/pygments/styles/onedark.py
+++ b/pygments/styles/onedark.py
@@ -13,7 +13,7 @@
 
 from pygments.style import Style
 from pygments.token import Comment, Keyword, Name, Number, Operator, \
-    Punctuation, String, Token
+    Punctuation, String, Token, Generic
 
 
 __all__ = ['OneDarkStyle']
@@ -59,5 +59,15 @@ class OneDarkStyle(Style):
 
         Operator:               '#56B6C2',
 
-        Comment:                '#7F848E'
+        Comment:                '#7F848E',
+
+        Generic.Heading:        'bold #ABB2BF',
+        Generic.Subheading:     'bold #ABB2BF',
+        Generic.Deleted:        '#E06C75',
+        Generic.Inserted:       '#98C379',
+        Generic.Error:          '#E06C75',
+        Generic.Emph:           'italic',
+        Generic.Strong:         'bold',
+        Generic.Output:         '#E06C75',
+        Generic.Traceback:      '#E06C75',
     }


### PR DESCRIPTION
I use one dark theme myself, but I noticed that there wasn't styling for `.diff` files.
After a bit of a research, I found that some missing entries in the `styles/onedark.py` was the issue.

I filled the missing entries with what makes sense to me, while comparing with what I get with `git diff`.