### PR TITLE
fix(lexers): prevent ReDoS in archetype lexer GUID and ID patterns

### DIFF
--- a/pygments/lexers/archetype.py
+++ b/pygments/lexers/archetype.py
@@ -35,8 +35,8 @@ class AtomsLexer(RegexLexer):
             (r'([ \t]*)(--.*)$', bygroups(Whitespace, Comment)),
         ],
         'archetype_id': [
-            (r'([ \t]*)(([a-zA-Z]\w+(\.[a-zA-Z]\w+)*::)?[a-zA-Z]\w+(-[a-zA-Z]\w+){2}'
-             r'\.\w+[\w-]*\.v\d+(\.\d+){,2}((-[a-z]+)(\.\d+)?)?)',
+            (r'([ \t]*)(([a-zA-Z]\w{1,100}(\.[a-zA-Z]\w{1,100})*::)?[a-zA-Z]\w{1,100}(-[a-zA-Z]\w{1,100}){2}'
+             r'\.\w{1,100}[\w-]*\.v\d+(\.\d+){,2}((-[a-z]+)(\.\d+)?)?)',
              bygroups(Whitespace, Name.Decorator)),
         ],
         'date_constraints': [
@@ -293,7 +293,7 @@ class AdlLexer(AtomsLexer):
             # numbers and version ids
             (r'\d+(\.\d+)*', Literal),
             # Guids
-            (r'(\d|[a-fA-F])+(-(\d|[a-fA-F])+){3,}', Literal),
+            (r'[0-9a-fA-F]{1,36}(-[0-9a-fA-F]{1,36}){3,}', Literal),
             (r'\w+', Name.Class),
             (r'"', String, 'string'),
             (r'=', Operator),


### PR DESCRIPTION
The GUID-matching regex at line [296](https://github.com/pygments/pygments/blob/75cbbe6d5a31324dca4b74aa5ffa73e279093ecf/pygments/lexers/archetype.py#L296) uses nested repeating quantifiers  `(\d|[a-fA-F])+(-(\d|[a-fA-F])+){3,}` which causes catastrophic backtracking on crafted input. Additionally, the [`archetype_id` ](https://github.com/pygments/pygments/blob/75cbbe6d5a31324dca4b74aa5ffa73e279093ecf/pygments/lexers/archetype.py#L37)pattern's unbounded `\w+` causes O(n²) behavior when the lexer tests the pattern at every position of llong non-matching input.

**BEFORE**
```sh
python3 -c "
import time
from pygments.lexers import AdlLexer
from pygments import lex
malicious_input = 'A' * 10000 + '-'
lexer = AdlLexer()
start = time.time()
list(lex(malicious_input, lexer))
elapsed = time.time() - start
print(f'Elapsed time: {elapsed:.2f}s')
"
Elapsed time: 4.34s
```


**AFTER**

```sh
python3 -c "
import time
from pygments.lexers import AdlLexer
from pygments import lex
malicious_input = 'A' * 10000 + '-'
lexer = AdlLexer()
start = time.time()
list(lex(malicious_input, lexer))
elapsed = time.time() - start
print(f'Elapsed time: {elapsed:.2f}s')
"
Elapsed time: 0.11s
```

Issues: 
- https://github.com/pygments/pygments/issues/3058
- https://github.com/pygments/pygments/issues/3065