### PR TITLE
php: Add new reserved keywords

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -258,7 +258,7 @@ Other contributors, listed alphabetically, are:
 * Matthias Vallentin -- Bro lexer
 * Benoît Vinot -- AMPL lexer
 * Linh Vu Hong -- RSL lexer
-* Taavi Väänänen -- Debian control lexer
+* Taavi Väänänen -- Debian control, PHP lexers
 * Immanuel Washington -- Smithy lexer
 * Nathan Weizenbaum -- Haml and Sass lexers
 * Nathan Whetsell -- Csound lexers

--- a/pygments/lexers/php.py
+++ b/pygments/lexers/php.py
@@ -211,6 +211,7 @@ class PhpLexer(RegexLexer):
              bygroups(Keyword, Text, Operator, Text), 'functionname'),
             (r'(const)(\s+)(' + _ident_inner + ')',
              bygroups(Keyword, Text, Name.Constant)),
+            # source: https://www.php.net/manual/en/reserved.keywords.php
             (r'(and|E_PARSE|old_function|E_ERROR|or|as|E_WARNING|parent|'
              r'eval|PHP_OS|break|exit|case|extends|PHP_VERSION|cfunction|'
              r'FALSE|print|for|require|continue|foreach|require_once|'
@@ -220,8 +221,8 @@ class PhpLexer(RegexLexer):
              r'endif|list|endswitch|new|endwhile|not|'
              r'array|E_ALL|NULL|final|php_user_filter|interface|'
              r'implements|public|private|protected|abstract|clone|try|'
-             r'catch|throw|this|use|namespace|trait|yield|'
-             r'finally|match)\b', Keyword),
+             r'catch|throw|this|use|namespace|trait|yield( from)?|'
+             r'finally|match|readonly)\b', Keyword),
             (r'(true|false|null)\b', Keyword.Constant),
             include('magicconstants'),
             (r'\$\{', Name.Variable, 'variablevariable'),

--- a/tests/examplefiles/php/test.php
+++ b/tests/examplefiles/php/test.php
@@ -508,7 +508,7 @@ function &byref() {
 // Test highlighting of magic methods and variables
 class MagicClass {
   public $magic_str;
-  public $ordinary_str;
+  public readonly string $ordinary_str;
 
   public function __construct($some_var) {
     $this->magic_str = __FILE__;
@@ -519,8 +519,17 @@ class MagicClass {
     return $this->magic_str;
   }
 
-  public function nonMagic() {
+  public function nonMagic(): string {
     return $this->ordinary_str;
+  }
+
+  public function getStrings() {
+    yield [ $this->magic_str, $this->nonMagic() ];
+  }
+
+  public function getData() {
+    yield from $this->getStrings();
+    yield 42;
   }
 }
 

--- a/tests/examplefiles/php/test.php.output
+++ b/tests/examplefiles/php/test.php.output
@@ -2975,6 +2975,10 @@
 '\n  '        Text
 'public'      Keyword
 ' '           Text
+'readonly'    Keyword
+' '           Text
+'string'      Name.Other
+' '           Text
 '$ordinary_str' Name.Variable
 ';'           Punctuation
 '\n\n  '      Text
@@ -3033,6 +3037,9 @@
 ' '           Text
 'nonMagic'    Name.Function
 '()'          Punctuation
+':'           Operator
+' '           Text
+'string'      Name.Other
 ' '           Text
 '{'           Punctuation
 '\n    '      Text
@@ -3041,6 +3048,56 @@
 '$this'       Name.Variable
 '->'          Operator
 'ordinary_str' Name.Attribute
+';'           Punctuation
+'\n  '        Text
+'}'           Punctuation
+'\n\n  '      Text
+'public'      Keyword
+' '           Text
+'function'    Keyword
+' '           Text
+'getStrings'  Name.Function
+'()'          Punctuation
+' '           Text
+'{'           Punctuation
+'\n    '      Text
+'yield'       Keyword
+' '           Text
+'['           Punctuation
+' '           Text
+'$this'       Name.Variable
+'->'          Operator
+'magic_str'   Name.Attribute
+','           Punctuation
+' '           Text
+'$this'       Name.Variable
+'->'          Operator
+'nonMagic'    Name.Attribute
+'()'          Punctuation
+' '           Text
+'];'          Punctuation
+'\n  '        Text
+'}'           Punctuation
+'\n\n  '      Text
+'public'      Keyword
+' '           Text
+'function'    Keyword
+' '           Text
+'getData'     Name.Function
+'()'          Punctuation
+' '           Text
+'{'           Punctuation
+'\n    '      Text
+'yield from'  Keyword
+' '           Text
+'$this'       Name.Variable
+'->'          Operator
+'getStrings'  Name.Attribute
+'();'         Punctuation
+'\n    '      Text
+'yield'       Keyword
+' '           Text
+'42'          Literal.Number.Integer
 ';'           Punctuation
 '\n  '        Text
 '}'           Punctuation


### PR DESCRIPTION
`readonly` and `yield from` have been added as language keywords in PHP 8.1 or later. Update the lexer accordingly.
