### PR TITLE
Fix ASN.1 lexer: recognize minus sign and fix range operator

### DIFF
--- a/pygments/lexers/asn1.py
+++ b/pygments/lexers/asn1.py
@@ -136,7 +136,7 @@ class Asn1Lexer(RegexLexer):
             (r'--.*$', Comment.Single),
             (r'/\*', Comment.Multiline, 'comment'),
             #  Numbers:
-            (r'\d+\.\d*([eE][-+]?\d+)?', Number.Float),
+            (r'\d+\.\d+([eE][-+]?\d+)?', Number.Float),
             (r'\d+', Number.Integer),
             # Identifier:
             (r"&?[a-z][-a-zA-Z0-9]*[a-zA-Z0-9]\b", Name.Variable),
@@ -155,7 +155,7 @@ class Asn1Lexer(RegexLexer):
             # Type identifier:
             (r"&?[A-Z][-a-zA-Z0-9]*[a-zA-Z0-9]\b", Name.Type),
             # Operators:
-            (r"(::=|\.\.\.|\.\.|\[\[|\]\]|\||\^)", Operator),
+            (r"(::=|\.\.\.|\.\.|\[\[|\]\]|\||\^|-)", Operator),
             # Punctuation:
             (r"(\.|,|\{|\}|\(|\)|\[|\])", Punctuation),
             # String:

--- a/tests/examplefiles/asn1/x509.asn1.output
+++ b/tests/examplefiles/asn1/x509.asn1.output
@@ -237,8 +237,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -345,8 +345,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -407,8 +407,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ')'           Punctuation
@@ -422,8 +422,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ')'           Punctuation
@@ -437,8 +437,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ')'           Punctuation
@@ -452,8 +452,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ')'           Punctuation
@@ -467,8 +467,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ')'           Punctuation
@@ -672,8 +672,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -702,8 +702,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -903,8 +903,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 '200'         Literal.Number.Integer
 ')'           Punctuation
 ')'           Punctuation
@@ -918,8 +918,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 '200'         Literal.Number.Integer
 ')'           Punctuation
 ')'           Punctuation
@@ -933,8 +933,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 '200'         Literal.Number.Integer
 ')'           Punctuation
 ')'           Punctuation
@@ -948,8 +948,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 '200'         Literal.Number.Integer
 ')'           Punctuation
 ')'           Punctuation
@@ -981,8 +981,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1035,8 +1035,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1244,8 +1244,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1291,8 +1291,8 @@
 'INTEGER'     Keyword.Type
 ' '           Text.Whitespace
 '('           Punctuation
-'0.'          Literal.Number.Float
-'.'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1356,8 +1356,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1412,8 +1412,8 @@
 'INTEGER'     Keyword.Type
 ' '           Text.Whitespace
 '('           Punctuation
-'0.'          Literal.Number.Float
-'.'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 '\n\n'        Text.Whitespace
@@ -1472,8 +1472,8 @@
 'INTEGER'     Keyword.Type
 ' '           Text.Whitespace
 '('           Punctuation
-'0.'          Literal.Number.Float
-'.'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 '\n\n'        Text.Whitespace
@@ -1502,8 +1502,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1713,8 +1713,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -1914,8 +1914,8 @@
 'INTEGER'     Keyword.Type
 ' '           Text.Whitespace
 '('           Punctuation
-'0.'          Literal.Number.Float
-'.'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 '\n\n'        Text.Whitespace
@@ -2027,8 +2027,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -2126,8 +2126,8 @@
 'SIZE'        Keyword.Declaration
 ' '           Text.Whitespace
 '('           Punctuation
-'1.'          Literal.Number.Float
-'.'           Punctuation
+'1'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 ' '           Text.Whitespace
@@ -2344,8 +2344,8 @@
 'INTEGER'     Keyword.Type
 ' '           Text.Whitespace
 '('           Punctuation
-'0.'          Literal.Number.Float
-'.'           Punctuation
+'0'           Literal.Number.Integer
+'..'          Operator
 'MAX'         Keyword.Constant
 ')'           Punctuation
 '\n\n'        Text.Whitespace

--- a/tests/snippets/asn1/negative-integer.txt
+++ b/tests/snippets/asn1/negative-integer.txt
@@ -1,0 +1,19 @@
+---input---
+Temperature ::= INTEGER (-50..150)  -- Temperature in Celsius
+
+---tokens---
+'Temperature' Name.Type
+' '           Text.Whitespace
+'::='         Operator
+' '           Text.Whitespace
+'INTEGER'     Keyword.Type
+' '           Text.Whitespace
+'('           Punctuation
+'-'           Operator
+'50'          Literal.Number.Integer
+'..'          Operator
+'150'         Literal.Number.Integer
+')'           Punctuation
+'  '          Text.Whitespace
+'-- Temperature in Celsius' Comment.Single
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

Fixes #3014 — the ASN.1 lexer was producing an error token for the minus sign in value constraints like `(-50..150)`.

Two issues found and fixed:

1. **Missing `-` operator**: The operator regex didn't include `-`, so a standalone minus sign (used for negation in value ranges) was not matched by any rule and produced an error token. Fix: add `-` to the operator alternation.

2. **Float regex consuming `..` range operator**: The float pattern `\d+\.\d*` allowed zero digits after the decimal point, so `50..150` was incorrectly tokenized as float `50.` + punctuation `.` + int `150` instead of int `50` + range operator `..` + int `150`. Fix: require at least one digit after the decimal point (`\d+\.\d+`).

## Test plan

- Added `tests/snippets/asn1/negative-integer.txt` covering `Temperature ::= INTEGER (-50..150)`
- Updated `tests/examplefiles/asn1/x509.asn1.output` golden file (now correctly tokenizes `..` ranges)
- All 768 snippet tests pass, all ASN.1 example file tests pass