### PR TITLE
speedup: cache entry points

### DIFF
--- a/pygments/plugin.py
+++ b/pygments/plugin.py
@@ -32,6 +32,7 @@
     :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
     :license: BSD, see LICENSE for details.
 """
+import functools
 from importlib.metadata import entry_points
 
 LEXER_ENTRY_POINT = 'pygments.lexers'
@@ -40,6 +41,7 @@ STYLE_ENTRY_POINT = 'pygments.styles'
 FILTER_ENTRY_POINT = 'pygments.filters'
 
 
+@functools.lru_cache(maxsize=None)
 def iter_entry_points(group_name):
     groups = entry_points()
     if hasattr(groups, 'select'):


### PR DESCRIPTION
I found that multiple calls to `get_lexer_for_filename` were somewhat slow in my environment, due to `find_plugin_lexers` discovering entry points every time it ran.

Its interesting that pkg_resources (used in the past) seems to cache entry points: https://github.com/pypa/pkg_resources/blob/main/__init__.py#L3212  But importlib.metadata does not.

I did some simple testing like this:

```python
start = time.perf_counter_ns()
for i in range(100):
    get_lexer_for_filename("some.py", encoding="chardet")
    get_lexer_for_filename("some.c", encoding="chardet")
    get_lexer_for_filename("some.cpp", encoding="chardet")
    get_lexer_for_filename("some.java", encoding="chardet")
    try:
        get_lexer_for_filename("some.fasdf", encoding="chardet")
    except pygments.util.ClassNotFound:
        pass
end = time.perf_counter_ns()
print(f"Time: {(end - start) / 1_000_000} ms")
```

On my system I got these timings:
* Pygments 2.12 (using pkg_resources) took about 1,400ms
* Pygments 2.13-2.19.2 (importlib) took about 14,000ms
* 2.19.2 with a cache added took about 800-1100ms

It seems to me that adding this caching would not be a problem if pkg_resources cached entry points in the past.  I'm not sure how someone would modify entry points at runtime anyway.

