### PR TITLE
Fix using() to not mutate closure-captured kwargs dict

### DIFF
--- a/pygments/lexer.py
+++ b/pygments/lexer.py
@@ -444,8 +444,9 @@ def using(_other, **kwargs):
             # function has to create a new lexer instance
             if kwargs:
                 # XXX: cache that somehow
-                kwargs.update(lexer.options)
-                lx = lexer.__class__(**kwargs)
+                d = dict(lexer.options)
+                d.update(kwargs)
+                lx = lexer.__class__(**d)
             else:
                 lx = lexer
             s = match.start()
@@ -456,8 +457,9 @@ def using(_other, **kwargs):
     else:
         def callback(lexer, match, ctx=None):
             # XXX: cache that somehow
-            kwargs.update(lexer.options)
-            lx = _other(**kwargs)
+            d = dict(lexer.options)
+            d.update(kwargs)
+            lx = _other(**d)
 
             s = match.start()
             for i, t, v in lx.get_tokens_unprocessed(match.group(), **gt_kwargs):


### PR DESCRIPTION
## Problem

`using()` callbacks mutate the closure-captured `kwargs` dict via `kwargs.update(lexer.options)`. This causes two issues:

1. **State accumulation**: The dict grows with each invocation, mixing in options from previous lexer instances.

2. **Wrong precedence**: `kwargs.update(lexer.options)` gives the parent lexer's generic options priority over the explicitly-provided kwargs. For example, `using(PhpLexer, startinline=True)` can be overridden if the parent lexer was created with `startinline=False`.

## Fix

Create a fresh dict per callback invocation. Start from lexer.options and then overlay explicit kwargs, so user-specified arguments take priority:

```python
d = dict(lexer.options)
d.update(kwargs)
lx = _other(**d)
```
