### PR TITLE
Add PytestSessionLexer to properly highlight pytest session output

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -416,6 +416,7 @@ LEXERS = {
     'Python2TracebackLexer': ('pygments.lexers.python', 'Python 2.x Traceback', ('py2tb',), ('*.py2tb',), ('text/x-python2-traceback',)),
     'PythonConsoleLexer': ('pygments.lexers.python', 'Python console session', ('pycon', 'python-console'), (), ('text/x-python-doctest',)),
     'PythonLexer': ('pygments.lexers.python', 'Python', ('python', 'py', 'sage', 'python3', 'py3', 'bazel', 'starlark', 'pyi'), ('*.py', '*.pyw', '*.pyi', '*.jy', '*.sage', '*.sc', 'SConstruct', 'SConscript', '*.bzl', 'BUCK', 'BUILD', 'BUILD.bazel', 'WORKSPACE', '*.tac'), ('text/x-python', 'application/x-python', 'text/x-python3', 'application/x-python3')),
+    'PytestSessionLexer': ('pygments.lexers.python', 'Pytest Session', ('pytest'), ()),
     'PythonTracebackLexer': ('pygments.lexers.python', 'Python Traceback', ('pytb', 'py3tb'), ('*.pytb', '*.py3tb'), ('text/x-python-traceback', 'text/x-python3-traceback')),
     'PythonUL4Lexer': ('pygments.lexers.ul4', 'Python+UL4', ('py+ul4',), ('*.pyul4',), ()),
     'QBasicLexer': ('pygments.lexers.basic', 'QBasic', ('qbasic', 'basic'), ('*.BAS', '*.bas'), ('text/basic',)),

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -18,7 +18,7 @@ from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
 from pygments import unistring as uni
 
 __all__ = ['PythonLexer', 'PythonConsoleLexer', 'PythonTracebackLexer',
-           'Python2Lexer', 'Python2TracebackLexer',
+           'Python2Lexer', 'Python2TracebackLexer', "PytestSessionLexer", 
            'CythonLexer', 'DgLexer', 'NumPyLexer']
 
 
@@ -824,6 +824,51 @@ class Python2TracebackLexer(RegexLexer):
             (r'( {4,})(\^)', bygroups(Text, Punctuation.Marker), '#pop'),
             default('#pop'),
         ],
+    }
+
+
+class PytestSessionLexer(RegexLexer):
+    """
+    Lexer for pytest session output.
+
+    This lexer highlights:
+    * section headings like "==== FAILURES ===="
+    * subtest lines such as ">   FAILED subtests for..."
+    * captured stdout/stderr markers
+    * assertions and error lines (E   AssertionError)
+    * file:line references
+    """
+
+    name = "Pytest Session"
+    aliases = ["pytest"]
+    filenames = []
+    flags = re.MULTILINE
+
+    tokens = {
+        "root": [
+            # === FAILURES === headers / === ERRORS ===
+            (r"={4,}.*?={4,}", Generic.Heading),
+
+            # --- Captured stdout/stderr --- style headers
+            (r"-{3,}.*?-{3,}", Generic.Subheading),
+
+            # Subtest lines, e.g.:
+            # FAILED [100%] tests/test_file.py::TestClass::test_method[subtest x]
+            (
+                r"^(FAILED|PASSED|ERROR|SKIPPED).*?\[.*?\].*$",
+                Generic.Strong,
+            ),
+
+            # E   AssertionError: message
+            (r"^E\s+.*", Generic.Error),
+
+            # pytest error location lines
+            # example: tests/test_file.py:14: AssertionError
+            (r"^[^\s]+\.py:\d+.*$", Generic.Traceback),
+
+            # fallback
+            (r".+", Text),
+        ]
     }
 
 

--- a/tests/test_pytest_session.py
+++ b/tests/test_pytest_session.py
@@ -1,0 +1,39 @@
+import pytest
+from pygments.lexers import get_lexer_by_name
+from pygments.token import Generic
+
+
+def test_pytest_header_highlighting():
+    lexer = get_lexer_by_name("pytest")
+    tokens = list(lexer.get_tokens("==== FAILURES ===="))
+
+    assert any(toktype is Generic.Heading for toktype, _ in tokens)
+
+
+def test_pytest_captured_output_header():
+    lexer = get_lexer_by_name("pytest")
+    tokens = list(lexer.get_tokens("--- Captured stdout ---"))
+
+    assert any(toktype is Generic.Subheading for toktype, _ in tokens)
+
+
+def test_pytest_assertion_error_line():
+    lexer = get_lexer_by_name("pytest")
+    tokens = list(lexer.get_tokens("E   AssertionError: test message"))
+
+    assert any(toktype is Generic.Error for toktype, _ in tokens)
+
+
+def test_pytest_subtest_line():
+    lexer = get_lexer_by_name("pytest")
+    line = "FAILED [100%] tests/test_file.py::test_example[subtest-x]"
+    tokens = list(lexer.get_tokens(line))
+
+    assert any(toktype is Generic.Strong for toktype, _ in tokens)
+
+
+def test_pytest_filename_traceback():
+    lexer = get_lexer_by_name("pytest")
+    tokens = list(lexer.get_tokens("tests/test_file.py:14: AssertionError"))
+
+    assert any(toktype is Generic.Traceback for toktype, _ in tokens)


### PR DESCRIPTION
### Summary
This PR adds a dedicated `PytestSessionLexer` to Pygments to properly highlight pytest session output in documentation, examples, and testing outputs. Previously, the subtest lines in documentation were incorrectly highlighted, implying all subtests passed. This lexer fixes that while preserving existing highlighting for section headers, captured output, assertions, and tracebacks.

### Details
`PytestSessionLexer` is a `RegexLexer` with:
- Section header highlighting (`==== FAILURES ====`)
- Subtest line highlighting (e.g., `FAILED [100%] tests/test_file.py::TestClass::test_method[subtest x]`)
- Captured stdout/stderr blocks
- Assertion errors (`E AssertionError`)
- File:line references (`tests/test_file.py:14: AssertionError`)
- Fallback to `Text` for other lines
The lexer is registered under the alias `"pytest"`.

This PR resolves [#2995 ](https://github.com/pygments/pygments/issues/2995)