### PR TITLE
fix(lexers): remove Lua multiline comment pattern from MoonScriptLexer

### DIFF
--- a/pygments/lexers/scripting.py
+++ b/pygments/lexers/scripting.py
@@ -509,6 +509,10 @@ class MoonScriptLexer(LuaLexer):
     For MoonScript source code.
     """
 
+    # MoonScript does not support Lua-style multiline comments
+    # (--[[ ... ]]). See https://github.com/leafo/moonscript/issues/15
+    _comment_multiline = None
+
     name = 'MoonScript'
     url = 'http://moonscript.org'
     aliases = ['moonscript', 'moon']

--- a/tests/snippets/moon/test_no_lua_multiline_comment.txt
+++ b/tests/snippets/moon/test_no_lua_multiline_comment.txt
@@ -1,0 +1,31 @@
+---input---
+--[[
+This spans
+multiple lines
+]]
+x = 1
+
+---tokens---
+'--[['        Comment.Single
+'\n'          Text.Whitespace
+
+'This'        Name.Class
+' '           Text
+'spans'       Name
+'\n'          Text.Whitespace
+
+'multiple'    Name
+' '           Text
+'lines'       Name
+'\n'          Text.Whitespace
+
+']'           Keyword.Type
+']'           Keyword.Type
+'\n'          Text.Whitespace
+
+'x'           Name
+' '           Text
+'='           Operator
+' '           Text
+'1'           Literal.Number.Integer
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

MoonScript does not support Lua-style multiline comments (`--[[ ... ]]`).
The `_comment_multiline` regex pattern was inherited from `LuaLexer`
but is not valid MoonScript syntax.

References:
- https://github.com/leafo/moonscript/issues/15
- https://moonscript.org/reference/#the-language/comments

## Fix

Override `_comment_multiline = None` in `MoonScriptLexer` to disable
the inherited Lua multiline comment pattern.

Fixes #3050