### PR TITLE
Update zig website url

### DIFF
--- a/pygments/lexers/zig.py
+++ b/pygments/lexers/zig.py
@@ -22,7 +22,7 @@ class ZigLexer(RegexLexer):
     grammar: https://ziglang.org/documentation/master/#Grammar
     """
     name = 'Zig'
-    url = 'http://www.ziglang.org'
+    url = 'http://ziglang.org'
     aliases = ['zig']
     filenames = ['*.zig']
     mimetypes = ['text/zig']


### PR DESCRIPTION
www.ziglang.org is not valid (needed to just be ziglang.org).