### PR TITLE
Monokai: improve `pytb` output

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Pygments
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
     tags: ['*']
   pull_request:
 

--- a/pygments/styles/monokai.py
+++ b/pygments/styles/monokai.py
@@ -55,7 +55,7 @@ class MonokaiStyle(Style):
 
         Name:                      "#f8f8f2", # class: 'n'
         Name.Attribute:            "#a6e22e", # class: 'na' - to be revised
-        Name.Builtin:              "",        # class: 'nb'
+        Name.Builtin:              "#a6e22e", # class: 'nb'
         Name.Builtin.Pseudo:       "",        # class: 'bp'
         Name.Class:                "#a6e22e", # class: 'nc' - to be revised
         Name.Constant:             "#66d9ef", # class: 'no' - to be revised
@@ -100,7 +100,7 @@ class MonokaiStyle(Style):
         Generic:                   "",        # class: 'g'
         Generic.Deleted:           "#ff4689", # class: 'gd',
         Generic.Emph:              "italic",  # class: 'ge'
-        Generic.Error:             "",        # class: 'gr'
+        Generic.Error:             "#ff4689", # class: 'gr'
         Generic.Heading:           "",        # class: 'gh'
         Generic.Inserted:          "#a6e22e", # class: 'gi'
         Generic.Output:            "#66d9ef", # class: 'go'
@@ -108,5 +108,5 @@ class MonokaiStyle(Style):
         Generic.Strong:            "bold",    # class: 'gs'
         Generic.EmphStrong:        "bold italic",  # class: 'ges'
         Generic.Subheading:        "#959077", # class: 'gu'
-        Generic.Traceback:         "",        # class: 'gt'
+        Generic.Traceback:         "#66d9ef", # class: 'gt'
     }


### PR DESCRIPTION
The CPython docs use the default Pygments theme for light mode and Monokai for dark.

Compare the traceback at https://docs.python.org/3.15/whatsnew/3.13.html#improved-error-messages

Light looks good:

<img width="774" height="176" alt="image" src="https://github.com/user-attachments/assets/be561612-5171-4203-9aed-173fcb9549b0" />

But dark is almost monochrome:

<img width="776" height="176" alt="image" src="https://github.com/user-attachments/assets/7c0616d5-39f5-4fb2-8633-40c4a125e672" />

This PR adds some colour:

<img width="773" height="173" alt="image" src="https://github.com/user-attachments/assets/b030f37f-7329-4d27-849a-6a54c0f41e61" />

They're all above the minimum ratio of the WCAG AA guidelines.  
