### PR TITLE
Fix duplicate END check in ComponentPascalLexer.analyse_text

### DIFF
--- a/pygments/lexers/oberon.py
+++ b/pygments/lexers/oberon.py
@@ -114,7 +114,7 @@ class ComponentPascalLexer(RegexLexer):
             result += 0.01
         if 'PROCEDURE' in text:
             result += 0.01
-        if 'END' in text:
+        if 'MODULE' in text:
             result += 0.01
 
         return result


### PR DESCRIPTION
## Summary

Fix the duplicate `'END' in text` check in `ComponentPascalLexer.analyse_text`.

## Problem

The `analyse_text` method checks for `'END'` twice (lines 114 and 118), making the second check redundant. This means the method awards +0.02 for `END` but only +0.01 for `BEGIN` and `PROCEDURE`, which is unintentional.

## Fix

Replace the second `'END'` check with `'MODULE'`, since Component Pascal programs are structured as `MODULE ... END` blocks, making it a natural and distinctive keyword to check for.

Fixes #3028