### PR TITLE
Python lexer: support t-strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,10 @@ Version 2.20.0
 
   * Rell (#2914)
 
+- Updated lexers:
+
+  * Python: Aff support for t-strings.
+
 Version 2.19.2
 --------------
 (released June 21st, 2025)

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -118,27 +118,27 @@ class PythonLexer(RegexLexer):
             include('expr'),
         ],
         'expr': [
-            # raw f-strings
-            ('(?i)(rf|fr)(""")',
+            # raw f-strings and t-strings
+            ('(?i)(r[ft]|[ft]r)(""")',
              bygroups(String.Affix, String.Double),
              combined('rfstringescape', 'tdqf')),
-            ("(?i)(rf|fr)(''')",
+            ("(?i)(r[ft]|[ft]r)(''')",
              bygroups(String.Affix, String.Single),
              combined('rfstringescape', 'tsqf')),
-            ('(?i)(rf|fr)(")',
+            ('(?i)(r[ft]|[ft]r)(")',
              bygroups(String.Affix, String.Double),
              combined('rfstringescape', 'dqf')),
-            ("(?i)(rf|fr)(')",
+            ("(?i)(r[ft]|[ft]r)(')",
              bygroups(String.Affix, String.Single),
              combined('rfstringescape', 'sqf')),
-            # non-raw f-strings
-            ('([fF])(""")', bygroups(String.Affix, String.Double),
+            # non-raw f-strings and t-strings
+            ('([fFtT])(""")', bygroups(String.Affix, String.Double),
              combined('fstringescape', 'tdqf')),
-            ("([fF])(''')", bygroups(String.Affix, String.Single),
+            ("([fFtT])(''')", bygroups(String.Affix, String.Single),
              combined('fstringescape', 'tsqf')),
-            ('([fF])(")', bygroups(String.Affix, String.Double),
+            ('([fFtT])(")', bygroups(String.Affix, String.Double),
              combined('fstringescape', 'dqf')),
-            ("([fF])(')", bygroups(String.Affix, String.Single),
+            ("([fFtT])(')", bygroups(String.Affix, String.Single),
              combined('fstringescape', 'sqf')),
             # raw bytes and strings
             ('(?i)(rb|br|r)(""")',

--- a/tests/snippets/python/test_raw_tstring.txt
+++ b/tests/snippets/python/test_raw_tstring.txt
@@ -1,0 +1,46 @@
+# Tests that the lexer can parse raw f-strings
+
+---input---
+rt"m_\nu = x"
+
+t"m_\nu = {x}"
+
+rt"m_{{\nu}} = {x}"
+
+---tokens---
+'rt'          Literal.String.Affix
+'"'           Literal.String.Double
+'m_'          Literal.String.Double
+'\\'          Literal.String.Double
+'nu = x'      Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'t'           Literal.String.Affix
+'"'           Literal.String.Double
+'m_'          Literal.String.Double
+'\\n'         Literal.String.Escape
+'u = '        Literal.String.Double
+'{'           Literal.String.Interpol
+'x'           Name
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'rt'          Literal.String.Affix
+'"'           Literal.String.Double
+'m_'          Literal.String.Double
+'{{'          Literal.String.Escape
+'\\'          Literal.String.Double
+'nu'          Literal.String.Double
+'}}'          Literal.String.Escape
+' = '         Literal.String.Double
+'{'           Literal.String.Interpol
+'x'           Name
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/python/test_tstring_a.txt
+++ b/tests/snippets/python/test_tstring_a.txt
@@ -1,0 +1,25 @@
+---input---
+t'My name is {name}, my age next year is {age+1}, my anniversary is {anniversary:%A, %B %d, %Y}.'
+
+---tokens---
+'t'           Literal.String.Affix
+"'"           Literal.String.Single
+'My name is ' Literal.String.Single
+'{'           Literal.String.Interpol
+'name'        Name
+'}'           Literal.String.Interpol
+', my age next year is ' Literal.String.Single
+'{'           Literal.String.Interpol
+'age'         Name
+'+'           Operator
+'1'           Literal.Number.Integer
+'}'           Literal.String.Interpol
+', my anniversary is ' Literal.String.Single
+'{'           Literal.String.Interpol
+'anniversary' Name
+':'           Literal.String.Interpol
+'%A, %B %d, %Y' Literal.String.Single
+'}'           Literal.String.Interpol
+'.'           Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/python/test_tstring_b.txt
+++ b/tests/snippets/python/test_tstring_b.txt
@@ -1,0 +1,25 @@
+---input---
+t"My name is {name}, my age next year is {age+1}, my anniversary is {anniversary:%A, %B %d, %Y}."
+
+---tokens---
+'t'           Literal.String.Affix
+'"'           Literal.String.Double
+'My name is ' Literal.String.Double
+'{'           Literal.String.Interpol
+'name'        Name
+'}'           Literal.String.Interpol
+', my age next year is ' Literal.String.Double
+'{'           Literal.String.Interpol
+'age'         Name
+'+'           Operator
+'1'           Literal.Number.Integer
+'}'           Literal.String.Interpol
+', my anniversary is ' Literal.String.Double
+'{'           Literal.String.Interpol
+'anniversary' Name
+':'           Literal.String.Interpol
+'%A, %B %d, %Y' Literal.String.Double
+'}'           Literal.String.Interpol
+'.'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fix #3009.

I didn't duplicate all tests for f-strings because f- and t-strings use the same rules.
