### PR TITLE
Create a lexer for Markless.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,6 +94,7 @@ Other contributors, listed alphabetically, are:
 * Patrick Gotthardt -- PHP namespaces support
 * Hubert Gruniaux -- C and C++ lexer improvements
 * Olivier Guibe -- Asymptote lexer
+* Yukari Hafner -- Markless lexer
 * Phil Hagelberg -- Fennel lexer
 * Florian Hahn -- Boogie lexer
 * Martin Harriman -- SNOBOL lexer

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -311,6 +311,7 @@ LEXERS = {
     'MapleLexer': ('pygments.lexers.maple', 'Maple', ('maple',), ('*.mpl', '*.mi', '*.mm'), ('text/x-maple',)),
     'MaqlLexer': ('pygments.lexers.business', 'MAQL', ('maql',), ('*.maql',), ('text/x-gooddata-maql', 'application/x-gooddata-maql')),
     'MarkdownLexer': ('pygments.lexers.markup', 'Markdown', ('markdown', 'md'), ('*.md', '*.markdown'), ('text/x-markdown',)),
+    'MarklessLexer': ('pygments.lexers.markup', 'Markless', ('markless',), ('*.mess', '*.markless'), ('text/x-markless',)),
     'MaskLexer': ('pygments.lexers.javascript', 'Mask', ('mask',), ('*.mask',), ('text/x-mask',)),
     'MasonLexer': ('pygments.lexers.templates', 'Mason', ('mason',), ('*.m', '*.mhtml', '*.mc', '*.mi', 'autohandler', 'dhandler'), ('application/x-mason',)),
     'MathematicaLexer': ('pygments.lexers.algebra', 'Mathematica', ('mathematica', 'mma', 'nb'), ('*.nb', '*.cdf', '*.nbp', '*.ma'), ('application/mathematica', 'application/vnd.wolfram.mathematica', 'application/vnd.wolfram.mathematica.package', 'application/vnd.wolfram.cdf')),

--- a/tests/snippets/markless/test_codeblock.txt
+++ b/tests/snippets/markless/test_codeblock.txt
@@ -1,0 +1,65 @@
+---input---
+::
+a
+::
+
+:: c
+int foo();
+::
+
+:: markless
+This //should// be parsed
+::
+
+---tokens---
+'::'          Keyword
+''            Text.Whitespace
+''            Name.Function
+''            Literal.String
+'\n'          Text.Whitespace
+
+'a\n'         Literal.String
+
+'::'          Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'::'          Keyword
+' '           Text.Whitespace
+'c'           Name.Function
+''            Literal.String
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'foo'         Name.Function
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'::'          Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'::'          Keyword
+' '           Text.Whitespace
+'markless'    Name.Function
+''            Literal.String
+'\n'          Text.Whitespace
+
+'This'        Text
+' '           Text.Whitespace
+'//'          Keyword
+'should'      Generic.Emph
+'//'          Keyword
+' '           Text.Whitespace
+'be'          Text
+' '           Text.Whitespace
+'parsed'      Text
+'\n'          Text.Whitespace
+
+'::'          Keyword
+'\n'          Text.Whitespace

--- a/tests/snippets/markless/test_full.txt
+++ b/tests/snippets/markless/test_full.txt
@@ -1,0 +1,655 @@
+---input---
+# Hello there!
+This is a playground for ''Markless''(https://shirakumo.org/docs/markless, color red, large), a //text based// **markup language** intended for __simple__ document and comment publications.
+
+Markless is a relatively new[1] markup standard that focuses on being intuitive first and fast for computers to process second. Being a purely text-based markup, no complicated editor software is required to create documents in it, any simple text editor will do. v(Though of course, having syntax highlighting and previews are nice.)
+
+[1] Development of the standard started in 2015
+
+The Markless standard does not specify its results based on another document format, meaning that an implementation could be written to turn a Markless document into practically any other format[2]. Markless is strict and does not allow for any ambiguities in its markup. This should both make it less confusing for you, and easier to parse for a computer program.
+
+[2] While the output here is HTML, cl-markless for instance can also translate to BBCode, LaTeX, and EPUB, among other formats.
+
+Here's some more useful links:
+- https://shirakumo.org/docs/markless/
+  For a more complete tutorial on Markless' syntax
+- https://shirakumo.org/docs/markless/markless.html
+  The full specification document
+- https://shirakumo.org/project/cl-markless/releases/latest
+  Downloads for cl-markless to convert documents offline
+
+The Markless document standard and ecosystem is brought to you by the ''Shirakumo Collective''(link #logo).
+
+[ image https://shirakumo.org/logo2.png, description Shirakumo Logo, caption The logo for the Shirakumo Team, link https://shirakumo.org, label logo ]
+
+==
+
+:::
+- ::This should //not// be parsed
+:::
+
+:: markless
+- This //should// be parsed
+::
+
+| Quoting for justice
+~ Someone, probably
+
+~ Yukari | And **this** is how you do the
+         | inline quotes.
+~ Haruna | //Woah.//
+
+1. First things first, this <-is great->
+10. Now for something different.
+
+---tokens---
+'# '          Keyword
+'Hello there!' Generic.Heading
+'\n'          Text.Whitespace
+
+'This'        Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'playground'  Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+"''"          Keyword
+'Markless'    Text
+"''("         Keyword
+'https://shirakumo.org/docs/markless' Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'color'       Name.Function
+' red'        Literal.String
+','           Punctuation
+' large'      Name.Tag
+')'           Keyword
+','           Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'//'          Keyword
+'text based'  Generic.Emph
+'//'          Keyword
+' '           Text.Whitespace
+'**'          Keyword
+'markup language' Generic.Strong
+'**'          Keyword
+' '           Text.Whitespace
+'intended'    Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'__'          Keyword
+'simple'      Generic.Underline
+'__'          Keyword
+' '           Text.Whitespace
+'document'    Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'comment'     Text
+' '           Text.Whitespace
+'publications.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Markless'    Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'relati'      Text
+'v'           Text
+'ely'         Text
+' '           Text.Whitespace
+'new'         Text
+'['           Keyword
+'1'           Name.Variable
+']'           Keyword
+' '           Text.Whitespace
+'markup'      Text
+' '           Text.Whitespace
+'standard'    Text
+' '           Text.Whitespace
+'that'        Text
+' '           Text.Whitespace
+'focuses'     Text
+' '           Text.Whitespace
+'on'          Text
+' '           Text.Whitespace
+'being'       Text
+' '           Text.Whitespace
+'intuiti'     Text
+'v'           Text
+'e'           Text
+' '           Text.Whitespace
+'first'       Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'fast'        Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'computers'   Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'process'     Text
+' '           Text.Whitespace
+'second.'     Text
+' '           Text.Whitespace
+'Being'       Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'purely'      Text
+' '           Text.Whitespace
+'text'        Text
+'-'           Text
+'based'       Text
+' '           Text.Whitespace
+'markup,'     Text
+' '           Text.Whitespace
+'no'          Text
+' '           Text.Whitespace
+'complicated' Text
+' '           Text.Whitespace
+'editor'      Text
+' '           Text.Whitespace
+'software'    Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'required'    Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'create'      Text
+' '           Text.Whitespace
+'documents'   Text
+' '           Text.Whitespace
+'in'          Text
+' '           Text.Whitespace
+'it,'         Text
+' '           Text.Whitespace
+'any'         Text
+' '           Text.Whitespace
+'simple'      Text
+' '           Text.Whitespace
+'text'        Text
+' '           Text.Whitespace
+'editor'      Text
+' '           Text.Whitespace
+'will'        Text
+' '           Text.Whitespace
+'do.'         Text
+' '           Text.Whitespace
+'v('          Keyword
+'Though'      Text
+' '           Text.Whitespace
+'of'          Text
+' '           Text.Whitespace
+'course,'     Text
+' '           Text.Whitespace
+'ha'          Text
+'v'           Text
+'ing'         Text
+' '           Text.Whitespace
+'syntax'      Text
+' '           Text.Whitespace
+'highlighting' Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'pre'         Text
+'v'           Text
+'iews'        Text
+' '           Text.Whitespace
+'are'         Text
+' '           Text.Whitespace
+'nice.'       Text
+')'           Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'['           Keyword
+'1'           Name.Variable
+']'           Keyword
+' '           Text.Whitespace
+'De'          Text
+'v'           Text
+'elopment'    Text
+' '           Text.Whitespace
+'of'          Text
+' '           Text.Whitespace
+'the'         Text
+' '           Text.Whitespace
+'standard'    Text
+' '           Text.Whitespace
+'started'     Text
+' '           Text.Whitespace
+'in'          Text
+' '           Text.Whitespace
+'2015'        Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The'         Text
+' '           Text.Whitespace
+'Markless'    Text
+' '           Text.Whitespace
+'standard'    Text
+' '           Text.Whitespace
+'does'        Text
+' '           Text.Whitespace
+'not'         Text
+' '           Text.Whitespace
+'specify'     Text
+' '           Text.Whitespace
+'its'         Text
+' '           Text.Whitespace
+'results'     Text
+' '           Text.Whitespace
+'based'       Text
+' '           Text.Whitespace
+'on'          Text
+' '           Text.Whitespace
+'another'     Text
+' '           Text.Whitespace
+'document'    Text
+' '           Text.Whitespace
+'format,'     Text
+' '           Text.Whitespace
+'meaning'     Text
+' '           Text.Whitespace
+'that'        Text
+' '           Text.Whitespace
+'an'          Text
+' '           Text.Whitespace
+'implementation' Text
+' '           Text.Whitespace
+'could'       Text
+' '           Text.Whitespace
+'be'          Text
+' '           Text.Whitespace
+'written'     Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'turn'        Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'Markless'    Text
+' '           Text.Whitespace
+'document'    Text
+' '           Text.Whitespace
+'into'        Text
+' '           Text.Whitespace
+'practically' Text
+' '           Text.Whitespace
+'any'         Text
+' '           Text.Whitespace
+'other'       Text
+' '           Text.Whitespace
+'format'      Text
+'['           Keyword
+'2'           Name.Variable
+']'           Keyword
+'.'           Text
+' '           Text.Whitespace
+'Markless'    Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'strict'      Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'does'        Text
+' '           Text.Whitespace
+'not'         Text
+' '           Text.Whitespace
+'allow'       Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'any'         Text
+' '           Text.Whitespace
+'ambiguities' Text
+' '           Text.Whitespace
+'in'          Text
+' '           Text.Whitespace
+'its'         Text
+' '           Text.Whitespace
+'markup.'     Text
+' '           Text.Whitespace
+'This'        Text
+' '           Text.Whitespace
+'should'      Text
+' '           Text.Whitespace
+'both'        Text
+' '           Text.Whitespace
+'make'        Text
+' '           Text.Whitespace
+'it'          Text
+' '           Text.Whitespace
+'less'        Text
+' '           Text.Whitespace
+'confusing'   Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'you,'        Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'easier'      Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'parse'       Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'computer'    Text
+' '           Text.Whitespace
+'program.'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'['           Keyword
+'2'           Name.Variable
+']'           Keyword
+' '           Text.Whitespace
+'While'       Text
+' '           Text.Whitespace
+'the'         Text
+' '           Text.Whitespace
+'output'      Text
+' '           Text.Whitespace
+'here'        Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'HTML,'       Text
+' '           Text.Whitespace
+'cl'          Text
+'-'           Text
+'markless'    Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'instance'    Text
+' '           Text.Whitespace
+'can'         Text
+' '           Text.Whitespace
+'also'        Text
+' '           Text.Whitespace
+'translate'   Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'BBCode,'     Text
+' '           Text.Whitespace
+'LaTeX,'      Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'EPUB,'       Text
+' '           Text.Whitespace
+'among'       Text
+' '           Text.Whitespace
+'other'       Text
+' '           Text.Whitespace
+'formats.'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Here'        Text
+"'"           Text
+'s'           Text
+' '           Text.Whitespace
+'some'        Text
+' '           Text.Whitespace
+'more'        Text
+' '           Text.Whitespace
+'useful'      Text
+' '           Text.Whitespace
+'links:'      Text
+'\n'          Text.Whitespace
+
+'- '          Keyword
+'https://shirakumo.org/docs/markless/' Literal.String
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'For'         Text
+' '           Text.Whitespace
+'a'           Text
+' '           Text.Whitespace
+'more'        Text
+' '           Text.Whitespace
+'complete'    Text
+' '           Text.Whitespace
+'tutorial'    Text
+' '           Text.Whitespace
+'on'          Text
+' '           Text.Whitespace
+'Markless'    Text
+"'"           Text
+' '           Text.Whitespace
+'syntax'      Text
+'\n'          Text.Whitespace
+
+'- '          Keyword
+'https://shirakumo.org/docs/markless/markless.html' Literal.String
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'The'         Text
+' '           Text.Whitespace
+'full'        Text
+' '           Text.Whitespace
+'specification' Text
+' '           Text.Whitespace
+'document'    Text
+'\n'          Text.Whitespace
+
+'- '          Keyword
+'https://shirakumo.org/project/cl-markless/releases/latest' Literal.String
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'Downloads'   Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'cl'          Text
+'-'           Text
+'markless'    Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'con'         Text
+'v'           Text
+'ert'         Text
+' '           Text.Whitespace
+'documents'   Text
+' '           Text.Whitespace
+'offline'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The'         Text
+' '           Text.Whitespace
+'Markless'    Text
+' '           Text.Whitespace
+'document'    Text
+' '           Text.Whitespace
+'standard'    Text
+' '           Text.Whitespace
+'and'         Text
+' '           Text.Whitespace
+'ecosystem'   Text
+' '           Text.Whitespace
+'is'          Text
+' '           Text.Whitespace
+'brought'     Text
+' '           Text.Whitespace
+'to'          Text
+' '           Text.Whitespace
+'you'         Text
+' '           Text.Whitespace
+'by'          Text
+' '           Text.Whitespace
+'the'         Text
+' '           Text.Whitespace
+"''"          Keyword
+'Shirakumo'   Text
+' '           Text.Whitespace
+'Collecti'    Text
+'v'           Text
+'e'           Text
+"''("         Keyword
+'link'        Name.Function
+' #logo'      Literal.String
+')'           Keyword
+'.'           Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[ '          Keyword
+'image'       Name.Function
+' '           Text.Whitespace
+'https://shirakumo.org/logo2.png' Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'description' Name.Function
+' Shirakumo Logo' Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'caption'     Name.Function
+' The logo for the Shirakumo Team' Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'link'        Name.Function
+' https://shirakumo.org' Literal.String
+','           Punctuation
+' '           Text.Whitespace
+'label'       Name.Function
+' logo '      Literal.String
+']'           Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'=='          Literal.Other
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+':::'         Keyword
+''            Text.Whitespace
+''            Name.Function
+''            Literal.String
+'\n'          Text.Whitespace
+
+'- ::This should //not// be parsed\n' Literal.String
+
+':::'         Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'::'          Keyword
+' '           Text.Whitespace
+'markless'    Name.Function
+''            Literal.String
+'\n'          Text.Whitespace
+
+'- '          Keyword
+'This'        Text
+' '           Text.Whitespace
+'//'          Keyword
+'should'      Generic.Emph
+'//'          Keyword
+' '           Text.Whitespace
+'be'          Text
+' '           Text.Whitespace
+'parsed'      Text
+'\n'          Text.Whitespace
+
+'::'          Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'| '          Keyword
+'Quoting for justice' Generic.Inserted
+'\n'          Text.Whitespace
+
+'~ '          Keyword
+'Someone, probably' Name.Entity
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'~ '          Keyword
+'Yukari '     Name.Entity
+'| '          Keyword
+'And **this** is how you do the\n' Generic.Inserted
+
+'         '   Text.Whitespace
+'| '          Keyword
+'inline quotes.' Generic.Inserted
+'\n'          Text.Whitespace
+
+'~ '          Keyword
+'Haruna '     Name.Entity
+'| '          Keyword
+'//Woah.//\n' Generic.Inserted
+
+'\n'          Text.Whitespace
+
+'1.'          Keyword
+' '           Text.Whitespace
+'First'       Text
+' '           Text.Whitespace
+'things'      Text
+' '           Text.Whitespace
+'first,'      Text
+' '           Text.Whitespace
+'this'        Text
+' '           Text.Whitespace
+'<-'          Keyword
+'is great'    Generic.Deleted
+'->'          Keyword
+'\n'          Text.Whitespace
+
+'10.'         Keyword
+' '           Text.Whitespace
+'Now'         Text
+' '           Text.Whitespace
+'for'         Text
+' '           Text.Whitespace
+'something'   Text
+' '           Text.Whitespace
+'different.'  Text
+'\n'          Text.Whitespace

--- a/tests/snippets/markless/test_headings.txt
+++ b/tests/snippets/markless/test_headings.txt
@@ -1,0 +1,86 @@
+---input---
+Headings:
+
+#Heading
+
+# Heading
+
+# Another heading
+
+# Another # heading
+
+# Heading #
+
+These are NOT parsed as headings:
+
+#
+
+a #
+
+*#
+
+---tokens---
+'Headings:'   Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'#Heading'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'# '          Keyword
+'Heading'     Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'# '          Keyword
+'Another heading' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'# '          Keyword
+'Another # heading' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'# '          Keyword
+'Heading #'   Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'These'       Text
+' '           Text.Whitespace
+'are'         Text
+' '           Text.Whitespace
+'NOT'         Text
+' '           Text.Whitespace
+'parsed'      Text
+' '           Text.Whitespace
+'as'          Text
+' '           Text.Whitespace
+'headings:'   Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'#'           Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'a'           Text
+' '           Text.Whitespace
+'#'           Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'*'           Text
+'#'           Text
+'\n'          Text.Whitespace

--- a/tests/snippets/markless/test_inline.txt
+++ b/tests/snippets/markless/test_inline.txt
@@ -1,0 +1,16 @@
+---input---
+This //should// be **bold**
+
+---tokens---
+'This'        Text
+' '           Text.Whitespace
+'//'          Keyword
+'should'      Generic.Emph
+'//'          Keyword
+' '           Text.Whitespace
+'be'          Text
+' '           Text.Whitespace
+'**'          Keyword
+'bold'        Generic.Strong
+'**'          Keyword
+'\n'          Text.Whitespace


### PR DESCRIPTION
Markless is an open document markup standard specified at

  https://shirakumo.org/docs/markless

Reference implementations of full parsers, a test suite, sample documents, and more can be found on the same page.

This lexer implements a simpler version of Markless without maintaining the standard component and directive stack. It also does not distinguish every possible component type in Markless, as Pygments/Chroma's types lack appropriate markers.

Nevertheless the lexer is useful enough to properly mark up syntax constructs in Markless documents, especially aiding in distinguishing syntactical elements from actual textual content at a glance.

<img width="1528" height="990" alt="2026 01 14 20:23:07" src="https://github.com/user-attachments/assets/68d7c8c5-bd13-4f66-b6e2-0cbf4999a610" />

If there's anything you'd like me to provide about Markless or change about the patch, please let me know.

Thanks a lot for all your work on Pygments!