### PR TITLE
fix(markdown): add support for bold-italics

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -585,6 +585,10 @@ class MarkdownLexer(RegexLexer):
             (r'([^`]?)(`[^`\n]+`)', bygroups(Text, String.Backtick)),
             # warning: the following rules eat outer tags.
             # eg. **foo _bar_ baz** => foo and baz are not recognized as bold
+            # bold-italics fenced by '***'
+            (r'([^\*]?)(\*\*\*[^* \n][^*\n]*\*\*\*)', bygroups(Text, Generic.EmphStrong)),
+            # bold-italics fenced by '___'
+            (r'([^_]?)(___[^_ \n][^_\n]*___)', bygroups(Text, Generic.EmphStrong)),
             # bold fenced by '**'
             (r'([^\*]?)(\*\*[^* \n][^*\n]*\*\*)', bygroups(Text, Generic.Strong)),
             # bold fenced by '__'

--- a/tests/snippets/md/test_bold_italics_fenced_by_asterisk.txt
+++ b/tests/snippets/md/test_bold_italics_fenced_by_asterisk.txt
@@ -1,0 +1,6 @@
+---input---
+***bold italics***
+
+---tokens---
+'***bold italics***' Generic.EmphStrong
+'\n'          Text.Whitespace

--- a/tests/snippets/md/test_bold_italics_fenced_by_underscore.txt
+++ b/tests/snippets/md/test_bold_italics_fenced_by_underscore.txt
@@ -1,0 +1,6 @@
+---input---
+___bold italics___
+
+---tokens---
+'___bold italics___' Generic.EmphStrong
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

This PR adds support for bold-italics syntax (`***text***` and `___text___`) in the MarkdownLexer, using the `Generic.EmphStrong` token.

## Changes

- Added rules for `***text***` and `___text___` in the inline section of MarkdownLexer, placed before the existing bold rules to ensure proper matching
- Added test cases for both asterisk and underscore variants

## Testing

All existing markdown/md tests pass (34 tests), including the new test cases for bold-italics:
- `test_bold_italics_fenced_by_asterisk.txt`
- `test_bold_italics_fenced_by_underscore.txt`

## Related Issue

Fixes #3067