### PR TITLE
reStructuredText: dot (".") and plus ("+") are allowed in directive/role name

### DIFF
--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -207,7 +207,7 @@ class RstLexer(RegexLexer):
              r'(\n[ \t]*\n)([ \t]+)(.*)(\n)((?:(?:\8.*)?\n)+)',
              _handle_sourcecode),
             # A directive
-            (r'^( *\.\.)(\s*)([\w:-]+?)(::)(?:([ \t]*)(.*))',
+            (r'^( *\.\.)(\s*)([\w:.+-]+?)(::)(?:([ \t]*)(.*))',
              bygroups(Punctuation, Text, Operator.Word, Punctuation, Text,
                       using(this, state='inline'))),
             # A reference target
@@ -239,9 +239,9 @@ class RstLexer(RegexLexer):
             (r'(`.+?)(<.+?>)(`__?)',  # reference with inline target
              bygroups(String, String.Interpol, String)),
             (r'`.+?`__?', String),  # reference
-            (r'(`.+?`)(:[a-zA-Z0-9:-]+?:)?',
+            (r'(`.+?`)(:[a-zA-Z0-9:.+-]+?:)?',
              bygroups(Name.Variable, Name.Attribute)),  # role
-            (r'(:[a-zA-Z0-9:-]+?:)(`.+?`)',
+            (r'(:[a-zA-Z0-9:.+-]+?:)(`.+?`)',
              bygroups(Name.Attribute, Name.Variable)),  # role (content first)
             (r'\*\*.+?\*\*', Generic.Strong),  # Strong emphasis
             (r'\*.+?\*', Generic.Emph),  # Emphasis

--- a/tests/snippets/rst/test_directives.txt
+++ b/tests/snippets/rst/test_directives.txt
@@ -1,0 +1,17 @@
+---input---
+.. image:: picture.png
+   :alt: Sample
+---tokens---
+'..'          Punctuation
+' '           Text
+'image'       Operator.Word
+'::'          Punctuation
+' '           Text
+'picture.png' Text
+'\n'          Text.Whitespace
+
+'   '         Text
+':alt:'       Name.Class
+' '           Text
+'Sample'      Text
+'\n'          Text.Whitespace

--- a/tests/snippets/rst/test_headings.txt
+++ b/tests/snippets/rst/test_headings.txt
@@ -1,0 +1,32 @@
+---input---
+Title
+=====
+
+Subtitle
+--------
+
+Section
+~~~~~~~
+
+---tokens---
+'Title'       Generic.Heading
+'\n'          Text
+
+'====='       Generic.Heading
+'\n'          Text
+
+'\n'          Text.Whitespace
+
+'Subtitle'    Generic.Heading
+'\n'          Text
+
+'--------'    Generic.Heading
+'\n'          Text
+
+'\n'          Text.Whitespace
+
+'Section'     Generic.Heading
+'\n'          Text
+
+'~~~~~~~'     Generic.Heading
+'\n'          Text

--- a/tests/snippets/rst/test_roles.txt
+++ b/tests/snippets/rst/test_roles.txt
@@ -1,0 +1,22 @@
+---input---
+:doc:`document`
+
+`document`:doc:
+
+`inline reference`_
+
+---tokens---
+':doc:'       Name.Attribute
+'`document`'  Name.Variable
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'`document`'  Name.Variable
+':doc:'       Name.Attribute
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'`inline reference`_' Literal.String
+'\n'          Text.Whitespace

--- a/tests/snippets/rst/test_valid_directive_role_name.txt
+++ b/tests/snippets/rst/test_valid_directive_role_name.txt
@@ -1,0 +1,53 @@
+---input---
+.. custom-dir::
+.. custom:dir::
+.. custom.dir::
+.. custom+dir::
+
+:custom-role:`content`
+:custom:role:`content`
+:custom.role:`content`
+:custom+role:`content`
+
+---tokens---
+'..'          Punctuation
+' '           Text
+'custom-dir'  Operator.Word
+'::'          Punctuation
+'\n'          Text.Whitespace
+
+'..'          Punctuation
+' '           Text
+'custom:dir'  Operator.Word
+'::'          Punctuation
+'\n'          Text.Whitespace
+
+'..'          Punctuation
+' '           Text
+'custom.dir'  Operator.Word
+'::'          Punctuation
+'\n'          Text.Whitespace
+
+'..'          Punctuation
+' '           Text
+'custom+dir'  Operator.Word
+'::'          Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+':custom-role:' Name.Attribute
+'`content`'   Name.Variable
+'\n'          Text.Whitespace
+
+':custom:role:' Name.Attribute
+'`content`'   Name.Variable
+'\n'          Text.Whitespace
+
+':custom.role:' Name.Attribute
+'`content`'   Name.Variable
+'\n'          Text.Whitespace
+
+':custom+role:' Name.Attribute
+'`content`'   Name.Variable
+'\n'          Text.Whitespace


### PR DESCRIPTION
> Directive types are case-insensitive single words (alphanumerics plus
> isolated internal hyphens, underscores, plus signs, colons, and
> periods; no whitespace).
>
> ...
>
> A role name is a single word consisting of alphanumerics plus isolated
> internal hyphens, underscores, plus signs, colons, and periods;

ref: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#interpreted-text