### PR TITLE
Add a PyPy console lexer

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -411,6 +411,7 @@ LEXERS = {
     'PtxLexer': ('pygments.lexers.ptx', 'PTX', ('ptx',), ('*.ptx',), ('text/x-ptx',)),
     'PugLexer': ('pygments.lexers.html', 'Pug', ('pug', 'jade'), ('*.pug', '*.jade'), ('text/x-pug', 'text/x-jade')),
     'PuppetLexer': ('pygments.lexers.dsls', 'Puppet', ('puppet',), ('*.pp',), ()),
+    'PyPyConsoleLexer': ('pygments.lexers.python', 'PyPy console session', ('pypycon', 'pypy-console'), (), ()),
     'PyPyLogLexer': ('pygments.lexers.console', 'PyPy Log', ('pypylog', 'pypy'), ('*.pypylog',), ('application/x-pypylog',)),
     'Python2Lexer': ('pygments.lexers.python', 'Python 2.x', ('python2', 'py2'), (), ('text/x-python2', 'application/x-python2')),
     'Python2TracebackLexer': ('pygments.lexers.python', 'Python 2.x Traceback', ('py2tb',), ('*.py2tb',), ('text/x-python2-traceback',)),

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -19,7 +19,8 @@ from pygments import unistring as uni
 
 __all__ = ['PythonLexer', 'PythonConsoleLexer', 'PythonTracebackLexer',
            'Python2Lexer', 'Python2TracebackLexer',
-           'CythonLexer', 'DgLexer', 'NumPyLexer']
+           'CythonLexer', 'DgLexer', 'NumPyLexer',
+           'PyPyConsoleLexer']
 
 
 class PythonLexer(RegexLexer):
@@ -721,6 +722,89 @@ class PythonConsoleLexer(DelegatingLexer):
         class _ReplaceInnerCode(DelegatingLexer):
             def __init__(self, **options):
                 super().__init__(pylexer, _PythonConsoleLexerBase, Other.Code, **options)
+        super().__init__(tblexer, _ReplaceInnerCode, Other.Traceback, **options)
+
+
+class _PyPyConsoleLexerBase(RegexLexer):
+    name = 'PyPy console session'
+    aliases = ['pypycon', 'pypy-console']
+
+    """Auxiliary lexer for `PyPyConsoleLexer`.
+
+    Code tokens are output as ``Token.Other.Code``, traceback tokens as
+    ``Token.Other.Traceback``.
+    """
+    tokens = {
+        'root': [
+            (r'(>>>> )(.*\n)', bygroups(Generic.Prompt, Other.Code), 'continuations'),
+            # This happens, e.g., when tracebacks are embedded in documentation;
+            # trailing whitespaces are often stripped in such contexts.
+            (r'(>>>>)(\n)', bygroups(Generic.Prompt, Whitespace)),
+            (r'(\^C)?Traceback \(most recent call last\):\n', Other.Traceback, 'traceback'),
+            # SyntaxError starts with this
+            (r'  File "[^"]+", line \d+', Other.Traceback, 'traceback'),
+            (r'.*\n', Generic.Output),
+        ],
+        'continuations': [
+            (r'(\.\.\.\. )(.*\n)', bygroups(Generic.Prompt, Other.Code)),
+            # See above.
+            (r'(\.\.\.\.)(\n)', bygroups(Generic.Prompt, Whitespace)),
+            default('#pop'),
+        ],
+        'traceback': [
+            # As soon as we see a traceback, consume everything until the next
+            # >>>> prompt.
+            (r'(?=>>>>( |$))', Text, '#pop'),
+            (r'(KeyboardInterrupt)(\n)', bygroups(Name.Class, Whitespace)),
+            (r'.*\n', Other.Traceback),
+        ],
+    }
+
+
+class PyPyConsoleLexer(DelegatingLexer):
+    """
+    For PyPy console output, such as:
+
+    .. sourcecode:: pypycon
+
+        >>>> a = 'foo'
+        >>>> print(a)
+        foo
+        >>>> 1 / 0
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        ZeroDivisionError: integer division or modulo by zero
+
+    Additional options:
+
+    `python3`
+        Use Python 3 lexer for code.  Default is ``True``.
+
+    .. versionadded:: 2.21
+    """
+
+    name = 'PyPy console session'
+    aliases = ['pypycon', 'pypy-console']
+    mimetypes = []
+    url = 'https://pypy.org'
+    version_added = '2.21'
+
+    def __init__(self, **options):
+        python3 = get_bool_opt(options, 'python3', True)
+        if python3:
+            pylexer = PythonLexer
+            tblexer = PythonTracebackLexer
+        else:
+            pylexer = Python2Lexer
+            tblexer = Python2TracebackLexer
+        # We have two auxiliary lexers. Use DelegatingLexer twice with
+        # different tokens.  TODO: DelegatingLexer should support this
+        # directly, by accepting a tuplet of auxiliary lexers and a tuple of
+        # distinguishing tokens. Then we wouldn't need this intermediary
+        # class.
+        class _ReplaceInnerCode(DelegatingLexer):
+            def __init__(self, **options):
+                super().__init__(pylexer, _PyPyConsoleLexerBase, Other.Code, **options)
         super().__init__(tblexer, _ReplaceInnerCode, Other.Traceback, **options)
 
 

--- a/tests/examplefiles/pypycon/pypycon_ctrlc_traceback
+++ b/tests/examplefiles/pypycon/pypycon_ctrlc_traceback
@@ -1,0 +1,118 @@
+x = r"""
+>>>> import os
+>>>> print os
+<module 'os' from '/file/path.py'>
+>>>> for x in range(10):
+....     y = x + 2
+....     print(x)
+....     if x > 5:
+....         raise Exception
+....
+0
+1
+2
+3
+4
+5
+6
+Traceback (most recent call last):
+  File "<stdin>", line 5, in <module>
+Exception
+>>>>
+>>>> while True:
+....     pass
+....
+^CTraceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+KeyboardInterrupt
+
+>>>> class A(Exception):pass
+....
+>>>> class B(Exception):pass
+....
+>>>> try:
+....     try:
+....         raise A('first')
+....     finally:
+....         raise B('second')
+.... except A as c:
+....     print(c)
+....
+Traceback (most recent call last):
+  File "<stdin>", line 3, in <module>
+__main__.A: first
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File "<stdin>", line 5, in <module>
+__main__.B: second
+
+>>>> x =
+  File "<stdin>", line 1
+    x =
+       ^
+SyntaxError: invalid syntax
+>>>>
+
+>>>> x = 3
+>>>> with 5 as y:
+....    print(x + y)
+....
+8
+
+# TODO
+#>>> raise ValueError('multi\n    line\ndetail')
+#Traceback (most recent call last):
+#........
+#ValueError: multi
+#    line
+#detail
+
+>>>> raise ValueError('multi\n    line\ndetail')
+Traceback (most recent call last):
+ .123
+ValueError: multi
+    line
+detail
+
+>>>> raise ValueError('multi\n    line\ndetail')
+Traceback (most recent call last):
+    ...
+ValueError: multi
+    line
+detail
+
+>>>> raise ValueError('multi\n    line\ndetail')
+Traceback (most recent call last):
+    ....
+ValueError: multi
+    line
+detail
+
+>>>> raise ValueError('multi\n    line\ndetail')
+Traceback (most recent call last):
+     ....
+ValueError: multi
+    line
+detail
+
+>>>> raise ValueError('multi\n    line\ndetail')
+Traceback (most recent call last):
+  ...
+ValueError: multi
+    line
+detail
+
+>>>> raise Exception
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+Exception
+>>>> import somemodule
+>>>> somemodule.blah()
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/path/to/stuff/somemodule/blah.py", line 658, in blah
+    raise Exception('Hi.')
+Exception: Hi.
+

--- a/tests/examplefiles/pypycon/pypycon_ctrlc_traceback.output
+++ b/tests/examplefiles/pypycon/pypycon_ctrlc_traceback.output
@@ -1,0 +1,587 @@
+'x = r"""\n'  Generic.Output
+
+'>>>> '       Generic.Prompt
+'import'      Keyword.Namespace
+' '           Text.Whitespace
+'os'          Name.Namespace
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'print'       Name.Builtin
+' '           Text
+'os'          Name
+'\n'          Text.Whitespace
+
+"<module 'os' from '/file/path.py'>\n" Generic.Output
+
+'>>>> '       Generic.Prompt
+'for'         Keyword
+' '           Text
+'x'           Name
+' '           Text
+'in'          Operator.Word
+' '           Text
+'range'       Name.Builtin
+'('           Punctuation
+'10'          Literal.Number.Integer
+')'           Punctuation
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'y'           Name
+' '           Text
+'='           Operator
+' '           Text
+'x'           Name
+' '           Text
+'+'           Operator
+' '           Text
+'2'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'print'       Name.Builtin
+'('           Punctuation
+'x'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'if'          Keyword
+' '           Text
+'x'           Name
+' '           Text
+'>'           Operator
+' '           Text
+'5'           Literal.Number.Integer
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'        '    Text
+'raise'       Keyword
+' '           Text
+'Exception'   Name.Exception
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'0\n'         Generic.Output
+
+'1\n'         Generic.Output
+
+'2\n'         Generic.Output
+
+'3\n'         Generic.Output
+
+'4\n'         Generic.Output
+
+'5\n'         Generic.Output
+
+'6\n'         Generic.Output
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'5'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'Exception'   Generic.Error
+'\n'          Text.Whitespace
+
+''            Text
+'>>>>'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'while'       Keyword
+' '           Text
+'True'        Keyword.Constant
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'pass'        Keyword
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'^CTraceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'1'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'KeyboardInterrupt' Name.Class
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'class'       Keyword
+' '           Text.Whitespace
+'A'           Name.Class
+'('           Punctuation
+'Exception'   Name.Exception
+')'           Punctuation
+':'           Punctuation
+'pass'        Keyword
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'class'       Keyword
+' '           Text.Whitespace
+'B'           Name.Class
+'('           Punctuation
+'Exception'   Name.Exception
+')'           Punctuation
+':'           Punctuation
+'pass'        Keyword
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'try'         Keyword
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'try'         Keyword
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'        '    Text
+'raise'       Keyword
+' '           Text
+'A'           Name
+'('           Punctuation
+"'"           Literal.String.Single
+'first'       Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'finally'     Keyword
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'        '    Text
+'raise'       Keyword
+' '           Text
+'B'           Name
+'('           Punctuation
+"'"           Literal.String.Single
+'second'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'except'      Keyword
+' '           Text
+'A'           Name
+' '           Text
+'as'          Keyword
+' '           Text
+'c'           Name
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'    '        Text
+'print'       Name.Builtin
+'('           Punctuation
+'c'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'3'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'__main__.A'  Generic.Error
+': '          Text
+'first'       Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'During handling of the above exception, another exception occurred:\n\n' Generic.Traceback
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'5'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'__main__.B'  Generic.Error
+': '          Text
+'second'      Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'x'           Name
+' '           Text
+'='           Operator
+'\n'          Text.Whitespace
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'1'           Literal.Number
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'x'           Name
+' '           Text
+'='           Operator
+'\n'          Text.Whitespace
+
+'       '     Text.Whitespace
+'^'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'SyntaxError' Generic.Error
+': '          Text
+'invalid syntax' Name
+'\n'          Text.Whitespace
+
+''            Text
+'>>>>'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'\n'          Generic.Output
+
+'>>>> '       Generic.Prompt
+'x'           Name
+' '           Text
+'='           Operator
+' '           Text
+'3'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'with'        Keyword
+' '           Text
+'5'           Literal.Number.Integer
+' '           Text
+'as'          Keyword
+' '           Text
+'y'           Name
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'.... '       Generic.Prompt
+'   '         Text
+'print'       Name.Builtin
+'('           Punctuation
+'x'           Name
+' '           Text
+'+'           Operator
+' '           Text
+'y'           Name
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'....'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'8\n'         Generic.Output
+
+'\n'          Generic.Output
+
+'# TODO\n'    Generic.Output
+
+"#>>> raise ValueError('multi\\n    line\\ndetail')\n" Generic.Output
+
+'#Traceback (most recent call last):\n' Generic.Output
+
+'#........\n' Generic.Output
+
+'#ValueError: multi\n' Generic.Output
+
+'#    line\n' Generic.Output
+
+'#detail\n'   Generic.Output
+
+'\n'          Generic.Output
+
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'ValueError'  Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'multi'       Literal.String.Single
+'\\n'         Literal.String.Escape
+'    line'    Literal.String.Single
+'\\n'         Literal.String.Escape
+'detail'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+' .123\nValueError' Generic.Error
+': '          Text
+'multi'       Name
+'\n'          Text.Whitespace
+
+'    line\n'  Other
+
+'detail\n'    Other
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'ValueError'  Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'multi'       Literal.String.Single
+'\\n'         Literal.String.Escape
+'    line'    Literal.String.Single
+'\\n'         Literal.String.Escape
+'detail'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'    '        Text.Whitespace
+'.'           Operator
+'.'           Operator
+'.'           Operator
+'\n'          Text.Whitespace
+
+'ValueError'  Generic.Error
+': '          Text
+'multi'       Name
+'\n'          Text.Whitespace
+
+'    line\n'  Other
+
+'detail\n'    Other
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'ValueError'  Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'multi'       Literal.String.Single
+'\\n'         Literal.String.Escape
+'    line'    Literal.String.Single
+'\\n'         Literal.String.Escape
+'detail'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'    '        Text.Whitespace
+'.'           Operator
+'.'           Operator
+'.'           Operator
+'.'           Operator
+'\n'          Text.Whitespace
+
+'ValueError'  Generic.Error
+': '          Text
+'multi'       Name
+'\n'          Text.Whitespace
+
+'    line\n'  Other
+
+'detail\n'    Other
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'ValueError'  Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'multi'       Literal.String.Single
+'\\n'         Literal.String.Escape
+'    line'    Literal.String.Single
+'\\n'         Literal.String.Escape
+'detail'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'    '        Text.Whitespace
+' '           Text
+'.'           Operator
+'.'           Operator
+'.'           Operator
+'.'           Operator
+'\n'          Text.Whitespace
+
+'ValueError'  Generic.Error
+': '          Text
+'multi'       Name
+'\n'          Text.Whitespace
+
+'    line\n'  Other
+
+'detail\n'    Other
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'ValueError'  Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'multi'       Literal.String.Single
+'\\n'         Literal.String.Escape
+'    line'    Literal.String.Single
+'\\n'         Literal.String.Escape
+'detail'      Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  '          Text.Whitespace
+'...'         Comment
+'\n'          Text.Whitespace
+
+'ValueError'  Generic.Error
+': '          Text
+'multi'       Name
+'\n'          Text.Whitespace
+
+'    line\n'  Other
+
+'detail\n'    Other
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'raise'       Keyword
+' '           Text
+'Exception'   Name.Exception
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'1'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'Exception'   Generic.Error
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'import'      Keyword.Namespace
+' '           Text.Whitespace
+'somemodule'  Name.Namespace
+'\n'          Text.Whitespace
+
+'>>>> '       Generic.Prompt
+'somemodule'  Name
+'.'           Operator
+'blah'        Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'1'           Literal.Number
+', in '       Text
+'<module>'    Name
+'\n'          Text.Whitespace
+
+'  File '     Text
+'"/path/to/stuff/somemodule/blah.py"' Name.Builtin
+', line '     Text
+'658'         Literal.Number
+', in '       Text
+'blah'        Name
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'raise'       Keyword
+' '           Text
+'Exception'   Name.Exception
+'('           Punctuation
+"'"           Literal.String.Single
+'Hi.'         Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'Exception'   Generic.Error
+': '          Text
+'Hi.'         Name
+'\n'          Text.Whitespace

--- a/tests/examplefiles/pypycon/pypycon_test.pypycon
+++ b/tests/examplefiles/pypycon/pypycon_test.pypycon
@@ -1,0 +1,17 @@
+>>>> :
+  File "<stdin>", line 1
+    :
+    ^
+SyntaxError: invalid syntax
+>>>> 
+KeyboardInterrupt
+>>>>
+
+>>>> 1/0
+Traceback (most recent call last):
+   ...
+ZeroDivisionError
+
+>>>> 1/0   # this used to swallow the traceback
+Traceback (most recent call last):
+   ...

--- a/tests/examplefiles/pypycon/pypycon_test.pypycon.output
+++ b/tests/examplefiles/pypycon/pypycon_test.pypycon.output
@@ -1,0 +1,65 @@
+'>>>> '       Generic.Prompt
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'  File '     Text
+'"<stdin>"'   Name.Builtin
+', line '     Text
+'1'           Literal.Number
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'^'           Punctuation.Marker
+'\n'          Text.Whitespace
+
+'SyntaxError' Generic.Error
+': '          Text
+'invalid syntax' Name
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'\n'          Text.Whitespace
+
+'KeyboardInterrupt\n' Generic.Output
+
+'>>>>'        Generic.Prompt
+'\n'          Text.Whitespace
+
+'\n'          Generic.Output
+
+'>>>> '       Generic.Prompt
+'1'           Literal.Number.Integer
+'/'           Operator
+'0'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'   '         Text.Whitespace
+'...'         Comment
+'\n'          Text.Whitespace
+
+'ZeroDivisionError' Generic.Error
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+''            Text
+'>>>> '       Generic.Prompt
+'1'           Literal.Number.Integer
+'/'           Operator
+'0'           Literal.Number.Integer
+'   '         Text
+'# this used to swallow the traceback' Comment.Single
+'\n'          Text.Whitespace
+
+'Traceback (most recent call last):\n' Generic.Traceback
+
+'   '         Text.Whitespace
+'...'         Comment
+'\n'          Text.Whitespace


### PR DESCRIPTION
Essentially copies the `PythonConsoleLexer` implementation and tests, with minor adjustments for PyPy's different prompts.