### PR TITLE
Add annotations/attributes (for C23 and C++26)

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -204,6 +204,9 @@ class CFamilyLexer(RegexLexer):
             (r'.*?\n', Comment),
         ],
         'classname': [
+            include('whitespace'),
+            # C/C++ attributes before type name
+            (r'\[\[(?=[^\[\]]*\]\])', Punctuation, 'attribute'),
             (_ident, Name.Class, '#pop'),
             # template specification
             (r'\s*(?=>)', Text, '#pop'),
@@ -215,7 +218,20 @@ class CFamilyLexer(RegexLexer):
             (_ident, Name.Constant),
             include('whitespace'),
             include('statements'),
-        ]
+        ],
+        'attribute': [
+            (r'\]\]', Punctuation, '#pop'),
+            (_ident, Name.Attribute),
+            (r'\(', Punctuation, 'attribute-args'),
+            (r'::', Punctuation),
+            (r',', Punctuation),
+            include('whitespace'),
+        ],
+        'attribute-args': [
+            (r'\)', Punctuation, '#pop'),
+            (r'\(', Punctuation, '#push'),
+            include('statements'),
+        ],
     }
 
     stdlib_types = {
@@ -299,6 +315,11 @@ class CLexer(CFamilyLexer):
     priority = 0.1
 
     tokens = {
+        'statements': [
+            # C23 attributes [[...]] — lookahead to avoid matching ObjC's [[obj msg] msg]
+            (r'\[\[(?=[^\[\]]*\]\])', Punctuation, 'attribute'),
+            inherit,
+        ],
         'keywords': [
             (words((
                 '_Alignas', '_Alignof', '_Noreturn', '_Countof', '_Generic', '_Thread_local',
@@ -359,6 +380,11 @@ class CppLexer(CFamilyLexer):
             (r'((?:[LuU]|u8)?R)(")([^\\()\s]{,16})(\()((?:.|\n)*?)(\)\3)(")',
              bygroups(String.Affix, String, String.Delimiter, String.Delimiter,
                       String, String.Delimiter, String)),
+            # C++26 annotations [[=Annotation]]
+            (r'(\[\[)(=)(' + CFamilyLexer._ident + r')',
+             bygroups(Punctuation, Punctuation, Name.Decorator), 'annotation'),
+            # C++11 attributes [[...]]
+            (r'\[\[(?=[^\[\]]*\]\])', Punctuation, 'attribute'),
             inherit,
         ],
         'root': [
@@ -370,14 +396,36 @@ class CppLexer(CFamilyLexer):
             # Offload C++ extensions, http://offload.codeplay.com/
             (r'__(offload|blockingoffload|outer)\b', Keyword.Pseudo),
         ],
-        'enumname': [
+        'classname': [
             include('whitespace'),
-            # 'enum class' and 'enum struct' C++11 support
-            (words(('class', 'struct'), suffix=r'\b'), Keyword),
+            # C++26 annotations before type name
+            (r'(\[\[)(=)(' + CFamilyLexer._ident + r')',
+             bygroups(Punctuation, Punctuation, Name.Decorator), 'annotation'),
+            # C++ attributes before type name
+            (r'\[\[(?=[^\[\]]*\]\])', Punctuation, 'attribute'),
             (CFamilyLexer._ident, Name.Class, '#pop'),
             # template specification
             (r'\s*(?=>)', Text, '#pop'),
             default('#pop')
+        ],
+        'enumname': [
+            include('whitespace'),
+            # 'enum class' and 'enum struct' C++11 support
+            (words(('class', 'struct'), suffix=r'\b'), Keyword),
+            # C++26 annotations before enum name
+            (r'(\[\[)(=)(' + CFamilyLexer._ident + r')',
+             bygroups(Punctuation, Punctuation, Name.Decorator), 'annotation'),
+            # C++ attributes before enum name
+            (r'\[\[(?=[^\[\]]*\]\])', Punctuation, 'attribute'),
+            (CFamilyLexer._ident, Name.Class, '#pop'),
+            # template specification
+            (r'\s*(?=>)', Text, '#pop'),
+            default('#pop')
+        ],
+        'attribute': [
+            (r'using\b', Keyword),
+            (r':', Punctuation),
+            inherit,
         ],
         'keywords': [
             (r'(class|concept|typename)(\s+)', bygroups(Keyword, Whitespace), 'classname'),
@@ -405,7 +453,20 @@ class CppLexer(CFamilyLexer):
             (r'inline\b', Keyword.Reserved),
             (CFamilyLexer._ident, Name.Namespace),
             include('statement')
-        ]
+        ],
+        'annotation': [
+            (r'\]\]', Punctuation, '#pop'),
+            (r'\(', Punctuation, 'annotation-args'),
+            (r'::', Punctuation),
+            (r',', Punctuation),
+            (CFamilyLexer._ident, Name.Decorator),
+            include('whitespace'),
+        ],
+        'annotation-args': [
+            (r'\)', Punctuation, '#pop'),
+            (r'\(', Punctuation, '#push'),
+            include('statements'),
+        ],
     }
 
     def analyse_text(text):

--- a/tests/examplefiles/c/attributes.c
+++ b/tests/examplefiles/c/attributes.c
@@ -1,0 +1,50 @@
+// C23 attributes
+
+[[nodiscard]] int compute(void);
+[[deprecated("use computeV2 instead")]] int computeOld(void);
+[[maybe_unused]] static int helper(void);
+
+[[noreturn]] void fatalError(const char* msg);
+
+// Vendor-specific attributes
+[[gnu::always_inline]] inline int fastAdd(int a, int b) {
+    return a + b;
+}
+
+[[gnu::cold]] void rarelyCalled(void) {}
+
+// Multiple attributes
+[[nodiscard, gnu::warn_unused_result]] int importantResult(void);
+
+// Attributes on declarations
+[[deprecated]] typedef int OldInt;
+
+// Attributes on the line above
+[[nodiscard]]
+int computeV2(void);
+
+[[gnu::always_inline]]
+inline int fastMul(int a, int b) {
+    return a * b;
+}
+
+[[deprecated("old API")]]
+void legacyInit(void);
+
+// Attribute on struct
+struct [[deprecated]] OldConfig {
+    int flags;
+};
+
+// Fallthrough in switch
+int testFallthrough(int x) {
+    switch (x) {
+    case 1:
+        x += 1;
+        [[fallthrough]];
+    case 2:
+        return x;
+    default:
+        return 0;
+    }
+}

--- a/tests/examplefiles/c/attributes.c.output
+++ b/tests/examplefiles/c/attributes.c.output
@@ -1,0 +1,359 @@
+'// C23 attributes\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'compute'     Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'deprecated'  Name.Attribute
+'('           Punctuation
+'"'           Literal.String
+'use computeV2 instead' Literal.String
+'"'           Literal.String
+')'           Punctuation
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'computeOld'  Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'maybe_unused' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'static'      Keyword
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'helper'      Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'noreturn'    Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'fatalError'  Name
+'('           Punctuation
+'const'       Keyword
+' '           Text.Whitespace
+'char'        Keyword.Type
+'*'           Operator
+' '           Text.Whitespace
+'msg'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Vendor-specific attributes\n' Comment.Single
+
+'[['          Punctuation
+'gnu'         Name.Attribute
+'::'          Punctuation
+'always_inline' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'inline'      Keyword.Reserved
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'fastAdd'     Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'b'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'gnu'         Name.Attribute
+'::'          Punctuation
+'cold'        Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'rarelyCalled' Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Multiple attributes\n' Comment.Single
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+','           Punctuation
+' '           Text.Whitespace
+'gnu'         Name.Attribute
+'::'          Punctuation
+'warn_unused_result' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'importantResult' Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Attributes on declarations\n' Comment.Single
+
+'[['          Punctuation
+'deprecated'  Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'typedef'     Keyword
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'OldInt'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Attributes on the line above\n' Comment.Single
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'computeV2'   Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'gnu'         Name.Attribute
+'::'          Punctuation
+'always_inline' Name.Attribute
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'inline'      Keyword.Reserved
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'fastMul'     Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'b'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'deprecated'  Name.Attribute
+'('           Punctuation
+'"'           Literal.String
+'old API'     Literal.String
+'"'           Literal.String
+')'           Punctuation
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'void'        Keyword.Type
+' '           Text.Whitespace
+'legacyInit'  Name
+'('           Punctuation
+'void'        Keyword.Type
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Attribute on struct\n' Comment.Single
+
+'struct'      Keyword
+' '           Text.Whitespace
+'[['          Punctuation
+'deprecated'  Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'OldConfig'   Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'flags'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Fallthrough in switch\n' Comment.Single
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'testFallthrough' Name.Function
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'switch'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'+'           Operator
+'='           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'[['          Punctuation
+'fallthrough' Name.Attribute
+']]'          Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'default'     Keyword
+':'           Operator
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/examplefiles/cpp/attributes.cpp
+++ b/tests/examplefiles/cpp/attributes.cpp
@@ -1,0 +1,87 @@
+// C++ attributes (C++11 and later)
+
+[[nodiscard]] int compute();
+[[deprecated("use computeV2 instead")]] int computeOld();
+[[maybe_unused]] static int helper();
+
+[[noreturn]] void fatalError(const char* msg);
+
+// Vendor-specific attributes
+[[gnu::always_inline]] inline int fastAdd(int a, int b) {
+    return a + b;
+}
+
+[[clang::optnone]] void debugOnly() {}
+
+// Multiple attributes
+[[nodiscard, gnu::warn_unused_result]] int importantResult();
+
+// Attribute with using prefix
+[[using gnu: always_inline, hot]] void optimizedFunc() {}
+
+// no_unique_address (C++20)
+struct CompressedPair {
+    [[no_unique_address]] int first;
+    [[no_unique_address]] int second;
+};
+
+// likely/unlikely (C++20)
+int testLikely(int x) {
+    if (x > 0) [[likely]] {
+        return x;
+    } else [[unlikely]] {
+        return -x;
+    }
+}
+
+// Fallthrough in switch
+int testFallthrough(int x) {
+    switch (x) {
+    case 1:
+        x += 1;
+        [[fallthrough]];
+    case 2:
+        return x;
+    default:
+        return 0;
+    }
+}
+
+// Attributes on the line above
+[[nodiscard]]
+int computeV2();
+
+[[gnu::always_inline]]
+inline int fastMul(int a, int b) {
+    return a * b;
+}
+
+[[deprecated("old API")]]
+void legacyInit();
+
+// C++26 annotations
+[[=Override]] void draw();
+[[=Deprecated("use draw_v2")]] void drawOld();
+[[=Contract]] int safeDivide(int a, int b);
+
+// C++26 annotations on type names
+struct [[=Serializable]] Document {
+    int id;
+};
+
+enum class [[=Debug]] Option {
+    NONE,
+    VERBOSE,
+};
+
+class [[=Immutable]] Point {
+    int x;
+    int y;
+};
+
+// Annotations on the line above
+[[=Exported]]
+void apiFunction();
+
+[[=MyLib::Cacheable]]
+int expensiveCompute(int n);

--- a/tests/examplefiles/cpp/attributes.cpp.output
+++ b/tests/examplefiles/cpp/attributes.cpp.output
@@ -1,0 +1,629 @@
+'// C++ attributes (C++11 and later)\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'compute'     Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'deprecated'  Name.Attribute
+'('           Punctuation
+'"'           Literal.String
+'use computeV2 instead' Literal.String
+'"'           Literal.String
+')'           Punctuation
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'computeOld'  Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'maybe_unused' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'static'      Keyword
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'helper'      Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'noreturn'    Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'fatalError'  Name
+'('           Punctuation
+'const'       Keyword
+' '           Text.Whitespace
+'char'        Keyword.Type
+'*'           Operator
+' '           Text.Whitespace
+'msg'         Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Vendor-specific attributes\n' Comment.Single
+
+'[['          Punctuation
+'gnu'         Name.Attribute
+':'           Punctuation
+':'           Punctuation
+'always_inline' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'inline'      Keyword.Reserved
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'fastAdd'     Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'b'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'clang'       Name.Attribute
+':'           Punctuation
+':'           Punctuation
+'optnone'     Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'debugOnly'   Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Multiple attributes\n' Comment.Single
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+','           Punctuation
+' '           Text.Whitespace
+'gnu'         Name.Attribute
+':'           Punctuation
+':'           Punctuation
+'warn_unused_result' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'importantResult' Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Attribute with using prefix\n' Comment.Single
+
+'[['          Punctuation
+'using'       Keyword
+' '           Text.Whitespace
+'gnu'         Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'always_inline' Name.Attribute
+','           Punctuation
+' '           Text.Whitespace
+'hot'         Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'optimizedFunc' Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// no_unique_address (C++20)\n' Comment.Single
+
+'struct'      Keyword
+' '           Text.Whitespace
+'CompressedPair' Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'[['          Punctuation
+'no_unique_address' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'first'       Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'[['          Punctuation
+'no_unique_address' Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'second'      Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// likely/unlikely (C++20)\n' Comment.Single
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'testLikely'  Name.Function
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'x'           Name
+' '           Text.Whitespace
+'>'           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'[['          Punctuation
+'likely'      Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+' '           Text.Whitespace
+'else'        Keyword
+' '           Text.Whitespace
+'[['          Punctuation
+'unlikely'    Name.Attribute
+']]'          Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'-'           Operator
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Fallthrough in switch\n' Comment.Single
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'testFallthrough' Name.Function
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'switch'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'+'           Operator
+'='           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'[['          Punctuation
+'fallthrough' Name.Attribute
+']]'          Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'case'        Keyword
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'default'     Keyword
+':'           Operator
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Attributes on the line above\n' Comment.Single
+
+'[['          Punctuation
+'nodiscard'   Name.Attribute
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'computeV2'   Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'gnu'         Name.Attribute
+':'           Punctuation
+':'           Punctuation
+'always_inline' Name.Attribute
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'inline'      Keyword.Reserved
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'fastMul'     Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'b'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'deprecated'  Name.Attribute
+'('           Punctuation
+'"'           Literal.String
+'old API'     Literal.String
+'"'           Literal.String
+')'           Punctuation
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'void'        Keyword.Type
+' '           Text.Whitespace
+'legacyInit'  Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// C++26 annotations\n' Comment.Single
+
+'[['          Punctuation
+'='           Punctuation
+'Override'    Name.Decorator
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'draw'        Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'='           Punctuation
+'Deprecated'  Name.Decorator
+'('           Punctuation
+'"'           Literal.String
+'use draw_v2' Literal.String
+'"'           Literal.String
+')'           Punctuation
+']]'          Punctuation
+' '           Text.Whitespace
+'void'        Keyword.Type
+' '           Text.Whitespace
+'drawOld'     Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'='           Punctuation
+'Contract'    Name.Decorator
+']]'          Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'safeDivide'  Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+','           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'b'           Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// C++26 annotations on type names\n' Comment.Single
+
+'struct'      Keyword
+' '           Text.Whitespace
+'[['          Punctuation
+'='           Punctuation
+'Serializable' Name.Decorator
+']]'          Punctuation
+' '           Text.Whitespace
+'Document'    Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'id'          Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'enum'        Keyword
+' '           Text.Whitespace
+'class'       Keyword
+' '           Text.Whitespace
+'[['          Punctuation
+'='           Punctuation
+'Debug'       Name.Decorator
+']]'          Punctuation
+' '           Text.Whitespace
+'Option'      Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'NONE'        Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'VERBOSE'     Name
+','           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'class'       Keyword
+' '           Text.Whitespace
+'[['          Punctuation
+'='           Punctuation
+'Immutable'   Name.Decorator
+']]'          Punctuation
+' '           Text.Whitespace
+'Point'       Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'y'           Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// Annotations on the line above\n' Comment.Single
+
+'[['          Punctuation
+'='           Punctuation
+'Exported'    Name.Decorator
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'void'        Keyword.Type
+' '           Text.Whitespace
+'apiFunction' Name
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'[['          Punctuation
+'='           Punctuation
+'MyLib'       Name.Decorator
+'::'          Punctuation
+'Cacheable'   Name.Decorator
+']]'          Punctuation
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'expensiveCompute' Name
+'('           Punctuation
+'int'         Keyword.Type
+' '           Text.Whitespace
+'n'           Name
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Attributes have existed since C++11, and were added to C23. Furthermore, annotations were added to C++26 with the inclusion of reflection.

Pygments currently does not support highlighting attributes on C/C++, so this pull request adds this long-needed feature as well as adds support for annotations for the upcoming C++26.