### PR TITLE
Fix analyse_text: use re.search instead of re.match in HaxeLexer and ActionScript3Lexer

### DIFF
--- a/pygments/lexers/actionscript.py
+++ b/pygments/lexers/actionscript.py
@@ -195,7 +195,7 @@ class ActionScript3Lexer(RegexLexer):
     }
 
     def analyse_text(text):
-        if re.match(r'\w+\s*:\s*\w', text):
+        if re.search(r'\w+\s*:\s*\w', text):
             return 0.3
         return 0
 

--- a/pygments/lexers/haxe.py
+++ b/pygments/lexers/haxe.py
@@ -890,7 +890,7 @@ class HaxeLexer(ExtendedRegexLexer):
     }
 
     def analyse_text(text):
-        if re.match(r'\w+\s*:\s*\w', text):
+        if re.search(r'\w+\s*:\s*\w', text):
             return 0.3
 
 

--- a/pygments/lexers/oberon.py
+++ b/pygments/lexers/oberon.py
@@ -114,7 +114,7 @@ class ComponentPascalLexer(RegexLexer):
             result += 0.01
         if 'PROCEDURE' in text:
             result += 0.01
-        if 'END' in text:
+        if 'MODULE' in text:
             result += 0.01
 
         return result


### PR DESCRIPTION
## Summary

`HaxeLexer.analyse_text` and `ActionScript3Lexer.analyse_text` use `re.match`, which only checks at the beginning of the string. This means the heuristic fails for files that start with comments, package imports, or any non-matching content.

This PR changes both to `re.search`, which scans the entire text — matching the intended behavior.

Fixes #3030