### PR TITLE
Fix guess_decode to actually try the locale's preferred encoding

### DIFF
--- a/pygments/util.py
+++ b/pygments/util.py
@@ -286,7 +286,7 @@ def guess_decode(text):
         try:
             import locale
             prefencoding = locale.getpreferredencoding()
-            text = text.decode()
+            text = text.decode(prefencoding)
             return text, prefencoding
         except (UnicodeDecodeError, LookupError):
             text = text.decode('latin1')


### PR DESCRIPTION
## Problem

`guess_decode()` is supposed to try UTF-8, then the locale encoding, then latin-1. But the locale fallback branch calls `text.decode()` with no argument:

```python
prefencoding = locale.getpreferredencoding()
text = text.decode()  # uses sys.getdefaultencoding() = 'utf-8'
```

In Python 3, `sys.getdefaultencoding()` is always `'utf-8'`, which the first `try` already attempted. This always fails, and every non-UTF-8 input falls straight through to latin-1.

On Windows (cp1252) or Japanese systems (euc-jp, shift_jis), valid locale-encoded text that isn't UTF-8 was never correctly decoded.

## Fix

Pass `prefencoding` to `text.decode()` so the locale encoding is actually attempted.