### PR TITLE
Add ❯ chevron prompt to shell lexer

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -237,7 +237,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _innerLexerCls = BashLexer
     _ps1rgx = re.compile(
         r'^((?:(?:\[.*?\])|(?:\(\S+\))?(?:| |sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)' \
-        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%]\s*)(.*\n?)')
+        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%❯]\s*)(.*\n?)')
     _ps2 = '> '
 
 


### PR DESCRIPTION
Several terminal themes use a `❯` character for the prompt rather than the traditional `$`:

  - Pure (zsh)
  - Starship
  - Spaceship (zsh)
  - Oh My Posh has themes using it
  - Powerlevel10k (zsh) has configs using it

GitHub supports `❯` with their `console` formatter:

```console
$ echo dollar
dollar
❯ echo chevron
chevron
X echo unsupported
unsupported
```

It would be useful if Pygments also supported the chevron (in addition to `$`, `#` and `%`) so we can copy and paste from our terminals and Sphinx `.. code-block:: console` will work with it.

Demo:

```python
from pygments.lexers import BashSessionLexer

lexer = BashSessionLexer()

for prompt in ("$", "❯"):
    print(f"=== {prompt} prompt ===")
    for token_type, value in lexer.get_tokens(f"{prompt} echo hello\nhello\n"):
        print(f"  {str(token_type):<30s} {value!r}")
    print()
```


Before:
```
=== $ prompt ===
  Token.Generic.Prompt           '$ '
  Token.Name.Builtin             'echo'
  Token.Text.Whitespace          ' '
  Token.Text                     'hello'
  Token.Text.Whitespace          '\n'
  Token.Generic.Output           'hello\n'

=== ❯ prompt ===
  Token.Generic.Output           '❯ echo hello\n'
  Token.Generic.Output           'hello\n'
```

After:

```
=== $ prompt ===
  Token.Generic.Prompt           '$ '
  Token.Name.Builtin             'echo'
  Token.Text.Whitespace          ' '
  Token.Text                     'hello'
  Token.Text.Whitespace          '\n'
  Token.Generic.Output           'hello\n'

=== ❯ prompt ===
  Token.Generic.Prompt           '❯ '
  Token.Name.Builtin             'echo'
  Token.Text.Whitespace          ' '
  Token.Text                     'hello'
  Token.Text.Whitespace          '\n'
  Token.Generic.Output           'hello\n'
```



