### PR TITLE
Add Python 3.14 to Trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Text Processing :: Filters",


### PR DESCRIPTION
Follow on from https://github.com/pygments/pygments/pull/2987 and https://github.com/pygments/pygments/commit/cfca37efebd16fa3e8fce60bd5b9650c8587e4d9.