### PR TITLE
Fix test_lexer_classes search path

### DIFF
--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -62,12 +62,7 @@ def test_lexer_classes(cls):
              "<major>.<minor>.<micro>).")
     if cls._example is not None:
         assert isinstance(cls._example, str)
-        p = (
-            pathlib.Path(inspect.getabsfile(pygments)).parent.parent
-            / "tests"
-            / "examplefiles"
-            / cls._example
-        )
+        p = pathlib.Path(path.join(TESTDIR, "examplefiles", cls._example))
         assert p.is_file(), f"Example file {p} not found"
         assert p.parent.name in cls.aliases, f"Example file {p} not in alias directory"
     result = cls.analyse_text("abc")


### PR DESCRIPTION
"Test the existence of the example file" (commit afd62f5e6ac, #2712) caused
the test to search for the example files relative to the import location of
pygments rather than relative to the tests.  In normal in-tree usage there
may be no practical difference, but in downstream packaging there may be.

Resolves: #2992
