### PR TITLE
Add PureScript lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -411,6 +411,7 @@ LEXERS = {
     'PtxLexer': ('pygments.lexers.ptx', 'PTX', ('ptx',), ('*.ptx',), ('text/x-ptx',)),
     'PugLexer': ('pygments.lexers.html', 'Pug', ('pug', 'jade'), ('*.pug', '*.jade'), ('text/x-pug', 'text/x-jade')),
     'PuppetLexer': ('pygments.lexers.dsls', 'Puppet', ('puppet',), ('*.pp',), ()),
+    'PureScriptLexer': ('pygments.lexers.purescript', 'PureScript', ('purescript', 'purs'), ('*.purs',), ('text/x-purescript',)),
     'PyPyLogLexer': ('pygments.lexers.console', 'PyPy Log', ('pypylog', 'pypy'), ('*.pypylog',), ('application/x-pypylog',)),
     'Python2Lexer': ('pygments.lexers.python', 'Python 2.x', ('python2', 'py2'), (), ('text/x-python2', 'application/x-python2')),
     'Python2TracebackLexer': ('pygments.lexers.python', 'Python 2.x Traceback', ('py2tb',), ('*.py2tb',), ('text/x-python2-traceback',)),

--- a/pygments/lexers/purescript.py
+++ b/pygments/lexers/purescript.py
@@ -1,0 +1,154 @@
+"""
+    pygments.lexers.purescript
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the PureScript language.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, default
+from pygments.token import Comment, Operator, Keyword, Name, String, \
+    Number, Punctuation, Whitespace
+from pygments import unistring as uni
+
+__all__ = ['PureScriptLexer']
+
+
+class PureScriptLexer(RegexLexer):
+    """
+    A lexer for the PureScript language.
+    """
+    name = 'PureScript'
+    url = 'https://www.purescript.org/'
+    aliases = ['purescript', 'purs']
+    filenames = ['*.purs']
+    mimetypes = ['text/x-purescript']
+    version_added = '2.19'
+
+    reserved = ('ado', 'case', 'class', 'data', 'derive', 'do', 'else',
+                'false', 'forall', 'foreign', 'if', 'in', 'infix[lr]?',
+                'instance', 'let', 'newtype', 'of',
+                'then', 'true', 'type', 'where', '_')
+
+    tokens = {
+        'root': [
+            # Whitespace
+            (r'\s+', Whitespace),
+            # Single-line comments
+            (r'--.*?$', Comment.Single),
+            # Multi-line comments
+            (r'\{-', Comment.Multiline, 'comment'),
+            # Lexemes:
+            #  Identifiers
+            (r"\bimport(?!')\b", Keyword.Reserved, 'import'),
+            (r"\bmodule(?!')\b", Keyword.Reserved, 'module'),
+            (r'\b({})(?!\')\b'.format('|'.join(reserved)), Keyword.Reserved),
+            # Typed holes
+            (r'\?\w[\w\']*', Name.Variable),
+            #  Character literal (before names to avoid confusion)
+            (r"'[^\\]'", String.Char),
+            #  Identifiers
+            (r'^[_' + uni.Ll + r'][\w\']*', Name.Function),
+            (r"[_" + uni.Ll + r"][\w']*", Name),
+            (r'[' + uni.Lu + r'][\w\']*', Keyword.Type),
+            #  Backtick operator
+            (r'`', Punctuation),
+            #  Operators
+            (r'\\(?![' + uni.Sm + uni.So + uni.Sc +
+             r':!#$%&*+.\\/<=>?@^|~-]+)', Name.Function),  # lambda
+            # Unicode operators
+            (r'[∀→←⇒∷]', Operator.Word),
+            (r'(<-|::|->|=>|=)(?![' + uni.Sm + uni.So + uni.Sc +
+             r':!#$%&*+.\\/<=>?@^|~-]+)', Operator.Word),
+            (r':[' + uni.Sm + uni.So + uni.Sc +
+             r':!#$%&*+.\\/<=>?@^|~-]*', Keyword.Type),  # Constructor operators
+            (r'[' + uni.Sm + uni.So + uni.Sc +
+             r':!#$%&*+.\\/<=>?@^|~-]+', Operator),  # Other operators
+            #  Numbers
+            (r'\d(_*\d)*_*e[+-]?\d(_*\d)*', Number.Float),
+            (r'\d(_*\d)*\.\d(_*\d)*(_*e[+-]?\d(_*\d)*)?', Number.Float),
+            (r'0x[\da-fA-F]+', Number.Hex),
+            (r'\d(_*\d)*', Number.Integer),
+            #  Character/String Literals
+            (r"'", String.Char, 'character'),
+            (r'"""', String, 'rawstring'),
+            (r'"', String, 'string'),
+            #  Special
+            (r'[][(),;{}]', Punctuation),
+        ],
+        'import': [
+            (r'\s+', Whitespace),
+            # import X as Y
+            (r'([' + uni.Lu + r'][\w.]*)(\s+)(as)(\s+)([' + uni.Lu + r'][\w.]*)',
+             bygroups(Name.Namespace, Whitespace, Keyword, Whitespace, Name),
+             '#pop'),
+            # import X hiding (functions)
+            (r'([' + uni.Lu + r'][\w.]*)(\s+)(hiding)(\s+)(\()',
+             bygroups(Name.Namespace, Whitespace, Keyword, Whitespace,
+                      Punctuation), 'funclist'),
+            # import X (functions)
+            (r'([' + uni.Lu + r'][\w.]*)(\s+)(\()',
+             bygroups(Name.Namespace, Whitespace, Punctuation), 'funclist'),
+            # 'as' after funclist: import X (foo) as Y
+            (r'(as)(\s+)([' + uni.Lu + r'][\w.]*)',
+             bygroups(Keyword, Whitespace, Name), '#pop'),
+            # import X (bare module name, must start with uppercase)
+            (r'[' + uni.Lu + r'][\w.]*', Name.Namespace, '#pop'),
+            # pop when import is done
+            default('#pop'),
+        ],
+        'module': [
+            (r'\s+', Whitespace),
+            (r'([' + uni.Lu + r'][\w.]*)(\s+)(\()',
+             bygroups(Name.Namespace, Whitespace, Punctuation), 'funclist'),
+            (r'[' + uni.Lu + r'][\w.]*', Name.Namespace, '#pop'),
+            default('#pop'),
+        ],
+        'funclist': [
+            (r'\s+', Whitespace),
+            (r'(module)(\s+)([' + uni.Lu + r'][\w.]*)',
+             bygroups(Keyword.Reserved, Whitespace, Name.Namespace)),
+            (r"\b(class|type)(?!')\b", Keyword.Reserved),
+            (r'[' + uni.Lu + r']\w*', Keyword.Type),
+            (r'(_[\w\']+|[' + uni.Ll + r'][\w\']*)', Name.Function),
+            (r'--.*?$', Comment.Single),
+            (r'\{-', Comment.Multiline, 'comment'),
+            (r',', Punctuation),
+            (r'\.\.', Punctuation),
+            (r'[' + uni.Sm + uni.So + uni.Sc +
+             r':!#$%&*+.\\/<=>?@^|~-]+', Operator),
+            (r'\(', Punctuation, 'funclist'),
+            (r'\)', Punctuation, '#pop'),
+        ],
+        'comment': [
+            (r'[^-{}]+', Comment.Multiline),
+            (r'\{-', Comment.Multiline, '#push'),
+            (r'-\}', Comment.Multiline, '#pop'),
+            (r'[-{}]', Comment.Multiline),
+        ],
+        'character': [
+            (r"[^\\']'", String.Char, '#pop'),
+            (r"\\", String.Escape, 'escape'),
+            ("'", String.Char, '#pop'),
+        ],
+        'string': [
+            (r'[^\\"]+', String),
+            (r"\\", String.Escape, 'escape'),
+            ('"', String, '#pop'),
+        ],
+        'rawstring': [
+            (r'"""', String, '#pop'),
+            (r'[^"]+', String),
+            (r'"', String),
+        ],
+        'escape': [
+            (r'[nrt"\'\\]', String.Escape, '#pop'),
+            (r'x[\da-fA-F]{1,6}', String.Escape, '#pop'),
+            # String gaps: backslash-whitespace-backslash
+            (r'(\s+)(\\)', bygroups(Whitespace, String.Escape), '#pop'),
+            # Invalid escape: pop back so the next char is handled normally
+            default('#pop'),
+        ],
+    }

--- a/tests/examplefiles/purescript/Example.purs
+++ b/tests/examplefiles/purescript/Example.purs
@@ -1,0 +1,180 @@
+module Main where
+
+import Prelude
+
+import Data.Array (head, tail, (..), length)
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Either (Either(..))
+import Data.String as S
+import Data.Foldable (foldl, foldr)
+import Effect (Effect)
+import Effect.Console (log, logShow)
+import Data.Maybe (Maybe(..)) as M
+import Prim (class Partial)
+
+-- | A simple type alias
+type Name = String
+
+-- | A newtype wrapper
+newtype UserId = UserId Int
+
+-- | An ADT with multiple constructors
+data Shape
+  = Circle Number
+  | Rectangle Number Number
+  | Triangle Number Number Number
+
+-- | A type class
+class Area a where
+  area :: a -> Number
+
+-- | Instance for Shape
+instance Area Shape where
+  area (Circle r) = 3.14159 * r * r
+  area (Rectangle w h) = w * h
+  area (Triangle a b c) =
+    let s = (a + b + c) / 2.0
+    in sqrt (s * (s - a) * (s - b) * (s - c))
+
+-- | A derived instance
+derive instance Eq UserId
+
+-- | Foreign import
+foreign import sqrt :: Number -> Number
+
+-- | Pattern matching with case
+describe :: Shape -> String
+describe shape = case shape of
+  Circle r -> "Circle with radius " <> show r
+  Rectangle w h -> "Rectangle " <> show w <> "x" <> show h
+  Triangle _ _ _ -> "A triangle"
+
+-- | Do notation
+main :: Effect Unit
+main = do
+  let shapes = [Circle 5.0, Rectangle 3.0 4.0, Triangle 3.0 4.0 5.0]
+  log "Shapes and their areas:"
+  for_ shapes \shape -> do
+    log (describe shape)
+    logShow (area shape)
+
+-- | Ado notation
+readConfig :: Effect { host :: String, port :: Int }
+readConfig = ado
+  host <- pure "localhost"
+  port <- pure 8080
+  in { host, port }
+
+-- | Typed holes
+incomplete :: Int -> String
+incomplete x = ?todo
+
+-- | Infix declarations
+infixl 6 add as +
+infixr 5 append as <>
+
+-- | Forall
+identity :: forall a. a -> a
+identity x = x
+
+-- | Unicode operators
+identity' :: ∀ a. a → a
+identity' x = x
+
+compose :: ∀ a b c. (b → c) → (a → b) → a → c
+compose f g x = f (g x)
+
+-- | Numeric literals
+integers :: Array Int
+integers = [0, 1, 42, 1000]
+
+hexadecimals :: Array Int
+hexadecimals = [0x00, 0xFF, 0xDEAD]
+
+floats :: Array Number
+floats = [0.0, 3.14, 1.0e10, 2.5e-3, 1.0e+5]
+
+-- | String literals
+greeting :: String
+greeting = "Hello, world!\n"
+
+-- | Triple-quoted (raw) strings
+rawString :: String
+rawString = """
+  This is a raw string.
+  It can contain "quotes" without escaping.
+  And spans multiple lines.
+"""
+
+-- | Char literal
+aChar :: Char
+aChar = 'a'
+
+escapedChar :: Char
+escapedChar = '\n'
+
+-- | Record syntax
+type Config =
+  { host :: String
+  , port :: Int
+  , debug :: Boolean
+  }
+
+defaultConfig :: Config
+defaultConfig =
+  { host: "localhost"
+  , port: 8080
+  , debug: false
+  }
+
+-- | Where clause
+fibonacci :: Int -> Int
+fibonacci n = go n 0 1
+  where
+    go 0 a _ = a
+    go n' a b = go (n' - 1) b (a + b)
+
+-- | Let expression
+quadratic :: Number -> Number -> Number -> Number -> Number
+quadratic a b c x =
+  let
+    term1 = a * x * x
+    term2 = b * x
+  in
+    term1 + term2 + c
+
+-- | Guards and operators
+abs :: Int -> Int
+abs n
+  | n < 0 = -n
+  | otherwise = n
+
+-- | Multi-line comment
+{- This is a
+   multi-line comment
+   {- with nesting -}
+-}
+
+-- | Constructor operators
+data List a = Nil | Cons a (List a)
+
+infixr 6 Cons as :
+
+-- | Backtick operator usage
+divides :: Int -> Int -> Boolean
+divides a b = b `mod` a == 0
+
+-- | If-then-else
+clamp :: Int -> Int -> Int -> Int
+clamp lo hi x =
+  if x < lo then lo
+  else if x > hi then hi
+  else x
+
+-- Boolean keywords
+booleans :: Array Boolean
+booleans = [true, false]
+
+-- | Hex unicode escape in string
+unicodeStr :: String
+unicodeStr = "\x0041\x0042\x0043"

--- a/tests/examplefiles/purescript/Example.purs.output
+++ b/tests/examplefiles/purescript/Example.purs.output
@@ -1,0 +1,1382 @@
+'module'      Keyword.Reserved
+' '           Text.Whitespace
+'Main'        Name.Namespace
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Prelude'     Name.Namespace
+'\n\n'        Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Array'  Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'head'        Name.Function
+','           Punctuation
+' '           Text.Whitespace
+'tail'        Name.Function
+','           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'..'          Punctuation
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'length'      Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Maybe'  Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'Maybe'       Keyword.Type
+'('           Punctuation
+'..'          Punctuation
+')'           Punctuation
+','           Punctuation
+' '           Text.Whitespace
+'fromMaybe'   Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Either' Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'Either'      Keyword.Type
+'('           Punctuation
+'..'          Punctuation
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.String' Name.Namespace
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'S'           Name
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Foldable' Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'foldl'       Name.Function
+','           Punctuation
+' '           Text.Whitespace
+'foldr'       Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Effect'      Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'Effect'      Keyword.Type
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Effect.Console' Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'log'         Name.Function
+','           Punctuation
+' '           Text.Whitespace
+'logShow'     Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Maybe'  Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'Maybe'       Keyword.Type
+'('           Punctuation
+'..'          Punctuation
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'M'           Name
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Prim'        Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'class'       Keyword.Reserved
+' '           Text.Whitespace
+'Partial'     Keyword.Type
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | A simple type alias' Comment.Single
+'\n'          Text.Whitespace
+
+'type'        Keyword.Reserved
+' '           Text.Whitespace
+'Name'        Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | A newtype wrapper' Comment.Single
+'\n'          Text.Whitespace
+
+'newtype'     Keyword.Reserved
+' '           Text.Whitespace
+'UserId'      Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'UserId'      Keyword.Type
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | An ADT with multiple constructors' Comment.Single
+'\n'          Text.Whitespace
+
+'data'        Keyword.Reserved
+' '           Text.Whitespace
+'Shape'       Keyword.Type
+'\n  '        Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'Circle'      Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n  '        Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'Rectangle'   Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n  '        Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'Triangle'    Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | A type class' Comment.Single
+'\n'          Text.Whitespace
+
+'class'       Keyword.Reserved
+' '           Text.Whitespace
+'Area'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n  '        Text.Whitespace
+'area'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | Instance for Shape' Comment.Single
+'\n'          Text.Whitespace
+
+'instance'    Keyword.Reserved
+' '           Text.Whitespace
+'Area'        Keyword.Type
+' '           Text.Whitespace
+'Shape'       Keyword.Type
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n  '        Text.Whitespace
+'area'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'Circle'      Keyword.Type
+' '           Text.Whitespace
+'r'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'3.14159'     Literal.Number.Float
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'r'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'r'           Name
+'\n  '        Text.Whitespace
+'area'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'Rectangle'   Keyword.Type
+' '           Text.Whitespace
+'w'           Name
+' '           Text.Whitespace
+'h'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'w'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'h'           Name
+'\n  '        Text.Whitespace
+'area'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'Triangle'    Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator.Word
+'\n    '      Text.Whitespace
+'let'         Keyword.Reserved
+' '           Text.Whitespace
+'s'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'/'           Operator
+' '           Text.Whitespace
+'2.0'         Literal.Number.Float
+'\n    '      Text.Whitespace
+'in'          Keyword.Reserved
+' '           Text.Whitespace
+'sqrt'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'s'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'s'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'s'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'s'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | A derived instance' Comment.Single
+'\n'          Text.Whitespace
+
+'derive'      Keyword.Reserved
+' '           Text.Whitespace
+'instance'    Keyword.Reserved
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'UserId'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | Foreign import' Comment.Single
+'\n'          Text.Whitespace
+
+'foreign'     Keyword.Reserved
+' '           Text.Whitespace
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'sqrt'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | Pattern matching with case' Comment.Single
+'\n'          Text.Whitespace
+
+'describe'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Shape'       Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n'          Text.Whitespace
+
+'describe'    Name.Function
+' '           Text.Whitespace
+'shape'       Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'shape'       Name
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+'\n  '        Text.Whitespace
+'Circle'      Keyword.Type
+' '           Text.Whitespace
+'r'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'"'           Literal.String
+'Circle with radius ' Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'<>'          Operator
+' '           Text.Whitespace
+'show'        Name
+' '           Text.Whitespace
+'r'           Name
+'\n  '        Text.Whitespace
+'Rectangle'   Keyword.Type
+' '           Text.Whitespace
+'w'           Name
+' '           Text.Whitespace
+'h'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'"'           Literal.String
+'Rectangle '  Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'<>'          Operator
+' '           Text.Whitespace
+'show'        Name
+' '           Text.Whitespace
+'w'           Name
+' '           Text.Whitespace
+'<>'          Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'x'           Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'<>'          Operator
+' '           Text.Whitespace
+'show'        Name
+' '           Text.Whitespace
+'h'           Name
+'\n  '        Text.Whitespace
+'Triangle'    Keyword.Type
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'"'           Literal.String
+'A triangle'  Literal.String
+'"'           Literal.String
+'\n\n'        Text.Whitespace
+
+'-- | Do notation' Comment.Single
+'\n'          Text.Whitespace
+
+'main'        Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Effect'      Keyword.Type
+' '           Text.Whitespace
+'Unit'        Keyword.Type
+'\n'          Text.Whitespace
+
+'main'        Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'do'          Keyword.Reserved
+'\n  '        Text.Whitespace
+'let'         Keyword.Reserved
+' '           Text.Whitespace
+'shapes'      Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'Circle'      Keyword.Type
+' '           Text.Whitespace
+'5.0'         Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'Rectangle'   Keyword.Type
+' '           Text.Whitespace
+'3.0'         Literal.Number.Float
+' '           Text.Whitespace
+'4.0'         Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'Triangle'    Keyword.Type
+' '           Text.Whitespace
+'3.0'         Literal.Number.Float
+' '           Text.Whitespace
+'4.0'         Literal.Number.Float
+' '           Text.Whitespace
+'5.0'         Literal.Number.Float
+']'           Punctuation
+'\n  '        Text.Whitespace
+'log'         Name
+' '           Text.Whitespace
+'"'           Literal.String
+'Shapes and their areas:' Literal.String
+'"'           Literal.String
+'\n  '        Text.Whitespace
+'for_'        Name
+' '           Text.Whitespace
+'shapes'      Name
+' '           Text.Whitespace
+'\\'          Name.Function
+'shape'       Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'do'          Keyword.Reserved
+'\n    '      Text.Whitespace
+'log'         Name
+' '           Text.Whitespace
+'('           Punctuation
+'describe'    Name
+' '           Text.Whitespace
+'shape'       Name
+')'           Punctuation
+'\n    '      Text.Whitespace
+'logShow'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'area'        Name
+' '           Text.Whitespace
+'shape'       Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Ado notation' Comment.Single
+'\n'          Text.Whitespace
+
+'readConfig'  Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Effect'      Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'host'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+','           Punctuation
+' '           Text.Whitespace
+'port'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'readConfig'  Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'ado'         Keyword.Reserved
+'\n  '        Text.Whitespace
+'host'        Name
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'pure'        Name
+' '           Text.Whitespace
+'"'           Literal.String
+'localhost'   Literal.String
+'"'           Literal.String
+'\n  '        Text.Whitespace
+'port'        Name
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'pure'        Name
+' '           Text.Whitespace
+'8080'        Literal.Number.Integer
+'\n  '        Text.Whitespace
+'in'          Keyword.Reserved
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'host'        Name
+','           Punctuation
+' '           Text.Whitespace
+'port'        Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Typed holes' Comment.Single
+'\n'          Text.Whitespace
+
+'incomplete'  Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n'          Text.Whitespace
+
+'incomplete'  Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'?todo'       Name.Variable
+'\n\n'        Text.Whitespace
+
+'-- | Infix declarations' Comment.Single
+'\n'          Text.Whitespace
+
+'infixl'      Keyword.Reserved
+' '           Text.Whitespace
+'6'           Literal.Number.Integer
+' '           Text.Whitespace
+'add'         Name
+' '           Text.Whitespace
+'as'          Name
+' '           Text.Whitespace
+'+'           Operator
+'\n'          Text.Whitespace
+
+'infixr'      Keyword.Reserved
+' '           Text.Whitespace
+'5'           Literal.Number.Integer
+' '           Text.Whitespace
+'append'      Name
+' '           Text.Whitespace
+'as'          Name
+' '           Text.Whitespace
+'<>'          Operator
+'\n\n'        Text.Whitespace
+
+'-- | Forall' Comment.Single
+'\n'          Text.Whitespace
+
+'identity'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'forall'      Keyword.Reserved
+' '           Text.Whitespace
+'a'           Name
+'.'           Operator
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n'          Text.Whitespace
+
+'identity'    Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'x'           Name
+'\n\n'        Text.Whitespace
+
+'-- | Unicode operators' Comment.Single
+'\n'          Text.Whitespace
+
+"identity'"   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'∀'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'.'           Operator
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n'          Text.Whitespace
+
+"identity'"   Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'x'           Name
+'\n\n'        Text.Whitespace
+
+'compose'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'∀'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+'.'           Operator
+' '           Text.Whitespace
+'('           Punctuation
+'b'           Name
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'c'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'c'           Name
+'\n'          Text.Whitespace
+
+'compose'     Name.Function
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'g'           Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'f'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'g'           Name
+' '           Text.Whitespace
+'x'           Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Numeric literals' Comment.Single
+'\n'          Text.Whitespace
+
+'integers'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Array'       Keyword.Type
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'integers'    Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'0'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'42'          Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'1000'        Literal.Number.Integer
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'hexadecimals' Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Array'       Keyword.Type
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'hexadecimals' Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'0x00'        Literal.Number.Hex
+','           Punctuation
+' '           Text.Whitespace
+'0xFF'        Literal.Number.Hex
+','           Punctuation
+' '           Text.Whitespace
+'0xDEAD'      Literal.Number.Hex
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'floats'      Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Array'       Keyword.Type
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n'          Text.Whitespace
+
+'floats'      Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'0.0'         Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'3.14'        Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'1.0e10'      Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'2.5e-3'      Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'1.0e+5'      Literal.Number.Float
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | String literals' Comment.Single
+'\n'          Text.Whitespace
+
+'greeting'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n'          Text.Whitespace
+
+'greeting'    Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'"'           Literal.String
+'Hello, world!' Literal.String
+'\\'          Literal.String.Escape
+'n'           Literal.String.Escape
+'"'           Literal.String
+'\n\n'        Text.Whitespace
+
+'-- | Triple-quoted (raw) strings' Comment.Single
+'\n'          Text.Whitespace
+
+'rawString'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n'          Text.Whitespace
+
+'rawString'   Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'"""'         Literal.String
+'\n  This is a raw string.\n  It can contain ' Literal.String
+'"'           Literal.String
+'quotes'      Literal.String
+'"'           Literal.String
+' without escaping.\n  And spans multiple lines.\n' Literal.String
+
+'"""'         Literal.String
+'\n\n'        Text.Whitespace
+
+'-- | Char literal' Comment.Single
+'\n'          Text.Whitespace
+
+'aChar'       Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Char'        Keyword.Type
+'\n'          Text.Whitespace
+
+'aChar'       Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+"'a'"         Literal.String.Char
+'\n\n'        Text.Whitespace
+
+'escapedChar' Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Char'        Keyword.Type
+'\n'          Text.Whitespace
+
+'escapedChar' Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'\\'          Literal.String.Escape
+'n'           Literal.String.Escape
+"'"           Literal.String.Char
+'\n\n'        Text.Whitespace
+
+'-- | Record syntax' Comment.Single
+'\n'          Text.Whitespace
+
+'type'        Keyword.Reserved
+' '           Text.Whitespace
+'Config'      Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+'\n  '        Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'host'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n  '        Text.Whitespace
+','           Punctuation
+' '           Text.Whitespace
+'port'        Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n  '        Text.Whitespace
+','           Punctuation
+' '           Text.Whitespace
+'debug'       Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Boolean'     Keyword.Type
+'\n  '        Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'defaultConfig' Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Config'      Keyword.Type
+'\n'          Text.Whitespace
+
+'defaultConfig' Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+'\n  '        Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'host'        Name
+':'           Keyword.Type
+' '           Text.Whitespace
+'"'           Literal.String
+'localhost'   Literal.String
+'"'           Literal.String
+'\n  '        Text.Whitespace
+','           Punctuation
+' '           Text.Whitespace
+'port'        Name
+':'           Keyword.Type
+' '           Text.Whitespace
+'8080'        Literal.Number.Integer
+'\n  '        Text.Whitespace
+','           Punctuation
+' '           Text.Whitespace
+'debug'       Name
+':'           Keyword.Type
+' '           Text.Whitespace
+'false'       Keyword.Reserved
+'\n  '        Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Where clause' Comment.Single
+'\n'          Text.Whitespace
+
+'fibonacci'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'fibonacci'   Name.Function
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'go'          Name
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n  '        Text.Whitespace
+'where'       Keyword.Reserved
+'\n    '      Text.Whitespace
+'go'          Name
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n    '      Text.Whitespace
+'go'          Name
+' '           Text.Whitespace
+"n'"          Name
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'go'          Name
+' '           Text.Whitespace
+'('           Punctuation
+"n'"          Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'a'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Let expression' Comment.Single
+'\n'          Text.Whitespace
+
+'quadratic'   Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Number'      Keyword.Type
+'\n'          Text.Whitespace
+
+'quadratic'   Name.Function
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'c'           Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+'\n  '        Text.Whitespace
+'let'         Keyword.Reserved
+'\n    '      Text.Whitespace
+'term1'       Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'x'           Name
+'\n    '      Text.Whitespace
+'term2'       Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'x'           Name
+'\n  '        Text.Whitespace
+'in'          Keyword.Reserved
+'\n    '      Text.Whitespace
+'term1'       Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'term2'       Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'c'           Name
+'\n\n'        Text.Whitespace
+
+'-- | Guards and operators' Comment.Single
+'\n'          Text.Whitespace
+
+'abs'         Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'abs'         Name.Function
+' '           Text.Whitespace
+'n'           Name
+'\n  '        Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'-'           Operator
+'n'           Name
+'\n  '        Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'otherwise'   Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'n'           Name
+'\n\n'        Text.Whitespace
+
+'-- | Multi-line comment' Comment.Single
+'\n'          Text.Whitespace
+
+'{-'          Comment.Multiline
+' This is a\n   multi' Comment.Multiline
+'-'           Comment.Multiline
+'line comment\n   ' Comment.Multiline
+'{-'          Comment.Multiline
+' with nesting ' Comment.Multiline
+'-}'          Comment.Multiline
+'\n'          Comment.Multiline
+
+'-}'          Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'-- | Constructor operators' Comment.Single
+'\n'          Text.Whitespace
+
+'data'        Keyword.Reserved
+' '           Text.Whitespace
+'List'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'Nil'         Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'Cons'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'('           Punctuation
+'List'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+'\n\n'        Text.Whitespace
+
+'infixr'      Keyword.Reserved
+' '           Text.Whitespace
+'6'           Literal.Number.Integer
+' '           Text.Whitespace
+'Cons'        Keyword.Type
+' '           Text.Whitespace
+'as'          Name
+' '           Text.Whitespace
+':'           Keyword.Type
+'\n\n'        Text.Whitespace
+
+'-- | Backtick operator usage' Comment.Single
+'\n'          Text.Whitespace
+
+'divides'     Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Boolean'     Keyword.Type
+'\n'          Text.Whitespace
+
+'divides'     Name.Function
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'b'           Name
+' '           Text.Whitespace
+'`'           Punctuation
+'mod'         Name
+'`'           Punctuation
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n\n'        Text.Whitespace
+
+'-- | If-then-else' Comment.Single
+'\n'          Text.Whitespace
+
+'clamp'       Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'clamp'       Name.Function
+' '           Text.Whitespace
+'lo'          Name
+' '           Text.Whitespace
+'hi'          Name
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+'\n  '        Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'lo'          Name
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'lo'          Name
+'\n  '        Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'>'           Operator
+' '           Text.Whitespace
+'hi'          Name
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'hi'          Name
+'\n  '        Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+'\n\n'        Text.Whitespace
+
+'-- Boolean keywords' Comment.Single
+'\n'          Text.Whitespace
+
+'booleans'    Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Array'       Keyword.Type
+' '           Text.Whitespace
+'Boolean'     Keyword.Type
+'\n'          Text.Whitespace
+
+'booleans'    Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'['           Punctuation
+'true'        Keyword.Reserved
+','           Punctuation
+' '           Text.Whitespace
+'false'       Keyword.Reserved
+']'           Punctuation
+'\n\n'        Text.Whitespace
+
+'-- | Hex unicode escape in string' Comment.Single
+'\n'          Text.Whitespace
+
+'unicodeStr'  Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n'          Text.Whitespace
+
+'unicodeStr'  Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'"'           Literal.String
+'\\'          Literal.String.Escape
+'x0041'       Literal.String.Escape
+'\\'          Literal.String.Escape
+'x0042'       Literal.String.Escape
+'\\'          Literal.String.Escape
+'x0043'       Literal.String.Escape
+'"'           Literal.String
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_comments.txt
+++ b/tests/snippets/purescript/test_comments.txt
@@ -1,0 +1,36 @@
+---input---
+-- single line comment
+--- also a comment
+--> also a comment
+{- multi line comment -}
+{- nested {- comment -} here -}
+x -- trailing comment
+
+---tokens---
+'-- single line comment' Comment.Single
+'\n'          Text.Whitespace
+
+'--- also a comment' Comment.Single
+'\n'          Text.Whitespace
+
+'--> also a comment' Comment.Single
+'\n'          Text.Whitespace
+
+'{-'          Comment.Multiline
+' multi line comment ' Comment.Multiline
+'-}'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'{-'          Comment.Multiline
+' nested '    Comment.Multiline
+'{-'          Comment.Multiline
+' comment '   Comment.Multiline
+'-}'          Comment.Multiline
+' here '      Comment.Multiline
+'-}'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'x'           Name.Function
+' '           Text.Whitespace
+'-- trailing comment' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_holes.txt
+++ b/tests/snippets/purescript/test_holes.txt
@@ -1,0 +1,20 @@
+---input---
+f x = ?todo
+g = ?myHole
+
+---tokens---
+'f'           Name.Function
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'?todo'       Name.Variable
+'\n'          Text.Whitespace
+
+'g'           Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'?myHole'     Name.Variable
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_imports.txt
+++ b/tests/snippets/purescript/test_imports.txt
@@ -1,0 +1,72 @@
+---input---
+import Data.Maybe
+import Data.Array (head, tail)
+import Data.String as S
+import Data.List hiding (head)
+import Data.Maybe (Maybe(..)) as M
+import Prim (class Partial)
+
+---tokens---
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Maybe'  Name.Namespace
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Array'  Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'head'        Name.Function
+','           Punctuation
+' '           Text.Whitespace
+'tail'        Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.String' Name.Namespace
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'S'           Name
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.List'   Name.Namespace
+' '           Text.Whitespace
+'hiding'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'head'        Name.Function
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Data.Maybe'  Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'Maybe'       Keyword.Type
+'('           Punctuation
+'..'          Punctuation
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'M'           Name
+'\n'          Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Prim'        Name.Namespace
+' '           Text.Whitespace
+'('           Punctuation
+'class'       Keyword.Reserved
+' '           Text.Whitespace
+'Partial'     Keyword.Type
+')'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_keywords.txt
+++ b/tests/snippets/purescript/test_keywords.txt
@@ -1,0 +1,282 @@
+---input---
+module Main where
+
+import Effect.Console
+
+case true of
+  _ -> do
+    let x = 1
+    if false then x else x
+
+class Eq a where
+  eq :: a -> a -> Boolean
+
+data Maybe a = Nothing | Just a
+
+newtype Name = Name String
+
+type Alias = String
+
+derive instance eqName :: Eq Name
+
+foreign import alert :: String -> Effect Unit
+
+instance eqMaybe :: Eq a => Eq (Maybe a) where
+  eq Nothing Nothing = true
+  eq (Just a) (Just b) = eq a b
+  eq _ _ = false
+
+infixl 4 eq as ==
+
+forall a. Eq a => a -> a -> Boolean
+
+ado
+  x <- getLine
+  in x
+
+---tokens---
+'module'      Keyword.Reserved
+' '           Text.Whitespace
+'Main'        Name.Namespace
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'Effect.Console' Name.Namespace
+'\n\n'        Text.Whitespace
+
+'case'        Keyword.Reserved
+' '           Text.Whitespace
+'true'        Keyword.Reserved
+' '           Text.Whitespace
+'of'          Keyword.Reserved
+'\n  '        Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'do'          Keyword.Reserved
+'\n    '      Text.Whitespace
+'let'         Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n    '      Text.Whitespace
+'if'          Keyword.Reserved
+' '           Text.Whitespace
+'false'       Keyword.Reserved
+' '           Text.Whitespace
+'then'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'else'        Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+'\n\n'        Text.Whitespace
+
+'class'       Keyword.Reserved
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n  '        Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Boolean'     Keyword.Type
+'\n\n'        Text.Whitespace
+
+'data'        Keyword.Reserved
+' '           Text.Whitespace
+'Maybe'       Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'Nothing'     Keyword.Type
+' '           Text.Whitespace
+'|'           Operator
+' '           Text.Whitespace
+'Just'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+'\n\n'        Text.Whitespace
+
+'newtype'     Keyword.Reserved
+' '           Text.Whitespace
+'Name'        Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'Name'        Keyword.Type
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'type'        Keyword.Reserved
+' '           Text.Whitespace
+'Alias'       Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+'\n\n'        Text.Whitespace
+
+'derive'      Keyword.Reserved
+' '           Text.Whitespace
+'instance'    Keyword.Reserved
+' '           Text.Whitespace
+'eqName'      Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'Name'        Keyword.Type
+'\n\n'        Text.Whitespace
+
+'foreign'     Keyword.Reserved
+' '           Text.Whitespace
+'import'      Keyword.Reserved
+' '           Text.Whitespace
+'alert'       Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'String'      Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Effect'      Keyword.Type
+' '           Text.Whitespace
+'Unit'        Keyword.Type
+'\n\n'        Text.Whitespace
+
+'instance'    Keyword.Reserved
+' '           Text.Whitespace
+'eqMaybe'     Name
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'Maybe'       Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'where'       Keyword.Reserved
+'\n  '        Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'Nothing'     Keyword.Type
+' '           Text.Whitespace
+'Nothing'     Keyword.Type
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'true'        Keyword.Reserved
+'\n  '        Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'('           Punctuation
+'Just'        Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'('           Punctuation
+'Just'        Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'b'           Name
+'\n  '        Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'_'           Keyword.Reserved
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'false'       Keyword.Reserved
+'\n\n'        Text.Whitespace
+
+'infixl'      Keyword.Reserved
+' '           Text.Whitespace
+'4'           Literal.Number.Integer
+' '           Text.Whitespace
+'eq'          Name
+' '           Text.Whitespace
+'as'          Name
+' '           Text.Whitespace
+'=='          Operator
+'\n\n'        Text.Whitespace
+
+'forall'      Keyword.Reserved
+' '           Text.Whitespace
+'a'           Name
+'.'           Operator
+' '           Text.Whitespace
+'Eq'          Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Boolean'     Keyword.Type
+'\n\n'        Text.Whitespace
+
+'ado'         Keyword.Reserved
+'\n  '        Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'getLine'     Name
+'\n  '        Text.Whitespace
+'in'          Keyword.Reserved
+' '           Text.Whitespace
+'x'           Name
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_numbers.txt
+++ b/tests/snippets/purescript/test_numbers.txt
@@ -1,0 +1,22 @@
+---input---
+42
+0xFF
+3.14
+1.0e10
+1e-3
+
+---tokens---
+'42'          Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'0xFF'        Literal.Number.Hex
+'\n'          Text.Whitespace
+
+'3.14'        Literal.Number.Float
+'\n'          Text.Whitespace
+
+'1.0e10'      Literal.Number.Float
+'\n'          Text.Whitespace
+
+'1e-3'        Literal.Number.Float
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_operators.txt
+++ b/tests/snippets/purescript/test_operators.txt
@@ -1,0 +1,43 @@
+---input---
+a :: Int -> Int
+f = \x -> x
+a <- getLine
+a => b
+
+---tokens---
+'a'           Name.Function
+' '           Text.Whitespace
+'::'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'f'           Name.Function
+' '           Text.Whitespace
+'='           Operator.Word
+' '           Text.Whitespace
+'\\'          Name.Function
+'x'           Name
+' '           Text.Whitespace
+'->'          Operator.Word
+' '           Text.Whitespace
+'x'           Name
+'\n'          Text.Whitespace
+
+'a'           Name.Function
+' '           Text.Whitespace
+'<-'          Operator.Word
+' '           Text.Whitespace
+'getLine'     Name
+'\n'          Text.Whitespace
+
+'a'           Name.Function
+' '           Text.Whitespace
+'=>'          Operator.Word
+' '           Text.Whitespace
+'b'           Name
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_strings.txt
+++ b/tests/snippets/purescript/test_strings.txt
@@ -1,0 +1,66 @@
+---input---
+"hello world"
+"escape\n\t\\\""
+"""raw string"""
+"""raw "quotes" here"""
+'a'
+'\n'
+"\x0041"
+"hello\  \world"
+
+---tokens---
+'"'           Literal.String
+'hello world' Literal.String
+'"'           Literal.String
+'\n'          Text.Whitespace
+
+'"'           Literal.String
+'escape'      Literal.String
+'\\'          Literal.String.Escape
+'n'           Literal.String.Escape
+'\\'          Literal.String.Escape
+'t'           Literal.String.Escape
+'\\'          Literal.String.Escape
+'\\'          Literal.String.Escape
+'\\'          Literal.String.Escape
+'"'           Literal.String.Escape
+'"'           Literal.String
+'\n'          Text.Whitespace
+
+'"""'         Literal.String
+'raw string'  Literal.String
+'"""'         Literal.String
+'\n'          Text.Whitespace
+
+'"""'         Literal.String
+'raw '        Literal.String
+'"'           Literal.String
+'quotes'      Literal.String
+'"'           Literal.String
+' here'       Literal.String
+'"""'         Literal.String
+'\n'          Text.Whitespace
+
+"'a'"         Literal.String.Char
+'\n'          Text.Whitespace
+
+"'"           Literal.String.Char
+'\\'          Literal.String.Escape
+'n'           Literal.String.Escape
+"'"           Literal.String.Char
+'\n'          Text.Whitespace
+
+'"'           Literal.String
+'\\'          Literal.String.Escape
+'x0041'       Literal.String.Escape
+'"'           Literal.String
+'\n'          Text.Whitespace
+
+'"'           Literal.String
+'hello'       Literal.String
+'\\'          Literal.String.Escape
+'  '          Text.Whitespace
+'\\'          Literal.String.Escape
+'world'       Literal.String
+'"'           Literal.String
+'\n'          Text.Whitespace

--- a/tests/snippets/purescript/test_unicode.txt
+++ b/tests/snippets/purescript/test_unicode.txt
@@ -1,0 +1,39 @@
+---input---
+∀ a. a → a
+a ⇒ b
+a ∷ Int
+a ← getLine
+
+---tokens---
+'∀'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'.'           Operator
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'→'           Operator.Word
+' '           Text.Whitespace
+'a'           Name
+'\n'          Text.Whitespace
+
+'a'           Name.Function
+' '           Text.Whitespace
+'⇒'           Operator.Word
+' '           Text.Whitespace
+'b'           Name
+'\n'          Text.Whitespace
+
+'a'           Name.Function
+' '           Text.Whitespace
+'∷'           Operator.Word
+' '           Text.Whitespace
+'Int'         Keyword.Type
+'\n'          Text.Whitespace
+
+'a'           Name.Function
+' '           Text.Whitespace
+'←'           Operator.Word
+' '           Text.Whitespace
+'getLine'     Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

Add a PureScript lexer to Pygments, based on the Haskell lexer but adapted to match PureScript's actual syntax as defined in the compiler's CST lexer (`Language.PureScript.CST.Lexer`).

Addresses issue: https://github.com/pygments/pygments/issues/1077

Key differences from the Haskell lexer:
- PureScript-specific keywords (`ado`, `derive`, `forall`, `foreign`)
- Typed holes (`?name`)
- Triple-quoted raw strings (`"""..."""`)
- Unicode operator equivalents (`∀→←⇒∷`)
- No binary or octal number literals
- No Template Haskell syntax
- Simplified escape sequences (only `\n \r \t \' \" \\ \xHEX`)
- Different import syntax where the import list precedes `as`

## Tests

- 8 snippet tests covering keywords, comments, strings, numbers, operators, Unicode, imports, and typed holes
- A comprehensive example file (~180 lines) exercising modules, imports, type aliases, newtypes, ADTs, type classes, instances, derive, foreign import, pattern matching, do/ado notation, typed holes, infix declarations, forall, Unicode operators, all numeric literal formats, string/char/raw string literals, records, where clauses, let expressions, guards, nested comments, constructor operators, backtick operators, and if-then-else
- Zero Error tokens across all test inputs

## Test plan

- [x] All 8 snippet tests pass
- [x] Example file produces zero Error tokens
- [x] `uv run pytest tests/snippets/purescript/ tests/examplefiles/purescript/` passes