### PR TITLE
Improve architecture parsing in 'Debian control' lexer

### DIFF
--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -343,7 +343,7 @@ class DebianControlLexer(RegexLexer):
             (r'\n', Whitespace, '#pop'),
             (r'[,\s]', Text),
             (r'[+.a-zA-Z0-9-]+', Name.Function),
-            (r'\[.*?\]', Name.Entity),
+            (r'(\[)(!?)(.*?)(\])', bygroups(Punctuation, Operator, Name.Entity, Punctuation)),
         ],
         'package_list_vers': [
             (r'\)', Punctuation, '#pop'),

--- a/tests/examplefiles/control/control
+++ b/tests/examplefiles/control/control
@@ -23,7 +23,7 @@ Pre-Depends:
  p1 | p2
 Depends:
  python3-bar,
- p1 | p2,
+ p1 [amd64] | p2 [!riscv64],
  otherdependancies,
  ${python3:Depends}
 Provides: x-terminal-emulator

--- a/tests/examplefiles/control/control.output
+++ b/tests/examplefiles/control/control.output
@@ -138,9 +138,18 @@
 '\n '         Text.Whitespace
 'p1'          Name.Function
 ' '           Text
+'['           Punctuation
+'amd64'       Name.Entity
+']'           Punctuation
+' '           Text
 '|'           Operator
 ' '           Text
 'p2'          Name.Function
+' '           Text
+'['           Punctuation
+'!'           Operator
+'riscv64'     Name.Entity
+']'           Punctuation
 ','           Text
 '\n '         Text.Whitespace
 'otherdependancies' Name.Function


### PR DESCRIPTION
The dependancy fields accept specification of architectures and forbidden architectures. For examples:
- `Depends: foo [i386], bar [amd64]`
- `Build-Depends: foo [!i386] | bar [!amd64]`

The regexp modification splits the '[]' characters, the optional '!' and the architecture names.

The examples are copied from Debian Policy documentation: https://www.debian.org/doc/debian-policy/ch-relationships.html