### PR TITLE
fix(lexers.less): Fix support for single‑line comments in LESS

### DIFF
--- a/pygments/lexers/css.py
+++ b/pygments/lexers/css.py
@@ -590,13 +590,43 @@ class LessCssLexer(CssLexer):
     version_added = '2.1'
 
     tokens = {
+        # FIXME: It's not currently possible to simply do the following,
+        #        as `include('basics')` doesn't take overrides into account:
+        # 'basics': [
+        #     (r'//.*\n', Comment.Single),
+        #     (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
+        #     inherit,
+        # ],
         'root': [
             (r'@\w+', Name.Variable),
+            (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
+            inherit,
+        ],
+        'atcontent': [
+            (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
+            inherit,
+        ],
+        'atrule': [
+            (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
             inherit,
         ],
         'content': [
             (r'\{', Punctuation, '#push'),
             (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
+            inherit,
+        ],
+        'value-start': [
+            (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
+            inherit,
+        ],
+        'function-start': [
+            (r'//.*\n', Comment.Single),
+            (r'/\*(?:.|\n)*?\*/', Comment.Multiline),
             inherit,
         ],
     }

--- a/tests/snippets/less/test_single_line_comments.txt
+++ b/tests/snippets/less/test_single_line_comments.txt
@@ -1,9 +1,18 @@
 ---input---
+// Top-level comment
+/* Multiline comment (control)
+ */
 .font-light {
     font-weight: 100; // Comment
+    /* Another control comment */
 }
 
 ---tokens---
+'// Top-level comment\n' Comment.Single
+
+'/* Multiline comment (control)\n */' Comment.Multiline
+'\n'          Text.Whitespace
+
 '.'           Punctuation
 'font-light'  Name.Class
 ' '           Text.Whitespace
@@ -16,6 +25,10 @@
 ';'           Punctuation
 ' '           Text.Whitespace
 '// Comment\n' Comment.Single
+
+'    '        Text.Whitespace
+'/* Another control comment */' Comment.Multiline
+'\n'          Text.Whitespace
 
 '}'           Punctuation
 '\n'          Text.Whitespace


### PR DESCRIPTION
This fixes the **LESS** part of <https://github.com/pygments/pygments/issues/2852>.

--------------------------------------------------------------------------------

Unfortunately, the single‑line comment definitions have to be copied in every location instead of defining them once in `basics`, as `include('basics')` doesn’t take overrides into account.