### PR TITLE
Turtle: Allow "empty" comment lines

### DIFF
--- a/pygments/lexers/rdf.py
+++ b/pygments/lexers/rdf.py
@@ -265,7 +265,7 @@ class TurtleLexer(RegexLexer):
              bygroups(Name.Namespace, Punctuation, Name.Tag)),
 
             # Comment
-            (r'#[^\n]+', Comment),
+            (r'#([^\n]+|$)', Comment),
 
             (r'\b(true|false)\b', Literal),
             (r'[+\-]?\d*\.\d+', Number.Float),

--- a/tests/examplefiles/turtle/example.ttl
+++ b/tests/examplefiles/turtle/example.ttl
@@ -28,6 +28,9 @@ Quoted [multiline] string
 	] ;
 	:exists true .
 
+# Explanatory block of comments.
+#
+# With empty comments for formatting.
 <http://data.ub.uio.no/realfagstermer/006839> a mads:Topic,
     skos:Concept ;
     dcterms:created "2014-08-25"^^xs:date ;

--- a/tests/examplefiles/turtle/example.ttl.output
+++ b/tests/examplefiles/turtle/example.ttl.output
@@ -221,6 +221,15 @@
 '.'           Punctuation
 '\n\n'        Text
 
+'# Explanatory block of comments.' Comment
+'\n'          Text
+
+'#'           Comment
+'\n'          Text
+
+'# With empty comments for formatting.' Comment
+'\n'          Text
+
 '<http://data.ub.uio.no/realfagstermer/006839>' Name.Variable
 ' '           Text
 'a'           Keyword.Type


### PR DESCRIPTION
Comments may consist of only a `#` symbol immediately followed by a newline character. Comments like this are likely to appear for formatting purposes in larger blocks of comments.