### PR TITLE
fix(regexopt): Fix os.path.commonprefix deprecation warning in python3.15

### DIFF
--- a/pygments/regexopt.py
+++ b/pygments/regexopt.py
@@ -11,12 +11,23 @@
 
 import re
 from re import escape
-from os.path import commonprefix
 from itertools import groupby
 from operator import itemgetter
 
 CS_ESCAPE = re.compile(r'[\[\^\\\-\]]')
 FIRST_ELEMENT = itemgetter(0)
+
+
+def commonprefix(m):
+    """Given an iterable of strings, returns the longest common leading substring"""
+    if not m:
+        return ""
+    s1 = min(m)
+    s2 = max(m)
+    for i, c in enumerate(s1):
+        if c != s2[i]:
+            return s1[:i]
+    return s1
 
 
 def make_charset(letters):


### PR DESCRIPTION
python/cpython#144436 deprecates `os.path.commonprefix` in 3.15

i copied the implementation of `commonprefix` (https://github.com/python/cpython/blob/957f9fe162398fceeaa9ddba8b40046b8a03176d/Lib/genericpath.py#L115-L129) and removed the unused `fspath`, as its only used with strings, not paths