### PR TITLE
Add HAProxy configuration file lexer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 2.20.0
 
 - New lexers:
 
+  * HAProxy
   * Rell (#2914)
 
 - Updated lexers:

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -202,6 +202,7 @@ LEXERS = {
     'GraphvizLexer': ('pygments.lexers.graphviz', 'Graphviz', ('graphviz', 'dot'), ('*.gv', '*.dot'), ('text/x-graphviz', 'text/vnd.graphviz')),
     'GroffLexer': ('pygments.lexers.markup', 'Groff', ('groff', 'nroff', 'man'), ('*.[1-9]', '*.man', '*.1p', '*.3pm'), ('application/x-troff', 'text/troff')),
     'GroovyLexer': ('pygments.lexers.jvm', 'Groovy', ('groovy',), ('*.groovy', '*.gradle'), ('text/x-groovy',)),
+    'HAProxyLexer': ('pygments.lexers.configs', 'HAProxy', ('haproxy',), ('haproxy.cfg',), ('text/x-haproxy-config',)),
     'HLSLShaderLexer': ('pygments.lexers.graphics', 'HLSL', ('hlsl',), ('*.hlsl', '*.hlsli'), ('text/x-hlsl',)),
     'HTMLUL4Lexer': ('pygments.lexers.ul4', 'HTML+UL4', ('html+ul4',), ('*.htmlul4',), ()),
     'HamlLexer': ('pygments.lexers.html', 'Haml', ('haml',), ('*.haml',), ('text/x-haml',)),

--- a/tests/examplefiles/haproxy/haproxy.cfg
+++ b/tests/examplefiles/haproxy/haproxy.cfg
@@ -1,0 +1,131 @@
+# This configuration creates a classical reverse-proxy and load balancer for
+# public services. It presents ports 80 and 443 (with 80 redirecting to 443),
+# enables caching up to one hour, and load-balances the service on a farm of
+# 4 servers on private IP addresses which are checked using HTTP checks and
+# by maintaining stickiness via session cookies. It offloads TLS processing
+# and enables HTTP compression. It uses HAProxy 2.4.
+
+# The global section deals with process-wide settings (security, resource usage)
+global
+	default-path config
+	zero-warning
+	chroot /var/empty
+	user haproxy
+	group haproxy
+	daemon
+	pidfile /var/run/haproxy-svc1.pid
+	hard-stop-after 5m
+	stats socket /var/run/haproxy-svc1.sock level admin mode 600 user haproxy expose-fd listeners
+	stats timeout 1h
+	log stderr local0 info
+	ssl-default-bind-ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
+	ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384
+	ssl-default-bind-options prefer-client-ciphers no-sslv3 no-tlsv10 no-tlsv11
+	maxconn 10000
+	uid 200
+	gid 200
+	tune.bufsize 16384
+	tune.ssl.default-dh-param 2048
+
+defaults http
+	mode http
+	option httplog
+	log global
+	timeout client 1m
+	timeout server 1m
+	timeout connect 10s
+	timeout http-keep-alive 2m
+	timeout queue 15s
+	timeout tunnel 4h
+
+frontend stats
+	bind :8181
+	stats uri /
+	stats show-modules
+
+.if feature(QUIC)
+frontend pub1
+	bind :80 name clear
+	bind :443 name secure ssl crt pub1.pem
+	bind quic4@:443 name quic ssl crt pub1.pem allow-0rtt
+	http-response add-header alt-svc 'h3=":443"; ma=90000'
+.else
+frontend pub1
+	bind :80 name clear
+	bind :443 name secure ssl crt pub1.pem
+.endif
+
+	http-after-response set-header Strict-Transport-Security "max-age=31536000"
+	http-request redirect scheme https code 301 if !{ ssl_fc }
+	option http-ignore-probes
+	http-request del-header x-forwarded-for
+	option forwardfor
+	compression algo deflate gzip
+	compression type text/ application/javascript application/xhtml+xml image/x-icon
+	http-request cache-use cache
+	http-response cache-store cache
+	default_backend app1
+	acl is_static path_beg /static /images
+	acl host_match hdr(host) -i www.example.com
+	use_backend static if is_static
+	use_backend app1 if { hdr_beg(host) -i api }
+	use_backend app1 if { path_beg /api } || { path_beg /v2 }
+
+cache cache
+	total-max-size 200
+	max-object-size 10485760
+	max-age 3600
+	process-vary on
+
+backend app1
+	balance random
+	option abortonclose
+	cookie app1 insert indirect nocache
+	option httpchk
+	http-check send meth GET uri / ver HTTP/1.1 hdr host svc1.example.com
+	server srv1 192.0.2.1:80 cookie s1 maxconn 100 check inter 1s
+	server srv2 192.0.2.2:80 cookie s2 maxconn 100 check inter 1s
+	server srv3 192.0.2.3:80 cookie s3 maxconn 100 check inter 1s
+	server srv4 192.0.2.4:80 cookie s4 maxconn 100 check inter 1s
+
+backend static
+	mode http
+	balance roundrobin
+	option prefer-last-server
+	retries 2
+	option redispatch
+	timeout connect 5s
+	timeout server 5s
+	option httpchk HEAD /favicon.ico
+	server statsrv1 192.168.1.8:80 check inter 1000
+	server statsrv2 192.168.1.9:80 check inter 1000
+
+listen health-check
+	bind :9000
+	mode http
+	monitor-uri /health
+	option httplog
+	server local 127.0.0.1:8080 check
+
+resolvers mydns
+	nameserver dns1 10.0.0.1:53
+	nameserver dns2 10.0.0.2:53
+	resolve_retries 3
+	timeout resolve 1s
+	timeout retry 1s
+	hold valid 10s
+
+peers mypeers
+	peer haproxy1 192.168.1.1:1024
+	peer haproxy2 192.168.1.2:1024
+
+userlist myusers
+	group admins users admin
+	user admin insecure-password changeme
+	user guest insecure-password guest
+
+.notice 'Configuration loaded successfully'
+
+# Environment variable usage
+# bind :${HAPROXY_PORT}
+# server app1 ${APP_HOST}:${APP_PORT} check

--- a/tests/examplefiles/haproxy/haproxy.cfg.output
+++ b/tests/examplefiles/haproxy/haproxy.cfg.output
@@ -1,0 +1,795 @@
+'# This configuration creates a classical reverse-proxy and load balancer for' Comment.Single
+'\n'          Text.Whitespace
+
+'# public services. It presents ports 80 and 443 (with 80 redirecting to 443),' Comment.Single
+'\n'          Text.Whitespace
+
+'# enables caching up to one hour, and load-balances the service on a farm of' Comment.Single
+'\n'          Text.Whitespace
+
+'# 4 servers on private IP addresses which are checked using HTTP checks and' Comment.Single
+'\n'          Text.Whitespace
+
+'# by maintaining stickiness via session cookies. It offloads TLS processing' Comment.Single
+'\n'          Text.Whitespace
+
+'# and enables HTTP compression. It uses HAProxy 2.4.' Comment.Single
+'\n\n'        Text.Whitespace
+
+'# The global section deals with process-wide settings (security, resource usage)' Comment.Single
+'\n'          Text.Whitespace
+
+'global'      Keyword
+'\n\t'        Text.Whitespace
+'default-path' Literal.String
+' '           Text.Whitespace
+'config'      Literal.String
+'\n\t'        Text.Whitespace
+'zero-warning' Literal.String
+'\n\t'        Text.Whitespace
+'chroot'      Literal.String
+' '           Text.Whitespace
+'/var/empty'  Literal.String
+'\n\t'        Text.Whitespace
+'user'        Literal.String
+' '           Text.Whitespace
+'haproxy'     Literal.String
+'\n\t'        Text.Whitespace
+'group'       Literal.String
+' '           Text.Whitespace
+'haproxy'     Literal.String
+'\n\t'        Text.Whitespace
+'daemon'      Literal.String
+'\n\t'        Text.Whitespace
+'pidfile'     Literal.String
+' '           Text.Whitespace
+'/var/run/haproxy-svc1.pid' Literal.String
+'\n\t'        Text.Whitespace
+'hard-stop-after' Literal.String
+' '           Text.Whitespace
+'5m'          Literal.Number
+'\n\t'        Text.Whitespace
+'stats'       Name.Attribute
+' '           Text.Whitespace
+'socket'      Literal.String
+' '           Text.Whitespace
+'/var/run/haproxy-svc1.sock' Literal.String
+' '           Text.Whitespace
+'level'       Literal.String
+' '           Text.Whitespace
+'admin'       Literal.String
+' '           Text.Whitespace
+'mode'        Name.Attribute
+' '           Text.Whitespace
+'600'         Literal.Number
+' '           Text.Whitespace
+'user'        Literal.String
+' '           Text.Whitespace
+'haproxy'     Literal.String
+' '           Text.Whitespace
+'expose-fd'   Literal.String
+' '           Text.Whitespace
+'listeners'   Literal.String
+'\n\t'        Text.Whitespace
+'stats'       Name.Attribute
+' '           Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'1h'          Literal.Number
+'\n\t'        Text.Whitespace
+'log'         Name.Attribute
+' '           Text.Whitespace
+'stderr'      Literal.String
+' '           Text.Whitespace
+'local0'      Literal.String
+' '           Text.Whitespace
+'info'        Literal.String
+'\n\t'        Text.Whitespace
+'ssl-default-bind-ciphers' Literal.String
+' '           Text.Whitespace
+'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256' Literal.String
+'\n\t'        Text.Whitespace
+'ssl-default-bind-ciphersuites' Literal.String
+' '           Text.Whitespace
+'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384' Literal.String
+'\n\t'        Text.Whitespace
+'ssl-default-bind-options' Literal.String
+' '           Text.Whitespace
+'prefer-client-ciphers' Literal.String
+' '           Text.Whitespace
+'no-sslv3'    Literal.String
+' '           Text.Whitespace
+'no-tlsv10'   Literal.String
+' '           Text.Whitespace
+'no-tlsv11'   Literal.String
+'\n\t'        Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'10000'       Literal.Number
+'\n\t'        Text.Whitespace
+'uid'         Literal.String
+' '           Text.Whitespace
+'200'         Literal.Number
+'\n\t'        Text.Whitespace
+'gid'         Literal.String
+' '           Text.Whitespace
+'200'         Literal.Number
+'\n\t'        Text.Whitespace
+'tune.bufsize' Literal.String
+' '           Text.Whitespace
+'16384'       Literal.Number
+'\n\t'        Text.Whitespace
+'tune.ssl.default-dh-param' Literal.String
+' '           Text.Whitespace
+'2048'        Literal.Number
+'\n\n'        Text.Whitespace
+
+'defaults'    Keyword
+' '           Text.Whitespace
+'http'        Name.Namespace
+'\n\t'        Text.Whitespace
+'mode'        Name.Attribute
+' '           Text.Whitespace
+'http'        Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'httplog'     Name.Builtin
+'\n\t'        Text.Whitespace
+'log'         Name.Attribute
+' '           Text.Whitespace
+'global'      Literal.String
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'client'      Name.Builtin
+' '           Text.Whitespace
+'1m'          Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'1m'          Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'connect'     Name.Builtin
+' '           Text.Whitespace
+'10s'         Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'http-keep-alive' Name.Builtin
+' '           Text.Whitespace
+'2m'          Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'queue'       Name.Builtin
+' '           Text.Whitespace
+'15s'         Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'tunnel'      Name.Builtin
+' '           Text.Whitespace
+'4h'          Literal.Number
+'\n\n'        Text.Whitespace
+
+'frontend'    Keyword
+' '           Text.Whitespace
+'stats'       Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':8181'       Literal.Number
+'\n\t'        Text.Whitespace
+'stats'       Name.Attribute
+' '           Text.Whitespace
+'uri'         Literal.String
+' '           Text.Whitespace
+'/'           Literal.String
+'\n\t'        Text.Whitespace
+'stats'       Name.Attribute
+' '           Text.Whitespace
+'show-modules' Literal.String
+'\n\n'        Text.Whitespace
+
+'.if'         Comment.Preproc
+' '           Text.Whitespace
+'feature(QUIC)' Comment.Preproc
+'\n'          Text.Whitespace
+
+'frontend'    Keyword
+' '           Text.Whitespace
+'pub1'        Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':80'         Literal.Number
+' '           Text.Whitespace
+'name'        Literal.String
+' '           Text.Whitespace
+'clear'       Literal.String
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':443'        Literal.Number
+' '           Text.Whitespace
+'name'        Literal.String
+' '           Text.Whitespace
+'secure'      Literal.String
+' '           Text.Whitespace
+'ssl'         Literal.String
+' '           Text.Whitespace
+'crt'         Literal.String
+' '           Text.Whitespace
+'pub1.pem'    Literal.String
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+'quic4@:443'  Literal.String
+' '           Text.Whitespace
+'name'        Literal.String
+' '           Text.Whitespace
+'quic'        Literal.String
+' '           Text.Whitespace
+'ssl'         Literal.String
+' '           Text.Whitespace
+'crt'         Literal.String
+' '           Text.Whitespace
+'pub1.pem'    Literal.String
+' '           Text.Whitespace
+'allow-0rtt'  Literal.String
+'\n\t'        Text.Whitespace
+'http-response' Name.Attribute
+' '           Text.Whitespace
+'add-header'  Literal.String
+' '           Text.Whitespace
+'alt-svc'     Literal.String
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'h3=":443"; ma=90000' Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+'.else'       Comment.Preproc
+'\n'          Text.Whitespace
+
+'frontend'    Keyword
+' '           Text.Whitespace
+'pub1'        Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':80'         Literal.Number
+' '           Text.Whitespace
+'name'        Literal.String
+' '           Text.Whitespace
+'clear'       Literal.String
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':443'        Literal.Number
+' '           Text.Whitespace
+'name'        Literal.String
+' '           Text.Whitespace
+'secure'      Literal.String
+' '           Text.Whitespace
+'ssl'         Literal.String
+' '           Text.Whitespace
+'crt'         Literal.String
+' '           Text.Whitespace
+'pub1.pem'    Literal.String
+'\n'          Text.Whitespace
+
+'.endif'      Comment.Preproc
+'\n\n\t'      Text.Whitespace
+'http-after-response' Name.Attribute
+' '           Text.Whitespace
+'set-header'  Literal.String
+' '           Text.Whitespace
+'Strict-Transport-Security' Literal.String
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'max-age=31536000' Literal.String.Double
+'"'           Literal.String.Double
+'\n\t'        Text.Whitespace
+'http-request' Name.Attribute
+' '           Text.Whitespace
+'redirect'    Name.Attribute
+' '           Text.Whitespace
+'scheme'      Literal.String
+' '           Text.Whitespace
+'https'       Literal.String
+' '           Text.Whitespace
+'code'        Literal.String
+' '           Text.Whitespace
+'301'         Literal.Number
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'!'           Literal.String
+'{'           Punctuation
+' '           Text.Whitespace
+'ssl_fc'      Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'http-ignore-probes' Name.Builtin
+'\n\t'        Text.Whitespace
+'http-request' Name.Attribute
+' '           Text.Whitespace
+'del-header'  Literal.String
+' '           Text.Whitespace
+'x-forwarded-for' Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'forwardfor'  Name.Builtin
+'\n\t'        Text.Whitespace
+'compression' Name.Attribute
+' '           Text.Whitespace
+'algo'        Literal.String
+' '           Text.Whitespace
+'deflate'     Literal.String
+' '           Text.Whitespace
+'gzip'        Literal.String
+'\n\t'        Text.Whitespace
+'compression' Name.Attribute
+' '           Text.Whitespace
+'type'        Literal.String
+' '           Text.Whitespace
+'text/'       Literal.String
+' '           Text.Whitespace
+'application/javascript' Literal.String
+' '           Text.Whitespace
+'application/xhtml+xml' Literal.String
+' '           Text.Whitespace
+'image/x-icon' Literal.String
+'\n\t'        Text.Whitespace
+'http-request' Name.Attribute
+' '           Text.Whitespace
+'cache-use'   Literal.String
+' '           Text.Whitespace
+'cache'       Literal.String
+'\n\t'        Text.Whitespace
+'http-response' Name.Attribute
+' '           Text.Whitespace
+'cache-store' Literal.String
+' '           Text.Whitespace
+'cache'       Literal.String
+'\n\t'        Text.Whitespace
+'default_backend' Name.Attribute
+' '           Text.Whitespace
+'app1'        Literal.String
+'\n\t'        Text.Whitespace
+'acl'         Name.Attribute
+' '           Text.Whitespace
+'is_static'   Literal.String
+' '           Text.Whitespace
+'path_beg'    Literal.String
+' '           Text.Whitespace
+'/static'     Literal.String
+' '           Text.Whitespace
+'/images'     Literal.String
+'\n\t'        Text.Whitespace
+'acl'         Name.Attribute
+' '           Text.Whitespace
+'host_match'  Literal.String
+' '           Text.Whitespace
+'hdr(host)'   Literal.String
+' '           Text.Whitespace
+'-i'          Operator
+' '           Text.Whitespace
+'www.example.com' Literal.String
+'\n\t'        Text.Whitespace
+'use_backend' Name.Attribute
+' '           Text.Whitespace
+'static'      Literal.String
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'is_static'   Literal.String
+'\n\t'        Text.Whitespace
+'use_backend' Name.Attribute
+' '           Text.Whitespace
+'app1'        Literal.String
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'hdr_beg(host)' Literal.String
+' '           Text.Whitespace
+'-i'          Operator
+' '           Text.Whitespace
+'api'         Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\t'        Text.Whitespace
+'use_backend' Name.Attribute
+' '           Text.Whitespace
+'app1'        Literal.String
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'path_beg'    Literal.String
+' '           Text.Whitespace
+'/api'        Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'||'          Literal.String
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'path_beg'    Literal.String
+' '           Text.Whitespace
+'/v2'         Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'cache'       Keyword
+' '           Text.Whitespace
+'cache'       Name.Namespace
+'\n\t'        Text.Whitespace
+'total-max-size' Literal.String
+' '           Text.Whitespace
+'200'         Literal.Number
+'\n\t'        Text.Whitespace
+'max-object-size' Literal.String
+' '           Text.Whitespace
+'10485760'    Literal.Number
+'\n\t'        Text.Whitespace
+'max-age'     Literal.String
+' '           Text.Whitespace
+'3600'        Literal.Number
+'\n\t'        Text.Whitespace
+'process-vary' Literal.String
+' '           Text.Whitespace
+'on'          Name.Constant
+'\n\n'        Text.Whitespace
+
+'backend'     Keyword
+' '           Text.Whitespace
+'app1'        Name.Namespace
+'\n\t'        Text.Whitespace
+'balance'     Name.Attribute
+' '           Text.Whitespace
+'random'      Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'abortonclose' Name.Builtin
+'\n\t'        Text.Whitespace
+'cookie'      Name.Attribute
+' '           Text.Whitespace
+'app1'        Literal.String
+' '           Text.Whitespace
+'insert'      Literal.String
+' '           Text.Whitespace
+'indirect'    Literal.String
+' '           Text.Whitespace
+'nocache'     Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'httpchk'     Name.Builtin
+'\n\t'        Text.Whitespace
+'http-check'  Name.Attribute
+' '           Text.Whitespace
+'send'        Literal.String
+' '           Text.Whitespace
+'meth'        Literal.String
+' '           Text.Whitespace
+'GET'         Literal.String
+' '           Text.Whitespace
+'uri'         Literal.String
+' '           Text.Whitespace
+'/'           Literal.String
+' '           Text.Whitespace
+'ver'         Literal.String
+' '           Text.Whitespace
+'HTTP/1.1'    Literal.String
+' '           Text.Whitespace
+'hdr'         Literal.String
+' '           Text.Whitespace
+'host'        Literal.String
+' '           Text.Whitespace
+'svc1.example.com' Literal.String
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'srv1'        Literal.String
+' '           Text.Whitespace
+'192.0'       Literal.Number
+'.2.1:80'     Literal.String
+' '           Text.Whitespace
+'cookie'      Name.Attribute
+' '           Text.Whitespace
+'s1'          Literal.String
+' '           Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'100'         Literal.Number
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'srv2'        Literal.String
+' '           Text.Whitespace
+'192.0'       Literal.Number
+'.2.2:80'     Literal.String
+' '           Text.Whitespace
+'cookie'      Name.Attribute
+' '           Text.Whitespace
+'s2'          Literal.String
+' '           Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'100'         Literal.Number
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'srv3'        Literal.String
+' '           Text.Whitespace
+'192.0'       Literal.Number
+'.2.3:80'     Literal.String
+' '           Text.Whitespace
+'cookie'      Name.Attribute
+' '           Text.Whitespace
+'s3'          Literal.String
+' '           Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'100'         Literal.Number
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'srv4'        Literal.String
+' '           Text.Whitespace
+'192.0'       Literal.Number
+'.2.4:80'     Literal.String
+' '           Text.Whitespace
+'cookie'      Name.Attribute
+' '           Text.Whitespace
+'s4'          Literal.String
+' '           Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'100'         Literal.Number
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\n'        Text.Whitespace
+
+'backend'     Keyword
+' '           Text.Whitespace
+'static'      Name.Namespace
+'\n\t'        Text.Whitespace
+'mode'        Name.Attribute
+' '           Text.Whitespace
+'http'        Literal.String
+'\n\t'        Text.Whitespace
+'balance'     Name.Attribute
+' '           Text.Whitespace
+'roundrobin'  Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'prefer-last-server' Name.Builtin
+'\n\t'        Text.Whitespace
+'retries'     Name.Attribute
+' '           Text.Whitespace
+'2'           Literal.Number
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'redispatch'  Name.Builtin
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'connect'     Name.Builtin
+' '           Text.Whitespace
+'5s'          Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'5s'          Literal.Number
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'httpchk'     Name.Builtin
+' '           Text.Whitespace
+'HEAD'        Literal.String
+' '           Text.Whitespace
+'/favicon.ico' Literal.String
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'statsrv1'    Literal.String
+' '           Text.Whitespace
+'192.168'     Literal.Number
+'.1.8:80'     Literal.String
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1000'        Literal.Number
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'statsrv2'    Literal.String
+' '           Text.Whitespace
+'192.168'     Literal.Number
+'.1.9:80'     Literal.String
+' '           Text.Whitespace
+'check'       Name.Builtin
+' '           Text.Whitespace
+'inter'       Literal.String
+' '           Text.Whitespace
+'1000'        Literal.Number
+'\n\n'        Text.Whitespace
+
+'listen'      Keyword
+' '           Text.Whitespace
+'health-check' Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':9000'       Literal.Number
+'\n\t'        Text.Whitespace
+'mode'        Name.Attribute
+' '           Text.Whitespace
+'http'        Literal.String
+'\n\t'        Text.Whitespace
+'monitor-uri' Name.Attribute
+' '           Text.Whitespace
+'/health'     Literal.String
+'\n\t'        Text.Whitespace
+'option'      Name.Attribute
+' '           Text.Whitespace
+'httplog'     Name.Builtin
+'\n\t'        Text.Whitespace
+'server'      Name.Attribute
+' '           Text.Whitespace
+'local'       Literal.String
+' '           Text.Whitespace
+'127.0'       Literal.Number
+'.0.1:8080'   Literal.String
+' '           Text.Whitespace
+'check'       Name.Builtin
+'\n\n'        Text.Whitespace
+
+'resolvers'   Keyword
+' '           Text.Whitespace
+'mydns'       Name.Namespace
+'\n\t'        Text.Whitespace
+'nameserver'  Name.Attribute
+' '           Text.Whitespace
+'dns1'        Literal.String
+' '           Text.Whitespace
+'10.0'        Literal.Number
+'.0.1:53'     Literal.String
+'\n\t'        Text.Whitespace
+'nameserver'  Name.Attribute
+' '           Text.Whitespace
+'dns2'        Literal.String
+' '           Text.Whitespace
+'10.0'        Literal.Number
+'.0.2:53'     Literal.String
+'\n\t'        Text.Whitespace
+'resolve_retries' Literal.String
+' '           Text.Whitespace
+'3'           Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'resolve'     Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'retry'       Literal.String
+' '           Text.Whitespace
+'1s'          Literal.Number
+'\n\t'        Text.Whitespace
+'hold'        Literal.String
+' '           Text.Whitespace
+'valid'       Literal.String
+' '           Text.Whitespace
+'10s'         Literal.Number
+'\n\n'        Text.Whitespace
+
+'peers'       Keyword
+' '           Text.Whitespace
+'mypeers'     Name.Namespace
+'\n\t'        Text.Whitespace
+'peer'        Literal.String
+' '           Text.Whitespace
+'haproxy1'    Literal.String
+' '           Text.Whitespace
+'192.168'     Literal.Number
+'.1.1:1024'   Literal.String
+'\n\t'        Text.Whitespace
+'peer'        Literal.String
+' '           Text.Whitespace
+'haproxy2'    Literal.String
+' '           Text.Whitespace
+'192.168'     Literal.Number
+'.1.2:1024'   Literal.String
+'\n\n'        Text.Whitespace
+
+'userlist'    Keyword
+' '           Text.Whitespace
+'myusers'     Name.Namespace
+'\n\t'        Text.Whitespace
+'group'       Literal.String
+' '           Text.Whitespace
+'admins'      Literal.String
+' '           Text.Whitespace
+'users'       Literal.String
+' '           Text.Whitespace
+'admin'       Literal.String
+'\n\t'        Text.Whitespace
+'user'        Literal.String
+' '           Text.Whitespace
+'admin'       Literal.String
+' '           Text.Whitespace
+'insecure-password' Literal.String
+' '           Text.Whitespace
+'changeme'    Literal.String
+'\n\t'        Text.Whitespace
+'user'        Literal.String
+' '           Text.Whitespace
+'guest'       Literal.String
+' '           Text.Whitespace
+'insecure-password' Literal.String
+' '           Text.Whitespace
+'guest'       Literal.String
+'\n\n'        Text.Whitespace
+
+'.notice'     Comment.Preproc
+' '           Text.Whitespace
+"'Configuration loaded successfully'" Literal.String
+'\n\n'        Text.Whitespace
+
+'# Environment variable usage' Comment.Single
+'\n'          Text.Whitespace
+
+'# bind :${HAPROXY_PORT}' Comment.Single
+'\n'          Text.Whitespace
+
+'# server app1 ${APP_HOST}:${APP_PORT} check' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/haproxy/test_comments.txt
+++ b/tests/snippets/haproxy/test_comments.txt
@@ -1,0 +1,15 @@
+---input---
+# this is a comment
+global
+	daemon # inline comment
+
+---tokens---
+'# this is a comment' Comment.Single
+'\n'          Text.Whitespace
+
+'global'      Keyword
+'\n\t'        Text.Whitespace
+'daemon'      Literal.String
+' '           Text.Whitespace
+'# inline comment' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/haproxy/test_inline_acl.txt
+++ b/tests/snippets/haproxy/test_inline_acl.txt
@@ -1,0 +1,25 @@
+---input---
+frontend web
+	use_backend app if { hdr_beg(host) -i api }
+
+---tokens---
+'frontend'    Keyword
+' '           Text.Whitespace
+'web'         Name.Namespace
+'\n\t'        Text.Whitespace
+'use_backend' Name.Attribute
+' '           Text.Whitespace
+'app'         Literal.String
+' '           Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'hdr_beg(host)' Literal.String
+' '           Text.Whitespace
+'-i'          Operator
+' '           Text.Whitespace
+'api'         Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/haproxy/test_preprocessor.txt
+++ b/tests/snippets/haproxy/test_preprocessor.txt
@@ -1,0 +1,39 @@
+---input---
+.if feature(QUIC)
+	bind quic4@:443
+.elif defined(USE_SSL)
+	bind :443 ssl
+.else
+	bind :80
+.endif
+
+---tokens---
+'.if'         Comment.Preproc
+' '           Text.Whitespace
+'feature(QUIC)' Comment.Preproc
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+'quic4@:443'  Literal.String
+'\n'          Text.Whitespace
+
+'.elif'       Comment.Preproc
+' '           Text.Whitespace
+'defined(USE_SSL)' Comment.Preproc
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':443'        Literal.Number
+' '           Text.Whitespace
+'ssl'         Literal.String
+'\n'          Text.Whitespace
+
+'.else'       Comment.Preproc
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':80'         Literal.Number
+'\n'          Text.Whitespace
+
+'.endif'      Comment.Preproc
+'\n'          Text.Whitespace

--- a/tests/snippets/haproxy/test_sections.txt
+++ b/tests/snippets/haproxy/test_sections.txt
@@ -1,0 +1,57 @@
+---input---
+global
+	daemon
+
+defaults http
+	mode http
+
+frontend web
+	bind :80
+
+backend app
+	balance roundrobin
+
+listen health
+	bind :9000
+
+---tokens---
+'global'      Keyword
+'\n\t'        Text.Whitespace
+'daemon'      Literal.String
+'\n\n'        Text.Whitespace
+
+'defaults'    Keyword
+' '           Text.Whitespace
+'http'        Name.Namespace
+'\n\t'        Text.Whitespace
+'mode'        Name.Attribute
+' '           Text.Whitespace
+'http'        Literal.String
+'\n\n'        Text.Whitespace
+
+'frontend'    Keyword
+' '           Text.Whitespace
+'web'         Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':80'         Literal.Number
+'\n\n'        Text.Whitespace
+
+'backend'     Keyword
+' '           Text.Whitespace
+'app'         Name.Namespace
+'\n\t'        Text.Whitespace
+'balance'     Name.Attribute
+' '           Text.Whitespace
+'roundrobin'  Literal.String
+'\n\n'        Text.Whitespace
+
+'listen'      Keyword
+' '           Text.Whitespace
+'health'      Name.Namespace
+'\n\t'        Text.Whitespace
+'bind'        Name.Attribute
+' '           Text.Whitespace
+':9000'       Literal.Number
+'\n'          Text.Whitespace

--- a/tests/snippets/haproxy/test_strings_and_numbers.txt
+++ b/tests/snippets/haproxy/test_strings_and_numbers.txt
@@ -1,0 +1,34 @@
+---input---
+global
+	timeout connect 5s
+	maxconn 10000
+	hard-stop-after 5m
+	http-after-response set-header Strict-Transport-Security "max-age=31536000"
+
+---tokens---
+'global'      Keyword
+'\n\t'        Text.Whitespace
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'connect'     Name.Builtin
+' '           Text.Whitespace
+'5s'          Literal.Number
+'\n\t'        Text.Whitespace
+'maxconn'     Name.Attribute
+' '           Text.Whitespace
+'10000'       Literal.Number
+'\n\t'        Text.Whitespace
+'hard-stop-after' Literal.String
+' '           Text.Whitespace
+'5m'          Literal.Number
+'\n\t'        Text.Whitespace
+'http-after-response' Name.Attribute
+' '           Text.Whitespace
+'set-header'  Literal.String
+' '           Text.Whitespace
+'Strict-Transport-Security' Literal.String
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'max-age=31536000' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace


### PR DESCRIPTION
HAProxy is one of the most widely used open-source reverse proxies and load balancers. The new `HAProxyLexer` (alias `haproxy`, matching `haproxy.cfg`) covers the full configuration syntax: section headers (`global`, `frontend`, `backend`, `listen`, `defaults`, `resolvers`, `peers`, etc.), directive keywords, preprocessor conditionals (`.if`/`.elif`/`.else`/`.endif`), inline ACL expressions (`{ ... }`), quoted strings with escape sequences, numeric values with time and size suffixes (`30s`, `10m`, `4k`), environment variable expansion (`${VAR}`), IP address literals, and ACL flags (`-i`, `-m`). An `analyse_text` heuristic is included so configs can be auto-detected without requiring an explicit lexer name.

The lexer was built against the official HAProxy configuration documentation:
- [Configuration Manual](https://docs.haproxy.org/3.1/configuration.html)
- [Management Guide](https://docs.haproxy.org/3.1/management.html)
- [HAProxy Starter Guide](https://docs.haproxy.org/3.1/intro.html)