### PR TITLE
Add bytestring support to DevicetreeLexer and update example DTS file

### DIFF
--- a/pygments/lexers/devicetree.py
+++ b/pygments/lexers/devicetree.py
@@ -63,7 +63,8 @@ class DevicetreeLexer(RegexLexer):
                     '#size-cells', 'reg', 'virtual-reg', 'ranges', 'dma-ranges',
                     'device_type', 'name'), suffix=r'\b'), Keyword.Reserved),
             (r'([~!%^&*+=|?:<>/#-])', Operator),
-            (r'[()\[\]{},.]', Punctuation),
+            (r'[(){},.\]]', Punctuation),
+            (r'\[', Punctuation, 'bytestring'),
             (r'[a-zA-Z_][\w-]*(?=(?:\s*,\s*[a-zA-Z_][\w-]*|(?:' + _ws + r'))*\s*[=;])',
              Name),
             (r'[a-zA-Z_]\w*', Name.Attribute),
@@ -104,5 +105,10 @@ class DevicetreeLexer(RegexLexer):
             (r'[^\\"\n]+', String),  # all other characters
             (r'\\\n', String),  # line continuation
             (r'\\', String),  # stray backslash
+        ],
+        'bytestring': [
+            (r'\]', Punctuation, '#pop'),
+            (r'[0-9a-fA-F]{2}', Number.Hex),
+            (r'\s+', Whitespace),
         ],
     }

--- a/tests/examplefiles/devicetree/example.dts
+++ b/tests/examplefiles/devicetree/example.dts
@@ -42,6 +42,14 @@
 	status = "okay";
 };
 
+&lan1 {
+	local-mac-address = [00 00 12 13 BE EF];
+};
+
+&lan2 {
+	local-mac-address = [1234ABCD5678];
+};
+
 &ecspi1 {
 	cs-gpios = <&gpio2 30 GPIO_ACTIVE_HIGH>, <&gpio4 11 GPIO_ACTIVE_HIGH>;
 	pinctrl-names = "default";

--- a/tests/examplefiles/devicetree/example.dts.output
+++ b/tests/examplefiles/devicetree/example.dts.output
@@ -251,6 +251,67 @@
 '\n'          Text.Whitespace
 
 '&'           Operator
+'lan1'        Name.Function
+' '           Comment.Multiline
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'local-mac-address' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'00'          Literal.Number.Hex
+' '           Text.Whitespace
+'00'          Literal.Number.Hex
+' '           Text.Whitespace
+'12'          Literal.Number.Hex
+' '           Text.Whitespace
+'13'          Literal.Number.Hex
+' '           Text.Whitespace
+'BE'          Literal.Number.Hex
+' '           Text.Whitespace
+'EF'          Literal.Number.Hex
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'&'           Operator
+'lan2'        Name.Function
+' '           Comment.Multiline
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'local-mac-address' Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'12'          Literal.Number.Hex
+'34'          Literal.Number.Hex
+'AB'          Literal.Number.Hex
+'CD'          Literal.Number.Hex
+'56'          Literal.Number.Hex
+'78'          Literal.Number.Hex
+']'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'&'           Operator
 'ecspi1'      Name.Function
 ' '           Comment.Multiline
 '{'           Punctuation


### PR DESCRIPTION
Add support for bytestring which, as per Devicetree Specification:

-  A bytestring is enclosed in square brackets [ ] with each byte represented by two hexadecimal digits. Spaces between each byte are optional. Example:

        local-mac-address = [00 00 12 34 56 78];

   or equivalently:

        local-mac-address = [000012345678];