### PR TITLE
Bump GitHub Actions to fix deprecation warnings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -43,8 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install tox
@@ -57,8 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install tox
@@ -76,8 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Install tox

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Pygments
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
     tags: ['*']
   pull_request:
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
     - name: Checkout Pygments
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install tox
       run: pip install -r requirements.txt
     - name: Sphinx build


### PR DESCRIPTION
Right now there are 15 warnings like:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


Before: https://github.com/pygments/pygments/actions/runs/24334198729?pr=3096

---

After: https://github.com/pygments/pygments/actions/runs/24584466617?pr=3098

No warnings.

