### PR TITLE
Add support for overlay/fragments in DevicetreeLexer and update example file

### DIFF
--- a/pygments/lexers/devicetree.py
+++ b/pygments/lexers/devicetree.py
@@ -71,7 +71,10 @@ class DevicetreeLexer(RegexLexer):
         'root': [
             include('whitespace'),
             include('macro'),
-
+            # Overlay/fragment: &label { ... } or &{/path/to/node} { ... }
+            (r'(&)(?:([A-Za-z_]\w*)|(\{)([^}]+)(\}))(' + _ws + r')(\{)',
+             bygroups(Operator, Name.Function, Punctuation, Name.Namespace,
+                      Punctuation, Comment.Multiline, Punctuation), 'node'),
             # Nodes
             (r'([^/*@\s&]+|/)(@?)((?:0x)?[0-9a-fA-F,]*)(' + _ws + r')(\{)',
              bygroups(Name.Function, Operator, Number.Integer,
@@ -87,7 +90,10 @@ class DevicetreeLexer(RegexLexer):
         'node': [
             include('whitespace'),
             include('macro'),
-
+            # Overlay/fragment: &label { ... } or &{/path/to/node} { ... }
+            (r'(&)(?:([A-Za-z_]\w*)|(\{)([^}]+)(\}))(' + _ws + r')(\{)',
+             bygroups(Operator, Name.Function, Punctuation, Name.Namespace,
+                      Punctuation, Comment.Multiline, Punctuation), '#push'),
             (r'([^/*@\s&]+|/)(@?)((?:0x)?[0-9a-fA-F,]*)(' + _ws + r')(\{)',
              bygroups(Name.Function, Operator, Number.Integer,
                       Comment.Multiline, Punctuation), '#push'),

--- a/tests/examplefiles/devicetree/example.dts
+++ b/tests/examplefiles/devicetree/example.dts
@@ -79,6 +79,21 @@
 	};
 };
 
+&i2c1 {
+	serlcd@72 {
+		compatible = "sparkfun,serlcd";
+		reg = <0x72>;
+		columns = <16>;
+		rows = <2>;
+		command-delay-ms = <10>;
+		special-command-delay-ms = <50>;
+	};
+};
+
+&{/soc/i2c@e000d800} {
+	status = "okay";
+};
+
 &i2c3 {
 	clock-frequency = <100000>;
 	pinctrl-names = "default";

--- a/tests/examplefiles/devicetree/example.dts.output
+++ b/tests/examplefiles/devicetree/example.dts.output
@@ -586,6 +586,122 @@
 '\n'          Text.Whitespace
 
 '&'           Operator
+'i2c1'        Name.Function
+' '           Comment.Multiline
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'serlcd'      Name.Function
+'@'           Operator
+'72'          Literal.Number.Integer
+' '           Comment.Multiline
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'compatible'  Keyword.Reserved
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'sparkfun,serlcd' Literal.String
+'"'           Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'reg'         Keyword.Reserved
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'<'           Operator
+'0x72'        Literal.Number.Hex
+'>'           Operator
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'columns'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'<'           Operator
+'16'          Literal.Number.Integer
+'>'           Operator
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'rows'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'<'           Operator
+'2'           Literal.Number.Integer
+'>'           Operator
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'command-delay-ms' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'<'           Operator
+'10'          Literal.Number.Integer
+'>'           Operator
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t\t'        Text.Whitespace
+'special-command-delay-ms' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'<'           Operator
+'50'          Literal.Number.Integer
+'>'           Operator
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'&'           Operator
+'{'           Punctuation
+'/soc/i2c@e000d800' Name.Namespace
+'}'           Punctuation
+' '           Comment.Multiline
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'status'      Keyword.Reserved
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'okay'        Literal.String
+'"'           Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'&'           Operator
 'i2c3'        Name.Function
 ' '           Comment.Multiline
 '{'           Punctuation


### PR DESCRIPTION
The DTS lexer had issues with recognizing overlay/fragment syntax, whereby in the following snippet i2c1 wouldn't be seen as a "node"

```devicetree
&i2c1 {
	serlcd@72 {
		compatible = "sparkfun,serlcd";
		reg = <0x72>;
		columns = <16>;
		rows = <2>;
		command-delay-ms = <10>;
		special-command-delay-ms = <50>;
	};
};
```

and "i2c1" was being tokenized as a Name.Attribute instead of a Name.Function, causing the rest of the lexing to fail as it encountered the "@" character in an unexpected location.

This fixes the issue by adding proper support for overlay/fragment syntax, both `&label` form as well as `&{node/full/path}`.

Note that as can be seen from the diff this doesn't change anything else in the tokenization, so there's that :)


Before:

<img width="419" height="252" alt="image" src="https://github.com/user-attachments/assets/be22464f-5622-43f5-8687-910f40d3f66b" />

After:

<img width="443" height="247" alt="image" src="https://github.com/user-attachments/assets/b9839acc-fe28-43c2-b9a4-8b0e8750016b" />
