### PR TITLE
Add a Fountain lexer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Version 2.21.0
   * BitBake (#3103)
   * CEL (#3048)
   * PureScript (#1077, #3054)
+  * Fountain
 
 - Updated lexers:
 

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -177,6 +177,7 @@ LEXERS = {
     'ForthLexer': ('pygments.lexers.forth', 'Forth', ('forth',), ('*.frt', '*.fs'), ('application/x-forth',)),
     'FortranFixedLexer': ('pygments.lexers.fortran', 'FortranFixed', ('fortranfixed',), ('*.f', '*.F'), ()),
     'FortranLexer': ('pygments.lexers.fortran', 'Fortran', ('fortran', 'f90'), ('*.f03', '*.f90', '*.F03', '*.F90'), ('text/x-fortran',)),
+    'FountainLexer': ('pygments.lexers.fountain', 'Fountain', ('fountain',), ('*.fountain', '*.spmd'), ()),
     'FoxProLexer': ('pygments.lexers.foxpro', 'FoxPro', ('foxpro', 'vfp', 'clipper', 'xbase'), ('*.PRG', '*.prg'), ()),
     'FreeFemLexer': ('pygments.lexers.freefem', 'Freefem', ('freefem',), ('*.edp',), ('text/x-freefem',)),
     'FuncLexer': ('pygments.lexers.func', 'FunC', ('func', 'fc'), ('*.fc', '*.func'), ()),

--- a/pygments/lexers/fountain.py
+++ b/pygments/lexers/fountain.py
@@ -42,9 +42,10 @@ class FountainLexer(Lexer):
         re.IGNORECASE,
     )
     _scene_number_re = re.compile(r'^(.*?)(\s*)(#[-.A-Za-z0-9]+#)$')
+    _inline_scene_number_re = re.compile(r'#[-.A-Za-z0-9]+#')
     _section_re = re.compile(r'^(#+)(\s*.*)$')
     _page_break_re = re.compile(r'^={3,}$')
-    _transition_re = re.compile(r'^[^a-z]+TO:$')
+    _transition_re = re.compile(r'^(?=[^a-z]*[A-Z])[^a-z]*TO:$')
 
     def __init__(self, **options):
         super().__init__(**options)
@@ -246,9 +247,6 @@ class FountainLexer(Lexer):
     def _is_parenthetical(self, stripped):
         return stripped.startswith('(') and stripped.endswith(')')
 
-    def _looks_like_dialogue(self, stripped):
-        return bool(stripped)
-
     def _is_character(self, lines, index, forced=False):
         line, _ = self._split_line(lines[index])
         stripped = line.strip()
@@ -266,7 +264,7 @@ class FountainLexer(Lexer):
         if not self._next_is_nonblank(lines, index):
             return False
         next_line, _ = self._split_line(lines[index + 1])
-        if not self._looks_like_dialogue(next_line.strip()):
+        if not next_line.strip():
             return False
 
         ext_index = body.find('(')
@@ -435,10 +433,11 @@ class FountainLexer(Lexer):
             if tail:
                 yield cursor, Whitespace, tail
         if dual:
-            caret_ws = dual[:-1]
-            if caret_ws:
-                yield offset + len(body), Whitespace, caret_ws
-            yield offset + len(body) + len(caret_ws), Punctuation, '^'
+            # dual[0] is always '^'; dual[1:] is any trailing whitespace
+            yield offset + len(body), Punctuation, '^'
+            trailing = dual[1:]
+            if trailing:
+                yield offset + len(body) + 1, Whitespace, trailing
 
     def _emit_parenthetical(self, line, pos):
         indent = self._indent_len(line)
@@ -525,7 +524,7 @@ class FountainLexer(Lexer):
                 i += 2
                 continue
 
-            match = re.match(r'#[-.A-Za-z0-9]+#', text[i:])
+            match = self._inline_scene_number_re.match(text, i)
             if match is not None:
                 value = match.group(0)
                 yield pos + i, Name.Label, value
@@ -533,10 +532,10 @@ class FountainLexer(Lexer):
                 continue
 
             for marker, token in (
-                ('***', Generic.Strong),
-                ('**', Generic.Strong),
-                ('*', Generic.Emph),
-                ('_', Generic.Emph),
+                ('***', Generic.EmphStrong),  # bold-italic
+                ('**', Generic.Strong),        # bold
+                ('*', Generic.Emph),           # italic
+                ('_', Generic.EmphStrong),     # underline (no dedicated token; EmphStrong is closest)
             ):
                 if text.startswith(marker, i):
                     end = self._find_emphasis_end(text, i, marker)

--- a/pygments/lexers/fountain.py
+++ b/pygments/lexers/fountain.py
@@ -1,0 +1,584 @@
+"""
+    pygments.lexers.fountain
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the Fountain screenplay format.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import Lexer
+from pygments.token import Comment, Generic, Keyword, Name, Operator, \
+    Punctuation, String, Text, Whitespace
+
+__all__ = ['FountainLexer']
+
+
+class FountainLexer(Lexer):
+    """
+    Lexer for Fountain screenplay markup.
+    """
+
+    name = 'Fountain'
+    aliases = ['fountain']
+    filenames = ['*.fountain', '*.spmd']
+    mimetypes = []
+    url = 'https://fountain.io/syntax/'
+    version_added = '2.21'
+    _example = 'fountain/example.fountain'
+
+    _title_key_re = re.compile(r'^([A-Za-z][A-Za-z ]*[A-Za-z]|[A-Za-z]):(?:[ \t].*)?$')
+    _title_start_re = re.compile(
+        r'^(title|credit|author|authors|source|draft date|contact|copyright|notes):(?:[ \t].*)?$',
+        re.IGNORECASE,
+    )
+    _title_continuation_re = re.compile(r'^(?: {3,}|\t).*$')
+    _character_name_re = re.compile(r"^[A-Z0-9 .\-()'/]+$")
+    _scene_heading_re = re.compile(
+        r'^(?:INT\./EXT|INT/EXT|INT|EXT|EST|I/E)(?:\.|\s)',
+        re.IGNORECASE,
+    )
+    _scene_number_re = re.compile(r'^(.*?)(\s*)(#[-.A-Za-z0-9]+#)$')
+    _section_re = re.compile(r'^(#+)(\s*.*)$')
+    _page_break_re = re.compile(r'^={3,}$')
+    _transition_re = re.compile(r'^[^a-z]+TO:$')
+
+    def __init__(self, **options):
+        super().__init__(**options)
+        self._in_boneyard = False
+        self._in_note = False
+
+    @staticmethod
+    def analyse_text(text):  # type: ignore[override]
+        if re.search(r'^(Title|Credit|Author|Authors|Source|Draft date|Contact):',
+                     text, re.MULTILINE):
+            return 0.3
+        if re.search(r'^(INT\.|EXT\.|EST\.|INT\./EXT\.|INT/EXT\.|I/E\.)',
+                     text, re.MULTILINE | re.IGNORECASE):
+            return 0.2
+        if re.search(r'^[A-Z0-9 .\-\'()]+\n(?:\([^\n]+\)\n)?.+',
+                     text, re.MULTILINE):
+            return 0.1
+        return 0.0
+
+    def get_tokens_unprocessed(self, text):
+        self._in_boneyard = False
+        self._in_note = False
+
+        lines = text.splitlines(True)
+        pos = 0
+        i = 0
+        in_title_page = self._starts_title_page(lines)
+        in_dialogue = False
+
+        while i < len(lines):
+            raw_line = lines[i]
+            line, newline = self._split_line(raw_line)
+            stripped = line.strip()
+
+            if self._in_boneyard or self._in_note:
+                yield from self._emit_inline(line, pos, Text)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+                pos += len(raw_line)
+                i += 1
+                continue
+
+            if in_title_page:
+                if stripped == '':
+                    in_title_page = False
+                    yield pos, Whitespace, raw_line
+                    pos += len(raw_line)
+                    i += 1
+                    continue
+                if self._is_title_entry(line, started=True) or self._is_title_continuation(line):
+                    yield from self._emit_title_line(line, pos)
+                    if newline:
+                        yield pos + len(line), Whitespace, newline
+                    pos += len(raw_line)
+                    i += 1
+                    continue
+                in_title_page = False
+
+            if in_dialogue:
+                if stripped == '':
+                    if line and line.strip() == '' and len(line) >= 2:
+                        yield pos, String, line
+                        if newline:
+                            yield pos + len(line), Whitespace, newline
+                    else:
+                        yield pos, Whitespace, raw_line
+                        in_dialogue = False
+                    pos += len(raw_line)
+                    i += 1
+                    continue
+                if self._is_parenthetical(stripped):
+                    yield from self._emit_parenthetical(line, pos)
+                else:
+                    yield from self._emit_dialogue(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+                pos += len(raw_line)
+                i += 1
+                continue
+
+            if stripped == '':
+                yield pos, Whitespace, raw_line
+            elif self._page_break_re.match(stripped):
+                yield from self._emit_simple_line(line, pos, Operator)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif stripped.startswith('>') and stripped.endswith('<') and len(stripped) >= 2:
+                yield from self._emit_centered(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif stripped.startswith('#'):
+                yield from self._emit_section(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif stripped.startswith('='):
+                yield from self._emit_simple_line(line, pos, Comment.Special)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif self._is_forced_transition(stripped):
+                yield from self._emit_transition(line, pos, forced=True)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif self._is_forced_scene_heading(stripped):
+                yield from self._emit_scene_heading(line, pos, forced=True)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif stripped.startswith('!'):
+                yield from self._emit_forced_action(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif stripped.startswith('~'):
+                yield from self._emit_lyric(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif self._is_transition(lines, i):
+                yield from self._emit_transition(line, pos, forced=False)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif self._is_scene_heading(lines, i):
+                yield from self._emit_scene_heading(line, pos, forced=False)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+            elif self._is_character(lines, i, forced=stripped.startswith('@')):
+                yield from self._emit_character(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+                in_dialogue = True
+            else:
+                yield from self._emit_action(line, pos)
+                if newline:
+                    yield pos + len(line), Whitespace, newline
+
+            pos += len(raw_line)
+            i += 1
+
+    def _split_line(self, raw_line):
+        if raw_line.endswith('\n'):
+            return raw_line[:-1], '\n'
+        return raw_line, ''
+
+    def _starts_title_page(self, lines):
+        for raw_line in lines:
+            line, _ = self._split_line(raw_line)
+            if line.strip() == '':
+                continue
+            return self._is_title_entry(line, started=False)
+        return False
+
+    def _is_title_entry(self, line, started):
+        stripped = line.strip()
+        if not self._title_key_re.match(stripped):
+            return False
+        if started:
+            return True
+        return bool(self._title_start_re.match(stripped))
+
+    def _is_title_continuation(self, line):
+        return bool(self._title_continuation_re.match(line))
+
+    def _prev_blank(self, lines, index):
+        if index == 0:
+            return True
+        prev, _ = self._split_line(lines[index - 1])
+        return prev.strip() == ''
+
+    def _next_blank(self, lines, index):
+        if index + 1 >= len(lines):
+            return True
+        nxt, _ = self._split_line(lines[index + 1])
+        return nxt.strip() == ''
+
+    def _next_is_nonblank(self, lines, index):
+        if index + 1 >= len(lines):
+            return False
+        nxt, _ = self._split_line(lines[index + 1])
+        return nxt.strip() != ''
+
+    def _has_alpha(self, text):
+        return re.search(r'[^\W\d_]', text, re.UNICODE) is not None
+
+    def _is_scene_heading(self, lines, index):
+        line, _ = self._split_line(lines[index])
+        stripped = line.strip()
+        return self._prev_blank(lines, index) and self._next_blank(lines, index) and \
+            bool(self._scene_heading_re.match(stripped))
+
+    def _is_forced_scene_heading(self, stripped):
+        return len(stripped) > 1 and stripped[0] == '.' and stripped[1].isalnum()
+
+    def _is_transition(self, lines, index):
+        line, _ = self._split_line(lines[index])
+        stripped = line.strip()
+        return self._prev_blank(lines, index) and self._next_blank(lines, index) and \
+            bool(self._transition_re.match(stripped))
+
+    def _is_forced_transition(self, stripped):
+        return stripped.startswith('>') and not stripped.endswith('<')
+
+    def _is_parenthetical(self, stripped):
+        return stripped.startswith('(') and stripped.endswith(')')
+
+    def _looks_like_dialogue(self, stripped):
+        return bool(stripped)
+
+    def _is_character(self, lines, index, forced=False):
+        line, _ = self._split_line(lines[index])
+        stripped = line.strip()
+        if not forced and not self._prev_blank(lines, index):
+            return False
+
+        body = stripped[1:] if forced and stripped.startswith('@') else stripped
+        body = body.rstrip()
+        if body.endswith('^'):
+            body = body[:-1].rstrip()
+        if not body:
+            return False
+        if self._transition_re.match(body) or self._scene_heading_re.match(body):
+            return False
+        if not self._next_is_nonblank(lines, index):
+            return False
+        next_line, _ = self._split_line(lines[index + 1])
+        if not self._looks_like_dialogue(next_line.strip()):
+            return False
+
+        ext_index = body.find('(')
+        if ext_index != -1:
+            name = body[:ext_index].rstrip()
+            ext = body[ext_index:]
+            if not re.fullmatch(r'(?:\s*\([^\n)]*\)\s*)+', ext):
+                return False
+        else:
+            name = body
+        if not name or not self._has_alpha(name):
+            return False
+        return forced or bool(self._character_name_re.fullmatch(name))
+
+    def _indent_len(self, line):
+        return len(line) - len(line.lstrip(' \t'))
+
+    def _emit_simple_line(self, line, pos, token):
+        if line:
+            yield pos, token, line
+
+    def _emit_title_line(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        if self._is_title_continuation(line):
+            yield from self._emit_inline(body, pos + indent, String)
+            return
+
+        key, _, value = body.partition(':')
+        yield pos + indent, Name.Attribute, key
+        yield pos + indent + len(key), Punctuation, ':'
+        if value:
+            if value.startswith((' ', '\t')):
+                ws_len = len(value) - len(value.lstrip(' \t'))
+                if ws_len:
+                    yield pos + indent + len(key) + 1, Whitespace, value[:ws_len]
+                yield from self._emit_inline(
+                    value[ws_len:],
+                    pos + indent + len(key) + 1 + ws_len,
+                    String,
+                )
+
+    def _emit_section(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        match = self._section_re.match(body)
+        if match is None:
+            yield from self._emit_simple_line(line, pos, Generic.Subheading)
+            return
+        hashes, rest = match.groups()
+        yield pos + indent, Punctuation, hashes
+        if rest:
+            yield from self._emit_inline(rest, pos + indent + len(hashes), Generic.Subheading)
+
+    def _emit_transition(self, line, pos, forced):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        offset = pos + indent
+        if forced:
+            yield offset, Punctuation, '>'
+            body = body[1:]
+            offset += 1
+        yield from self._emit_inline(body, offset, Keyword)
+
+    def _emit_scene_heading(self, line, pos, forced):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        offset = pos + indent
+        if forced:
+            yield offset, Punctuation, '.'
+            body = body[1:]
+            offset += 1
+
+        match = self._scene_number_re.match(body.rstrip())
+        if match:
+            heading, spaces, scene_no = match.groups()
+            yield from self._emit_inline(heading, offset, Generic.Heading)
+            if spaces:
+                yield offset + len(heading), Generic.Heading, spaces
+            yield offset + len(heading) + len(spaces), Name.Label, scene_no
+            trailing = body[len(heading) + len(spaces) + len(scene_no):]
+            if trailing:
+                yield offset + len(heading) + len(spaces) + len(scene_no), Generic.Heading, trailing
+            return
+
+        yield from self._emit_inline(body, offset, Generic.Heading)
+
+    def _emit_forced_action(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        if not body:
+            return
+        yield pos + indent, Punctuation, '!'
+        yield from self._emit_inline(body[1:], pos + indent + 1, Text)
+
+    def _emit_lyric(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        if not body:
+            return
+        yield pos + indent, Punctuation, '~'
+        yield from self._emit_inline(body[1:], pos + indent + 1, String.Other)
+
+    def _emit_character(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        offset = pos + indent
+
+        if body.startswith('@'):
+            yield offset, Punctuation, '@'
+            body = body[1:]
+            offset += 1
+
+        dual = ''
+        if body.rstrip().endswith('^'):
+            stripped_body = body.rstrip()
+            dual_start = len(stripped_body) - 1
+            dual = body[dual_start:]
+            body = body[:dual_start]
+
+        ext_index = body.find('(')
+        if ext_index == -1:
+            name = body.rstrip()
+            rest = body[len(name):]
+            yield offset, Name.Label, name
+            if rest:
+                yield offset + len(name), Whitespace, rest
+        else:
+            name = body[:ext_index].rstrip()
+            rest = body[len(name):ext_index]
+            yield offset, Name.Label, name
+            cursor = offset + len(name)
+            if rest:
+                yield cursor, Whitespace, rest
+                cursor += len(rest)
+            ext = body[ext_index:]
+            last_end = 0
+            for match in re.finditer(r'\s*\([^\n)]*\)', ext):
+                segment = match.group(0)
+                gap = ext[last_end:match.start()]
+                if gap:
+                    yield cursor, Whitespace, gap
+                    cursor += len(gap)
+                ws_len = len(segment) - len(segment.lstrip(' '))
+                if ws_len:
+                    yield cursor, Whitespace, segment[:ws_len]
+                    cursor += ws_len
+                yield cursor, Name.Decorator, segment[ws_len:]
+                cursor += len(segment[ws_len:])
+                last_end = match.end()
+            tail = ext[last_end:]
+            if tail:
+                yield cursor, Whitespace, tail
+        if dual:
+            caret_ws = dual[:-1]
+            if caret_ws:
+                yield offset + len(body), Whitespace, caret_ws
+            yield offset + len(body) + len(caret_ws), Punctuation, '^'
+
+    def _emit_parenthetical(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        yield pos + indent, Name.Decorator, body
+
+    def _emit_dialogue(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        yield from self._emit_inline(body, pos + indent, String)
+
+    def _emit_action(self, line, pos):
+        indent = self._indent_len(line)
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        yield from self._emit_inline(line[indent:], pos + indent, Text)
+
+    def _emit_centered(self, line, pos):
+        indent = self._indent_len(line)
+        body = line[indent:]
+        if indent:
+            yield pos, Whitespace, line[:indent]
+        offset = pos + indent
+        if len(body) < 2:
+            yield from self._emit_inline(body, offset, Text)
+            return
+        yield offset, Punctuation, '>'
+        inner = body[1:-1]
+        yield from self._emit_inline(inner, offset + 1, Generic.Strong)
+        yield offset + 1 + len(inner), Punctuation, '<'
+
+    def _emit_inline(self, text, pos, default_token):
+        yield from self._emit_inline_segment(text, pos, default_token)
+
+    def _emit_inline_segment(self, text, pos, default_token):
+        i = 0
+        while i < len(text):
+            if self._in_boneyard:
+                end = text.find('*/', i)
+                if end == -1:
+                    yield pos + i, Comment.Multiline, text[i:]
+                    return
+                yield pos + i, Comment.Multiline, text[i:end + 2]
+                self._in_boneyard = False
+                i = end + 2
+                continue
+
+            if self._in_note:
+                end = text.find(']]', i)
+                if end == -1:
+                    yield pos + i, Comment.Special, text[i:]
+                    return
+                yield pos + i, Comment.Special, text[i:end + 2]
+                self._in_note = False
+                i = end + 2
+                continue
+
+            if text.startswith('/*', i):
+                end = text.find('*/', i + 2)
+                if end == -1:
+                    self._in_boneyard = True
+                    yield pos + i, Comment.Multiline, text[i:]
+                    return
+                yield pos + i, Comment.Multiline, text[i:end + 2]
+                i = end + 2
+                continue
+
+            if text.startswith('[[', i):
+                end = text.find(']]', i + 2)
+                if end == -1:
+                    self._in_note = True
+                    yield pos + i, Comment.Special, text[i:]
+                    return
+                yield pos + i, Comment.Special, text[i:end + 2]
+                i = end + 2
+                continue
+
+            if text[i] == '\\' and i + 1 < len(text):
+                yield pos + i, String.Escape, text[i:i + 2]
+                i += 2
+                continue
+
+            match = re.match(r'#[-.A-Za-z0-9]+#', text[i:])
+            if match is not None:
+                value = match.group(0)
+                yield pos + i, Name.Label, value
+                i += len(value)
+                continue
+
+            for marker, token in (
+                ('***', Generic.Strong),
+                ('**', Generic.Strong),
+                ('*', Generic.Emph),
+                ('_', Generic.Emph),
+            ):
+                if text.startswith(marker, i):
+                    end = self._find_emphasis_end(text, i, marker)
+                    if end != -1:
+                        yield pos + i, Punctuation, marker
+                        inner_start = i + len(marker)
+                        inner_end = end
+                        yield from self._emit_inline_segment(
+                            text[inner_start:inner_end],
+                            pos + inner_start,
+                            token,
+                        )
+                        yield pos + end, Punctuation, marker
+                        i = end + len(marker)
+                        break
+            else:
+                next_special = self._next_special_index(text, i)
+                if next_special == i:
+                    yield pos + i, default_token, text[i]
+                    i += 1
+                    continue
+                yield pos + i, default_token, text[i:next_special]
+                i = next_special
+                continue
+            continue
+
+    def _find_emphasis_end(self, text, start, marker):
+        inner_start = start + len(marker)
+        end = text.find(marker, inner_start)
+        while end != -1:
+            inner = text[inner_start:end]
+            if inner and not inner[0].isspace() and not inner[-1].isspace():
+                return end
+            end = text.find(marker, end + len(marker))
+        return -1
+
+    def _next_special_index(self, text, start):
+        i = start
+        while i < len(text):
+            if text.startswith(('/*', '[[', '***', '**'), i):
+                return i
+            if text[i] in '\\*_#':
+                return i
+            i += 1
+        return len(text)

--- a/tests/examplefiles/fountain/Big-Fish.fountain.output
+++ b/tests/examplefiles/fountain/Big-Fish.fountain.output
@@ -467,15 +467,15 @@
 
 "No Dad, they don't.  " Literal.String
 '_'           Punctuation
-'I'           Generic.Emph
+'I'           Generic.EmphStrong
 '_'           Punctuation
 ' do not like the story.  Not anymore, not after a ' Literal.String
 '_'           Punctuation
-'thousand'    Generic.Emph
+'thousand'    Generic.EmphStrong
 '_'           Punctuation
 ' '           Literal.String
 '_'           Punctuation
-'times'       Generic.Emph
+'times'       Generic.EmphStrong
 '_'           Punctuation
 '.  I know all the punchlines, Dad.  I can tell them as well as you can.' Literal.String
 '\n'          Text.Whitespace
@@ -731,7 +731,7 @@
 '>'           Punctuation
 ' '           Generic.Strong
 '_'           Punctuation
-'BIG FISH'    Generic.Emph
+'BIG FISH'    Generic.EmphStrong
 '_'           Punctuation
 ' '           Generic.Strong
 '<'           Punctuation
@@ -2376,7 +2376,7 @@
 
 'You mean, while ' Literal.String
 '_'           Punctuation
-"I'm"         Generic.Emph
+"I'm"         Generic.EmphStrong
 '_'           Punctuation
 ' here.'      Literal.String
 '\n'          Text.Whitespace
@@ -3751,7 +3751,7 @@
 
 "Mmm-hmm.  Life'll do that to you.  And truthfully, the long way " Literal.String
 '_'           Punctuation
-'is'          Generic.Emph
+'is'          Generic.EmphStrong
 '_'           Punctuation
 " easier, but it's longer." Literal.String
 '\n'          Text.Whitespace
@@ -5158,7 +5158,7 @@
 
 '"You think ' Literal.String
 '_'           Punctuation
-"you've"      Generic.Emph
+"you've"      Generic.EmphStrong
 '_'           Punctuation
 ' had a bad day," she said.  "This morning the milkman dropped dead on the porch!"' Literal.String
 '\n'          Text.Whitespace
@@ -5467,11 +5467,11 @@
 
 "Ladies and Gentlemen, you may think you've seen the " Literal.String
 '_'           Punctuation
-'unusual'     Generic.Emph
+'unusual'     Generic.EmphStrong
 '_'           Punctuation
 ".  You may think you've seen the " Literal.String
 '_'           Punctuation
-'bizarre'     Generic.Emph
+'bizarre'     Generic.EmphStrong
 '_'           Punctuation
 ".  But I've travelled to the five corners of the world, and let me tell you, I've never seen anything like this." Literal.String
 '\n'          Text.Whitespace
@@ -5909,7 +5909,7 @@
 
 "I've got a whole backpack " Literal.String
 '_'           Punctuation
-'full'        Generic.Emph
+'full'        Generic.EmphStrong
 '_'           Punctuation
 ' of clothes!' Literal.String
 '\n'          Text.Whitespace
@@ -6586,7 +6586,7 @@
 
 "But you're wrong.  I " Literal.String
 '_'           Punctuation
-'do'          Generic.Emph
+'do'          Generic.EmphStrong
 '_'           Punctuation
 " know you, at least by reputation.  Edward Bloom from Ashton.  See, I'm actually engaged to a boy from Ashton.  Don Price.  He was a few years older than you." Literal.String
 '\n'          Text.Whitespace
@@ -7681,7 +7681,7 @@
 '\n'          Text.Whitespace
 
 '_'           Punctuation
-'In Chinese, subtitled...' Generic.Emph
+'In Chinese, subtitled...' Generic.EmphStrong
 '_'           Punctuation
 '\n'          Text.Whitespace
 
@@ -7827,7 +7827,7 @@
 '\n'          Text.Whitespace
 
 '_'           Punctuation
-'Still subtitled:' Generic.Emph
+'Still subtitled:' Generic.EmphStrong
 '_'           Punctuation
 '\n'          Text.Whitespace
 

--- a/tests/examplefiles/fountain/Big-Fish.fountain.output
+++ b/tests/examplefiles/fountain/Big-Fish.fountain.output
@@ -1,0 +1,12530 @@
+'Title'       Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'Big Fish'    Literal.String
+'\n'          Text.Whitespace
+
+'Credit'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'written by'  Literal.String
+'\n'          Text.Whitespace
+
+'Author'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'John August' Literal.String
+'\n'          Text.Whitespace
+
+'Source'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'based on the novel by Daniel Wallace' Literal.String
+'\n'          Text.Whitespace
+
+'Notes'       Name.Attribute
+':'           Punctuation
+'\t'          Text.Whitespace
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'FINAL PRODUCTION DRAFT' Literal.String
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'includes post-production dialogue ' Literal.String
+'\n'          Text.Whitespace
+
+'\t'          Text.Whitespace
+'and omitted scenes' Literal.String
+'\n'          Text.Whitespace
+
+'Copyright'   Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'(c) 2003 Columbia Pictures' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'This is a Southern story, full of lies and fabrications, but truer for their inclusion.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'===='        Operator
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'**'          Punctuation
+'FADE IN:'    Generic.Strong
+'**'          Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A RIVER.'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We're underwater, watching a fat catfish swim along.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'This is The Beast.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"There are some fish that cannot be caught.  It's not that they're faster or stronger than other fish.  They're just touched by something extra.  Call it luck.  Call it grace.  One such fish was The Beast.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The Beast's journey takes it past a dangling fish hook, baited with worms.  Past a tempting lure, sparkling in the sun.  Past a swiping bear claw.  The Beast isn't worried." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"By the time I was born, he was already a legend.  He'd taken more hundred-dollar lures than any fish in Alabama. Some said that fish was the ghost of Henry Walls, a thief who'd drowned in that river 60 years before.   Others claimed he was a lesser dinosaur, left over from the Cretaceous period." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL'S BEDROOM - NIGHT (1973)" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"WILL BLOOM, AGE 3, listens wide-eyed as his father EDWARD BLOOM, 40's and handsome, tells the story.  In every gesture, Edward is bigger than life, describing each detail with absolute conviction." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I didn't put any stock into such speculation or superstition.  All I knew was I'd been trying to catch that fish since I was a boy no bigger than you.  " Literal.String
+'\n'          Text.Whitespace
+
+'(closer)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'And on the day you were born, that was the day I finally caught him.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  CAMPFIRE - NIGHT (1977)' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A few years later, and Will sits with the other INDIAN GUIDES as Edward continues telling the story to the tribe.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Now, I'd tried everything on it:  worms, lures, peanut butter, peanut butter-and-cheese.  But on that day I had a revelation:  if that fish was the ghost of a thief, the usual bait wasn't going to work.  I would have to use something he truly desired. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward points to his wedding band, glinting in the firelight.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'LITTLE BRAVE' Name.Label
+'\n'          Text.Whitespace
+
+'(confused)'  Name.Decorator
+'\n'          Text.Whitespace
+
+'Your finger?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward slips his ring off.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Gold.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"While the other boys are rapt with attention, Will looks bored.  He's heard this story before." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I tied my ring to the strongest line they made -- strong enough to hold up a bridge, they said, if just for a few minutes -- and I cast upriver.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM FRONT HALL - NIGHT (1987)' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward is chatting up Will's pretty DATE to the homecoming dance.  She is enjoying the story, but also the force of Edward's charisma.  He's hypnotizing." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'The Beast jumped up and grabbed it before the ring even hit the water.  And just as fast, he snapped clean through that line.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL, now 17 with braces, is fuming and ready to leave.  His mother SANDRA -- from whom he gets his good looks and practicality -- stands with him at the door.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You can see my predicament.  My wedding ring, the symbol of fidelity to my wife, soon to be the mother of my child, was now lost in the gut of an uncatchable fish.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON WILL AND SANDRA' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(low but insistent)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Make him stop.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'His mother pats him sympathetically, then adjusts his tie.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"WILL'S DATE" Name.Label
+'\n'          Text.Whitespace
+
+'What did you do?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I followed that fish up-river and down-river for three days and three nights, until I finally had him boxed in.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will regards his father with exasperated contempt.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'With these two hands, I reached in and snatched that fish out of the river.  I looked him straight in the eye.  And I made a remarkable discovery. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  TINY PARIS RESTAURANT (LA RUE 14°) - NIGHT (1998)' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL, now 28, sits with his gorgeous bride JOSEPHINE.  This is their wedding reception, crowded with their friends and family.  They should be joyful, but Will is furious.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward has the floor, ostensibly for a toast.  The room is cozy and drunk.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'This fish, the Beast.  The whole time we were calling it a him, when in fact it was a her.  It was fat with eggs, and was going to lay them any day.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Over near the doorway, we spot Sandra, just returned from the restrooms.  She looks gorgeous.  She couldn't be any happier if this were her own wedding." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Now, I was in a situation.  I could gut that fish and get my ring back, but doing so I would be killing the smartest catfish in the Ashton River, soon to be mother of a hundred others.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will can't take any more.  Josephine tries to hold him back, but he gets up and leaves.  Edward doesn't even notice." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Did I want to deprive my soon-to-be-born son the chance to catch a fish like this of his own?  This lady fish and I, well, we had the same destiny.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As he leaves, Will mutters in perfect unison with his father--' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD AND WILL' Name.Label
+'\n'          Text.Whitespace
+
+'We were part of the same equation.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will reaches the door, where his mother intercepts him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Honey, it's still your night." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will can't articulate his anger.  He just leaves." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Now, you may well ask, since this lady fish wasn't the ghost of a thief, why did it strike so quick on gold when nothing else would attract it?" Literal.String
+'\n'          Text.Whitespace
+
+'(closer; he holds up his ring)' Name.Decorator
+'\n'          Text.Whitespace
+
+'That was the lesson I learned that day, the day my son was born.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He focuses his words on Sandra.  This story is -- and has always been -- about her more than anyone.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Sometimes, the only way to catch an uncatchable woman is to offer her a wedding ring.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A LAUGH from the crowd.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward motions for Sandra to get up here with him.  As she crosses, we can see that thirty years of marriage has not lessened their affection for each other.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As they kiss, Edward tweaks her chin a special little way.  The crowd APPLAUDS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward toasts the happy couple.  Josephine covers well for her absent husband, a smile as warm as summer.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward downs his champagne in a gulp.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  OUTSIDE LA RUE 14° - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We come into the middle of an argument on the sidewalk.  Occasional PASSERSBY take notice, especially as it gets more heated.  Both men are a little drunk.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"What, a father's not allowed to talk about his son?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(disbelieving)' Name.Decorator
+'\n'          Text.Whitespace
+
+'I am a footnote in that story.  I am the context for your great adventure.  Which never happened!  Incidentally!  You were selling novelty products in Wichita the day I was born.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(shaking his head)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Jesus Christ.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Friend of yours?  Did you help him out of a bind?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Come on, Will.  Everyone likes that story.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"No Dad, they don't.  " Literal.String
+'_'           Punctuation
+'I'           Generic.Emph
+'_'           Punctuation
+' do not like the story.  Not anymore, not after a ' Literal.String
+'_'           Punctuation
+'thousand'    Generic.Emph
+'_'           Punctuation
+' '           Literal.String
+'_'           Punctuation
+'times'       Generic.Emph
+'_'           Punctuation
+'.  I know all the punchlines, Dad.  I can tell them as well as you can.' Literal.String
+'\n'          Text.Whitespace
+
+'(closer)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'For one night, one night in your entire life, the universe does not revolve around Edward Bloom.  It revolves around me and my wife.  How can you not understand that?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat, then...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(low)'       Name.Decorator
+'\n'          Text.Whitespace
+
+'Sorry to embarrass you.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will won't let him get the last word." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You're embarrassing yourself, Dad.  You just don't see it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ANGLE ON Edward.  Fine.  A hand to wave, enough of you. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He walks away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"ANGLE ON Will, still fuming with righteous anger.  It's then we FREEZE FRAME." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"After that night, I didn't speak to my father again for three years.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  A.P. NEWSROOM (PARIS) - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A typically busy day.  On hold with the phone cradled under an ear, Will sorts through a bundle of mail dropped on his desk.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(ON PHONE)'  Name.Decorator
+'\n'          Text.Whitespace
+
+'(without pauses)' Name.Decorator
+'\n'          Text.Whitespace
+
+'William Bloom with the Associated Press if I could just...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He's put back on hold.  Returning to the mail, he finds a hand-addressed envelope.  Rips it open." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'We communicated indirectly I guess.  In her letters and Christmas cards, my mother would write for both of them.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE KITCHEN - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'At the table, Sandra talks on the phone while Edward fixes a sandwich.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"When I'd call, Mom would say that Dad was out driving.  Or swimming in the pool." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward takes a seat, starting to eat his sandwich.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'True to form, we never talked about our not talking.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE MASTER BEDROOM - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra stands by the window, watching as...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BLOOM BACK YARD - NIGHT [CONTINUOUS]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward swims laps in the family pool.  He's born to the water." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"The truth is, I didn't see anything of myself in my father, and I don't think he saw anything of himself in me.  We were like strangers who knew each other very well." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  RIVER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward stares intently into the water, a lion in wait.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"In telling the story of my father's life, it's impossible to separate the fact from the fiction, the man from the myth.  The best I can do is to tell it the way he told me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We LOOK DOWN at the river, where Edward's reflection is caught in the dark water.  As the water ripples past, something changes.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sure enough, as we LOOK UP again, it's a younger EDWARD BLOOM, 20's, staring into the water.  He's not just handsome, not just charming.  It's as if all the forces of the natural world had conspired to create him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"It doesn't always make sense, and most of it never happened." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Suddenly, this Edward thrusts both hands into the water, grabbing hold of' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE BEAST.'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He brings the catfish up to his face.  Looks it right in the eye.  A beat, then the Beast spits out Edward's gold ring." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"But that's what kind of story this is." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Smiling, Edward takes the ring, then throws the Beast back into the water with a splash.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TITLE OVER:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+' '           Generic.Strong
+'_'           Punctuation
+'BIG FISH'    Generic.Emph
+'_'           Punctuation
+' '           Generic.Strong
+'<'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Young Dr. Bennett stands between the Wife's legs.  She's flustered and sweating, but the doctor has a comforting bedside manner..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"Now, Mrs. Bloom, I'll need you to give me one good push.  On three.  One... " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, we hear a POP as a slimy mass of human being rockets into the doctor's unprepared hands.  Bennett tries to hold tight, but the infant is slippery like a fish.  It shoots up into air." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The NURSES and the Husband try to grab the baby, but no one can hold it.  As the newborn sails upward TOWARDS CAMERA, we can see a GIGGLING SMILE on its face.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As it falls, the newborn knocks over a tray, which provides it a ramp to slide right out of the room.  Everyone races after it.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL HALLWAY - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Bursting through the doors --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Grab that baby!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A NURSE finally scoops up the slippery baby.  Everyone lets out a collective sigh of relief.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"My father's birth would set the pace for his unlikely life.  No longer than most men's, but larger.  And as strange as his stories got, the endings were always the most surprising of all." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HALF-DARK PARIS APARTMENT - (PRESENT) DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Over the sound of rain, a phone RINGS on a chair.  By the tone of the ring, we know we're not in the U.S. -- it has that insistent European sound.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As it keeps RINGING, we look to see the apartment is mostly empty, just a few half-unpacked boxes.  A cradle is still in its carton.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KEYS in the lock.  LAUGHTER in the hallway.  The door swings open to reveal a drenched Will (29) carrying four sacks of groceries, the bottoms collapsing from the rain.  His wife Josephine (28) pushes past him to get the phone.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Allo oui?'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will begins stripping out of his wet clothes, each layer unleashing a new drizzle.  He plays it up, trying to get a reaction out of Josephine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(on phone)'  Name.Decorator
+'\n'          Text.Whitespace
+
+"Yes, he's here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She hands the phone to Will, concerned.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"It's your mother." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Half-stripped, Will takes the phone.  This won't be good news." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(on phone)'  Name.Decorator
+'\n'          Text.Whitespace
+
+'Hi.  Uh-huh.  Uh-huh.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As Josephine takes off her rain coat, we see she is very, very pregnant.  She listens carefully to Will's side of the conversation, trying to gauge how bad the news is." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"What does Dr. Bennett say?  Okay.  No, sure, let me talk to him.   I'll wait." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He covers the mouthpiece.  Looks over to Josephine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"It's bad."   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"It's more than they thought.  They're going to stop chemo." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'You need to go.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Probably tonight.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"I'm going with you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You don't have to." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(a simple fact)' Name.Decorator
+'\n'          Text.Whitespace
+
+"I'm going with you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  AIR FRANCE 747 - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the plane continues boarding, a STEWARDESS recites the welcome spiel in French.  Will has a window seat in coach.  Josephine sits beside him, putting on hand lotion.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Taking his hands, she rubs the excess into him.  There's an effortless intimacy between them.  She can pinpoint what he's feeling before he can." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  747 / FLYING - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Hours later, and the lights are dimmed.  Most of the PASSENGERS are asleep, including Josephine.  Her head is propped against Will's shoulder, her hands tucked under her belly. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will watches her sleep, brushing back her hair.  A beat, then he notices a BORED BOY in the next row over.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Off the glow of the reading light, the boy is using his hands to cast shadows on the seat back.   The kid is pretty good, making a convincing bird, a passable monkey, and finally a dog.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We PUSH IN on the silhouettes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(O.S., PRELAP)' Name.Decorator
+'\n'          Text.Whitespace
+
+"So which one's it gonna be?  The Monkey in the Barn, the Dog in the Road?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Focusing on the final shadow, we...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MATCH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'...come to find Edward making the shapes. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will (6) sits in his pajamas on the floor next to him.  The endtable lamp lies between them, its shade off to cast big shadows on the wall.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'The one about the witch.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Your mom says I can't tell you that one anymore.  You get nightmares." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I'm not scared." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks around for a beat, seeing if his wife is in earshot.  He then leans in, complicitous.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Neither was I.  At first.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will smiles, excited to hear the forbidden story.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"This all happened in the swamp outside of Ashton.  Kids weren't supposed to go out in the swamp, on account of the snakes and spiders and quicksand that would swallow you up before you could even scream.  But there were five of us out there that night:  Me, Ruthie, Wilbur Freely, and the Price Brothers, Don and Zacky." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward holds up his hand, counting the names on his fingers.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Not a one of us knew what was in store.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As his hand moves past the light, we' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'COME TO:'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A flashlight SWEEPS past.  We are...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FIELD AT THE SWAMP EDGE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The night is WHIRRING and BREATHING, alive.  The moon hangs low, casting long shadows.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Five kids walk past in silhouette.  Four have flashlights on.  The fifth keeps tripping, crashing into YOUNG EDWARD (10).' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Zacky, turn your flashlight on!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ZACKY'       Name.Label
+'\n'          Text.Whitespace
+
+"I don't got any batteries!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Red-headed ZACKY PRICE is 10.  His brother DON PRICE is 12, and a lot bigger than the others.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+"Then why'd you bring it?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ZACKY'       Name.Label
+'\n'          Text.Whitespace
+
+"I don't want to be in the swamp with a witch and no flashlight." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILBUR FREELY, also 10, is the black asthmatic son of a sharecropper.  Redheaded RUTHIE MACKLIN, 8, is happy just to be there.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Is it true she got a glass eye?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILBUR FREELY' Name.Label
+'\n'          Text.Whitespace
+
+'I heard she got it from Gypsies.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"What's a Gypsy?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ZACKY'       Name.Label
+'\n'          Text.Whitespace
+
+"Your momma's a Gypsy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+"Your momma's a bitch." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'RUTHIE'      Name.Label
+'\n'          Text.Whitespace
+
+"You shouldn't swear.  There's ladies present." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'Shit.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ZACKY'       Name.Label
+'\n'          Text.Whitespace
+
+'Damn.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILBUR FREELY' Name.Label
+'\n'          Text.Whitespace
+
+'Screw.  '    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(whispering)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Turn off your flashlights!  She'll see 'em." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MOVING UP behind the kids, we find ourselves at the gates of...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  A CREEPY OLD HOUSE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ADULT EDWARD' Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Now, it's common knowledge that most towns of a certain size have a witch, if only to eat misbehaving children and the occasional puppy who wanders into her yard.  Witches use those bones to cast spells and curses that make the land infertile." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We PULL BACK, and BACK, revealing more of the Gothically creepy house:  its broken windows, strangling vines, and eerie gargoyles half-buried in the dirt.  Even bats are afraid to fly over it.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'In the moonlight, the house is especially sinister.  Who knows what is lurking in the shadows?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ADULT EDWARD' Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Yet of the all the witches in Alabama, there was one who was the most feared.  For she had one glass eye, which was said to contain mystical powers.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We finally come to the kids, staring in through the gate.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILBUR FREELY' Name.Label
+'\n'          Text.Whitespace
+
+"I hear if you look right at it, you can see how you're gonna die." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"That's bull-s-h-i-t, that is.  She's not even a real witch." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+"You're so sure, why don't you go in and get that eye?  I heard she keeps it in a box on her nighttable." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks back at the spooky house.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Or are you too scared?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'll go in right now and get that eye." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'Then do it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Fine, I will.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'Fine, you do it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Fine, I'm doing it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He hands Zacky his flashlight, then starts climbing the gate.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'RUTHIE'      Name.Label
+'\n'          Text.Whitespace
+
+"Edward, don't!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILBUR FREELY' Name.Label
+'\n'          Text.Whitespace
+
+"She'll make soap out of you!" Literal.String
+'\n'          Text.Whitespace
+
+'(to Ruthie)' Name.Decorator
+'\n'          Text.Whitespace
+
+"That's what she does, she makes soap out of people." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward drops down on the far side of the gate.  Truth be told, Edward is scared, but he forges ahead anyway.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Wilbur looks to Ruthie, and they're in complete agreement.  They get the hell out of there.  Zacky would run too, but Don holds him by the collar." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. APPROACHING THE HOUSE' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward curves around the tall bushes that hide the front door.  Anything could jump out of them. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He steps on the porch.  The boards SQUEAL and CREAK, but he continues on.  A cat SCREAMS OUT from a broken wicker rocker.  Catching his breath, Edward reaches the front door.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The doorknob is ancient brass, two projections that look like horns.  Yet Edward extends his hand, reaching closer and closer before he finally' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'RINGS THE DOORBELL.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Impossibly fast, the door opens, revealing an OLD WOMAN with a patch over her left eye.  She looks like she's been dead for years, but too stubborn to lie down." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(calm and straightforward)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Ma'am, my name is Edward Bloom, and there's some folks'd like to see your eye." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. BACK AT THE GATE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Zacky and Don Price wait for Edward, each moment more convinced he's already dead.  But suddenly, he's back at the gate." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'You get the eye?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I brought it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'(dubious)'   Name.Decorator
+'\n'          Text.Whitespace
+
+"Let's see it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Old Woman steps out of the shadows behind Edward, flipping up her eye patch.  When their flashlight beam hits her left eye, it shines with a hellish glow.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We RUSH IN on Zacky, who is paralyzed by what he sees.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FRONT PORCH OF HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'An OLD MAN -- Zacky -- stands on a wobbly stepladder, changing a lightbulb.  Suddenly, the ladder gives way and he falls.  Dead.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  AT THE GATE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We RUSH IN on Don Price.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  FRATERNITY HOUSE BATHROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Twenty-year old Don Price falls face-forward on the tile, face mushed in the grout.  Very much dead.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  AT THE GATE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Don and Zacky both tremble with fear.  The latter has tears in his eyes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ZACKY'       Name.Label
+'\n'          Text.Whitespace
+
+'I saw how I was gonna die.  I was old, and I fell.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+"I wasn't old at all." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The brothers suddenly bolt.  Still standing next to the Old Woman, Edward smiles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  AT THE OLD WOMAN'S DOOR - NIGHT" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward helps her back inside.  He could leave now, but curiosity gets the better of him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I was thinking about death and all.  About seeing how you're gonna die." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Old Woman turns to him slightly, still not facing him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I mean, on one hand, if dying was all you thought about, it could kind of screw you up.  But it could kind of help you, couldn't it?  Because you'd know that everything else you can survive." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Old Woman smiles a little, a crooked grin of broken teeth.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I guess I'm saying, I'd like to know." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Old Woman turns leaning her face right in front of his.  And on a silent count of one, two, three -- Edward looks into The Eye.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"This time we don't cut.  Instead, we HOLD ON Edward as he witnesses his death.  He stares transfixed, perplexed and amused.  Whatever he sees, it's not as dire as the other boys.  His future has something strange in store." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Huh.  That's how I go?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Old Woman nods.  Still a little overwhelmed, Edward turns and leaves.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ADULT EDWARD' Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'From that moment on, I no longer feared death.  And for that, I was as good as immortal.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As Edward leaves, the door swings SHUT on its own.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MATCH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT./EXT.  BLOOM HOUSE - (PRESENT) DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The front door opens to reveal Will and Josephine on the porch with their bags.  REVERSE to Will's mother Sandra (53), surprised and a little annoyed. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'How did you get here?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"We swam.  The Atlantic, it's not that big really." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Ruth McHibbon offered to pick you up at the airport.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'We rented a car.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(simply)'    Name.Decorator
+'\n'          Text.Whitespace
+
+"You didn't need to do that.  You just didn't." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  Starting over...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Hi, Mom.'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He leans in and hugs her.  She surrenders, squeezing her son tight.  Will and his mother are cut from the same cloth -- strong-willed but practical.  They've always been close." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm so glad you're here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'That hug finished, Sandra pushes past her son to her daughter-in-law.  Seeing the size of her belly --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"You shouldn't have flown.  But..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'They hug.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"It's good to see you.  You look beautiful." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's not flattery.  It's the truth." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Thank you.  I'll bet you need to --" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Yes.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Down the hall on the right.  The door sticks.  You have to really pull it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine squeezes past, a smile to her husband -- be nice.  Will heads back to the rental car to retrieve luggage.  Sandra follows him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Coming down the driveway, we get to see the house for the first time:  an older suburban home, three bedrooms, big for the neighborhood, and nicely grown into the lot.  KIDS are playing on the street.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Is that Dr. Bennett's car?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"He's up with your father." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Heading back to the house...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'How is he?'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"He's impossible.  He won't eat.   And because he won't eat, he gets weaker.  And because he's weaker, he doesn't want to eat." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'How much time does he have left?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"You don't talk about those things.  Not yet." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  KITCHEN - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra is pouring iced tea for Will and Josephine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"DR. JULIUS BENNETT (85) enters from the foyer, still winded from coming down the stairs.  He was the town's first Black physician.  He's still the town's best physician." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Will.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Dr. Bennett.  It's good to see you." Literal.String
+'\n'          Text.Whitespace
+
+'(they shake)' Name.Decorator
+'\n'          Text.Whitespace
+
+'My wife, Josephine.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'A pleasure.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He judges her belly.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"You're seven months." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(impressed)' Name.Decorator
+'\n'          Text.Whitespace
+
+'To the day.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He leans close to her, whispering in her ear...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"It's a boy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She smiles, surprised but not doubting.  Will looks over -- what did he say?  Josephine shakes her head.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Back to the main subject...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"You don't think he looks any worse." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"No.  I would say he's the same." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"And in the silence that follows, a lot is said.  It wasn't the upbeat reply Sandra was hoping for." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Can I see him?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Absolutely.  Be good for you to talk to him.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A moment of awkwardness -- everyone here knows they haven't spoken in years." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra hands Will a squat can of Ensure from the case on the counter.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Get him to drink one of these.  He won't, but tell him he has to." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  FOYER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Coming out from the kitchen, Will slowly climbs the stairs.  They CREAK with every step.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The wall is filled with family photos, happier times.  Most of the pictures are of Will, starting when he was an infant and ending at his wedding.  As he climbs the stairs, we can see him growing up with every step.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  UPSTAIRS HALLWAY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A crack of sunlight spills around the half-open door at the end of the hallway.  Will walks towards it, running a hand along the wallpaper.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Almost at the door, he stops for a beat.  Gets his breath.  Then goes inside.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST ROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward Bloom, 61, lies asleep on the bed.  Although he's not the vibrant man we've seen before, it's not as bad we feared.  The illness has been quick, and left him largely intact." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"There are no I.V.'s, no monitors, nothing." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Coming up to the bed --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Dad?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward cracks open an eye, a beat before he focuses.  He tries to say something, but no words come out.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He looks over at a pitcher on the nightstand.  Will pours him a glass of water, helping him hold it to his parched lips.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finished, Edward sets down the glass by himself.  A very long, tense beat.  Will almost speaks again to fill the silence.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finally...'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You --'      Literal.String
+'\n'          Text.Whitespace
+
+'(he points)' Name.Decorator
+'\n'          Text.Whitespace
+
+'-- are in for a surprise.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Am I?'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Having a kid changes everything.  I mean, there's the diapers and the burping and the midnight feedings..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Did you do any of that?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"No, but I hear it's terrible.  Then you spend years trying to corrupt and mislead this child, fill its head with nonsense and still it turns out perfectly fine." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You think I'm up for it?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You learned from the best.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will doesn't rise to the challenge.  A beat, then he remembers the can of Ensure.  Holds it up.  Edward recoils." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Just drink half the can.  I'll tell her you drank the whole thing.  Everyone wins." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat, then Edward rolls his eyes.  Fine.  Will cracks open the can, finding a straw on the nightstand.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"People needn't worry so much.  It's not my time yet.  This isn't how I go." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Really.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Truly.  I saw it in The Eye.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'The Old Lady by the swamp.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'She was a witch.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'No, she was old and probably senile.  Maybe schizophrenic.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I saw my death in that eye.  And this is not how it happens.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'So how does it happen?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Surprise ending.  Wouldn't want to ruin it for you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward slurps down as much of the Ensure as he can stand, then pushes the can away.  He swallows with difficulty.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'There was this panhandler who used to stop me every morning when I came out of this coffee shop near the office.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Okay.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'And every day I gave him a quarter.  Every day.  Then I got sick and was out for a couple of weeks.  And when I went back there, you know what he said?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'What did he say?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You owe me three-fifty.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Really.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'True story.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'When did you ever work in an office?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"There's a lot you don't know about me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You're right." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward gives a wry smile.  He walked into that.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Your mother was worried we wouldn't talk again.  And look at us.  We're talking fine.  We're storytellers, both of us.  I speak mine out, you write yours down.  Same thing." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will won't commit to Edward's assessment." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Dad, I'm hoping we can talk about some things while I'm here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You mean, while ' Literal.String
+'_'           Punctuation
+"I'm"         Generic.Emph
+'_'           Punctuation
+' here.'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I'd just like to know the true versions of things.  Events.  Stories.  You." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward LAUGHS a little, which becomes a COUGH.  The HACKING escalates until another drink of water gets it under control.  It's not clear whether any of this was an act to keep from talking." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Your mother hasn't been keeping up the pool.  If you wanted to you could..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'I will.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You know where the chemicals are?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'I used to do it when you were gone, remember?  I used to do it a lot.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He didn't mean for that to sound so pointed.  Taking the half-empty Ensure, Will gets up to go.  He's at the door when..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I was never much for being at home, Will.  It's too confining.  And this, here.  Being stuck in bed.  Dying is the worst thing that ever happened to me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He smiles at his joke.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I thought you weren't dying." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I said this isn't how I go.  The last part is much more unusual.  Trust me on that." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  UPSTAIRS HALLWAY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Shutting the door behind himself, Will drinks the rest of the Ensure himself.  Edward was right.  It tastes horrible.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Heading for the stairs, Will walks past an open door.  As he leaves frame, we STAY BEHIND to look inside...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL'S BEDROOM - DAY  [FLASHBACK]" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"...where an eight-year old Will is propped up in bed, his face covered with chicken pox and pink calamine lotion.  He's showing Edward how many bumps there are on his arm." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG WILL'  Name.Label
+'\n'          Text.Whitespace
+
+"Dr. Bennett says I'm going to have to be home for a week." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"That's nothing.  I once had to stay in bed for three years." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG WILL'  Name.Label
+'\n'          Text.Whitespace
+
+'Did you have chicken pox?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I wish.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  TINY CHURCH - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Wearing a white shirt and tie, YOUNG EDWARD -- still about 10 -- sings "Down to the River My Lord" along with the CONGREGATION.  His voice is high and thin, but he gives it his all.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, his voice CRACKS and DROPS a half-octave.  And then another.  His friends Wilbur Freeley and Ruthie look over, wondering what's wrong.  Embarrassed, Edward just keeps SINGING, trying to follow along with the baritone part." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He pulls at his collar.  Then pulls again, his face getting red.  Starting to panic, he loosens his tie.  He's starting to undo the collar button when it POPS off by itself.  Two more buttons fly off.  One hits a CHUBBY WOMAN in the neck." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON HIS SHOES' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As we watch, Edward's pant cuffs rise inch by inch -- that's how fast he's growing." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Truth is, no one quite knew what was wrong.  Most times, a person grows up gradually.  I found myself in a hurry.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  YOUNG EDWARD'S BEDROOM - DAY  " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Young Edward lies in bed, his limbs connected to various pulleys and levers to support his weight.  He has a dozen encyclopedias around him, and another dozen on the floor.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'My muscles couldn\'t keep up with my bones, and my bones couldn\'t keep up with my body\'s ambition.  So I spent the better part of three years confined to my bed, with the World Book Encyclopedia being my only means of exploration.  I had made it all the way to the "G\'s," hoping to find an answer to my gigantificationism, when I uncovered an article about the common goldfish.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INSERT:  The encyclopedia article, complete with drawings.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG EDWARD' Name.Label
+'\n'          Text.Whitespace
+
+'(reading)'   Name.Decorator
+'\n'          Text.Whitespace
+
+'"Kept in a small bowl, the goldfish will remain small.  With more space, the fish can grow double, triple, or quadruple its size."' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Young Edward thinks this through.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"It occurred to me then, that perhaps the reason for my growth was that I was intended for larger things.  After all, a giant man can't have an ordinary-sized life." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BASEBALL FIELD - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The CRACK of a bat announces the game-winning home run.  The crowd CHEERS the swing, and especially the batter as he rounds the bases.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Although we've seen him briefly before, this is our first real exposure to GROWN-UP EDWARD, who we'll follow from roughly the ages of 18 to 30.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.0.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'As soon as my bones had settled in their adult configuration, I set upon my plan to make a bigger place for myself in Ashton.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SCHOOL FIELDS - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SINGLE SHOTS:  Football hero Edward leads his team to victory.  On the sidelines, a PRETTY GIRL admits the name of her secret love:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'GIRL'        Name.Label
+'\n'          Text.Whitespace
+
+'Edward Bloom!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The other GIRLS SQUEAL in agreement.  Don Price looks over, glowers.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  NEIGHBORHOOD - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"SINGLE SHOT:  A lawnmower ROARS along the grass.  We LOOK UP to see who's pushing it, but it's not Edward.  It's one of his teenage EMPLOYEES." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward is back at the truck, which is painted to read, "Bloom Landscaping."  He has workers on every lawn.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He signs an autograph for an ADMIRING CUB SCOUT.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BASKETBALL COURT - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward takes an impossible shot at the buzzer from the other end of the court.  Naturally, he makes it, winning the game.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As the crowd goes wild for Edward, Don Price is the only teammate who doesn't mob him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  TOWN - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward carries a dog out of a burning house.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  SCIENCE FAIR - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward wins a blue ribbon for his invention, a machine labelled "Perpetual Motion."  He and the JUDGE pose for a photograph.  A FLASH.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Pissed, Don Price throws his crappy lima bean plants in the trash.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HIGH SCHOOL STAGE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A dashingly handsome Edward leads the CAST out for a curtain call.  He's the star of the show.  Off to the side, we see Don Price is the ass-end of a horse costume." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward soaks in his applause, smiling and gracious.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  GRADUATION STAGE - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward accepts his diploma.  The PRINCIPAL hugs him tight.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'I was the biggest thing Ashton had ever seen.  Until one day, a stranger arrived.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FARM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As two FARMERS shake their heads, we REVERSE to a show a massive hole punched through the side of a barn.  It's roughly the shape of man, but no human could be that large." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SHEEP PEN - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Two fat ewes look up, a shadow falling across them.  They BLEAT in panic as ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TWO OVERSIZED HANDS' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"reach in and scoop them up.  Their protests continue as they're carried away, one under each arm.  We still haven't seen the full stranger." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  COURT HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A MOB of about 50 have gathered, many of them with shotguns.  Amid the crowd we see Don Price.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SHARECROPPER' Name.Label
+'\n'          Text.Whitespace
+
+'He ate an entire cornfield!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'LITTLE GIRL' Name.Label
+'\n'          Text.Whitespace
+
+'He ate my dog!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'HOT-BLOODED SHOTGUN TOTER' Name.Label
+'\n'          Text.Whitespace
+
+"If you ain't gonna stop him Mayor, we will!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MAYOR'       Name.Label
+'\n'          Text.Whitespace
+
+"I won't have mob violence in this town.  Now, has someone tried talking to him?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SOME FARMER' Name.Label
+'\n'          Text.Whitespace
+
+"You can't reason with 'im!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SHEPHARD'    Name.Label
+'\n'          Text.Whitespace
+
+"He's a monster!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Agreement from the crowd.  And then...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A VOICE'     Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"I'll do it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Everyone turns to see who said that.  The crowd parts to reveal none other than Edward Bloom.  Don Price glowers.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'll talk to him.  See if I can get him to move on." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MAYOR'       Name.Label
+'\n'          Text.Whitespace
+
+'Son, that creature could crush you without trying.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Trust me, he'll have to try." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  HILL OUTSIDE ASHTON - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward climbs up the last bit of the steep hillside, reaching the mouth of a cave.  Outside, buzzards squabble over the remains of the giant's feast:  broken barrels, bones picked clean." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'In his most serious voice, Edward calls out:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Hello!'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"There's no answer." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'My name is Edward Bloom!  I want to talk to you!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'From deep in a cave, a thunderous voice:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'VOICE'       Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'GO AWAY!'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The giant's voice has such force, it blows Edward's hair back." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm not going anywhere until you show yourself.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A beat, then we hear a RUMBLE, like a train coming.  Edward braces himself, fists ready for a fight, if that's what it's going to take." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the RUMBLE gets louder, the ground starts to shake.  Even Edward starts to worry.  Just how big is this guy?  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Armed with the foreknowledge of my own death, I knew the giant couldn't kill me.  All the same, I preferred to keep my bones unbroken." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward picks up a stone, ready to play David to Goliath.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Then suddenly, the giant bursts forth.  Hunched over, he slams into a stunned Edward, knocking him halfway down the hill.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"KARL THE GIANT is bigger than any man you've ever seen.  Not just tall, but massive.  He's completely feral, with a beard to his elbow and skin scratched and blistered.  What remains of his clothes are ragged and muddy.  God knows what's living in his matted hair." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Karl leans over Edward, blocking the sun.  Edward throws his rock, but it just bounces off.  The giant didn't even notice it." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'Why are you here?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward ponders the best response, settling on...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'So you can eat me.  The town decided to send a human sacrifice, and I volunteered. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Karl's eyes narrow, confused.  Edward stands up." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"My arms are a little stringy, but there's some good eating on my legs.  I mean, I'd be tempted to eat them myself." Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"So I guess, just, if you could get it over with quick.  Because I'm not much for pain, really." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward closes his eyes, hands at his side, ready to be eaten.  Karl just stares at him, not sure what to do.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"After a beat, Edward opens his eyes a tiny bit, just to see what the giant is doing.  Relieved to see he's not licking his chops --" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Look, I can't go back.  I'm a human sacrifice.  If I go back, everyone will think I'm a coward.  And I'd rather be dinner than a coward." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl sits down with a BOOM, dejected.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Here, start with my hand.  It'll be an appetizer." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Reaching up, Edward shoves his hand into Karl's mouth.  But the giant spits it back out." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+"I don't want to eat you.  I don't want to eat anybody.  It's just I get so hungry.  I'm too big." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"And that's the sad truth.  Karl is less a monster than a freak -- a giant man, but in the end, just a man." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward takes a seat beside him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Did you ever think maybe you're not too big?  Maybe this town's just too small.  I mean, look at it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Circling behind them, we look down at Ashton -- a tiny town in a tiny valley.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Hardly two stories in the whole place.  Now I've heard in real cities, they've got buildings so tall you can't even see the tops of 'em." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'Really?'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Wouldn't lie to you.  And they've got all-you-can-eat buffets.  You can eat a lot, can't you?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'I can.'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"So why are you wasting your time in a small town?  You're a big man.  You should be in the big city." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl smiles, but then it fades.  A certain sad suspicion --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+"You're just trying to get me to leave, aren't you?  That's why they sent you here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"What's your name, Giant?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'Karl.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Mine's Edward.  And truthfully, I do want you to leave, Karl.  But I want to leave with you.  " Literal.String
+'\n'          Text.Whitespace
+
+'(closer)'    Name.Decorator
+'\n'          Text.Whitespace
+
+"You think this town is too small for you, well, it's too small for a man of my ambition.  I can't see staying here a day longer.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+"You don't like it?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I love every square inch of it.  But I can feel the edges closing in on me.  A man's life can only grow to a certain size in a place like this." Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'So what do you say?  Join me?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl thinks a moment.  Then --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'Okay.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Okay.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'They shake on it.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Now first, we gotta get you ready for the city.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  RIVER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'IN A SINGLE SHOT, Karl cuts his hair with hedge clippers, while Edward cuts up a surplus army tent to make him a shirt.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  MAIN STREET OF ASHTON - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Spirits buoyed by the high school MARCHING BAND, all the good CITIZENS of Ashton are gathered to see off Edward and Karl.  There's a few tears amid the familiar faces." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MAYOR'       Name.Label
+'\n'          Text.Whitespace
+
+'(loudly, for the crowd)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Edward Bloom, first son of Ashton, it's with a heavy heart we see you go.  But take with you this Key to the City, and know that any time you want to come back, all our doors are open to you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward ducks a bit so the Mayor can put the key around his neck.  The crowd CHEERS.  And with that, Edward and Karl start walking, waving as they go.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Only DON PRICE, smoking on the corner, isn't sad to see Edward go.  He crushes his cigarette under his heel.  He wishes he could crush Edward." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Many of the townfolk come onto the street to hug Edward or shake his hand.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'That afternoon as I left Ashton, everyone seemed to have advice.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'VARIOUS TOWNFOLK' Name.Label
+'\n'          Text.Whitespace
+
+"Find yourself a nice girl!  Don't trust anyone in Kentucky!  Watch your pride, Edward Bloom!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'But there was one person whose counsel I held above all others. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the crowd parts, he finds himself face to face with ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE OLD WOMAN. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The ruckus slows and quiets, as if a strange spell has been cast.  She motions for Edward to lean down, so she can whisper something to him.  Although we're VERY CLOSE, we can't hear her voice." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'She said that the biggest fish in the river gets that way by never being caught.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The advice only succeeds in confusing Edward.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(to the Old Woman)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Okay.  Thanks.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward and Karl keep walking.  The Old Woman shuffles off, somehow knowing her advice will go unheeded.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'What did she say?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Beats me.'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We TILT UP from the road to reveal Edward and Karl walking out of Ashton.  Each wears a backpack with all his earthly possessions.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"There were two roads out of Ashton, a new one which was paved, and an older one that wasn't.  People didn't use the old road anymore, and it had developed the reputation of being haunted." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward and Karl come to a bend, where the paved road veers left and an overgrown dirt road runs straight.  The old road is blocked with signs and warnings of danger.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Since I had no intention of ever returning to Ashton, this seemed as good a time as any to find out what lay down that old road.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl looks at the dirt road, wary.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+"You know anyone's who's taken it?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'That poet, Norther Winslow did.  He was going to Paris, France.  He must have liked it, because no one ever heard from him again.' Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Tell you what.  You take the other way and I'll cut through here.  Meet you on the far side." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A little paranoid...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+"You're not trying to run away?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Just to be sure, you can take my pack.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl perks up, even though it means more for him to carry.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  DIRT ROAD - DAY ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The road is overgrown, but not altogether creepy.  The sun is still shining, and the birds still CHIRPING.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Spinning the Key to the City, Edward WHISTLES, because it's a day meant for whistling.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. FURTHER ALONG - ROUGH PATH' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The road has narrowed to a rough path.  Spikes of sunlight break through the thick canopy, catching particles in the air.  Still, Edward WHISTLES.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Coming around a bend, his PITCH DROPS as he sees thick, thorny vines growing across the path.  He stops.  For the first time, he realizes the birds have stopped singing.  The forest is dead quiet.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He looks back the way he came.  It's tempting to go back.  It would be easier to go back.  But Edward presses on." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He carefully steps through the thorns.  His trouser legs catch on the barbs.  We can hear the fabric TEAR.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'FURTHER ALONG ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A scratched and sweaty Edward waves off various STINGING BUGS flying at him, finally whipping off his hat to swat at them.  Just then a CAWING crow swoops down and grabs the hat right out of his hands.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You stupid sonofa...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He stops his swearing, but grabs a rock and throws it.  The stone ricochets off a tree and into a BEE'S NEST.  The swarm roars out." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward high-tails it, each step still precarious.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE DARK FOREST - DAY [LATER]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward is bruised, battered and bee-stung.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A half-broken sign lies in the road.  Edward picks it up.  Reads it:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WARNING!  '  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JUMPING SPIDERS!' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sure enough, up ahead he sees the path is overgrown with thick cobwebs, heavy from the rain.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"There comes a point where a reasonable man will swallow his pride and admit he's made a terrible mistake.  The truth is, I was never a reasonable man.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward tosses the sign and forges ahead, into the spiderwebs.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'And what I recalled of Sunday School was that the more difficult something became, the more rewarding it was in the end.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  CLEARING / THE ROAD - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward emerges from the forest, brushing the last cobwebs off and shaking the spiders from his shirt.  One is stuck in his sleeve, and he has to dance to get it out.  Even then, he still keeps twitching, convinced another one is left behind.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'At his feet, the gravel road has returned, smooth and dusty and comforting. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Ahead lies a tiny one-street town -- smaller even than Ashton -- with powerlines emerging from the woods to feed it.  Dangling from the line above he sees two dozen pairs of shoes, their laces tied together.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He passes a sign that reads "Welcome To Spectre!"' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE TOWN OF SPECTRE   - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's a main street with stores on each side:  Cole's Pharmacy, Talbot's Five and Dime, Al's Country Store.  Everything is old, but this isn't a ghost town.  In fact, there's a group of about 20 CITIZENS spilling out to see Edward approach.  Most are smiling.  There are even a few tears of joy." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"What's more, all of these people are barefoot." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"MAN'S VOICE" Name.Label
+'\n'          Text.Whitespace
+
+'Friend!'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A forty-year old man named BEAMEN comes out of the seed store to greet Edward.  Friendly but a little drunk, he's the closest thing the town has to a mayor.  He's carrying a clipboard." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"Welcome to ya.  What's your name?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Edward Bloom.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Beamen checks the clipboard.  Not finding the name, he flips forward a few pages.  Still looking...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+'Bloom like a flower?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"Oh.  Here!  Right here.  Edward Bloom.  We weren't expecting you yet." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Still confused...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You were expecting me?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+'Not yet.'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A helpful woman named MILDRED chimes in:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MILDRED'     Name.Label
+'\n'          Text.Whitespace
+
+'You must have taken a shortcut.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I did.  It nearly killed me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"Mmm-hmm.  Life'll do that to you.  And truthfully, the long way " Literal.String
+'_'           Punctuation
+'is'          Generic.Emph
+'_'           Punctuation
+" easier, but it's longer." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MILDRED'     Name.Label
+'\n'          Text.Whitespace
+
+'Much longer.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"And you're here now, and that's what matters." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Beamen's daughter JENNY (8) hides behind her father, peering around to look at the handsome stranger." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'What is this place?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"The town of Spectre.  Best kept secret in Alabama.   Says here you're from Ashton, right?  Last person we had from Ashton was Norther Winslow." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'The poet?  What ever happened to him?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"He's still here.  Let me buy you a drink.  I'll tell you all about it.  Hell, I'll have him tell you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"No.  I've gotta meet somebody.  I'm already running late." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He didn't mean it as a joke, but for some reason, everyone's laughing." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"Son, I already told you.  You're early." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.   BEAMEN'S HOUSE - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sitting at the kitchen table, Edward takes a second slice of apple pie.  He and Beamen are joined by NORTHER WINSLOW (30), who fancies himself a cultured artist, though he's never left the state." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"Now tell me if that isn't the best pie you ever ate." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'It truly is.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'UNDER THE TABLE' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Young Jenny is stealthily untying the laces on Edward's shoes." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"Everything here tastes better.  Even the water is sweet.  Never gets too hot, too cold, too humid.  At night the wind goes through the trees and you'd swear there was a whole symphony out there, playing just for you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, Jenny YANKS OFF Edward's shoes.  She races for the door." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Hey!'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He chases after her.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  TOWN / MAIN STREET - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As she runs, Jenny ties Edward's laces together.  Reaching the edge of town, she tosses the shoes up and around the power line -- a perfect throw.  There's no way he's ever getting them down." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The gathered citizens of Spectre CHEER for Edward, who is confused and overwhelmed.  The women hug him.  Men shake his hand.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Still focused on his shoes...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Wait!  I need those!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+'There is no softer ground than town.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MILDRED'     Name.Label
+'\n'          Text.Whitespace
+
+'That rhymes!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+'He is our poet laureate.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The townsfolk continue to congratulate Edward...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Sometimes in a dream, you'll visit places that seem instantly familiar, filled with friends you've never met.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  UNDER A TREE - DUSK  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward sits with Norther Winslow.  The fireflies are out.  Thousands of them.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'A man might travel his entire life and never find a place so inviting.  My journey had scarcely begun, and I had arrived.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Norther hands him his noteboook.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"I've been working on this poem for 12 years." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Really.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"There's a lot of expectation.  I don't want to disappoint my fans." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"It's only three lines long." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Norther grabs his notebook back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"This is why you don't show work in progress." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Norther, do you ever regret not making it to Paris?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"I can't imagine any place better than here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You're a poet.  You oughta be able to.  And maybe if you'd seen more, you could." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Norther doesn't answer.  Just goes back to his notebook." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BY THE RIVER - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'By the light of the full moon, Edward soaks his feet in the water, trying to make sense of it all.  The Key to the City dangles around his neck.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He stares at himself in the reflection.  He smiles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's then that a WOMAN emerges at the far side of the river.  No telling where she came from -- she must have been swimming underwater.  We never see her face." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She stands in the river with her bare back to Edward, squeezing the water out of her golden hair, oblivious to his presence.  Edward is breathless.  It's the first woman he's seen in her natural state, and he doesn't dare move lest he frighten her away." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Then he sees the snake.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's a cottonmouth, has to be.  It leaves a break in the water, its small reptilian head aiming for her flesh.  There's no decision to be made.  On pure instinct, Edward dives in.  He swims as hard as can, " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'GRABBING THE SNAKE' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"just as it's about to strike." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The woman dives back underwater, understandably terrified that a man is coming at her.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"No, it's okay!  I got it.  I got the snake." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As the splashing subsides, Edward looks at what he holds in his hands.  Which isn't a snake at all, but rather a common stick.  And a non-threatening one at that." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'While Edward ponders his mistake, he looks around to discover that the Girl in the River is gone.  He never even saw her face.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Wait!  I'm sorry.  Hello?!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward keeps expecting her to surface, somewhere, but she never does.  He stands alone in the river, wondering what tricks his eyes are playing on him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. BY THE RIVER - NIGHT - CONTINUOUS' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A GIRL'S VOICE" Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"There's leeches in there!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks to the bank, where young Jenny Hill is watching him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Did you see that woman?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'What did she look like?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Well, she...uh...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Was she nekkid?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Embarrassed to admit it...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Yeah.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'(matter-of-fact)' Name.Decorator
+'\n'          Text.Whitespace
+
+"It's not a woman, it's a fish.   No one ever catches her." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Given the day he's had so far, Edward isn't inclined to follow up on the issue.  He starts to wade back to the bank." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Fish looks diff'rent to diff'rent people.  My daddy said it looked like the coon dog he had when he was kid, back from the dead." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward climbs up onto the shore, completely drenched.  He pulls up his pant legs to reveal three shiny leeches clinging to his skin.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Shoot.'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He starts to work pulling them off.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  PATH BACK TO TOWN - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward and Jenny walk back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'How old are you?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Eighteen.'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"I'm eight.  That means when I'm eighteen, you'll be 28.  And when I'm 28, you'll only be 38.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(a little wary)' Name.Decorator
+'\n'          Text.Whitespace
+
+"You're pretty good at arithmetic." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"And when I'm 38, you'll be 48.  And that's not much difference at all." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Eager to get off this subject...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Sure is a lot now, though, huh?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  MAIN STREET - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As Edward and Jenny approach Main Street, they find "downtown" has been transformed.  Lanterns and streamers hang on cables across the street, and a small stage has been built at one end to hold FIDDLERS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The whole town is there in celebration of its newest citizen, Edward Bloom.  Before he can protest, two WOMEN have grabbed him by the arms, pulling him in to dance with them.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The resulting dance number seems both choreographed and complete chaos.  From FARMER to BAKER'S WIFE, everyone wants to dance with Edward, who finds himself tossed around like a stick caught in a whirlpool.  Still, he's having a blast." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Jenny grabs both his hands, and they spin wildly.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Beamen plucks his LAUGHING daughter away to dance with her.   Then Mildred cuts in to dance with Edward.  It's hard to hear over the MUSIC." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MILDRED'     Name.Label
+'\n'          Text.Whitespace
+
+"Jenny thinks you're quite a catch.  We all do." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(not hearing)' Name.Decorator
+'\n'          Text.Whitespace
+
+'What?'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MILDRED'     Name.Label
+'\n'          Text.Whitespace
+
+"I said you're quite a catch!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward stops dancing.  A beat, then he heads for the edge of the crowd.  Beamen is there, with Jenny on his shoulders.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I have to leave.  Tonight.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+'Why?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"This town is everything a man could ask for.  And if I were to end up here, I'd consider myself lucky.  But the fact is, I'm not ready to end up anywhere." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+"No one's ever left.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'How are you gonna make it without your shoes?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I suspect it will hurt a lot.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'And with that, Edward walks down Main Street.  The townspeople stop dancing, disbelieving, some shaking their heads.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Poor Edward Bloom's gone crazy." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BEAMEN'      Name.Label
+'\n'          Text.Whitespace
+
+'(calling after him)' Name.Decorator
+'\n'          Text.Whitespace
+
+"You won't find a better place!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I don't expect to." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Jenny runs to him.  She'd tackle him if she could." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"Promise me you'll come back." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I promise.  Someday.  When I'm really supposed to." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's not good enough, but it will have to do.  Edward keeps walking." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE DARK FOREST - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"VARIOUS SHOTS:   Edward negotiates the thorns in his bare feet.  It's horrible.  Almost unendurable." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'And then it gets worse.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The trees ahead are moving.  At first, it just seems to be the wind blowing the branches, but as we hear the wood CRACKING and GROANING, there's no mistaking it:  they're trying to block him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Snake-like WHITE ROOTS shoot out of the ground, grabbing for his ankles.  He leaps up, kicking off one tree trunk to grab another one's branches.  He swings off, lands and rolls.  Now all the trees are moving to block him, their dark shapes towering over him in the flashes of LIGHTNING." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'As difficult as it was to reach Spectre, I was fated to get there eventually.  After all, no man can avoid reaching the end of his life.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As he ducks under branches, the chain holding the Key to the City gets caught.  He's almost strangled, but the chain finally breaks.  The silver key disappears into the mud." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Scrambling forward, he looks for a way out.  But the trees have encircled him, their spiky crowns bending down to crush him. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He SCREAMS up at the night, until his breath is gone.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"And then I realized, this wasn't the end of my life." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With a sudden calm...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(aloud)'     Name.Decorator
+'\n'          Text.Whitespace
+
+"This isn't how I die." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Another lightning FLASH, and suddenly the trees are back where they've always been.  Edward is lying shoeless and torn in a muddy puddle, staring up at the rain.  And LAUGHING." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'His bare foot steps onto asphalt.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A DEEP VOICE' Name.Label
+'\n'          Text.Whitespace
+
+'Friend!'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward turns to see ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL '       Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'to his right, coming down the larger, paved road.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'What happened to your shoes?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks down at his muddy, bloody feet.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'They got ahead of me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With that, the men start walking down the larger road.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  DINING ROOM - NIGHT ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward and Will sit at opposite ends of the table, with Sandra and Josephine in the middle.  Although Edward has a small plate of food in front of him, he hasn't touched it.  He's exhausted from the trip downstairs, but determined to maintain the family dinner ritual." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The other three eat awkwardly, each CLINK and SCRAPE of a knife or fork resonating.  Will finally breaks the silence.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I don't know if you've seen it, but Josephine has some photos in the most recent Newsweek." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Really!  That's wonderful." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I spent a week in Morocco for the story.  It was incredible.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"We'll have to pick up a copy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  As Will scoops out another serving of potatoes, Edward suddenly speaks:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I don't know if you're aware of this, Josephine, but African parrots, in their native home of the Congo -- they speak only French." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'All three stop to listen.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(amused)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'Really.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You're lucky to get four words out of them in English.  But if you were to walk through the jungle, you'd hear them speaking the most elaborate French.  Those parrots talk about everything:  politics, movies, fashion -- everything but religion." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Taking the bait...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Why not religion, Dad?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"It's rude to talk about religion.  You never know who you're going to offend." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Josephine actually went to the Congo last year.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Oh, so you know.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GROCERY STORE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will shakes a shopping cart free from the pile-up while his mother checks her list.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AT THE PRODUCE SECTION' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra starts to bag string beans.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Mom, would you say you understand Dad?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Of course.'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"What I mean is, do you really know what's going on in his head?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"How is that possible?  I mean, you try to ask him a question and suddenly it's another one of his stories." Literal.String
+'\n'          Text.Whitespace
+
+'(decidedly)' Name.Decorator
+'\n'          Text.Whitespace
+
+"You can't honestly say you know him." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Yes, Will, I do.  And don't presume things you don't know." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She's more amused than annoyed, but Will is entering dangerous territory." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Would you say you understand Josephine?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Yes.  But that's a different..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"No it's not.  It's exactly the same.  Your father and I met, we dated, and we married -- we chose each other -- because we understood each other on some fundamental level.  Just the same as you two.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She moves on to the carrots.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Josephine and I have a lot in common.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes, you both think William Bloom is a very smart man.' Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"The problem is, you only see me as your mother, and not as someone's wife.  And I've been his wife longer than I've been your mother.  You can't discount that." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"True.  But I've known him my whole life, and I don't feel like I know him at all.  Or ever will." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With a look, Sandra acknowledges the stakes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I know it's not easy.  Just remember, he didn't choose to be your father and you didn't choose to be his son.  You just ended up together.  You could pick numbers out of a dark bag and it'd be just the same.  If you ask me, it's a wonder parents and children can stand each other at all." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'But I understand you, Mom.  I always have.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Well, clearly you don't.  But I'm not the mystery you're trying to solve right now." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  AT THE CHECKOUT - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Reaching the CASHIER, Sandra hands over her coupons.  Will is approaching with a Newsweek magazine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Two checkstands over, an ATTRACTIVE BLONDE WOMAN in her 50's is getting her change.  Though she's Sandra's generation, she carries herself like a much younger woman, with blue jeans and sneakers." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She accidentally makes eye contact with Will as he passes.  We HOLD ON the woman, who tracks Will as he reaches Sandra.  It's hard to read her reaction:  does she recognize him, or just find him attractive? " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will notices the gaze.  The woman turns away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will racks his brain -- does he know this woman?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Before I forget, your father has papers in the basement I'd like you to go through.  I wouldn't know what's important." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(distracted)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Mom, do you know who that is?  Blonde hair.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra looks.  After a beat, the Blonde Woman turns again, semi-casually.  Noticing that both Will and Sandra are looking, she smiles a little before taking her cart to leave.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(no idea)'   Name.Decorator
+'\n'          Text.Whitespace
+
+'Was she one of your teachers?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"No.  But it's weird.  She seemed to recognize me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(to the cashier)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Do you know who that is?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Cashier turns to look.  He can only get a profile as the woman leaves.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CASHIER'     Name.Label
+'\n'          Text.Whitespace
+
+'Never seen her before.  Pretty, though.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST BEDROOM - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A portable fan quietly WHIRRS in the corner.  Turned low, the RADIO on the nightstand is playing a call-in AM sports show, just a wash of background chatter.  Edward lies asleep on his back.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"At the window, Josephine quietly lowers the shade.  She reaches over Edward to switch off the radio.  He stirs from the silence -- he wasn't fully asleep -- and sees Josephine stretched over him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(playfully lecherous)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Hello.'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She smiles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Hi.  How are you feeling?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I was dreaming.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'What were you dreaming about?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He tries to recollect, but it's already gone.  Josephine motions, is it okay for her to sit on the bed?  He nods." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I don't usually remember unless they're especially portentous.  You know what that word means, portentous?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She shakes her head.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Means when you dream about something that's going to happen.  " Literal.String
+'\n'          Text.Whitespace
+
+'(beat, gathering)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Like one night, I had a dream where this crow came and told me, "Your Aunt is going to die."  I was so scared I woke up my parents.  They told me it was just a dream, to go back to bed.  But the next morning, my Aunt Stacy was dead.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"That's terrible." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Terrible for her, but think about me, young boy with that kind of power.  Wasn\'t three weeks later that the crow came back to me in a dream and said, "Your Grampa is going to die."  Well, I ran right back to my parents.  My father said, no, Gramps is fine, but I could see there was trepidation.  And true enough, that next morning my Grampa was dead. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He sits up a bit in bed, his strength returning.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'For the next couple weeks, I didn\'t have another dream.  Until one night the crow came back and said, "Your Daddy is going to die."  ' Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Well, I didn\'t know what to do.  But finally I told my father.  And he said not to worry, but I could tell he was rattled.  That next day, he wasn\'t himself, always looking around, waiting for something to drop on his head.  Because the crow didn\'t tell how it was going to happen, just those words:  your Daddy is going to die.  Well, he went into town early and was gone for a long time.  And when he finally came back, he looked terrible, like he was waiting for the axe to fall all day.  He said to my mother, "Good God.  I just had the worst day of my life."' Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'"You think ' Literal.String
+'_'           Punctuation
+"you've"      Generic.Emph
+'_'           Punctuation
+' had a bad day," she said.  "This morning the milkman dropped dead on the porch!"' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine smiles, a half-laugh, which gets him smiling too.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat.  Then, deadpan...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Because see, my mother was banging the milkman.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'No, I understand.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'He was slipping her a little extra cream.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She nods, a bit more of a laugh.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'He was filling her basket.  He was making deliveries around back.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As Edward continues, she can't help but laugh harder, especially as the metaphors get more vulgar." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'He was buttering her rolls.  Pumping her churn.  Splashing milk in her box.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Stop.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'They were squeezing the cheese.  Clanking the bottles.  Licking the popsicle.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She's starting to cry from laughing. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Cracking the eggs and making an omelet.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With that, he stops.  She regains her composure.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Spooning the sherbet.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(interrupting)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Can I take your picture? ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You don't need a picture.  Just look up handsome in the dictionary." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Please?'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He rolls his eyes, why not.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine leaves, heading down the hall to get her camera.  We STAY WITH Edward in bed.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I have photos from the wedding to show you.  There's a great one of you and my father.  I had an extra print made." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward grimaces, a flash of pain.  Around others, he's hiding how much it hurts, but alone we can see how bad it is." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He controls his breathing, trying to push through it.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I want to see pictures of your wedding.  I've never seen any." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She returns with her camera.  Edward smiles, doing a good job masking the pain.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"That's because we didn't have a wedding.  Your mother-in-law was never supposed to marry me.  She was engaged to somebody else." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(loading film)' Name.Decorator
+'\n'          Text.Whitespace
+
+'I never knew.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Will never told you that?' Literal.String
+'\n'          Text.Whitespace
+
+'(she shakes her head)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Probably just as well.  He would have told it wrong anyway.  All the facts and none of the flavor.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Oh, so this is a tall tale?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Well, it's not a short one." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A devilish smile.  Pushing past Edward, we settle on the whirling fan.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MATCH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A SPINNING PINWHEEL' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"held by a LITTLE BOY.  He's slumped over his FATHER's shoulder, being carried towards a big-top tent.  We are..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  OLYMPIA CIRCUS - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"...where the second-rate carnival is parked for the moment in an Alabama field.  To the left, we spot Edward, 20-ish, halfway through a bag of peanuts.  He's still carrying the backpack we saw earlier, and scratched up from his trip through Spectre." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'I had just left Ashton, and was on my way to discover my destiny.  Not knowing what that would be exactly, I explored every opportunity that presented itself. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Joining the crowd, he heads into the big-top.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BIG TOP - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A troupe of STILT-WALKING FIREBREATHERS finishes their act to tremendous APPLAUSE.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As the performers clear away, the circus' owner-and-ringmaster AMOS CALLOWAY (50) approaches the stands.  He may only be four feet tall, but Amos has a titanic presence." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Ladies and Gentlemen, you may think you've seen the " Literal.String
+'_'           Punctuation
+'unusual'     Generic.Emph
+'_'           Punctuation
+".  You may think you've seen the " Literal.String
+'_'           Punctuation
+'bizarre'     Generic.Emph
+'_'           Punctuation
+".  But I've travelled to the five corners of the world, and let me tell you, I've never seen anything like this." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'From behind Amos, CARNIES start rolling a massive ball towards the crowd.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'When I found this man, he was picking oranges in Florida.  His fellow workers called him El Penumbra -- The Shadow -- because when you were working beside him, he blocked out the daylight.  He could take a whole tree in his hands and shake off the fruit.  I had to pay his crew boss $10,000 just so I could take him with me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos comes up to a MIDDLE-AGED WOMAN in the first row, a quieter moment.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Not to alarm you, Ma'am.  But if this man wanted to, he could crush your head between his toes." Literal.String
+'\n'          Text.Whitespace
+
+'(she trembles)' Name.Decorator
+'\n'          Text.Whitespace
+
+"But he won't." Literal.String
+'\n'          Text.Whitespace
+
+'(a long beat)' Name.Decorator
+'\n'          Text.Whitespace
+
+"He's not going to hurt her, folks, because he's our own Gentle Giant.  Ladies and Gentlemen, I give you Colossus!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The carnies back away from the ball as a deep DRUM ROLL begins.  A moment, then the ball starts to bulge from inside.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A foot suddenly bursts out from within.  GASPS from the crowd.  That foot is massive.  In the stands, Edward looks closer.  Intrigued.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the drum beat intensifies, a second foot breaks out.  Followed by hands.  Shoulders.  Finally, the head.  This is COLOSSUS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'From a very LOW ANGLE, we look up to see just how massive he is.  He seems to fill the Heavens.  With his shaved head and giant club, he seems more ogre than man.   ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"In the bandstands, a YOUNG BOY's jaw drops in awe.  Colossus walks down the row, letting the crowd get a better look at him.  Some reach out to touch him, disbelieving.  A tight spotlight follows him, revealing faces in the crowd.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Colossus passes Edward, who seems unimpressed.  He leans with the spotlight, WHISTLING to get the big man's attention.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He points to the edge of the stands, where his friend is sitting on the dirt --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL THE GIANT' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"stands up, so big the spotlight has to widen just to hold him.  He's a good foot taller than Colossus.  There's a GASP from the crowd, along with nervous anticipation -- what will happen next?" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ANGLE ON Amos, stunned, megaphone dangling.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ANGLE ON Colossus, realizing the gig is up.  With a resigned shrug, he rests his club on his shoulder and walks away into the shadows.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BIG-TOP - NIGHT / LATER' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the stands empty, Edward and Karl talk to Amos.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"What's his name?  Does he talk?  It's not important." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KARL'        Name.Label
+'\n'          Text.Whitespace
+
+'Karl.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'Tell me Karl, have you ever heard of the term  "involuntary servitude?"' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl shakes his head.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'"Unconscionable contract?"' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Nope.'       Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Great, great.  That's fantastic." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'It was on that night Karl met his destiny.  And I met mine.  Almost.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT. BIG TOP - NIGHT - CONTINUOUS' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As Amos pulls Karl aside to give him the hard sell, Edward notices a BEAUTIFUL YOUNG WOMAN (16) leaving with her family.  She's wearing a blue dress and hat.  For no good reason, she looks back at Edward.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The two make eye contact.  And as they do, all motion FREEZES.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A fiery baton remains mid-twirl, flames locked in place.  A spilled box of popcorn hangs in mid-air, each kernel like a snowflake.  Even the elephant is mid-poop.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Only Edward is free to move, winding his way between the frozen bodies, ducking underneath arms to get closer and closer to this woman.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+' '           Text.Whitespace
+'\n'          Text.Whitespace
+
+"They say when you meet the love of your life, time stops.  And that's true.  What they don't tell you, is that once time starts again, it moves extra fast to catch up." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, everything RUSHES.  The crowd becomes a blur, and the young woman is lost in its wake.  Now it's Edward who's frozen, helpless in time." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  DIRT PARKING LOT - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward checks in windows as cars pull out, searching for his fated love.  Not finding her, he becomes more frantic, running down the rows.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE EMPTY LOT' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Colossus is thumbing for a ride.  The last pickup truck stops and lets him climb in back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As the truck pulls out, it passes a dejected Edward.  He'll never find that girl, the love of his life." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BIG-TOP - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos leans over so Karl can sign a contract on his back.  He spots Edward walking back into the tent.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'Hey kid!  Your friend just made himself a star.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"That's great." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos hands off the contract to a CLOWN.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'(introducing)' Name.Decorator
+'\n'          Text.Whitespace
+
+'My attorney, Mr. Soggybottom.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Good to meet you.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Mr. Soggybottom HONKS his horn, then waddles off.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"What's the matter with you, kid?  I haven't seen a customer so depressed since the elephant sat on that farmer's wife." Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Get it?  "Depressed?"' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Karl chuckles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'See!  The big guy likes it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I just saw the woman I'm going to marry, I know it.  But then I lost her." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'Tough break.  Most men have to get married before they lose their wives.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(with absolute conviction)' Name.Decorator
+'\n'          Text.Whitespace
+
+"I'm going to spend the rest of my life looking for her.  That or die alone." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'Jesus, kid.' Literal.String
+'\n'          Text.Whitespace
+
+'(realizing)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Let me guess.  Real pretty, blonde hair, blue hat?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes!'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'I know her uncle.  Friends of the family.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Who is she?  Where does she live?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Kid.  Don't waste your time.  She's out of your league." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As Amos starts to walk away, Edward hurries to catch up with him.  Karl follows as well.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"What do you mean?  You don't even know me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Sure I do.  You were hot shit back in Hickville, but here in the real world, you got squat. You don't have a plan.  You don't have a job.  You don't have anything but the clothes on your back." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I've got a whole backpack " Literal.String
+'_'           Punctuation
+'full'        Generic.Emph
+'_'           Punctuation
+' of clothes!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He points to the bleachers, where no backpack is to be found.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(realizing)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Someone stole my backpack.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Kid, you were a big fish in a small pond.  This here is the ocean, and you're drowning.  Take my advice and go back to Puddleville.  You'll be happy there." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Getting in front of Amos, Edward stops him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Wait.  You said I don't have a plan.  I do.  I'm going to find that girl and marry her and spend the rest of my life with her.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos smiles, amused.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I don't have a job, but I would have a job if you gave me one.  And I may not have much, but I have more determination than any man you're ever going to meet." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Sorry, kid.  I don't do charity." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'll work night and day, and you won't have to pay me.  You just have to tell me who she is." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Amos takes a long look at him.  Ultimately, there's no way he can say no.  He shrugs.  What the hell." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Every month you work for me, I'll tell you one thing about her.  That's my final offer." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward shakes Amos's hand before he can retract the offer.  We move into a MONTAGE:" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BIG TOP CENTER RING - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"CLOSE ON Edward, smiling nervously.  His head is tilted to the side, and as we PULL BACK, we see why:  he's holding it in a MASSIVE LION's open mouth.  The beast's sharp teeth are just poking his skin.  If the lion so much as flinches, Edward is dead." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The CROWD applauds, which makes the lion antsy.  Which makes Edward antsier.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"From that moment on, I did everything Mr. Calloway asked, and a lot of things he didn't.  I'd go three days without stopping to eat, and four days without sleeping." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE HYDRA - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'His eyes droopy from lack of sleep, Edward mans the whirling amusement park ride.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'The only thing that kept me going was the promise of meeting the girl who would be my wife.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Nodding off, Edward falls backward, into the path of the spinning arms.  One of the Hydra cars hits him square in the gut, throwing him up and away, sailing 200 feet through the air.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FIELD - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward chases a costumed pig, tripping over tent cords, falling in the mud.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"His hunt leads him through the back of a tent, where he's unwittingly stepped in front of a line of motorized birds.  To the left, CUSTOMERS are shooting with rifles.  He dodges four SHOTS that knock down the birds around him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He catches his breath, lucky.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Then a half-blind OLD WOMAN pulls her trigger, hitting him in the shoulder.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BEHIND A TENT - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Karl the Giant bandages Edward's arm as well as he can.  Amos is walking past." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Mr. Calloway!  It's been a month today." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos stops, looks at the young man.  Finally...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'This girl, the love of your life.  Her favorite flower is daffodils.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He walks away.  We PUSH IN on Edward, enraptured by the concept.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Daffodils.  ' Literal.String
+'\n'          Text.Whitespace
+
+'(to Karl)'   Name.Decorator
+'\n'          Text.Whitespace
+
+'Daffodils!'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  STABLES - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward shovels shit in the nastiest stables you've ever seen.  But all he can think about is..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(to himself)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Daffodils!'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The wonder of it.  He goes back to shoveling, a smile on his face.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'True to his word, every month Amos would tell me something new about the woman of my dreams.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  A DARK PLACE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CLOSE ON Edward, lost in quiet reverie, pondering his latest bit of information.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"College!  She's going to college!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A sudden EXPLOSION as Edward is shot...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BIG TOP - NIGHT [CONTINUOUS]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'...out of a giant cannon.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  STABLES - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Under a full moon, Edward feeds the animals.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(to himself)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Music!  She likes music.  I like music too!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Over the months, I learned a lot about the woman I was going to marry, but not her name, and not where to find her.  That time had come.  I couldn't wait any longer." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  AMOS CALLOWAY'S TRAILER - NIGHT" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Under a full moon, Edward walks up to the battered camper, and is about to knock when he notices it's rocking.  A lot.  Not just that, there's MOANING coming from inside." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'But Edward KNOCKS anyway.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Mr. Calloway!  It's Edward Bloom.  I need to talk to you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Suddenly, the rocking and moaning stop.  A beat, then the door handle begins to RATTLE.  It seems to be stuck.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward turns the knob.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, the door BURSTS OPEN.  Edward is knocked down by a massive black dog, biggest you've ever seen.  It has green glowing eyes and a lick of fire for a tongue." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward wrestles with the beast, its mouth snapping at his throat.  Blocking with an arm, Edward tries to push himself free, but the creature's hands -- it has hands instead of paws -- hold on tight." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Entwined, they roll across the dirt.  The other nearby CARNIES scatter for cover.   Mr. Soggybottom pulls a revolver out of his clown suit.  Loads a silver bullet.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward finally succeeds in throwing the beast off.  He rolls to his feet.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The hell hound squares back on its haunches, GROWLING, ready for another leap.  Mr. Soggybottom sheds a clown tear, aiming the revolver at the dog.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'At the last moment...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'No, wait!'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward moves just as Mr. Soggybottom FIRES.  The bullet catches Edward in the shoulder, knocking him down.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The carnies GASP.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Licking its chops, the dog approaches the helpless Edward, who feels the ground around him, looking for some kind of weapon.  He finds only a small stick.  He waves it at the dog, ready to strike it.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Like magic, the dog's whole demeanor changes.  It bounces excitedly, ready to play fetch." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Seeing an opportunity, Edward throws the stick as far as he can.  The dog bounds after it, ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SMASHING DOWN THREE CARS.   ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It returns a beat later with the flaming stick, which it drops at Edward's feet.  Its tail whips back and forth." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'It was that night I discovered that most things you consider evil or wicked are simply lonely, and lacking in the social niceties.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward throws the stick again.  The dog takes off in a new direction.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TRANSITION TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FIELD - PRE-DAWN' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Exhausted from playing fetch all night, Edward throws the stick into the woods.  The still-spry dog goes after it.  It's gone for a long time, long enough that Edward becomes concerned." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He follows it into the woods.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  WOODS - DAWN' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos Calloway stands up behind a bush, buck naked and hairy.  He still has the stick in his mouth, which he takes out as Edward approaches.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Didn't kill anything, did I?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'A few rabbits, but I think one of them was already dead.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'That would explain the indigestion.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward tosses him his jacket to cover his privates.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'I was wrong about you kid.  You may not have much, but what you got, you got a lot of.  You could get any girl.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"There's only one I want." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+"Her name is Sandra Templeton.  She's going to Auburn.  The semester's almost over, so you better hurry." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Thank you.'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AMOS'        Name.Label
+'\n'          Text.Whitespace
+
+'Good luck, kid.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward walks away.  Then starts running.  He has to get there as soon as possible.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amos sits down and scratches his ear with his foot.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BIG TOP - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward shakes Karl's giant hand.  They hug." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'After saying my goodbyes, I hopped three trains to get to Auburn that afternoon.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  AUBURN UNIVERSITY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We DESCEND ON the main quad, to find Edward Bloom dunking his head in the fountain.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He changes out of his grubby shirt into a new one, just out of the package.  It's the mid-1960's, but by the conservative dress of the passing STUDENTS, it could be any era. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SORORITY HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward stands with a bouquet of daffodils in front of a half-open door.  Through the crack we can see the edge of a YOUNG WOMAN, talking in hushed tones with another girl we can't see. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Finally, a decision is reached.  The door opens to reveal the woman of Edward's dreams, Sandra Kay Templeton.  She's effortlessly beautiful, pure and simple as sunlight." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He can't believe he's finally reached her.  He half-laughs, nervous.  That makes her laugh, not sure what's going on." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You don't know me, but my name is Edward Bloom and I am in love with you.  I've spent the last three years working to find out who you are.  I've been shot and stabbed and trampled a few times, had my ribs broken twice, but it's all worth it to see you here, now, and to finally get to talk to you.  Because I am destined to marry you.  I knew that from the first moment I saw you at the circus.  And I know it now more than ever." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON SANDRA, overwhelmed.  All she can finally think of to say is...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm sorry."  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Don't need to apologize to me.  I mean, I'm the luckiest person you're going to find today..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She puts her hand on the door frame.  On her left ring finger, we see a diamond.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"No I'm sorry, I...I'm engaged to be married." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON EDWARD as his heart falls 20 floors.  He tries to suppress the reaction, put on a brave front.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Oh.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"But you're wrong.  I " Literal.String
+'_'           Punctuation
+'do'          Generic.Emph
+'_'           Punctuation
+" know you, at least by reputation.  Edward Bloom from Ashton.  See, I'm actually engaged to a boy from Ashton.  Don Price.  He was a few years older than you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'FLASHCUTS TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. CREEPY OLD HOUSE - THE GATE - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Young Don Price shines his flashlight on Edward.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'VARIOUS H.S. ATHLETIC COMPETITIONS' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Recapping earlier football, baseball and basketball highlights, we find Edward beats Don every time.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE STREET CORNER / ASHTON PARADE' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A smoking Don Price crushes his cigarette as Edward leaves town.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BACK TO:'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT/INT. SORORITY HOUSE - THE DOORWAY' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward is dumbstruck.  With all the strength he can muster...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Well.  Congratulations.  I'm sorry to have bothered you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He turns and walks down the front steps. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She stays in the doorway for a few beats, feeling genuinely horrible for what's happened.  But eventually she goes back inside.  We hear GIGGLES from inside as her sorority sisters get to the bottom of this." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Stop it.  It's not funny.  That poor boy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We LEAD Edward as he walks away, tears just starting to form.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Fate has a cruel way of circling around on you.  After all this work to leave Ashton, the girl I loved was now engaged to one of its biggest jerks.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He EXITS FRAME, leaving only the sorority house in the background.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"There's a time when a man needs to fight, and a time when he needs to accept that his destiny is lost, that the ship has sailed, and that only a fool would continue." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  Edward steps back INTO FRAME, looking at the sorority house.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"The truth is, I've always been a fool." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We CIRCLE as he shouts:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Sandra Templeton!  I love you!  And I am going to marry you!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  SORORITY HOUSE FOYER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra and her SISTERS peer out through the curtains.  Is this guy crazy?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  LECTURE HALL - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The tweedy ECONOMICS PROFESSOR continues his explanation.  Sandra isn't paying a lot of attention." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He switches on the overhead projector without looking at it.  There's a TITTER from the STUDENTS, but he doesn't notice." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A classmate nudges Sandra, who looks up.  Written on the projector is "I Love Sandra Templeton."  She\'s horrified and excited at the same time.   The professor finally notices what\'s written there.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  QUAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Walking with her books, Sandra shakes her head, disbelieving.  We look up to the blue sky, where a giant sky-written heart floats in the wind.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  SANDRA'S BEDROOM - [THE NEXT] MORNING" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"At her Sisters' prompting, a just-woken Sandra looks out the second-story window to find the lawn filled with " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TEN THOUSAND DAFFODILS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward stands amid the sea of flowers.  He's waited there six hours." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SORORITY HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra walks out to him.  She's smiling, confused, joyful and scared.  All down Greek Street, STUDENTS are coming out to see the display." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Daffodils?'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"They're your favorite flower." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'How did you get so many?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I called everywhere in five states and explained this was the only way I could get my wife to marry me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Out of nowhere, a tear drops down Sandra's cheek.  She wipes it off." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"You don't even know me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I have the rest of my life to find out.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'From down the street...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A MAN'S VOICE" Name.Label
+'\n'          Text.Whitespace
+
+'Sandra!'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"It's Don.  Promise me you won't hurt him." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"If that's what you want, I swear to it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The adult DON PRICE arrives.  He's 230 pounds of football-playing, Skynard-loving, fraternity-proud muscle.  And he's pissed." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A gang of his BROTHERS walk behind him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'Bloom!'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Don.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'What the hell are you doing?  This is my girl.  Mine!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I didn't know she belonged to anybody." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Don Price decks him, knocking him down.  Edward gets right back up, but makes no move to defend himself.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Unfazed, Don slugs him again.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Stop it!'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'(ignoring)'  Name.Decorator
+'\n'          Text.Whitespace
+
+'What the matter, Bloom?  Too scared to fight back?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I promised I wouldn't." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A beat.  Don shrugs, fine.  Then proceeds to kick Edward's ass nine ways to Sunday." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'While I took the beating of a lifetime, it was Don Price who was ultimately defeated.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the ass-whupping continues, we' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INTERCUT WITH:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  FRATERNITY HOUSE BATHROOM - DAY [FLASHFORWARD]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sitting on the can, Don Price pinches a loaf while reading the new Playboy.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"All the physical activity had worsened a congenital valve defect.  Put simply, his heart wasn't strong enough." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Don Price squeezes down hard, trying to shit the unshittable.  Suddenly, he grasps his chest and collapses face-first on the tile.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MATCH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  WITCH'S HOUSE / GATE - NIGHT [FLASHBACK]" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The same image of Don's dead face on the tile is reflected in The Eye.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'RETURNING BACK TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  THE SORORITY HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The thrashing continues.   Edward somehow fights his way back to his feet, ready to be knocked down again.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Don!'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Don is about to slug Edward again when he turns.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra pulls off her engagement ring.  There's an audible AHH! from her sisters, and an OHH! from Don's brothers." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'I will never marry you.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  Don stands stunned, his mind reeling.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward, whose eyes are swollen almost shut, keeps waiting for the next punch.  Where is it?  What's going on?" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DON PRICE'   Name.Label
+'\n'          Text.Whitespace
+
+'What.  You love this guy?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"He's almost a stranger and I prefer him to you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She hands him the ring.  Another beat, then Don storms off.  But not before decking Edward one last time.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra leans over Edward's broken body.  His head lies on the daffodils." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'How can I convince you to stop?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Go out with me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He smiles, his teeth bloody.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Okay.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the crowd of students APPLAUDS and CHEERS, we CRANE UP above the flowered battlefield.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'As it turned out, Sandra was able to keep her same date at the chapel.  Only the groom had changed.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the MUSIC reaches a crescendo, we suddenly...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST ROOM - NIGHT [PRESENT]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"I thought you said you didn't have a church wedding." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Well, we were all set to, but there was a complication.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He reaches for his glass of water, but Josephine already has it for him.  She watches him while he slowly drinks the entire glass, thirstier than he imagined.  While he's drinking, we..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  UPSTAIRS HALLWAY - NIGHT [CONTINUOUS]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will, back from the grocery store, reaches the top of the stairs.  He hears voices coming from the bedroom.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Is it the medicine that's making you thirsty?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Truth is, I've been thirsty my whole life.  Never really known why." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will quietly approaches the door, not exactly sneaking, but not exactly announcing his presence.  The door is open a few inches, letting him look in on his father and his wife.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INTERCUT HALLWAY / BEDROOM' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'There was one time when I was eleven...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(gently)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'You were talking about your wedding.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I didn't forget.  I was just working on a tangent.  See, most men, they'll tell a story straight through, and it won't be complicated, but it won't be interesting either." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I like your stories.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'And I like you.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He doesn't let the moment linger with undue sentimentality.  There's a story to be told." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Now.  The thing about working for a circus is you don't have a regular address, and after three years I had a lot of undelivered mail. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'In the hallway, Will shifts to a new position, letting himself listen to the story one more time.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'During the four weeks I was in the hospital, the postmaster finally caught up with me.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Bruised and bandaged, Edward sorts through a big bag of mail with help from Sandra.  He rips open an official-looking letter.  Reading it, his face drops.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'FLUTE and DRUM, music rising to a military cadence.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'It turned out that while my heart belonged to Sandra, the rest of my body belonged to the U.S. Government.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  ARMY AIRPLANE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With a buzz cut and paratrooper gear, Edward squats with a dozen other SOLDIERS.  The noise of the ENGINES is deafening, but Edward is engrossed in an Asian phrasebook.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"A hitch in the Army was up to three years at that point, and having waited three years just to meet Sandra, I knew I couldn't survive being away from her that long.  So I took every hazardous assignment I could find, with the hope of getting my time down to less than a year." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The JUMP LEADER yells...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JUMP LEADER' Name.Label
+'\n'          Text.Whitespace
+
+'GO!  GO!  GO!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'One by one the men jump out, their chutes clipped to a main line.  When his time comes, Edward leaps...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"...but he's stuck.  His cord is caught up in the assembly." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He twists and struggles, trying to free himself.  Looking down, he can see the white parachutes disappearing into the darkness.  They're already long gone." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Digging a knife out of his pocket, Edward gets to work cutting through the cable.  It finally POPS.  Edward jumps from the plane.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  OUTSIDE STAGE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A THOUSAND CHINESE SOLDIERS sit, bored, watching the equivalent of a U.S.O. show.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A CHINESE VENTRILOQUIST is on stage with his Communist puppet.  We have no idea what they're saying to each other, but every act is fundamentally the same." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The EMCEE comes on to usher him off the stage before he\'s finished.  The Ventriloquist protests, but finally gives in.  The Emcee makes a "shoot him in the neck" motion to one of the ARMED GUARDS off-stage.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  HIGH ABOVE THE STAGE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We LOOK DOWN with Edward, who is drifting right for the stage.  He can't steer.  He's helpless.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"But then, a BLAST of fireworks from the sides of the stage.  The lights go out as a DRUM ROLL begins.  It's just enough cover for Edward to remain unseen." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He lands with a CLANG on the lighting catwalk above the stage.  He barely grabs on, disconnecting his chute just as the curtain goes up.  Edward looks out at the sea of excited soldiers.  Every one of them would kill him.  He's the legless cricket left on the anthill." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. ON STAGE' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The curtain rises to reveal PING (27) at a microphone.  She's as gorgeous a woman as you'll ever see." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She stands with her hips turned in profile.  Her body is a knockout, dress cut to reveal skin.  The soldiers are on their feet, WHISTLING and HOLLERING.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'UP ON THE CATWALK, Edward is surprised by an ENEMY SOLDIER.  The two men begin to SCUFFLE.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MUSIC starts, a vampy torch song.  Ping sings melody while an off-stage voice carries perfect harmony.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+'*'           Literal.String
+'Sometimes a girl can feel so alone' Literal.String
+'\n'          Text.Whitespace
+
+'Without a lover to call her own.' Literal.String
+'\n'          Text.Whitespace
+
+"Sometimes it's so bad, she wants to explode." Literal.String
+'\n'          Text.Whitespace
+
+'Wants to grab the first man she sees and tear off his clothes.' Literal.String
+'*'           Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A ROAR from the soldiers.  She knows what they want.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Still fighting, Edward jumps for a pole on the far side of the catwalk, sliding down it to end up ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BACKSTAGE.'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'His determined opponent follows him down.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'*'           Literal.String
+"But she won't." Literal.String
+'\n'          Text.Whitespace
+
+"No, she can't." Literal.String
+'\n'          Text.Whitespace
+
+'She needs a special ' Literal.String
+'**'          Punctuation
+'special'     Generic.Strong
+'**'          Punctuation
+' different unusual man.' Literal.String
+'\n'          Text.Whitespace
+
+'Because that girl,' Literal.String
+'\n'          Text.Whitespace
+
+'Who looks like me,' Literal.String
+'\n'          Text.Whitespace
+
+'She has wants, but she has needs.' Literal.String
+'*'           Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(speaking)'  Name.Decorator
+'\n'          Text.Whitespace
+
+'Any of you got needs?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The soldiers ROAR LOUDER, STOMPING on the bleachers.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Backstage, the two men are still fighting.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(chorus)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'*'           Literal.String
+"I've had twice the adventure," Literal.String
+'\n'          Text.Whitespace
+
+'Cried double the tears.' Literal.String
+'\n'          Text.Whitespace
+
+'Two times the bad times in half the years.' Literal.String
+'\n'          Text.Whitespace
+
+"I need a strong man, because I've got" Literal.String
+'\n'          Text.Whitespace
+
+'Twice the love to give.' Literal.String
+'*'           Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'For the first time, Ping turns, and now we see why she was standing in profile.  Ping is one-half of ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SIAMESE TWINS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Her identical twin is JING, who's been singing harmony all this time.  They are two separate women who join at the waist, one set of perfect legs beneath them." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward sees the twins from behind, does a double-take.  It costs him a punch to the jaw.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Say hello, Jing.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JING'        Name.Label
+'\n'          Text.Whitespace
+
+'Hello Jing.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+'(to the crowd)' Name.Decorator
+'\n'          Text.Whitespace
+
+"I'm Ping.  She's Jing.  She's the good one." Literal.String
+'\n'          Text.Whitespace
+
+'(closer)'    Name.Decorator
+'\n'          Text.Whitespace
+
+"I'm the bad one." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the MUSIC builds towards the climax, Edward finishes the fight, knocking the guard out with a right hook.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As Ping and Jing reach the last chorus, they strike a final pose in the shape of a heart, their arms forming the arches, their backs forming the curves.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward slips behind curtains, trying to get away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The soldiers are SHOUTING for an encore, lighters waving.  The curtain slowly lowers, revealing' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EDWARD'S PARACHUTE." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The APPLAUSE dies, replaced by a concerned RUMBLE.  The Emcee yells for the Guards to search.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON STAGE'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Ping has no idea what's happening.  Jing reaches into her cleavage to pull out her eyeglasses. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  DRESSING ROOM - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As ARMED GUARDS search the halls below the stage, Ping and Jing shut the door to their dressing room.  At the closet, they start to change outfits.  Off-stage, their personalities become quite apparent:  Ping is brash, bitchy and ambitious, while Jing is quiet, sweet and bookish.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Punctuation
+'In Chinese, subtitled...' Generic.Emph
+'_'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+'How could you miss your cue?  You make me look like a fool, out there alone.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JING'        Name.Label
+'\n'          Text.Whitespace
+
+"You weren't alone." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Ping HUFFS, turning her back on her sister.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Jing reaches deeper into the closet to find a new dress, exposing Edward's hiding place.  She GASPS.  Ping turns to look." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+'Who the hell are you?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(in Chinese)' Name.Decorator
+'\n'          Text.Whitespace
+
+"I'm not going to hurt you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+"Damn right you're not. " Literal.String
+'\n'          Text.Whitespace
+
+'(yelling)'   Name.Decorator
+'\n'          Text.Whitespace
+
+'GUARD!'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Jing grabs her, a hand over her mouth, but it's too late.  A rifle-toting GUARD looks in." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Pretending to be her bitchy sister --  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JING'        Name.Label
+'\n'          Text.Whitespace
+
+'Tell your men not to bother us!  And lock that door!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The guard obeys.  Ping shakes her sister off.  Desperately flipping through his Asian phrasebook, he finds... ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Please, I need your help.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+"What makes you think we'll help you?  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward pulls a photo out of his flak jacket.  It's Sandra." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'VARIOUS SHOTS' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Over the next hour, I described my love for Sandra Kay Templeton, and the ordeal that brought me before them.  As it had always been, this love was my salvation.  It was destined to be.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Hearing the story, Jing wipes away a tear.  Even Ping is a little affected.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'We put together an elaborate plan for escape, involving a whaling ship to Russia, a barge to Cuba and a small, dirty canoe to Miami.  We all knew it would be dangerous.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'_'           Punctuation
+'Still subtitled:' Generic.Emph
+'_'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+'And what are we supposed to do when we get to America?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I can get you bookings.  I know the biggest man in show business.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JING'        Name.Label
+'\n'          Text.Whitespace
+
+'Bob Hope?'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Bigger.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TRANSITION TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  TEMPLETON FAMILY HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra checks the mail, hoping for a letter from Edward.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'And so the twins and I began our arduous journey halfway around the world. Unfortunately, there was no way to send a message back to America. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A black car pulls up.  Two ARMY OFFICERS get out.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'And so it was no surprise that the Army believed I was dead.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Hearing the news, Sandra CRIES OUT.  The pain of her shout makes church bells RING.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BEHIND THE TEMPLETON HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra hangs sheets to dry on the clotheslines, forming a tunnel of fabric.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"After four months, Sandra had gotten over the worst of the nightmares.  When the phone rang, she didn't think it was somehow me calling her.  When a car drove past, she didn't get up to check out the window." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Pulling a dress out of the basket, Sandra looks up to see ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A MAN'S SILHOUETTE " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"on the sheet in front of her.  She freezes, watching the shadow ripple across the white fabric, blowing so softly in the breeze.  She knows it can't be him.  He's dead." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She turns away.  With all the strength she can gather, she hangs up that dress and digs another one out of the basket.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Looking up, she sees not a shadow but Edward himself standing before her.  She GASPS, disbelieving, but his hand is real.   It is destiny.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Without another moment's hesitation, she kisses him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BRIGHT SUNLIGHT' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"filters through soft sheets.  We're under the covers, where a man's hand traces the curves of a woman's bare back.   A beat, then she turns over in bed, revealing her to be " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE.'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She blinks slowly, just waking up.  Will is watching her.  He's been up for a while.  We are actually..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL AND JOSEPHINE'S ROOM - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'...where the couple stays cocooned under the sheets, a kind of limbo.  A kiss good morning.  Legs entangling.  Neither wants to get up.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I talked with your father last night.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Did you?'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A look to say, should I be worried?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'You never told me how your parents met.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'They met at Auburn.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'What about the details?  How they fell in love.  The Circus.  The War.  You never told me any of that.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"That's because most of it never happened. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"But it's romantic." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(non-committal)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Mmm.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Mmm, what?'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Mmm, what.  I know better than to argue romance with a French woman.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He moves his head out from under the sheet.  She follows him to the "outside."' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'Do you love your father?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Everyone loves my father.  He's a very likeable guy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'(repeating)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Do you love him?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will doesn't want to answer yes or no." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You have to understand.  When I was growing up, he was gone more than he was here.  And I started thinking -- maybe he has a second life somewhere else.  With another house, another family.  He leaves us, he goes to them.  Or maybe there is no family.  Maybe he never wanted a family.  But whatever it is, maybe he likes that second life better.  And the reason he tells all those stories is because he can't stand this boring place." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"But it's not true." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'What is "true?"  I\'ve never heard my father say a single true thing.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Off her silence...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Look, I know why you like him.  I know why everyone likes him.  But I need you to tell me I'm not crazy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"You're not." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'I need you on my side.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I am always on your side.  And I think you should talk to him.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST ROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The family finishes eating breakfast off TV trays set up around the bed.  For his part, Edward is looking better.  Certainly not recovered, but there's an optimism to his expression.  And for the first time, he's actually hungry.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He watches as Sandra puts the cap back on the syrup.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Did I ever tell you about how...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(interrupting)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Yes.'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward is startled.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'The maple tree and the Buick.  We heard it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(re:  Josephine)' Name.Decorator
+'\n'          Text.Whitespace
+
+"I think someone hasn't." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'The tree fell on the car, spilling the syrup, which attracted the flies, which got stuck to it and flew off with the whole car.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(undeterred)' Name.Decorator
+'\n'          Text.Whitespace
+
+'But the real story is how I got the car.  You see...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(interrupting)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Dad?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Son?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Can we talk?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra SNAPS the cap back on the syrup.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm going to get started on dishes." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"I'll help you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Both women quickly gather plates.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will and Edward both smile.  The women clearly want this to happen.  It settles for a beat after they leave.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Do you know much about icebergs, Dad?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Do I?  I saw an iceberg once.  They were hauling it down to Texas for drinking water, only they didn't count on an elephant being frozen inside.  The woolly kind.  A mammoth." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(interrupting)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Dad!'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'What?'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I'm trying to make a metaphor here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Then you shouldn\'t have started with a question.  Because people want to answer questions.  You should have started with, "The thing about icebergs is..."' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(frustrated)' Name.Decorator
+'\n'          Text.Whitespace
+
+"The thing about icebergs is you only see 10 percent of them.  The other 90 percent is below the water where you can't see it.  And that's what it is with you Dad.  I'm only seeing this little bit that sticks above the water." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(joking)'    Name.Decorator
+'\n'          Text.Whitespace
+
+"What, you're seeing down to my nose?  My chin?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'I have no idea who you are because you have never told me a single fact.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I've told you a thousand facts.  That's all I do, Will.  I tell stories." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You tell lies, Dad.  You tell amusing lies.  Stories are what you tell a five-year old at bedtime.  They're not elaborate mythologies you maintain when your son is ten and fifteen and twenty and thirty.  And the thing is, I believed you.  I believed your stories so much longer than I should have.  And then when I realized that everything you said was impossible -- everything! -- I felt like such a fool to have trusted you.  You were like Santa Claus and the Easter Bunny combined.  Just as charming and just as fake." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You think I'm fake." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Only on the surface.  But that's all I've ever seen." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks away, angry and disbelieving.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Dad, I'm about to have a kid of my own here.  It would kill me if he went through his whole life never understanding me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'It would kill you, huh?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finally --'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'What do you want, Will?  Who do you want me to be?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Yourself.  Good, bad, everything.  Just show me who you are for once. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I have been nothing but myself since the day I was born.  And if you can't see that, it's your failing, not mine." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BACKYARD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"With a skimmer pole, Will cleans the leaves and debris out of the pool, but it's a fool's errand.  The pool has long since gone native, a shiny slick of algae on the surface, slime covering the cemented rocks.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, an underwater shape RIPPLES against the water's surface.  Will is so startled that he drops the pole, which disappears into the murky water.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  He looks around, relieved that no one saw that.  He casually walks away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BASEMENT STORAGE AREA - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The doors open to reveal Sandra, Will and Josephine, staring into the mouth of oblivion.  The storeroom is a museum of hasty decisions and half-finished projects:  partially built outboard motors, dead bonsai trees, Frankensteinian lawnmowers.  We also find boxes of products Edward used to sell.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Clearing a path, Sandra leads Will to a roll-top desk, its ribs covered in dust.  Two beaten metal file cabinets sit beside it.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"Your father decided he needed to have an office, and it wouldn't do to have it in the house.  You'll know better than me what's important." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"With some effort, Will forces up the desktop.  With a HISS, a neighbor's cat makes a run for it.  Will's getting used to being startled." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BASEMENT STORAGE AREA - DAY [LATER]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will, Sandra and Josephine have worked through two trash bags of papers to throw out.  Looking through a new file, Sandra makes a small sound.  A memory.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'What is it?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra hands Will a yellowed telegram.  He shares it with Josephine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'It was during the war.  Your father went missing.  They thought he was dead.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will can't believe what he's reading." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'That really happened?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Not everything your father says is a complete fabrication.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat, then Sandra stands.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm going to check on him." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I need to lie down for a bit.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Go.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine kisses him, then follows Sandra.  Will re-reads the telegram, still bewildered.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Looking for a place to put it, he tucks it into a strange mechanical hand on the desk.  It clamps down automatically.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will smiles, a memory.  He hasn't thought about this device in years.  We slowly PUSH IN on the telegram, held in the hand." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward's VOICE begins as a memory..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'After the war, the sons of Alabama returned home, looking for work.  Each had an advantage over me.  They were alive, while I was -- officially -- deceased.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  DOWNTOWN OFFICE - DAY [STORY]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward shakes hands with his new boss, a TOUPEED MAN.  The company is called "Confederated Products."  The OFFICE LADIES all love Edward.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"With my prospects few, I took a job as a travelling salesman.  It suited me. If there's one thing you can say about Edward Bloom, it's that I am a social person." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  COUNTY FAIR - DAY  [STORY] ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'On a low platform, Edward pitches a brilliant new product to the crowd.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I've travelled from Tennessee to Timbuktu, and if there's one thing people have in common, is we could all use a hand around the house." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward sets down a contraption, which looks something like a metal lava lamp.  Like a flower, it unfolds to reveal five fingers and a thumb.  This is the Hand Around the House.(TM)' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Why, with this product you can...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'QUICK MONTAGE as he demonstrates:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Open a jar.  Open a letter.  Scratch yourself while wearing mittens.  Hold a book.  Hold a baby.  Hold the dog away from kittens.  It's strong enough, you can do a handstand with no hands at all." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Indeed, a remarkably agile Edward is able to support his entire weight on it.  The crowd APPLAUDS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'You can use it to point out important information.  Or dangers.  Or beautiful women.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The hand points a finger at an HEAVYSET MAN IN OVERALLS.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"We're still working on that one." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The crowd LAUGHS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  A COUNTRY ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward drives, his hand out in the wind.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Soon I added other products, and other cities, until my territory stretched from the coast to western Texas.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  TRAILER PARK - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward kisses his pregnant wife goodbye, as much in love as ever.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"I could be gone for weeks at a time.  But every other Friday, I'd put all the money I'd made into an account set aside for a proper house with a white picket fence." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  HORIZON SAVINGS & LOAN - DAY ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Establishing this Texas institution, we come...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HORIZON SAVINGS & LOAN - DAY ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The bank is busy with the lunch-hour crowd.  Taking his place in line, Edward fills out a deposit slip.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the line snakes around through the ropes, the man in front of him gets a look at Edward.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE MAN'     Name.Label
+'\n'          Text.Whitespace
+
+'Edward?  Edward Bloom?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The man is none other than...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"It's me.  Norther Winslow." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'I was astonished to see the greatest poet of both Ashton and Spectre all the way out in Texas.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The men shake, disbelieving this lucky coincidence.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I don't believe it!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"I want you to know, when you left Spectre it opened my eyes.  There was a whole life out there that I was not living.  So I travelled.  I saw France, and Africa, half of South America.  Every day a new adventure, that's my motto." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"That's great, Norther.  I'm happy for you.  I can't believe I helped." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He's genuinely proud." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'So what are you up to now?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"I'm robbing this place." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Reaching the front of the line, Norther pulls two pistols out of his coat, FIRING both into the ceiling.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SCREAMS all around.  The skinny SECURITY GUARD makes a half-hearted reach for his gun, but Norther waves him off.  The guard takes out his gun and slides it over.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(to Edward)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Would you mind grabbing that?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"There's nothing threatening about his delivery -- he might as well be asking for a Budweiser.  Still, Edward senses it would be best to do as he says.  He takes the guard's gun." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(to the crowd)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Now, I want all of you to lie down.  I'm gonna be cleaning out the cash drawers, and my associate here is going to handle the vault." Literal.String
+'\n'          Text.Whitespace
+
+'(pointing to a Teller Woman)' Name.Decorator
+'\n'          Text.Whitespace
+
+'You help my friend, okay?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The TELLER WOMAN nods.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"ANGLE ON Edward, not sure what to do.  He has a gun, but he truly doesn't want to shoot Norther.  The Teller Woman is already waving him to the back." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He decides he better go.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  AT THE VAULT - DAY ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Teller Woman is crying as she works the combination.  Edward feels horrible.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Look, I'm really sorry.  I just don't want anybody to get hurt." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TELLER WOMAN' Name.Label
+'\n'          Text.Whitespace
+
+"It's not that, it's just..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She pulls open the vault door.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  THE VAULT - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The inner sanctum of the Horizon Savings and Loan holds exactly one folding chair.  Nothing else.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TELLER WOMAN' Name.Label
+'\n'          Text.Whitespace
+
+"...there's no money.  We're completely bankrupt. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'It turned out the savings and loan had already been robbed -- not by armed bandits, but by speculators in Texas real estate.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TELLER WOMAN' Name.Label
+'\n'          Text.Whitespace
+
+'(dead serious)' Name.Decorator
+'\n'          Text.Whitespace
+
+"You gotta promise you won't tell anybody." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  EDWARD'S CAR - DAY  " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward drives the getaway car, though truthfully they're going just a little over the speed limit.  No one's following them.  It's an empty country road for miles." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Norther HOLLERS with body-tingling joy as he counts the money.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"Sixty.  Eighty.  Four hundred dollars!   Not bad for just the drawers.  Let's see what you got from the vault." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward winces, but doesn't say anything yet.  Digging through the vault bag, Norther is surprised to find only a single deposit envelope.  He rips it open, revealing just a little cash inside.  Even some dimes and pennies." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'This is it?  The whole vault.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"'Fraid so."  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"Edward, it's got your deposit slip on it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Caught, Edward has to confess...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Look, I just didn't want you to go empty-handed.  There's something you should know, Norther.  You see, the reason why..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward continues his narration...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'I told Norther about the vagaries of Texas oil money and its effect on real estate prices, and how lax enforcement of fiduciary process had made savings and loans particularly vulnerable.  Hearing this news, Norther was left with one conclusion:' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  TEXAS ROAD - DAY ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Norther leans in the driver's side window." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+"I should go to Wall Street.  That's where all the money is." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward looks over at Norther, the reality sinking in.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"I knew then that while my days as a criminal were over, Norther's were just beginning. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The two men wave at each other as Edward drives off.  At the last moment, Norther calls out:' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NORTHER WINSLOW' Name.Label
+'\n'          Text.Whitespace
+
+'Edward, thank you for the hand!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He's talking about his Hand Around the House.  We HOLD ON Norther for a beat, dreaming of his future." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'When Norther made his first million dollars, he sent me a check for ten thousand.  I protested, but he said it was my fee as his career advisor.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  BLOOM HOUSE [MID/LATE '70'S] - DAY  " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra is watering the garden.  Will (5) runs past her to greet Edward, just returned from another trip.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Ten thousand dollars is no fortune to most men.  But it was enough to buy my wife a proper house with a white picket fence.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We reveal the Bloom house, the nicest one in the neighborhood.  Edward kisses his wife.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'And for that, it was all the riches a man could ever want.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra drops the hose, letting it run on the lawn.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TRANSITION TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE BATHROOM - DAY [PRESENT] ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"CLOSE ON Edward's hand as he turns knobs." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CLOSE ON water SPLASHING into the claw-foot bathtub, which begins to fill.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Still wearing his pajamas, Edward climbs into the tub.  Carefully lowers himself.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the water reaches the third button up on his pajama shirt, Edward suddenly slides ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'UNDERWATER.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Bubbles rise from his nose for a few beats, then stop.  It's quiet, except for the distant SPLASHING of water from the spigot.  Edward's eyes are closed." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat.  Another.  Then the SPLASHING water goes silent.  Edward opens one eye.  The other eye.  He sits up to find ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA '     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"sitting on the edge of the tub.  She doesn't seem particularly worried -- her husband has always done this." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I was drying out.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'I see.  We need to get you one of those plant misters.  We can spray you like a fern.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He smiles, then pulls his knees up, making room for her in the tub.  A beat while she considers.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra steps out of her sandals and climbs into the tub, facing him.  Her dress is soaked, but she doesn't mind." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He leans forward and kisses her.  When they separate, she has tears hanging in her eyes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Come now.'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He wipes them away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I don't think I'll ever dry out." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BASEMENT STORAGE AREA - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Perched awkwardly on a canoe, Will's made it through another file cabinet.  He goes through the folders page by page, but usually ends up tossing the whole thing in the trash." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He's about to toss a file when he stops.  Takes another look. Something doesn't make sense." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE / STAIRS - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will is headed upstairs when his mother comes around the corner with an armful of laundry, including her wet dress.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Is he awake?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"He just fell asleep.  Josephine's with him." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She passes him.  He turns.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Mom?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will quickly debates whether or not to ask her...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Did you and Dad have any other property?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(thinking)'  Name.Decorator
+'\n'          Text.Whitespace
+
+"I suppose your grandmother's house when she passed on.  But we sold that right away.  Your cousin Shirley bought it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'So you never bought any land.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Heavens no.  We had a hard enough time keeping the mortgage on this place.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will nods, just curious.  He continues heading up.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL AND JOSEPHINE'S ROOM - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will changes his shirt.  Takes his keys off the nightstand.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  COUNTY ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will\'s rental car drives past a sign reading, "Ashton, 10 miles."' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL'S CAR - DAY / DRIVING" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will checks the address on one of his father's files." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ASHTON GAS - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will talks to the ATTENDANT, who points him in a direction, then gestures a series of left, right, left, rights.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will drives down a road that seems somewhat familiar.  And then we realize why:  a roadsign reads "Welcome to Spectre!"' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  A LONE HOUSE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sitting at the edge of a swamp, the little two-story feels lonely, set deep in its lot.  Dapples of light break through the trees, a light breeze swaying the branches.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As Will walks from the car, the WHIRR of cicadas grows.  He checks the number:  33.  This is the house.  It is surrounded by a white square-picket fence, identical to his mother's.  Will notices this." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Reaching the porch, we hear a PIANO playing inside.  Badly.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Re-checking the number on a form he's carrying, Will KNOCKS.  The piano stops." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"WOMAN'S VOICE" Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Go back to the start.  Right hand only.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The piano starts again.  FOOTSTEPS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The door opens to reveal a blonde woman in her 50's -- the woman from the grocery store.  Her name is Jenny Hill." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She and Will are startled to see each other.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Oh.  Oh.'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Hello.'      Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"I wasn't expecting you." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Confused, Will checks the name on the form.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Are you Jenny Hill?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"I am.  And you're Will.  I've seen your picture, that's how I recognize you.  I almost said something at the store, but it would have been awkward." Literal.String
+'\n'          Text.Whitespace
+
+'(a beat)'    Name.Decorator
+'\n'          Text.Whitespace
+
+'Like this.'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The PIANO STUDENT, a black boy of eight, has stopped.  He's watching the conversation at the door.  Speaking of awkward..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(to the student)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Listen, Kenny.  Why don't we skip the lesson today?  We can go again next week." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She hands him five dollars out of her pocket.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'STUDENT'     Name.Label
+'\n'          Text.Whitespace
+
+'Do I have to give it back to my Mom?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"I won't tell her if you won't." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"You don't have to tell him twice.  He's out the door in a flash." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  JENNY'S KITCHEN - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'While Will sips his iced tea, Jenny flips through a form she never expected to see again.  She hands it back to Will. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'How did you know my father?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'This was on his sales route, so he was through here all the time.  Everyone in town knew him.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  Not flinching...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Were you and my father having an affair?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'(taken aback)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Wow.  Wow, you just said it.  I was expecting to dance around this for another half hour.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I've seen him with women.  He flirts.  He always has.  On some level, I presumed he was cheating on my mother.  I just never had proof." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She moves, trying to get out of the corner he's boxed her into.  Once she's finally free..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"Can I ask you a question?  Why did you come here today?  If you found this deed, why didn't you just ask Eddie?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Because he's dying." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A long beat.  Jenny is taken back by the suddenness of it.  She's a tangle of conflicting emotions." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"Look, I don't know how much you want to know about any of this.  You have one image of your father and it would be wrong for me to go and change it.  Especially this late in the game." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"My father talked about a lot of things he never did, and I'm sure he did a lot of things he never talked about.  I'm just trying to reconcile the two." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Fair enough.  Jenny takes a seat across from him at the table.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'The first thing you have to understand, is that your father never meant to end up here.  And yet he did, twice.  The first time, he was early.  The second time, he was late.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  EDWARD'S CAR / DRIVING - NIGHT " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's late, and Edward is pensive. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Those days, your father was working for himself.  If there was one thing you could say about Edward Bloom, it's that he was a social person, and people took a liking to him.  One night he was returning from three weeks on the road, when he hit a thunderstorm unlike any in his life." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The first raindrops hit the windshield.  Edward turns on the wipers. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT. EDWARD'S CAR - NIGHT - [THE STORM]" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Suddenly, a deluge descends.  It's not even rain anymore -- there's no space between the drops.  It's like being caught in a waterfall.  It's that loud." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'No choice, Edward stops the car.  Puts on the handbrake.  Just as suddenly, the sound changes -- no longer pounding, but softly SPLASHING.  The world is close and echoing, because --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  EDWARD'S CAR - NIGHT " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'-- the car is underwater.  The tires are still on the road, but where there used to be air is water.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Three catfish swim in front of his headlights.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  THE CAR - NIGHT ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Realizing his plight, Edward tries to remain calm.  Water is trickling in through the crack between the window and the door, but very slowly.  For now, he's fine." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"That's when he sees her -- The Girl in the River.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She's swimming outside the car.  While we never see her face exactly, she remains just as beautiful, just as mysterious, as the first time we saw her." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She puts her hand to the windshield.  He puts his up to meet hers.  And smiles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'FLASH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  FIELD BY DIRT ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's morning, and the sun shines brightly.  Birds CHIRP.  Trees drip and the grass shines, still wet from last night's rain." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward gathers the clothes that have spilled out of his suitcase, which broke open when he dropped it from ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'HIS CAR,'    Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'which balances precariously ten feet up in an elm tree.  As Edward gathers his last pair of socks, he notices a shiny piece of metal sticking out of the dirt.  He pulls it out, rubs it off.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's a key.  It's the Key to the City he lost years ago." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Fate has a way of circling back on a man, and taking him by surprise.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Carrying his busted suitcase, a tired Edward walks toward a one-street town in the distance.  We pass a rusty sign...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'"Welcome to Spectre."' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  MAIN STREET - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Amazed and disbelieving, Edward walks down the center of the road, no cars coming from either direction.  He looks up to find his faded shoes still dangling from the power line, along with the rest of the town's." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"A man sees things differently at different times in his life.  This town didn't seem the same now that he was older.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT. TOWN OF SPECTRE - VARIOUS SHOTS' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We look around the town, on and off Main Street.   There are "FOR SALE" signs in many of the windows' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'A new road had brought the outside world to Spectre, and with it, banks, liens and debt.  Almost everywhere you looked, people were bankrupt.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SPECTRE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We slowly MOVE THROUGH a foreclosure auction to find Edward watching.  Two very corporate MEN IN SUITS, stick out among the bidders.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Two different corporations were looking at buying the town, if they could get the price low enough.   One wanted to open a chicken processing plant.  The other, a municipal dump.  Either way, Spectre would be destroyed.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward raises his hand.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Fifty-thousand!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Everyone turns to look at this new bidder.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'And so Edward Bloom decided to buy the town, in order to save it.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  NORTHER WINSLOW'S MANHATTAN - DAY  " Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward pitches his plan to Norther.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'He was never a wealthy man, but he had made other men rich, and now he asked for their favors.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT./EXT.  VARIOUS LOCATIONS - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'VARIOUS SHOTS:  Expressive and passionate as always, Edward talks to Ping, Jing and Amos Calloway.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Most of them had never seen Spectre -- they only had Edward's words to describe it.  That's all they needed.  He sold them on the dream.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JING'        Name.Label
+'\n'          Text.Whitespace
+
+"You can structure it as a historical trust.  But you'll need every contiguous piece of property.  It's all or nothing." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As Edward takes notes...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'So first he bought the farms.  Then he bought the houses.  Then he bought the stores.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  AL'S COUNTRY - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finishing up with AL, Edward shakes hands.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Whatever he bought, the people were not asked to leave or pay rent or anything.  They were just asked to keep doing as they were doing.  In that way, he could make sure the town would never die.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ROAD IN THE SWAMP - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward climbs out of his car, the road having literally stopped.  The sun is shining, but it can barely penetrate the trees' thick canopy.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Within six months, his trust had purchased the entire town.  With one exception.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"In the distance, he sees a shack, so old it's nearly fallen.  He walks toward it, the marshy ground SQUISHING up around his feet, soaking the hems of his trousers." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We hear a PIANO playing from inside the shack.  Edward KNOCKS on the half-hung door, which swings open by itself.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  SHACK - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The inside is nicer than you'd think, a real home.  A fire burns in the stove, and curtains hang in the windows." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"With her back turned to him, Jenny Hill plays the piano.  Edward doesn't recognize her as the little girl who used to have a crush on him.  Without turning, she says..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'You must be Edward Bloom.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'How did you know?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She keeps PLAYING.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"No one would come out here unless they had business.  And no one would have business with me except for you.  You're buying the town." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Apparently I've overlooked this one piece of it, and I'd like to remedy that.  You see, in order for the town to be preserved, the trust must own it in its entirety.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"So I've heard." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'll offer you more than it's worth.  And you know you won't have to move.  Nothing will change except the name on the deed, you have my word." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Jenny stops playing, her piece not quite finished.  She turns to face him.  Edward still doesn't recognize her." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"Now let me get this straight.  You'll buy the swamp from me, but I'll stay in it.  You'll own the house, but it'll still be mine.  I'll be here, and you'll come and go as you please to one place or another.  Do I have that right?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Strange to hear it put that way, but --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'In so many words, yes.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"Then I don't think so Mr. Bloom.  If nothing is going to change, I'd just as soon it not change in the way it hasn't been changing all this time." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"It's not like you're going to lose anything.  You can ask anyone in town.  I've been nothing if not generous.  I want the best for everyone." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Mr. Bloom, why are you buying this land?  Some sort of midlife crisis?  Instead of buying a convertible, you buy a town?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He looks at her, puzzled and surprised.  No one has really asked before.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Helping people makes me happy.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"I'm not convinced you should be happy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm sorry.  Have I offended you?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She finally turns to face him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'No, you did exactly what you promised.  You came back.  I was just expecting you sooner.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'FLASHBACK TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SPECTRE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Young Jenny Hill watches barefoot Edward leave Spectre for the first time.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BACK TO:'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  SHACK - DAY  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finally realizing who this woman is...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"You're Beamen's daughter.  Your last name is different." Literal.String
+'\n'          Text.Whitespace
+
+'(realizing)' Name.Decorator
+'\n'          Text.Whitespace
+
+'You married.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'I was 18.  He was 28.  Turns out that was a big difference.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Before he can say anything more...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I won't be selling you this house, Mr. Bloom." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I see.  I thank you for your time.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A bit bewildered, Edward tips his hat to her as he leaves.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT/INT.  SWAMP SHACK - DAY' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward pulls the door shut behind him as he leaves, but it breaks off in his hands.  It's not the clean exit he was hoping for." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Inside Jenny looks out, surprised and annoyed.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward tries to lift the door back on the hinges, but they SNAP off.  The door frame buckles and the whole shack CREAKS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm sorry."  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He tries to lean the door against the frame, but it keeps slipping.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"It's okay, just leave it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'I can get it.  I can just...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He leans the door a different way.  It holds for a beat then falls in, SMASHING a small table.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Lord, I'm sorry I..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Please.  Go.  Just go.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'll..."     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Go.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She's dead serious.  Weighing the scales of chivalry, he finally backs away.  Turns and heads back towards his car." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We STAY ON Jenny, watching him go.  She's furious, but there's something more in her feelings for him.  Something softer." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Most men in that situation would accept their failure and move on.  But Edward was not like most men.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SWAMP SHACK ROAD - ANOTHER DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"With Karl the Giant's help, Edward unloads a brand new door from a pickup truck.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SHACK - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'While Jenny watches, half-annoyed, half-amused, Edward tries to set the door square.  Karl pushes against the side of the house until it fits.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  SHACK - ANOTHER DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Holding nails between his lips, Edward puts in new windows himself.  Jenny is making soup, laughing at the story he's telling." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'As the months passed, he found more and more things to fix, until the shack no longer resembled itself.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SWAMP - ANOTHER DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward and Karl cut down a tree, letting in a flood of light.  Through the golden pollen hanging in the air, we RISE UP to see the shack is now ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE LOVELY HOUSE' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"we saw before.  It's tiny and white, with black shutters and a steep roof.  A white picket fence.  In every detail it is impossibly charming." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  JENNY'S HOUSE - DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward is screwing a hat rack into the wall in the foyer.  Jenny leans against the doorframe listening to his story.  And watching him with deepest affection.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Of course, the best part was creating new material.  By the time the twins and I got to Havana, we had a whole new routine worked out for them, with just a ukulele and a harmonica.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Finished with his work, he takes his hat off the chair and hangs it on the rack.  Perfect.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"A beat.  A look between them.  With that last job done, there's no reason for him to be staying any longer." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'I suppose I should...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He takes his hat off the rack.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'You can leave it there.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  Does she really mean it?  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She comes closer.  Edward holds his ground.  She takes his hand, lifting his hat up to the peg.  She's very close -- just a half-inch from kissing him when --" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'-- Edward gently holds her back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'No.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She freezes, stunned and humiliated.  She pulls away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Don't.  Don't be embarrassed.  I should never have let you think that..." Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'I am in love with my wife.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'I know.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"And from the moment I saw her until the moment I die, she's the only one.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Lucky girl.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"I'm sorry, Jenny.  I am." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With that, he begins to leaves.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Wait!  Edward!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She finds a pen and hastily signs the deed to the house.  Hands it to him.  With a look, he thanks her.  Then goes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  SPECTRE - MAGIC HOUR' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward takes a final look at this perfect little town.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"One day, Edward Bloom left, and never returned to the town he'd saved." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He climbs in his car and starts the engine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"EXT.  JENNY HILL'S HOUSE - DAY TO NIGHT" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As we watch, the swamp begins to overtake the house, swallowing it in a tangle of vines and mossy branches.  Shoots burst up through the planks in the porch.  Snakes slither through the marsh.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Day becomes night.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"As for the girl, the common belief was that she'd become a witch, and crazy at that.  She became something of a legend herself." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We REVERSE to find FOUR KIDS looking in through the rusty iron gate with flashlights.  A beat, then they run away.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'And the story ended where it began.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  JENNY HILL'S KITCHEN - PRESENT DAY" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will and Jenny are still sitting at her table, a pitcher of iced tea between them.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"Logically, you couldn't be the Witch, because she was old back when he was young." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+"No, it's logical if you think like your father.  See, to him, there's only two women:  your mother and everyone else." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"You didn't become crazy." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'Well, therapy.  And one day I realized I was in love with a man who could never love me back.  I was living in a fairy tale.  ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will smiles to hear it called that.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"People aren't like they are in stories.  They hurt each other without meaning to.  They are kind and unbelievably cruel at the same moment.  Like me, now.  I'm not sure I should have told you any of this." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Her composure is starting to break.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"No, I wanted to know.  I'm glad I know. " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat, both staring at their iced tea.  Jenny is working herself into more of a state by not talking.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+'\n'          Text.Whitespace
+
+'I wanted to meet you for the longest time.  I did.' Literal.String
+'\n'          Text.Whitespace
+
+'(a smile)'   Name.Decorator
+'\n'          Text.Whitespace
+
+"I envied you so much.  The way Eddie would talk about you when you were at Missouri, that award you won.  Congratulations, incidentally.  And when you got the job at the A.P., everything, he was so proud of you.  I mean, that's the thing.  Every moment he loved you.  " Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"She's fighting tears, not the first ones she's shed over this." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'And as brightly as the sun would shine when he was with me, every time he left it disappeared.  I wanted to be as important to him as you were, and I was never going to be.  I was make-believe and his other life, you, were real. ' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ANGLE ON Will, sorting through his swirling thoughts.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JENNY'       Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"You knew that, didn't you?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"INT.  WILL'S CAR - DAY / DRIVING" Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will skips through the stations on the radio, but ultimately turns it off.  He's trying to think." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BLOOM HOUSE - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will walks up the front steps.  There's a subtle change to his expression, a dark cloud lifted.  He unlocks the door." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BLOOM HOUSE FOYER - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's half-dark and quiet in the house, no talking, no TV.  Will sets his keys on the table." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  KITCHEN - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will looks in.  Empty.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(calling out)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Hello?  Mom?  Dad?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  UPSTAIRS HALLWAY - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We follow Will, looking into his and Josephine's room.  He aims for the guest room at the end of the hall." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST ROOM - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Looking over his shoulder, we see his father's bed is empty.  The sheets are in a tangle on the floor." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat, then Will half-runs back down the hall.  Back down the stairs.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  FOYER - DUSK' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Headed out, Will grabs his keys off the table.  We LOOK RIGHT, where the "MESSAGE" light blinks on the answering machine.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ENTRANCE - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The hospital is so new, it's not even finished -- thick plastic hangs from exposed framing.  There's no one at the information desk, so Will forges ahead." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL HALLWAY - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will reads a directory board, trying to decide the best place to start.  Then, behind him --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Will!'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He turns to see his wife at a payphone.  She hangs up.  She was calling him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'What happened?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"Your father had a stroke.  He's upstairs with your mom and Dr. Bennett." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Is he going to be okay?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.  How can she answer?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He half-smiles, realizing the idiocy of his question.  Of course his father's not going to be okay." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'What I mean is, will he get back to the way he was when...' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She cuts him off --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"No.  He won't.  I'm sorry." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"And like that, it's done.  We HOLD ON Will, reeling from the news." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward sleeps peacefully, just an oxygen tube under his nose.  There are no beeping monitors, no blinking lights.  It's mercifully quiet." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra squeezes Will's hand tightly.  She's holding herself together, but it's been a tough day.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Dr. Bennett has just gone through the details for the third time.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+"I don't suppose one of us could stay with him.  In case he..." Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'In case he wakes up, one of us should be there.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I'll stay.  Why don't you go home with Josephine and I'll stay tonight." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(to Dr. Bennett)' Name.Decorator
+'\n'          Text.Whitespace
+
+"That's okay?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"It's fine."  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'(to Will)'   Name.Decorator
+'\n'          Text.Whitespace
+
+"You'll call if..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"I will.  I'll call." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat.'     Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Mom, do you want some time with Dad?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Yes.  Thank you.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A nod, then Will holds the door for Dr. Bennett and Josephine as they leave.  Sandra is alone in the room with her husband.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She neatens his hair.  Holds his hand.  As she kisses his fingers, she tweaks her chin with them -- his signature move.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TRANSITION TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL HALLWAY - NIGHT  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sandra waits outside the women's restroom.  Her face is a study in strained composure -- acknowledging the inevitable but refusing to surrender to it." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine emerges.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"I'm sorry.  It seems every hour I have to..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'I know.  It was the same when I was carrying Will.  Like clockwork.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The two women start to walk, no hurry.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'Do you like it, being pregnant?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+'I do.'       Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'I loved it.  It sounds peculiar, but I loved every minute of it.  I did.  Eddie was travelling a lot, so he was gone, but I felt like I always had a piece of him with me.  A little part of  his soul inside me.  I could feel it.  It was alive and kicking.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Sandra has accidentally evoked a storm of emotion.  She struggles to keep it in check.  Almost a whisper...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SANDRA'      Name.Label
+'\n'          Text.Whitespace
+
+'I really miss that.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With a few breaths, Sandra tries to hold on.  Hold back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'JOSEPHINE'   Name.Label
+'\n'          Text.Whitespace
+
+"Don't stop.  Don't." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A beat, then Sandra finally melts.  Josephine holds her.  The two women stand together in the hallway, letting the moment be.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - NIGHT' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will sits in a chair beside the bed, working through the crossword puzzle.  A KNOCK as Dr. Bennett enters with his overcoat and bag, ready to leave for the night.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"Glad to see you're not trying to have a heartfelt talk.  It's one of my greatest annoyances, when people talk to those who can't hear them." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'My father and I have an advantage.  We never talk.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Dr. Bennett smiles as he checks Edward's chart." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'How long have you known my father?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Thirty years.  Maybe more.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'How would you describe him?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'(re: chart)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Five-eleven.  One-eighty.  Regulated hypertension.' Literal.String
+'\n'          Text.Whitespace
+
+'(beat)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'How would his son describe him?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Tables turned, Will searches for an answer.   He doesn't have one." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Dr. Bennett hangs the chart back on the bed.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Did your father ever tell you about the day you were born?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'A thousand times.  He caught an uncatchable fish.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Not that one.  The real story.  Did he ever tell you that?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(suddenly interested)' Name.Decorator
+'\n'          Text.Whitespace
+
+'No.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+"Your mother came in about three in the afternoon.  Her neighbor drove her, on account of your father was on business in Wichita.  You were born a week early, but there were no complications.  It was a perfect delivery.  Now, your father was sorry to miss it, but it wasn't the custom for the men to be in the room for deliveries then, so I can't see as it would have been much different had he been there.  And that's the real story of how you were born." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long silence, just the sounds of the hospital, doctors being paged.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Not very exciting, is it?  And I suppose if I had to choose between the true version and an elaborate one involving a fish and a wedding ring, I might choose the fancy version.  But that's just me." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will half-smiles.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Patting Will's shoulder, Dr. Bennett leaves.  We STAY ON Will and his father for a long time, then Will takes his pen and starts making a list." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT. HOSPITAL ROOM - VARIOUS SHOTS' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will flips to a new page.  The list keeps getting longer.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He smiles, remembering something.  On his fourth page, he looks up at his motionless father.   A beat, then we slowly' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - PRE-DAWN  ' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's very early morning, and the first blue light of day is glowing through the vertical blinds.  Still in his chair, Will wakes up a bit at a time.  The notepad is on his lap, the pen in his hand.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He cracks his neck, crooked from sleeping on it wrong.  What woke him up?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He looks to his right.  Holds his gaze for a breath.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Dad?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'His father is awake, silently GASPING for breath.  His eyes are open, scared and confused.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'Dad!  Do you want me to get a nurse?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward shakes his head unambiguously.  Will already has his finger on the orange "nurse call" button, but doesn\'t push it.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'What can I do?  Can I help?  Can I get you something?  Water?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward nods.  Will pours a glass from the pitcher on the nightstand.  He holds it to his father's lips, but Edward won't drink.  He pushes it away.  He wanted something else." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(whispering)' Name.Decorator
+'\n'          Text.Whitespace
+
+'The river.'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'The river?'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It takes Edward all his strength to put together each thought.  It's like he's only half-there, fighting to hang on to this world." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Tell me how it happens.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'How what happens?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'How I go.'   Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON WILL, realizing...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'You mean what you saw in The Eye?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward nods.  Yes, that's what he was trying to say." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A long beat.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"I don't know that story, Dad.  You never told me that one." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will pushes his fingers under his father's heavy hand, and holds it.  There's nothing else to do." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward looks around, confused and increasingly scared.  He sees the end approaching, but doesn't know exactly what's coming.  Without the story, he's lost." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Fighting the urge to panic --' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'I can try, Dad.  If you help.  Just tell me how it starts.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Like this.'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Okay.  Okay.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will looks around the room, increasingly desperate.  He looks to the nurse call button.  He really wants to press it.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'ON EDWARD, waiting for Will to begin.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'  '          Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Okay.  It's morning, and you and I are in the hospital.  I'd fallen asleep in the chair.  I wake up and I see you, and..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO:'     Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - DAY [STORY VERSION]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Dad?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's dawn, and the first golden glow is shining through the vertical blinds. " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'(louder and concerned)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Dad?'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We LOOK OVER to find a nimble Edward sitting up in bed, combing his hair.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"Let's get out of here." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Somehow, you're better.  Different.  You're getting ready to go.  And I say..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\xa0'        Text.Whitespace
+'\n'          Text.Whitespace
+
+"Dad, you're in no condition to..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'But Edward throws back the covers.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+"There's a fold-up wheelchair in the bathroom.  Wrap a blanket around me.  As soon as we get off this floor, we'll be in the clear." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will heads for the bathroom.  Sure enough, the wheelchair is there.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Hurry!  We don't have much time." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL HALLWAY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'With the blanket draped over his head like a ghost, Edward points for his son to steer the wheelchair thataway.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Faster!'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'They pass a HEAVYSET NURSE, who turns to look.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Rounding a corner, they nearly crash into Dr. Bennett.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DR. BENNETT' Name.Label
+'\n'          Text.Whitespace
+
+'Will!  I...What are you doing?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Before he can answer, Will spots Edward rolling the chair himself, pumping both arms.  Will dashes to catch up with him.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The Heavyset Nurse leans out of Edward's hospital room." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'NURSE'       Name.Label
+'\n'          Text.Whitespace
+
+'Security!  Stop them!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DOWN THE HALL' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'At the elevators, Sandra and Josephine step out to find Will and Edward barreling straight at them.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'No time to explain!  Follow us!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Seeing SECURITY GUARDS heading their way, a quick-thinking Sandra shoves a nearby cart into them, bowling them down.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  ELEVATOR - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will brakes hard, sliding with both feet.  The chair nearly crashes into the back wall as the doors close.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  PARKING LOT - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will races Edward down the row, finally reaching the Chevrolet.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'AT THE CAR'  Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will lifts his father out of the chair.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"I pick you up and you hardly weigh anything.  I can't explain it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will sets him in the passenger seat.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Water.  I need water.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Scrambling in back, Will finds a liter of Arrowhead.  Hands it off.  Edward unscrews the cap, but instead of drinking it, he douses himself.  Soaks the blanket.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will pops the trunk.  Starts to fold up the wheelchair.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+"Leave it!  We won't need it." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TIRES SMOKE as the car peals out.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BACK TO:'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - DAY [REALITY]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TIGHT ON Will, trying to hold back tears as he talks.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'And we have to take Glenville to avoid all the church traffic, because those damn church people drive too slow.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"TIGHT ON Edward, enjoying that detail.  He's focused completely on Will's story." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+"(CONT'D)"    Name.Decorator
+'\n'          Text.Whitespace
+
+'I ask...'    Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BACK TO:'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  GLENVILLE BLVD. - DAY [STORY VERSION]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Chevy slaloms through the Sunday-morning traffic.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(O.S.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Where are we headed?' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'You say...'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  CHEVY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'The River!'  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will stops short, the traffic backed up.  He HONKS, trying to get around the jam.  But it's no use." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Then, up ahead, the cars start moving, shoved aside by massive hands.  It's Karl the Giant, clearing a path by brute force." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward leans out the window and waves.  Karl waves back.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  ASHTON RIVER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The same stretch of the river where it all began.  A CROWD of more than 100 waiting.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"As we get closer to the river, we see everybody's already there.  And I mean everybody." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Amos Calloway is here with the circus folk, including Mr. Soggybottom.  We also find Edward's Mother and Father, the Mayor, and many others from along the way.  No one has aged a day since we saw them last." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"While Ping scans the horizon, Jing nuzzles with her boyfriend, Norther Winslow.  It's Ping who first spots the Chevrolet." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PING'        Name.Label
+'\n'          Text.Whitespace
+
+"He's here!"  Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The crowd CHEERS.  The Ashton marching band PLAYS.  Jenny Hill smiles.  So does the Old Woman.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"We PUSH IN on the Old Woman's glass eye, where we see..." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'YOUNG EDWARD' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'reflected.  This is what he saw.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  THE CHEVROLET - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Amazed, Will turns to his father.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+"It's unbelievable." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Story of my life.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  RIVERSIDE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will gets out of the Chevrolet, overwhelmed by the crowd.  Behind him, Sandra, Josephine and Dr. Bennett pull up.  Karl comes just after that.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Crossing to the passenger side, Will lifts his father out.  Strangely, he's gotten even lighter.  Will carries him easily." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward pulls off his shoes, tying the laces together.  He hands them to Josephine.  She throws them up at the powerline.  They loop over.  APPLAUSE and CHEERS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The crowd parts to let Will and Edward get to the river.  As he passes, Edward shakes some hands, pats some people on the cheek, and gives others a good poke in the ribs.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"And the strange thing is, there's not a sad face to be found.  Everyone's just so glad to see you, and send you off right." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will walks into the river, up to his knees.  He turns back so his father can face the crowd.  Edward waves.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'Goodbye everybody!  Farewell!  Adieu!' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE CROWD'   Name.Label
+' '           Text.Whitespace
+'(VARIOUS)'   Name.Decorator
+'\n'          Text.Whitespace
+
+"Goodbye Edward! / See ya! / We'll miss you!" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"But one face is missing from the crowd -- Sandra.  Will turns to see she's already standing in the river beside them." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"The reflection of the light off the water gives Sandra an unearthly glow.  She's more tranquil and more beautiful than we've ever seen her." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'My girl in the river.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'She kisses him.  He tweaks her chin.  The crowd HOLLERS in approval, but their moment remains strangely private.  Only Will is there to witness.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"As the kiss ends, Edward tries to pull off his wedding ring.  But it's stuck.  Finally, he sucks on it, pulling it free with his teeth." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A look to Will, a smile with a glint of gold.  Will takes the ring out of his mouth.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Edward suddenly drops out of Will's arms with a SPLASH.  For he's no longer a man, but rather" Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A FAT CATFISH' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'swimming at his feet.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We watch as the catfish circles, then heads for deeper water, disappearing.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will and his mother stand knee-deep in the water, watching Edward Bloom swim away into the sunlight.  Josephine is back on the shore, along with the entire crowd.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MUSIC BUILDS to a climax, then...' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Down the river, a GIANT FISH suddenly jumps out of the water, cutting a beautiful arc across the sunset.  It then dives back under with a SPLASH.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE BACK TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL ROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will has tears hanging in the corners of his eyes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'You become what you always were.  A very big fish.  ' Literal.String
+'\n'          Text.Whitespace
+
+'(he smiles)' Name.Decorator
+'\n'          Text.Whitespace
+
+"And that's the way it happens." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EDWARD'      Name.Label
+'\n'          Text.Whitespace
+
+'(a whisper)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Yes.  Exactly.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Edward smiles, proud of both of them.   His eyes are so pale and so open, we can almost see his soul.  In every atom of his body, in every thought, Edward Bloom is entirely happy.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'And this is how he goes.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL HALLWAY - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will shuts the door to his father's room behind him.  The walk to the payphones seems to take a lifetime." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He finds a quarter, starts to dial.  He has to squint to see through the water in his eyes.   It's ringing.  And ringing.  The other end answers." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'(voice cracking)' Name.Decorator
+'\n'          Text.Whitespace
+
+'Hi.'         Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"That's all he can get out before the dam breaks inside him.  He presses closer to the phone, trying to shield himself." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'MUSIC begins that will carry us through the next passage.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  HOSPITAL RECEPTION - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will waits at reception as Sandra and Josephine come off the elevator.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  GUEST ROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine opens the curtains, letting white sunlight in.  She strips the bed.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT.  BEDROOM - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will and his mother pick out one of Edward's ties, for Will to wear at the funeral.  Will tries to button the cuffs on the shirt he borrowed, but they're the kind that need links." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'He goes through the top drawer of the dresser, trying to find a matching pair.  Further down, he finds a ribbon tied to ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'THE KEY TO THE CITY.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"He smiles, disbelieving.  It's a real thing." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  CEMETERY / ROAD - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will helps his mother out of a black sedan.  She's well-composed, not nearly the wreck we might have expected.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Josephine hugs Dr. Bennett and shakes hands with his WIFE.  The service is crowded, more than 200 people, many more than expected.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As his mother talks to a WELL-WISHER, Will looks left to see an Oldsmobile parking.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CLOSE ON the license plates.  Missouri.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The passenger side opens, but the man who steps out is barely visible over the door.  He shuts it to reveal himself to be 70.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's Amos Calloway.  Will doesn't recognize him." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The Driver climbs out, a size 15 foot on the gravel.  We TILT UP to see this man is huge.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"This man is KARL, now 55.  He's not 12 feet tall, but at least six-eight." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CLOSE ON Will, bewildered to see that this man really exists. ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  CEMETERY / GRAVESIDE - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'As the service gets ready to begin, Will guides his mother to a seat near the grave.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Sitting beside Will, Josephine spots a stunning ASIAN WOMAN (50) behind them.  A beat later, an identical face with glasses peers out -- the woman's twin sister.  " Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"It's PING and JING." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Josephine almost GASPS.  She elbows Will, who turns to look.  From this angle, the sisters seem conjoined, but then Jing steps forward.  They're really two separate people." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A sea of familiar faces, all of them aged through the years:  BEAMEN, NORTHER WINSLOW, the MAYOR, and ZACKY PRICE.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  CEMETERY - DAY [LATER]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"After the service, we see the crowd gathered in small groups.  By the LAUGHTER and hand gestures, we can see they're telling stories.  They're telling Edward's stories." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We find Will watching them.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"Have you ever heard a joke so many times you've forgotten why it's funny?  But then you hear it again and suddenly it's new.  You remember why you loved it in the first place." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will joins in, laughing.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'We slowly CIRCLE BEHIND a monument, letting it black out the screen.  ' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'TRANSITION TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  BLOOM HOUSE BACKYARD - DAY [SUMMER]' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'Will sits on the porch with Sandra and Josephine, watching his SON play in the pool with two NEIGHBOR KIDS.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SON'         Name.Label
+'\n'          Text.Whitespace
+
+'(to the other boys)' Name.Decorator
+'\n'          Text.Whitespace
+
+"So he said he'd fight the giant who was fifteen feet tall." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'KID'         Name.Label
+'\n'          Text.Whitespace
+
+'No way.'     Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SON'         Name.Label
+'\n'          Text.Whitespace
+
+'(calling over)' Name.Decorator
+'\n'          Text.Whitespace
+
+"Dad, that's right, isn't it?" Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+'\n'          Text.Whitespace
+
+'Something like that.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SON'         Name.Label
+'\n'          Text.Whitespace
+
+"See.  So he was a giant but my grampa was going to fight him because he wasn't afraid of anything because he'd seen how he was going to die in this old lady's glass eye..." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"Will smiles as his son continues the tale, which FADES.  Sandra takes Will's hand in hers, just listening." Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+"That was my father's final joke I guess.  A man tells his stories so many times that he becomes the stories.  They live on after him." Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CROSSFADE TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXT.  RIVER / UNDERWATER - DAY' Generic.Heading
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'A fat and happy catfish swims towards us.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'WILL'        Name.Label
+' '           Text.Whitespace
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'And in that way, he becomes immortal.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'The fish passes us with a SPLASH.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'CUT TO BLACK.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+' '           Generic.Strong
+'_'           Punctuation
+'**'          Punctuation
+'THE END'     Generic.Strong
+'**'          Punctuation
+'_'           Punctuation
+' '           Generic.Strong
+'<'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/examplefiles/fountain/example.fountain
+++ b/tests/examplefiles/fountain/example.fountain
@@ -1,0 +1,22 @@
+Title: Example Fountain
+Credit: Written by
+Author: Pygments Test Suite
+Contact:
+    555 Example St.
+    Brno
+
+# ACT I
+= Opening image.
+
+INT. OFFICE - DAY #1#
+
+BRICK
+(quietly)
+This is *important*.
+
+STEEL ^
+And **urgent**.
+
+> CUT TO BLACK.
+
+> THE END <

--- a/tests/examplefiles/fountain/example.fountain.output
+++ b/tests/examplefiles/fountain/example.fountain.output
@@ -1,0 +1,87 @@
+'Title'       Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'Example Fountain' Literal.String
+'\n'          Text.Whitespace
+
+'Credit'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'Written by'  Literal.String
+'\n'          Text.Whitespace
+
+'Author'      Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'Pygments Test Suite' Literal.String
+'\n'          Text.Whitespace
+
+'Contact'     Name.Attribute
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'555 Example St.' Literal.String
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Brno'        Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'#'           Punctuation
+' ACT I'      Generic.Subheading
+'\n'          Text.Whitespace
+
+'= Opening image.' Comment.Special
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT. OFFICE - DAY' Generic.Heading
+' '           Generic.Heading
+'#1#'         Name.Label
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'BRICK'       Name.Label
+'\n'          Text.Whitespace
+
+'(quietly)'   Name.Decorator
+'\n'          Text.Whitespace
+
+'This is '    Literal.String
+'*'           Punctuation
+'important'   Generic.Emph
+'*'           Punctuation
+'.'           Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'STEEL'       Name.Label
+' '           Text.Whitespace
+'^'           Punctuation
+'\n'          Text.Whitespace
+
+'And '        Literal.String
+'**'          Punctuation
+'urgent'      Generic.Strong
+'**'          Punctuation
+'.'           Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+' CUT TO BLACK.' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+' THE END '   Generic.Strong
+'<'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/fountain/test_blocks.txt
+++ b/tests/snippets/fountain/test_blocks.txt
@@ -1,0 +1,92 @@
+---input---
+Title: Test Script
+Author:
+    Test Author
+
+INT. LAB - NIGHT #12A#
+
+!SCANNING THE AISLES...
+Where is that pit boss?
+
+@McCLANE
+(V.O.)
+Yippie ki-yay.
+
+>SMASH CUT TO:
+
+> THE END <
+
+===
+
+# Act I
+= Setup.
+
+---tokens---
+'Title'       Name.Attribute
+':'           Punctuation
+' '           Text.Whitespace
+'Test Script' Literal.String
+'\n'          Text.Whitespace
+
+'Author'      Name.Attribute
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Test Author' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'INT. LAB - NIGHT' Generic.Heading
+' '           Generic.Heading
+'#12A#'       Name.Label
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'!'           Punctuation
+'SCANNING THE AISLES...' Text
+'\n'          Text.Whitespace
+
+'Where is that pit boss?' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'@'           Punctuation
+'McCLANE'     Name.Label
+'\n'          Text.Whitespace
+
+'(V.O.)'      Name.Decorator
+'\n'          Text.Whitespace
+
+'Yippie ki-yay.' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+'SMASH CUT TO:' Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'>'           Punctuation
+' THE END '   Generic.Strong
+'<'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'==='         Operator
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'#'           Punctuation
+' Act I'      Generic.Subheading
+'\n'          Text.Whitespace
+
+'= Setup.'    Comment.Special
+'\n'          Text.Whitespace

--- a/tests/snippets/fountain/test_comments_and_markup.txt
+++ b/tests/snippets/fountain/test_comments_and_markup.txt
@@ -37,7 +37,7 @@ Escape this: \*9765\*
 'Sing a '     Literal.String.Other
 '*'           Punctuation
 '_'           Punctuation
-'song'        Generic.Emph
+'song'        Generic.EmphStrong
 '_'           Punctuation
 '*'           Punctuation
 '.'           Literal.String.Other

--- a/tests/snippets/fountain/test_comments_and_markup.txt
+++ b/tests/snippets/fountain/test_comments_and_markup.txt
@@ -1,0 +1,55 @@
+---input---
+This is [[a note]] inside action.
+
+/*
+Hidden scene.
+Still hidden.
+*/
+
+~Sing a *_song_*.
+
+STEEL
+Escape this: \*9765\*
+
+---tokens---
+'This is '    Text
+'[[a note]]'  Comment.Special
+' inside action.' Text
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'/*'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'Hidden scene.' Comment.Multiline
+'\n'          Text.Whitespace
+
+'Still hidden.' Comment.Multiline
+'\n'          Text.Whitespace
+
+'*/'          Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'~'           Punctuation
+'Sing a '     Literal.String.Other
+'*'           Punctuation
+'_'           Punctuation
+'song'        Generic.Emph
+'_'           Punctuation
+'*'           Punctuation
+'.'           Literal.String.Other
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'STEEL'       Name.Label
+'\n'          Text.Whitespace
+
+'Escape this: ' Literal.String
+'\\*'         Literal.String.Escape
+'9765'        Literal.String
+'\\*'         Literal.String.Escape
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary
- add a new `FountainLexer` with context-aware parsing for screenplay blocks such as title pages, scene headings, character cues, dialogue, transitions, centered text, notes, boneyard comments, and sections
- support inline Fountain markup including emphasis, escapes, and scene numbers, and register the lexer for `.fountain` and `.spmd` files
- add real-world and focused test coverage with `Big-Fish.fountain`, a smaller example file, and snippet-based golden tests
## Testing
- `python3 -m pytest tests/snippets/fountain tests/examplefiles/fountain tests/test_guess.py`