### PR TITLE
Fix xterm-256 color table: wrong cube count and missing grayscale entries

### DIFF
--- a/pygments/formatters/terminal256.py
+++ b/pygments/formatters/terminal256.py
@@ -169,19 +169,19 @@ class Terminal256Formatter(Formatter):
         self.xterm_colors.append((0x00, 0xff, 0xff))  # 14
         self.xterm_colors.append((0xff, 0xff, 0xff))  # 15
 
-        # colors 16..232: the 6x6x6 color cube
+        # colors 16..231: the 6x6x6 color cube
 
         valuerange = (0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff)
 
-        for i in range(217):
+        for i in range(216):
             r = valuerange[(i // 36) % 6]
             g = valuerange[(i // 6) % 6]
             b = valuerange[i % 6]
             self.xterm_colors.append((r, g, b))
 
-        # colors 233..253: grayscale
+        # colors 232..255: grayscale
 
-        for i in range(1, 22):
+        for i in range(24):
             v = 8 + i * 10
             self.xterm_colors.append((v, v, v))
 
@@ -189,7 +189,7 @@ class Terminal256Formatter(Formatter):
         distance = 257*257*3  # "infinity" (>distance from #000000 to #ffffff)
         match = 0
 
-        for i in range(0, 254):
+        for i in range(0, 256):
             values = self.xterm_colors[i]
 
             rd = r - values[0]


### PR DESCRIPTION
## Problem

The xterm-256 color table in `Terminal256Formatter` has two off-by-one errors:

1. **Color cube**: `range(217)` generates 217 entries instead of 216 (6x6x6 = 216). The extra entry at index 232 contains `(0,0,0)` (black) instead of the correct grayscale start.

2. **Grayscale ramp**: `range(1, 22)` generates only 21 entries instead of the correct 24 (colors 232-255). Three grayscale values are missing entirely.

Total entries: 16 + 217 + 21 = 254 instead of the correct 256. The extra cube entry shifts all grayscale indices by one, and the missing entries cause wrong color matching for grays.

Additionally, `_closest_color` iterates `range(0, 254)` which doesn't cover all entries.

## Fix

- Color cube: `range(216)`
- Grayscale: `range(24)`
- Closest color search: `range(256)`
