### PR TITLE
Fix: C/C++ lexer support for preprocessor multiline comment

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -184,12 +184,12 @@ class CFamilyLexer(RegexLexer):
             (r'\\', String),  # stray backslash
         ],
         'macro': [
-            (r'('+_ws1+r')(include)('+_ws1+r')("[^"]+")([^\n]*)',
+            (r'('+_ws1+r')(include)('+_ws1+r')("[^"]+"|<[^>]+>)([^\S\n]*)([^/\n]*/[*](.|\n)*?[*]/)',
                 bygroups(using(this), Comment.Preproc, using(this),
-                         Comment.PreprocFile, Comment.Single)),
-            (r'('+_ws1+r')(include)('+_ws1+r')(<[^>]+>)([^\n]*)',
+                         Comment.PreprocFile, using(this), Comment.Multiline)),
+            (r'('+_ws1+r')(include)('+_ws1+r')("[^"]+"|<[^>]+>)([^\S\n]*)([^\n]*)',
                 bygroups(using(this), Comment.Preproc, using(this),
-                         Comment.PreprocFile, Comment.Single)),
+                         Comment.PreprocFile, using(this), Comment.Single)),
             (r'[^/\n]+', Comment.Preproc),
             (r'/[*](.|\n)*?[*]/', Comment.Multiline),
             (r'//.*?\n', Comment.Single, '#pop'),

--- a/tests/snippets/c/test_preproc_comments.txt
+++ b/tests/snippets/c/test_preproc_comments.txt
@@ -1,0 +1,120 @@
+Everything that follows an include directive, up to the end of the line or 
+potentially further for multi-line comments, is ignored by a C/C++ compiler
+and tokenized as 'comment' by the lexer.
+
+---input---
+#include <plain_include.h>
+#include "with_spaces_before_new_line.h"     
+#include <file1.h>  compiler-ignored text
+#include <file2.h>  // single-line comment
+#include <file2.h>   /* multi-line comment on single line */
+#include <file3.h>   /* multi-line comment on
+                        multiple lines */
+#include <file4.h>  compiler-ignored text // with single-line comment
+#include <file5.h>  compiler-ignored text  /* with multi-line comment on
+                                             multiple lines */
+#include <other_plain_include.h>
+
+void dummy_function_to_ensure_lexer_goes_back_to_root_state_after_the_above(char a, int b, float c) {
+    return;
+}
+
+---tokens---
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<plain_include.h>' Comment.PreprocFile
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'"with_spaces_before_new_line.h"' Comment.PreprocFile
+'     '       Text.Whitespace
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file1.h>'   Comment.PreprocFile
+'  '          Text.Whitespace
+'compiler-ignored text' Comment.Single
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file2.h>'   Comment.PreprocFile
+'  '          Text.Whitespace
+'// single-line comment' Comment.Single
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file2.h>'   Comment.PreprocFile
+'   '         Text.Whitespace
+'/* multi-line comment on single line */' Comment.Multiline
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file3.h>'   Comment.PreprocFile
+'   '         Text.Whitespace
+'/* multi-line comment on\n                        multiple lines */' Comment.Multiline
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file4.h>'   Comment.PreprocFile
+'  '          Text.Whitespace
+'compiler-ignored text // with single-line comment' Comment.Single
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<file5.h>'   Comment.PreprocFile
+'  '          Text.Whitespace
+'compiler-ignored text  /* with multi-line comment on\n                                             multiple lines */' Comment.Multiline
+'\n'          Comment.Preproc
+
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<other_plain_include.h>' Comment.PreprocFile
+'\n'          Comment.Preproc
+
+'\n'          Text.Whitespace
+
+'void'        Keyword.Type
+' '           Text.Whitespace
+'dummy_function_to_ensure_lexer_goes_back_to_root_state_after_the_above' Name.Function
+'('           Punctuation
+'char'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+','           Punctuation
+' '           Text.Whitespace
+'float'       Keyword.Type
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/c/test_preproc_comments.txt
+++ b/tests/snippets/c/test_preproc_comments.txt
@@ -15,7 +15,7 @@ and tokenized as 'comment' by the lexer.
                                              multiple lines */
 #include <other_plain_include.h>
 
-void dummy_function_to_ensure_lexer_goes_back_to_root_state_after_the_above(char a, int b, float c) {
+void lexer_must_be_in_a_proper_state_to_emit_this_as_a_Function_token(char a, int b, float c) {
     return;
 }
 
@@ -91,7 +91,7 @@ void dummy_function_to_ensure_lexer_goes_back_to_root_state_after_the_above(char
 
 'void'        Keyword.Type
 ' '           Text.Whitespace
-'dummy_function_to_ensure_lexer_goes_back_to_root_state_after_the_above' Name.Function
+'lexer_must_be_in_a_proper_state_to_emit_this_as_a_Function_token' Name.Function
 '('           Punctuation
 'char'        Keyword.Type
 ' '           Text.Whitespace


### PR DESCRIPTION
# Issue 

Current C/C++ lexers behavior is to treat everything that follows an `#include <file>` directive as comments, even when it's not written as a proper C/C++ comment. This makes sense since a compiler would simply ignore such text and this is a comment for practical purposes.

But when this is a proper multi-line comment, the lexer processes the second line (and others if any) in a `statement` state instead of a continuing comment, and emits various incorrect tokens, depending on the comment content. 

For example:

```c
#include <file1.h>   // Correct: rest of the line, including leading whitespaces, is tokenized as a comment
#include <file2.h>   Correct: this is returned as a comment too, even without the leading double-slash.
#include <file3.h>   /* Incorrect: this line returned as a comment, but
                                 this line gets processed as a statement */
```

The last line yields:

```text
'#'           Comment.Preproc
'include'     Comment.Preproc
' '           Text.Whitespace
'<file3.h>'   Comment.PreprocFile
'   /* Incorrect: this line returned as a comment, but' Comment.Single
'\n'          Comment.Preproc

'                                 ' Text.Whitespace
'this'        Name
' '           Text.Whitespace
'line'        Name
' '           Text.Whitespace
'gets'        Name
' '           Text.Whitespace
'processed'   Name
' '           Text.Whitespace
'as'          Name
' '           Text.Whitespace
'a'           Name
' '           Text.Whitespace
'statement'   Name
' '           Text.Whitespace
'*'           Operator
'/'           Operator
'\n'          Text.Whitespace
```

Also after such failure, the lexer may also remain in `statement` state for the rest of the program to parse, thus failing to identify functions as `Function` tokens (rather emits the more generic `Name` token).


# Expected Behavior

Full comment is returned from the lexer as a single token, as with comments appearing elsewhere in the code, and lexer internally returns to `root` state afterwards.


# Proposed Changes

Fix: parse `/* ... */`  as a `Comment.Multiline`
- Also handle a valid C/C++ code corner case: text between the include directive and the proper comment is included in the comment, as it is ignored by the compiler as well. For example:
    ```c
    #include <file.h>  Some text here /* followed by a multi-line
                                    comment is valid code */
    ```
  returns `"Some text here /* followed by multi-line\n            comment is valid code */"` as a `Comment.Multiline`
- Merge `"file"` and `<file>` cases in regex to avoid combinatory rules duplication

Other consistency change:
- To align with `Comment` tokens from elsewhere in the code, leading whitespaces (i.e. between `#include <file>` and the comment) are now returned as a single `Text.Whitespace` token, followed by `Comment.Single` (or `Multiline`). 
  - Does not make much difference when coloring/formatting text as those are whitespaces, but can be less confusing for a `Filter` or other automated token processing.

