### PR TITLE
Clean-out obsolete hardcoded escape_html func.

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -26,20 +26,6 @@ except ImportError:
 __all__ = ['HtmlFormatter']
 
 
-_escape_html_table = {
-    ord('&'): '&amp;',
-    ord('<'): '&lt;',
-    ord('>'): '&gt;',
-    ord('"'): '&quot;',
-    ord("'"): '&#39;',
-}
-
-
-def escape_html(text, table=_escape_html_table):
-    """Escape &, <, > as well as single and double quotes for HTML."""
-    return text.translate(table)
-
-
 def webify(color):
     if color.startswith('calc') or color.startswith('var'):
         return color
@@ -832,7 +818,7 @@ class HtmlFormatter(Formatter):
     @functools.lru_cache(maxsize=100)
     def _translate_parts(self, value):
         """HTML-escape a value and split it by newlines."""
-        return value.translate(_escape_html_table).split('\n')
+        return html_escape(value).split('\n')
 
     def _format_lines(self, tokensource):
         """

--- a/pygments/formatters/svg.py
+++ b/pygments/formatters/svg.py
@@ -10,18 +10,9 @@
 
 from pygments.formatter import Formatter
 from pygments.token import Comment
-from pygments.util import get_bool_opt, get_int_opt
+from pygments.util import get_bool_opt, get_int_opt, html_escape
 
 __all__ = ['SvgFormatter']
-
-
-def escape_html(text):
-    """Escape &, <, > as well as single and double quotes for HTML."""
-    return text.replace('&', '&amp;').  \
-                replace('<', '&lt;').   \
-                replace('>', '&gt;').   \
-                replace('"', '&quot;'). \
-                replace("'", '&#39;')
 
 
 class2style = {}
@@ -148,7 +139,7 @@ class SvgFormatter(Formatter):
             style = self._get_style(ttype)
             tspan = style and '<tspan' + style + '>' or ''
             tspanend = tspan and '</tspan>' or ''
-            value = escape_html(value)
+            value = html_escape(value)
             if self.spacehack:
                 value = value.expandtabs().replace(' ', '&#160;')
             parts = value.split('\n')

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -15,9 +15,9 @@ from os import path
 import pytest
 
 from pygments.formatters import HtmlFormatter, NullFormatter
-from pygments.formatters.html import escape_html
 from pygments.lexers import PythonLexer
 from pygments.style import Style
+from pygments.util import html_escape
 
 TESTDIR = path.dirname(path.abspath(__file__))
 TESTFILE = path.join(TESTDIR, 'test_html_formatter.py')
@@ -36,7 +36,7 @@ def test_correct_output():
     nfmt.format(tokensource, noutfile)
 
     stripped_html = re.sub('<.*?>', '', houtfile.getvalue())
-    escaped_text = escape_html(noutfile.getvalue())
+    escaped_text = html_escape(noutfile.getvalue())
     assert stripped_html == escaped_text
 
 


### PR DESCRIPTION
Hi,

According to pygments/pygments#3078 discussion, my proposal to clean-out obsolete hardcoded escape_html func. and use the one implemented in the linked PR when required.