### PR TITLE
Add Hobbes language lexer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 2.20.0
 
 - New lexers:
 
+  * Hobbes
   * Rell (#2914)
 
 - Updated lexers:

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -211,6 +211,7 @@ LEXERS = {
     'HaskellLexer': ('pygments.lexers.haskell', 'Haskell', ('haskell', 'hs'), ('*.hs',), ('text/x-haskell',)),
     'HaxeLexer': ('pygments.lexers.haxe', 'Haxe', ('haxe', 'hxsl', 'hx'), ('*.hx', '*.hxsl'), ('text/haxe', 'text/x-haxe', 'text/x-hx')),
     'HexdumpLexer': ('pygments.lexers.hexdump', 'Hexdump', ('hexdump',), (), ()),
+    'HobbesLexer': ('pygments.lexers.hobbes', 'Hobbes', ('hobbes',), ('*.hob',), ()),
     'HsailLexer': ('pygments.lexers.asm', 'HSAIL', ('hsail', 'hsa'), ('*.hsail',), ('text/x-hsail',)),
     'HspecLexer': ('pygments.lexers.haskell', 'Hspec', ('hspec',), ('*Spec.hs',), ()),
     'HtmlDjangoLexer': ('pygments.lexers.templates', 'HTML+Django/Jinja', ('html+django', 'html+jinja', 'htmldjango'), ('*.html.j2', '*.htm.j2', '*.xhtml.j2', '*.html.jinja2', '*.htm.jinja2', '*.xhtml.jinja2'), ('text/html+django', 'text/html+jinja')),

--- a/pygments/lexers/hobbes.py
+++ b/pygments/lexers/hobbes.py
@@ -1,0 +1,129 @@
+"""
+    pygments.lexers.hobbes
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the Hobbes language.
+
+    :copyright: Copyright 2006-2025 by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, include
+from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Whitespace
+
+__all__ = ['HobbesLexer']
+
+
+class HobbesLexer(RegexLexer):
+    """
+    A lexer for the Hobbes language, a Haskell-like functional language
+    used for high-performance data processing.
+    """
+    name = 'Hobbes'
+    url = 'https://github.com/morganstanley/hobbes'
+    aliases = ['hobbes']
+    filenames = ['*.hob']
+    version_added = '2.20'
+
+    tokens = {
+        'root': [
+            # Whitespace
+            (r'\s+', Whitespace),
+
+            # Pragmas: {-# ... #-}
+            (r'\{-#.*?#-\}', Comment.Special),
+
+            # Nested block comments: /* ... */
+            (r'/\*', Comment.Multiline, 'comment'),
+
+            # Single-line comments
+            (r'//.*$', Comment.Single),
+
+            # String literal
+            (r'"', String, 'string'),
+
+            # Character literal
+            (r"'", String.Char, 'character'),
+
+            # Type-annotated names: <std.string>, <hobbes.storage.Transaction>
+            (r'<[\w.]+>', Keyword.Type),
+
+            # Declaration keywords
+            (r'\b(class|instance|where|type|data|import|module)\b',
+             Keyword.Declaration),
+
+            # Reserved keywords
+            (r'\b(if|then|else|let|in|do|return|match|with|case|of'
+             r'|exists|forall|where)\b', Keyword.Reserved),
+
+            # Boolean constants
+            (r'\b(true|false)\b', Keyword.Constant),
+
+            # Built-in type names (lowercase in hobbes)
+            (r'\b(bool|byte|char|short|int|long|int128'
+             r'|float|double|timespan|time|datetime)\b', Keyword.Type),
+
+            # Special operators
+            (r'::', Operator.Word),
+            (r'->', Operator.Word),
+            (r'=>', Operator.Word),
+            (r'<-', Operator.Word),
+
+            # Lambda
+            (r'\\', Name.Function),
+
+            # Operators
+            (r'[+\-*/%]=?', Operator),
+            (r'[=!<>]=', Operator),
+            (r'===', Operator),
+            (r'[<>]', Operator),
+            (r'&&|\|\||!|~', Operator),
+            (r'\+\+', Operator),
+
+            # Hex number literals (before integer to match first)
+            (r'0[xX][\da-fA-F]+', Number.Hex),
+
+            # Float literals (with optional f suffix)
+            (r'\d+\.\d+[fF]?', Number.Float),
+
+            # Integer literals with type suffixes: L (long), S (short),
+            # H (int128), s (timespan)
+            (r'\d+[LSHs]\b', Number.Integer),
+
+            # Plain integer literals
+            (r'\d+', Number.Integer),
+
+            # Uppercase identifiers are types
+            (r'[A-Z]\w*', Keyword.Type),
+
+            # Function definitions at start of line
+            (r'^[a-z_]\w*', Name.Function),
+
+            # Other lowercase identifiers
+            (r'[a-z_]\w*', Name),
+
+            # Variant/record syntax and other punctuation
+            (r'[|(){}\[\],;.^@?#:=]', Punctuation),
+        ],
+
+        'comment': [
+            (r'[^/*]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),  # nested
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[/*]', Comment.Multiline),
+        ],
+
+        'string': [
+            (r'[^"\\]+', String),
+            (r'\\[abfnrtv"\'\\]', String.Escape),
+            (r'\\x[\da-fA-F]{2}', String.Escape),
+            (r'"', String, '#pop'),
+        ],
+
+        'character': [
+            (r"[^'\\]", String.Char),
+            (r"\\[abfnrtv\"'\\]", String.Char),
+            (r"'", String.Char, '#pop'),
+        ],
+    }

--- a/tests/examplefiles/hobbes/example.hob
+++ b/tests/examplefiles/hobbes/example.hob
@@ -1,0 +1,128 @@
+/*
+ * maybe
+ */
+
+// [doc] constructs a maybe out of a value
+just :: a -> (()+a)
+just x = |1=x|
+
+// by the monotype requirement one must write e.g. `nothing :: (()+int)`
+nothing :: (()+a)
+nothing = |0=()|
+
+either :: (()+a, b, a -> b) -> b
+either x d f = case x of |0:_=d,1:y=f(y)|
+
+eitherC :: (()+a, b, exists E.(((E, a)->b) * E)) -> b
+eitherC x d f = case x of |0:_=d,1:y=apply(f,y)|
+
+// [doc] returns true iff its argument contains a value
+isJust :: (()+a) -> bool
+isJust x = case x of |0:_=false, 1:_=true|
+
+dropNulls :: [()+a] -> [a]
+dropNulls xs = [x | |1=x| <- xs]
+
+// [doc] returns true iff its argument is nothing
+isNothing :: (()+a) -> bool
+isNothing x = case x of |0:_=true,1:_=false|
+
+// an easy way to check for the null case in nullable types (assuming the null value is on the left)
+isNull :: (()+a) -> bool
+isNull = isNothing
+
+fromMaybe :: (a,()+a) -> a
+fromMaybe d x = either(x,d,id)
+
+mmap :: (a -> b, ()+a) -> (()+b)
+mmap f x = case x of |0:_=|0=()|, 1:y=|1=f(y)||
+
+mmapC :: (exists E.(((E, a) -> b) * E), ()+a) -> (()+b)
+mmapC f x = case x of |0:_=|0=()|, 1:y=|1=apply(f,y)||
+
+instance SeqDesc (l+r) "either" r
+
+// [doc] Functor over a Either (with potential default on the left type)
+instance Map f c a b "either" (l+a) "either" (l+b) where
+  fmap f la = case la of |0:l=|0=l|, 1:a=|1=apply(f,a)||
+
+instance (HasDef l) => FilterMap p pc f c a b "either" (l+a) "either" (l+b) where
+  ffilterMap p f la = case la of |0:l=|0=l|, 1:a=if (apply(p,a)) then |1=apply(f,a)| else |0=def||
+
+instance (HasDef l) => FilterMMap f c a b "either" (l+a) "either" (l+b) where
+  ffilterMMap f la = case la of |0:l=|0=l|, 1:a=case apply(f,a) of |0:_=|0=def|,1:b=|1=b|||
+
+atm :: (Array as a, Convert i long) => (as, i) -> (()+a)
+atm xs i = elementM(xs, i)
+
+atMay :: (Convert b long) => ([a],b) -> (()+a)
+atMay = atm 
+
+headMay :: [a] -> (()+a)
+headMay xs = atm(xs,0L)
+
+tailMay :: [a] -> (()+[a])
+tailMay xs = if (length(xs) == 0L) then nothing else just(xs[1:])
+
+// [doc] either just the one element of a size-1 array or nothing
+justOne :: [a] -> (()+a)
+justOne xs = if (length(xs) == 1) then just(xs[0]) else nothing
+
+// [doc] just the first element of an array or nothing
+justFirst :: [a] -> (()+a)
+justFirst xs = if (length(xs) == 0) then nothing else just(xs[0])
+
+// [doc] just the last element of an array or nothing
+justLast :: [a] -> (()+a)
+justLast xs = if (length(xs) == 0) then nothing else just(xs[length(xs)-1])
+
+// [doc] map a function over a maybe
+mapm :: (a -> b, (()+a)) -> (()+b)
+mapm f m = match m with | |1=x| -> just(f(x)) | _ -> nothing
+
+// arithmetic on maybe values
+instance (Add a b c, HasZero a, HasZero b) => Add (()+a) (()+b) (()+c) where
+  mx + my = match mx my with | |1=x| |1=y| -> just(x+y) | |1=x| _ -> just(x+(zero::b)) | _ |1=y| -> just((zero::a)+y) | _ _ -> nothing
+instance (Add a b c) => Add (()+a) (()+b) (()+c) where
+  mx + my = match mx my with | |1=x| |1=y| -> just(x+y) | _ _ -> nothing
+instance (Add a b c) => Add (()+a) b (()+c) where
+  mx + y = match mx with | |1=x| -> just(x+y) | _ -> nothing
+instance (Add a b c) => Add a (()+b) (()+c) where
+  x + my = match my with | |1=y| -> just(x+y) | _ -> nothing
+
+instance (Subtract a b c, HasZero a, HasZero b) => Subtract (()+a) (()+b) (()+c) where
+  mx - my = match mx my with | |1=x| |1=y| -> just(x-y) | |1=x| _ -> just(x-(zero::b)) | _ |1=y| -> just((zero::a)-y) | _ _ -> nothing
+instance (Subtract a b c) => Subtract (()+a) (()+b) (()+c) where
+  mx - my = match mx my with | |1=x| |1=y| -> just(x-y) | _ _ -> nothing
+instance (Subtract a b c) => Subtract (()+a) b (()+c) where
+  mx - y = match mx with | |1=x| -> just(x-y) | _ -> nothing
+instance (Subtract a b c) => Subtract a (()+b) (()+c) where
+  x - my = match my with | |1=y| -> just(x-y) | _ -> nothing
+
+instance (Multiply a b c, HasOne a, HasOne b) => Multiply (()+a) (()+b) (()+c) where
+  mx * my = match mx my with | |1=x| |1=y| -> just(x*y) | |1=x| _ -> just(x*(one::b)) | _ |1=y| -> just((one::a)*y) | _ _ -> nothing
+instance (Multiply a b c) => Multiply (()+a) (()+b) (()+c) where
+  mx * my = match mx my with | |1=x| |1=y| -> just(x*y) | _ _ -> nothing
+instance (Multiply a b c) => Multiply (()+a) b (()+c) where
+  mx * y = match mx with | |1=x| -> just(x*y) | _ -> nothing
+instance (Multiply a b c) => Multiply a (()+b) (()+c) where
+  x * my = match my with | |1=y| -> just(x*y) | _ -> nothing
+
+instance (Divide a b c, HasOne a, HasOne b) => Divide (()+a) (()+b) (()+c) where
+  mx / my = match mx my with | |1=x| |1=y| -> just(x/y) | |1=x| _ -> just(x/(one::b)) | _ |1=y| -> just((one::a)/y) | _ _ -> nothing
+instance (Divide a b c) => Divide (()+a) (()+b) (()+c) where
+  mx / my = match mx my with | |1=x| |1=y| -> just(x/y) | _ _ -> nothing
+instance (Divide a b c) => Divide (()+a) b (()+c) where
+  mx / y = match mx with | |1=x| -> just(x/y) | _ -> nothing
+instance (Divide a b c) => Divide a (()+b) (()+c) where
+  x / my = match my with | |1=y| -> just(x/y) | _ -> nothing
+
+// split a variant tag out into an equivalent enumeration
+class Enum a b | a -> b where
+  enum :: a -> b
+
+instance (v=|lbl:h+0|, |lbl:()+0|=e) => Enum v e where
+  enum = unsafeCast
+instance (v=|lbl:h+t|, Enum t vt, |lbl:()+vt|=e) => Enum v e where
+  enum = unsafeCast
+

--- a/tests/examplefiles/hobbes/example.hob.output
+++ b/tests/examplefiles/hobbes/example.hob.output
@@ -1,0 +1,2949 @@
+'/*'          Comment.Multiline
+'\n '         Comment.Multiline
+'*'           Comment.Multiline
+' maybe\n '   Comment.Multiline
+'*/'          Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'// [doc] constructs a maybe out of a value' Comment.Single
+'\n'          Text.Whitespace
+
+'just'        Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'just'        Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// by the monotype requirement one must write e.g. `nothing :: (()+int)`' Comment.Single
+'\n'          Text.Whitespace
+
+'nothing'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'nothing'     Name.Function
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'('           Punctuation
+')'           Punctuation
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'either'      Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'b'           Name
+','           Punctuation
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+'\n'          Text.Whitespace
+
+'either'      Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'d'           Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'d'           Name
+','           Punctuation
+'1'           Literal.Number.Integer
+':'           Punctuation
+'y'           Name
+'='           Punctuation
+'f'           Name
+'('           Punctuation
+'y'           Name
+')'           Punctuation
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'eitherC'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'b'           Name
+','           Punctuation
+' '           Text.Whitespace
+'exists'      Keyword.Reserved
+' '           Text.Whitespace
+'E'           Keyword.Type
+'.'           Punctuation
+'('           Punctuation
+'('           Punctuation
+'('           Punctuation
+'E'           Keyword.Type
+','           Punctuation
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+'->'          Operator.Word
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'E'           Keyword.Type
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+'\n'          Text.Whitespace
+
+'eitherC'     Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'d'           Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'d'           Name
+','           Punctuation
+'1'           Literal.Number.Integer
+':'           Punctuation
+'y'           Name
+'='           Punctuation
+'apply'       Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+'y'           Name
+')'           Punctuation
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// [doc] returns true iff its argument contains a value' Comment.Single
+'\n'          Text.Whitespace
+
+'isJust'      Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'bool'        Keyword.Type
+'\n'          Text.Whitespace
+
+'isJust'      Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'false'       Keyword.Constant
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'true'        Keyword.Constant
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'dropNulls'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'dropNulls'   Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'['           Punctuation
+'x'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'xs'          Name
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// [doc] returns true iff its argument is nothing' Comment.Single
+'\n'          Text.Whitespace
+
+'isNothing'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'bool'        Keyword.Type
+'\n'          Text.Whitespace
+
+'isNothing'   Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'true'        Keyword.Constant
+','           Punctuation
+'1'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'false'       Keyword.Constant
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// an easy way to check for the null case in nullable types (assuming the null value is on the left)' Comment.Single
+'\n'          Text.Whitespace
+
+'isNull'      Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'bool'        Keyword.Type
+'\n'          Text.Whitespace
+
+'isNull'      Name.Function
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'isNothing'   Name
+'\n\n'        Text.Whitespace
+
+'fromMaybe'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+','           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n'          Text.Whitespace
+
+'fromMaybe'   Name.Function
+' '           Text.Whitespace
+'d'           Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'either'      Name
+'('           Punctuation
+'x'           Name
+','           Punctuation
+'d'           Name
+','           Punctuation
+'id'          Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'mmap'        Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'mmap'        Name.Function
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'('           Punctuation
+')'           Punctuation
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'y'           Name
+'='           Punctuation
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'f'           Name
+'('           Punctuation
+'y'           Name
+')'           Punctuation
+'||'          Operator
+'\n\n'        Text.Whitespace
+
+'mmapC'       Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'exists'      Keyword.Reserved
+' '           Text.Whitespace
+'E'           Keyword.Type
+'.'           Punctuation
+'('           Punctuation
+'('           Punctuation
+'('           Punctuation
+'E'           Keyword.Type
+','           Punctuation
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'E'           Keyword.Type
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'mmapC'       Name.Function
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'('           Punctuation
+')'           Punctuation
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'y'           Name
+'='           Punctuation
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'apply'       Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+'y'           Name
+')'           Punctuation
+'||'          Operator
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'SeqDesc'     Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'r'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'r'           Name
+'\n\n'        Text.Whitespace
+
+'// [doc] Functor over a Either (with potential default on the left type)' Comment.Single
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'Map'         Keyword.Type
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'fmap'        Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'l'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'l'           Name
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'a'           Name
+'='           Punctuation
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'apply'       Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+'a'           Name
+')'           Punctuation
+'||'          Operator
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'HasDef'      Keyword.Type
+' '           Text.Whitespace
+'l'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'FilterMap'   Keyword.Type
+' '           Text.Whitespace
+'p'           Name
+' '           Text.Whitespace
+'pc'          Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'ffilterMap'  Name
+' '           Text.Whitespace
+'p'           Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'l'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'l'           Name
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'a'           Name
+'='           Punctuation
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'apply'       Name
+'('           Punctuation
+'p'           Name
+','           Punctuation
+'a'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'apply'       Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+'a'           Name
+')'           Punctuation
+'|'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'def'         Name
+'||'          Operator
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'HasDef'      Keyword.Type
+' '           Text.Whitespace
+'l'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'FilterMMap'  Keyword.Type
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'either'      Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'('           Punctuation
+'l'           Name
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'ffilterMMap' Name
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'la'          Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'l'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'l'           Name
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'a'           Name
+'='           Punctuation
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'apply'       Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+'0'           Literal.Number.Integer
+':'           Punctuation
+'_'           Name
+'='           Punctuation
+'|'           Punctuation
+'0'           Literal.Number.Integer
+'='           Punctuation
+'def'         Name
+'|'           Punctuation
+','           Punctuation
+'1'           Literal.Number.Integer
+':'           Punctuation
+'b'           Name
+'='           Punctuation
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'b'           Name
+'||'          Operator
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'atm'         Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'Array'       Keyword.Type
+' '           Text.Whitespace
+'as'          Name
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'Convert'     Keyword.Type
+' '           Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'long'        Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'as'          Name
+','           Punctuation
+' '           Text.Whitespace
+'i'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'atm'         Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'elementM'    Name
+'('           Punctuation
+'xs'          Name
+','           Punctuation
+' '           Text.Whitespace
+'i'           Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'atMay'       Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'Convert'     Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'long'        Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+','           Punctuation
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'atMay'       Name.Function
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'atm'         Name
+' \n\n'       Text.Whitespace
+
+'headMay'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'headMay'     Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'atm'         Name
+'('           Punctuation
+'xs'          Name
+','           Punctuation
+'0L'          Literal.Number.Integer
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'tailMay'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'tailMay'     Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'length'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'0L'          Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'nothing'     Name
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'xs'          Name
+'['           Punctuation
+'1'           Literal.Number.Integer
+':'           Punctuation
+']'           Punctuation
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// [doc] either just the one element of a size-1 array or nothing' Comment.Single
+'\n'          Text.Whitespace
+
+'justOne'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'justOne'     Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'length'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'xs'          Name
+'['           Punctuation
+'0'           Literal.Number.Integer
+']'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'// [doc] just the first element of an array or nothing' Comment.Single
+'\n'          Text.Whitespace
+
+'justFirst'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'justFirst'   Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'length'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'nothing'     Name
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'xs'          Name
+'['           Punctuation
+'0'           Literal.Number.Integer
+']'           Punctuation
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// [doc] just the last element of an array or nothing' Comment.Single
+'\n'          Text.Whitespace
+
+'justLast'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'a'           Name
+']'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'justLast'    Name.Function
+' '           Text.Whitespace
+'xs'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'length'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'nothing'     Name
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'xs'          Name
+'['           Punctuation
+'length'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+'-'           Operator
+'1'           Literal.Number.Integer
+']'           Punctuation
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'// [doc] map a function over a maybe' Comment.Single
+'\n'          Text.Whitespace
+
+'mapm'        Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'mapm'        Name.Function
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'m'           Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'f'           Name
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'// arithmetic on maybe values' Comment.Single
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'+'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'+'           Operator
+'('           Punctuation
+'zero'        Name
+'::'          Operator.Word
+'b'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'('           Punctuation
+'zero'        Name
+'::'          Operator.Word
+'a'           Name
+')'           Punctuation
+'+'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'+'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'y'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'+'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Add'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'+'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'-'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'-'           Operator
+'('           Punctuation
+'zero'        Name
+'::'          Operator.Word
+'b'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'('           Punctuation
+'zero'        Name
+'::'          Operator.Word
+'a'           Name
+')'           Punctuation
+'-'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'-'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'y'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'-'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Subtract'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'-'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasOne'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasOne'      Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'*'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'*'           Operator
+'('           Punctuation
+'one'         Name
+'::'          Operator.Word
+'b'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'('           Punctuation
+'one'         Name
+'::'          Operator.Word
+'a'           Name
+')'           Punctuation
+'*'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'*'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'y'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'*'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Multiply'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'*'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasOne'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'HasOne'      Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'/'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'/'           Operator
+'('           Punctuation
+'one'         Name
+'::'          Operator.Word
+'b'           Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'('           Punctuation
+'one'         Name
+'::'          Operator.Word
+'a'           Name
+')'           Punctuation
+'/'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'/'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'y'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'mx'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'/'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Divide'      Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'my'          Name
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'y'           Name
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'just'        Name
+'('           Punctuation
+'x'           Name
+'/'           Operator
+'y'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nothing'     Name
+'\n\n'        Text.Whitespace
+
+'// split a variant tag out into an equivalent enumeration' Comment.Single
+'\n'          Text.Whitespace
+
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'Enum'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'enum'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'v'           Name
+'='           Punctuation
+'|'           Punctuation
+'lbl'         Name
+':'           Punctuation
+'h'           Name
+'+'           Operator
+'0'           Literal.Number.Integer
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'lbl'         Name
+':'           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'0'           Literal.Number.Integer
+'|'           Punctuation
+'='           Punctuation
+'e'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Enum'        Keyword.Type
+' '           Text.Whitespace
+'v'           Name
+' '           Text.Whitespace
+'e'           Name
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'enum'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'unsafeCast'  Name
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'('           Punctuation
+'v'           Name
+'='           Punctuation
+'|'           Punctuation
+'lbl'         Name
+':'           Punctuation
+'h'           Name
+'+'           Operator
+'t'           Name
+'|'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'Enum'        Keyword.Type
+' '           Text.Whitespace
+'t'           Name
+' '           Text.Whitespace
+'vt'          Name
+','           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'lbl'         Name
+':'           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'vt'          Name
+'|'           Punctuation
+'='           Punctuation
+'e'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Enum'        Keyword.Type
+' '           Text.Whitespace
+'v'           Name
+' '           Text.Whitespace
+'e'           Name
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'enum'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'unsafeCast'  Name
+'\n'          Text.Whitespace

--- a/tests/snippets/hobbes/test_basic.txt
+++ b/tests/snippets/hobbes/test_basic.txt
@@ -1,0 +1,332 @@
+---input---
+/* block comment */
+
+// single line comment
+
+{-# SAFE toArray #-}
+
+just :: a -> (()+a)
+just x = |1=x|
+
+class HasZero a where
+  zero :: a
+
+instance HasZero int where
+  zero = 0
+
+instance HasZero long where
+  zero = 0L
+
+instance HasZero float where
+  zero = 0.0f
+
+instance HasZero byte where
+  zero = 0X00
+
+toLower :: char -> char
+toLower c = if (c >= 'A' and c <= 'Z') then ((c - 'A') + 'a') else c
+
+show x = "hello"
+
+floatFormatConfig = do {
+  c = (newPrim() :: {floatPrecision:int,doublePrecision:int});
+  c.floatPrecision <- -1;
+  return c
+}
+
+match unroll(xs) with
+| |1=(h,t)| -> cons(f(h), lmap(f, t))
+| _         -> nil()
+
+---tokens---
+'/*'          Comment.Multiline
+' block comment ' Comment.Multiline
+'*/'          Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'// single line comment' Comment.Single
+'\n\n'        Text.Whitespace
+
+'{-# SAFE toArray #-}' Comment.Special
+'\n\n'        Text.Whitespace
+
+'just'        Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+')'           Punctuation
+'+'           Operator
+'a'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'just'        Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'x'           Name
+'|'           Punctuation
+'\n\n'        Text.Whitespace
+
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'zero'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'zero'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'long'        Keyword.Type
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'zero'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0L'          Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'float'       Keyword.Type
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'zero'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0.0f'        Literal.Number.Float
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Declaration
+' '           Text.Whitespace
+'HasZero'     Keyword.Type
+' '           Text.Whitespace
+'byte'        Keyword.Type
+' '           Text.Whitespace
+'where'       Keyword.Declaration
+'\n  '        Text.Whitespace
+'zero'        Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'0X00'        Literal.Number.Hex
+'\n\n'        Text.Whitespace
+
+'toLower'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'char'        Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'char'        Keyword.Type
+'\n'          Text.Whitespace
+
+'toLower'     Name.Function
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'c'           Name
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'A'           Literal.String.Char
+"'"           Literal.String.Char
+' '           Text.Whitespace
+'and'         Name
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'Z'           Literal.String.Char
+"'"           Literal.String.Char
+')'           Punctuation
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'('           Punctuation
+'('           Punctuation
+'c'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'A'           Literal.String.Char
+"'"           Literal.String.Char
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'a'           Literal.String.Char
+"'"           Literal.String.Char
+')'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'c'           Name
+'\n\n'        Text.Whitespace
+
+'show'        Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'"'           Literal.String
+'hello'       Literal.String
+'"'           Literal.String
+'\n\n'        Text.Whitespace
+
+'floatFormatConfig' Name.Function
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'do'          Keyword.Reserved
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'='           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'newPrim'     Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'{'           Punctuation
+'floatPrecision' Name
+':'           Punctuation
+'int'         Keyword.Type
+','           Punctuation
+'doublePrecision' Name
+':'           Punctuation
+'int'         Keyword.Type
+'}'           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n  '        Text.Whitespace
+'c'           Name
+'.'           Punctuation
+'floatPrecision' Name
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'-'           Operator
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n  '        Text.Whitespace
+'return'      Keyword.Reserved
+' '           Text.Whitespace
+'c'           Name
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'match'       Keyword.Reserved
+' '           Text.Whitespace
+'unroll'      Name
+'('           Punctuation
+'xs'          Name
+')'           Punctuation
+' '           Text.Whitespace
+'with'        Keyword.Reserved
+'\n'          Text.Whitespace
+
+'|'           Punctuation
+' '           Text.Whitespace
+'|'           Punctuation
+'1'           Literal.Number.Integer
+'='           Punctuation
+'('           Punctuation
+'h'           Name
+','           Punctuation
+'t'           Name
+')'           Punctuation
+'|'           Punctuation
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'cons'        Name
+'('           Punctuation
+'f'           Name
+'('           Punctuation
+'h'           Name
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'lmap'        Name
+'('           Punctuation
+'f'           Name
+','           Punctuation
+' '           Text.Whitespace
+'t'           Name
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'|'           Punctuation
+' '           Text.Whitespace
+'_'           Name
+'         '   Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'nil'         Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

- Add a new `HobbesLexer` for the [Hobbes](https://github.com/morganstanley/hobbes) language, a Haskell-like functional language used for high-performance data processing
- Implemented as a standalone `RegexLexer` (not inheriting from `HaskellLexer`) due to significant syntax differences: C-style comments (`/* */`, `//`), type-suffixed number literals (`5L`, `3S`, `0.0f`), variant/record syntax, and brace-delimited do-blocks
- Includes snippet test, example file with golden tokens, and CHANGES entry

## Test plan

- [x] Visual check with `python -m pygments` on hobbes source files
- [x] Snippet golden test passes (`tests/snippets/hobbes/test_basic.txt`)
- [x] Example file golden test passes (`tests/examplefiles/hobbes/example.hob`)
- [x] Full test suite passes (5214 passed, 8 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)