### PR TITLE
Add BitBake lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -264,6 +264,7 @@ Other contributors, listed alphabetically, are:
 * Nathan Whetsell -- Csound lexers
 * Dietmar Winkler -- Modelica lexer
 * Nils Winter -- Smalltalk lexer
+* Trevor Woerner -- BitBake lexer
 * Davy Wybiral -- Clojure lexer
 * Whitney Young -- ObjectiveC lexer
 * Diego Zamboni -- CFengine3 lexer

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -53,6 +53,7 @@ LEXERS = {
     'BefungeLexer': ('pygments.lexers.esoteric', 'Befunge', ('befunge',), ('*.befunge',), ('application/x-befunge',)),
     'BerryLexer': ('pygments.lexers.berry', 'Berry', ('berry', 'be'), ('*.be',), ('text/x-berry', 'application/x-berry')),
     'BibTeXLexer': ('pygments.lexers.bibtex', 'BibTeX', ('bibtex', 'bib'), ('*.bib',), ('text/x-bibtex',)),
+    'BitBakeLexer': ('pygments.lexers.bitbake', 'BitBake', ('bitbake',), ('*.bbclass', '*.bbappend'), ('text/x-bitbake',)),
     'BlitzBasicLexer': ('pygments.lexers.basic', 'BlitzBasic', ('blitzbasic', 'b3d', 'bplus'), ('*.bb', '*.decls'), ('text/x-bb',)),
     'BlitzMaxLexer': ('pygments.lexers.basic', 'BlitzMax', ('blitzmax', 'bmax'), ('*.bmx',), ('text/x-bmx',)),
     'BlueprintLexer': ('pygments.lexers.blueprint', 'Blueprint', ('blueprint',), ('*.blp',), ('text/x-blueprint',)),

--- a/pygments/lexers/bitbake.py
+++ b/pygments/lexers/bitbake.py
@@ -1,0 +1,166 @@
+"""
+    pygments.lexers.bitbake
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for BitBake recipes, classes, includes and configuration files
+    used by the Yocto Project / OpenEmbedded build system.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, bygroups, include, using, words
+from pygments.lexers.python import PythonLexer
+from pygments.lexers.shell import BashLexer
+from pygments.token import Comment, Keyword, Name, Operator, Punctuation, \
+    String, Text, Whitespace
+
+__all__ = ['BitBakeLexer']
+
+# A bare BitBake identifier (variable, function or flag name). Allows the
+# characters used by OE-Core variable names (digits, ``-``, ``.``, ``+``).
+_IDENT = r'[A-Za-z_][A-Za-z0-9_\-.+]*'
+
+# Optional OE override chain such as ``:append``, ``:remove``, ``:class-target``
+# or ``:${PN}-doc``. Anchored so it only consumes ``:foo`` runs and never
+# eats the leading ``:`` of the ``:=`` assignment operator.
+_OVERRIDE = r'(?::[A-Za-z0-9_\-.+${}]+)*'
+
+# All BitBake variable assignment operators, ordered so that the longer
+# operators win the regex alternation.
+_ASSIGN = r'(?:\?\?=|\?=|:=|\+=|=\+|\.=|=\.|=)'
+
+
+class BitBakeLexer(RegexLexer):
+    """
+    Lexer for BitBake recipes, classes, includes and configuration files
+    used by the Yocto Project and OpenEmbedded build system.
+    """
+
+    name = 'BitBake'
+    url = 'https://docs.yoctoproject.org/bitbake/'
+    aliases = ['bitbake']
+    filenames = ['*.bbclass', '*.bbappend']
+    mimetypes = ['text/x-bitbake']
+    version_added = '2.21'
+
+    flags = re.MULTILINE
+
+    tokens = {
+        'root': [
+            (r'[ \t]+', Whitespace),
+            (r'\n', Whitespace),
+            (r'#.*$', Comment.Single),
+
+            # ``python [name]() { ... }`` blocks (also ``fakeroot python``).
+            # Must be tried before the generic shell function rule so the
+            # ``python`` keyword is not mistaken for a shell function name.
+            (r'(^(?:fakeroot[ \t]+)?)(python)((?:[ \t]+' + _IDENT + r')?)'
+             r'([ \t]*\([ \t]*\)[ \t]*)(\{[ \t]*\n)'
+             r'((?:.*\n)*?)'
+             r'(^\}[ \t]*$)',
+             bygroups(Keyword.Type, Keyword, Name.Function, Text,
+                      Punctuation, using(PythonLexer), Punctuation)),
+
+            # Shell task bodies: ``[fakeroot ]name[:override]() { ... }``.
+            (r'(^(?:fakeroot[ \t]+)?)(' + _IDENT + r')(' + _OVERRIDE + r')'
+             r'([ \t]*\([ \t]*\)[ \t]*)(\{[ \t]*\n)'
+             r'((?:.*\n)*?)'
+             r'(^\}[ \t]*$)',
+             bygroups(Keyword.Type, Name.Function, Name.Decorator, Text,
+                      Punctuation, using(BashLexer), Punctuation)),
+
+            # Top-level python ``def`` blocks; the body is any run of
+            # indented or blank lines following the signature.
+            (r'^def[ \t]+' + _IDENT + r'[ \t]*\([^)]*\)[ \t]*:[ \t]*\n'
+             r'(?:[ \t]+.*\n|\n)+',
+             using(PythonLexer)),
+
+            # ``inherit`` / ``inherit_defer`` / ``include`` / ``include_all`` /
+            # ``require`` directives. Longer keywords are listed first so the
+            # regex alternation does not match the shorter prefix.
+            (r'^(inherit_defer|inherit|include_all|include|require)\b',
+             Keyword.Namespace, 'include-line'),
+
+            # ``addtask`` / ``deltask`` / ``addhandler`` / ``EXPORT_FUNCTIONS``.
+            (r'^(addtask|deltask|addhandler|EXPORT_FUNCTIONS)\b',
+             Keyword, 'statement'),
+
+            # ``VAR[flag] = "value"`` (varflag assignment).
+            (r'^(' + _IDENT + r')(\[)(' + _IDENT + r')(\])([ \t]*)('
+             + _ASSIGN + r')',
+             bygroups(Name.Variable, Punctuation, Name.Attribute,
+                      Punctuation, Whitespace, Operator),
+             'value'),
+
+            # ``[export ]VAR[:override...] OP "value"`` assignments.
+            (r'^(export[ \t]+)?(' + _IDENT + r')(' + _OVERRIDE + r')'
+             r'([ \t]*)(' + _ASSIGN + r')',
+             bygroups(Keyword.Type, Name.Variable, Name.Decorator,
+                      Whitespace, Operator),
+             'value'),
+
+            # Anything else: consume runs of "boring" characters in one
+            # token, then fall back to a single character if needed.
+            (r'[^\s#${}\[\]:=+?.@\\"\']+', Text),
+            (r'.', Text),
+        ],
+
+        'include-line': [
+            (r'[ \t]+', Whitespace),
+            (r'\\\n', Text),
+            (r'\n', Whitespace, '#pop'),
+            include('interp'),
+            (r'[^\s$]+', String),
+        ],
+
+        'statement': [
+            (r'[ \t]+', Whitespace),
+            (r'\\\n', Text),
+            (r'\n', Whitespace, '#pop'),
+            (words(('after', 'before'), suffix=r'\b'), Keyword),
+            include('interp'),
+            (r'[^\s$\\]+', Name),
+        ],
+
+        'value': [
+            (r'[ \t]+', Whitespace),
+            (r'\\\n', String.Escape),
+            (r'\n', Whitespace, '#pop'),
+            (r'"', String.Double, 'string-double'),
+            (r"'", String.Single, 'string-single'),
+            include('interp'),
+            (r'[^\s"\'$\\]+', String),
+        ],
+
+        'string-double': [
+            (r'\\\n', String.Escape),
+            (r'\\.', String.Escape),
+            (r'"', String.Double, '#pop'),
+            include('interp'),
+            (r'[^"\\$]+', String.Double),
+        ],
+
+        'string-single': [
+            (r'\\\n', String.Escape),
+            (r'\\.', String.Escape),
+            (r"'", String.Single, '#pop'),
+            include('interp'),
+            (r"[^'\\$]+", String.Single),
+        ],
+
+        'interp': [
+            # ``${@ python expression }`` evaluated by BitBake at parse time.
+            (r'\$\{@', String.Interpol, 'py-interp'),
+            # ``${VAR}`` variable expansion.
+            (r'(\$\{)([A-Za-z0-9_\-:.+/]+)(\})',
+             bygroups(String.Interpol, Name.Variable, String.Interpol)),
+        ],
+
+        'py-interp': [
+            (r'\}', String.Interpol, '#pop'),
+            (r'[^}]+', using(PythonLexer)),
+        ],
+    }

--- a/tests/examplefiles/bitbake/example.bbclass
+++ b/tests/examplefiles/bitbake/example.bbclass
@@ -1,0 +1,61 @@
+# Example BitBake recipe exercising the BitBake lexer.
+SUMMARY = "Hello world example"
+DESCRIPTION = "A small recipe used to exercise the BitBake Pygments lexer."
+HOMEPAGE = "https://example.com/${BPN}"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=0000000000000000000000000000000000"
+
+SRC_URI = " \
+    https://example.com/${BPN}-${PV}.tar.gz \
+    file://fix-build.patch \
+"
+SRC_URI[sha256sum] = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+S = "${WORKDIR}/${BPN}-${PV}"
+
+inherit autotools pkgconfig
+inherit_defer ${PYTHON_PN}-setuptools
+include_all conf/multilib.conf
+
+DEPENDS = "zlib openssl"
+RDEPENDS:${PN} = "bash"
+RDEPENDS:${PN}:append:class-target = " systemd"
+RRECOMMENDS:${PN}-doc = "man-pages"
+
+EXTRA_OECONF = "--disable-static"
+CFLAGS += "-O2"
+CFLAGS:append:qemux86 = " -m32"
+
+PACKAGECONFIG ??= "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}"
+PACKAGECONFIG[systemd] = "--with-systemd,--without-systemd,systemd"
+
+do_compile:prepend() {
+    echo "preparing build"
+}
+
+do_install:append() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/hello ${D}${bindir}/hello
+}
+
+fakeroot do_rootfs() {
+    echo "stage rootfs into ${IMAGE_ROOTFS}"
+}
+
+python do_check() {
+    bb.warn("checking %s" % d.getVar('PN'))
+}
+
+fakeroot python () {
+    d.setVar('FOO', 'bar')
+}
+
+def my_helper(d):
+    return d.getVar('PN') + '-helper'
+
+addtask check after do_compile before do_install
+deltask do_package_qa
+EXPORT_FUNCTIONS do_install do_compile
+
+do_install[depends] = "qemu-native:do_populate_sysroot"
+do_compile[noexec] = "1"

--- a/tests/examplefiles/bitbake/example.bbclass.output
+++ b/tests/examplefiles/bitbake/example.bbclass.output
@@ -1,0 +1,475 @@
+'# Example BitBake recipe exercising the BitBake lexer.' Comment.Single
+'\n'          Text.Whitespace
+
+'SUMMARY'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'Hello world example' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'DESCRIPTION' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'A small recipe used to exercise the BitBake Pygments lexer.' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'HOMEPAGE'    Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'https://example.com/' Literal.String.Double
+'${'          Literal.String.Interpol
+'BPN'         Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'LICENSE'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'MIT'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'LIC_FILES_CHKSUM' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'file://COPYING;md5=0000000000000000000000000000000000' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'SRC_URI'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+' '           Literal.String.Double
+'\\\n'        Literal.String.Escape
+
+'    https://example.com/' Literal.String.Double
+'${'          Literal.String.Interpol
+'BPN'         Name.Variable
+'}'           Literal.String.Interpol
+'-'           Literal.String.Double
+'${'          Literal.String.Interpol
+'PV'          Name.Variable
+'}'           Literal.String.Interpol
+'.tar.gz '    Literal.String.Double
+'\\\n'        Literal.String.Escape
+
+'    file://fix-build.patch ' Literal.String.Double
+'\\\n'        Literal.String.Escape
+
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SRC_URI'     Name.Variable
+'['           Punctuation
+'sha256sum'   Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'S'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'WORKDIR'     Name.Variable
+'}'           Literal.String.Interpol
+'/'           Literal.String.Double
+'${'          Literal.String.Interpol
+'BPN'         Name.Variable
+'}'           Literal.String.Interpol
+'-'           Literal.String.Double
+'${'          Literal.String.Interpol
+'PV'          Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'inherit'     Keyword.Namespace
+' '           Text.Whitespace
+'autotools'   Literal.String
+' '           Text.Whitespace
+'pkgconfig'   Literal.String
+'\n'          Text.Whitespace
+
+'inherit_defer' Keyword.Namespace
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'PYTHON_PN'   Name.Variable
+'}'           Literal.String.Interpol
+'-setuptools' Literal.String
+'\n'          Text.Whitespace
+
+'include_all' Keyword.Namespace
+' '           Text.Whitespace
+'conf/multilib.conf' Literal.String
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'DEPENDS'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'zlib openssl' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'RDEPENDS'    Name.Variable
+':${PN}'      Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'bash'        Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'RDEPENDS'    Name.Variable
+':${PN}:append:class-target' Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+' systemd'    Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'RRECOMMENDS' Name.Variable
+':${PN}-doc'  Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'man-pages'   Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'EXTRA_OECONF' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'--disable-static' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'CFLAGS'      Name.Variable
+' '           Text.Whitespace
+'+='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'-O2'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'CFLAGS'      Name.Variable
+':append:qemux86' Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+' -m32'       Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'PACKAGECONFIG' Name.Variable
+' '           Text.Whitespace
+'??='         Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${@'         Literal.String.Interpol
+'bb'          Name
+'.'           Operator
+'utils'       Name
+'.'           Operator
+'contains'    Name
+'('           Punctuation
+"'"           Literal.String.Single
+'DISTRO_FEATURES' Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'systemd'     Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'systemd'     Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+'d'           Name
+')'           Punctuation
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PACKAGECONFIG' Name.Variable
+'['           Punctuation
+'systemd'     Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'--with-systemd,--without-systemd,systemd' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'do_compile'  Name.Function
+':prepend'    Name.Decorator
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'echo'        Name.Builtin
+' '           Text.Whitespace
+'"preparing build"' Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'do_install'  Name.Function
+':append'     Name.Decorator
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'install'     Text
+' '           Text.Whitespace
+'-d'          Text
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'D'           Name.Variable
+'}'           Literal.String.Interpol
+'${'          Literal.String.Interpol
+'bindir'      Name.Variable
+'}'           Literal.String.Interpol
+'\n    '      Text.Whitespace
+'install'     Text
+' '           Text.Whitespace
+'-m'          Text
+' '           Text.Whitespace
+'0755'        Literal.Number
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'B'           Name.Variable
+'}'           Literal.String.Interpol
+'/hello'      Text
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'D'           Name.Variable
+'}'           Literal.String.Interpol
+'${'          Literal.String.Interpol
+'bindir'      Name.Variable
+'}'           Literal.String.Interpol
+'/hello'      Text
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'fakeroot '   Keyword.Type
+'do_rootfs'   Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'echo'        Name.Builtin
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'stage rootfs into ' Literal.String.Double
+'${'          Literal.String.Interpol
+'IMAGE_ROOTFS' Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'python'      Keyword
+' do_check'   Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text
+'bb'          Name
+'.'           Operator
+'warn'        Name
+'('           Punctuation
+'"'           Literal.String.Double
+'checking '   Literal.String.Double
+'%s'          Literal.String.Interpol
+'"'           Literal.String.Double
+' '           Text
+'%'           Operator
+' '           Text
+'d'           Name
+'.'           Operator
+'getVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'PN'          Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'fakeroot '   Keyword.Type
+'python'      Keyword
+' () '        Text
+'{\n'         Punctuation
+
+'    '        Text
+'d'           Name
+'.'           Operator
+'setVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'FOO'         Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'bar'         Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'def'         Keyword
+' '           Text.Whitespace
+'my_helper'   Name.Function
+'('           Punctuation
+'d'           Name
+')'           Punctuation
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'d'           Name
+'.'           Operator
+'getVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'PN'          Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+' '           Text
+'+'           Operator
+' '           Text
+"'"           Literal.String.Single
+'-helper'     Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'addtask'     Keyword
+' '           Text.Whitespace
+'check'       Name
+' '           Text.Whitespace
+'after'       Keyword
+' '           Text.Whitespace
+'do_compile'  Name
+' '           Text.Whitespace
+'before'      Keyword
+' '           Text.Whitespace
+'do_install'  Name
+'\n'          Text.Whitespace
+
+'deltask'     Keyword
+' '           Text.Whitespace
+'do_package_qa' Name
+'\n'          Text.Whitespace
+
+'EXPORT_FUNCTIONS' Keyword
+' '           Text.Whitespace
+'do_install'  Name
+' '           Text.Whitespace
+'do_compile'  Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'do_install'  Name.Variable
+'['           Punctuation
+'depends'     Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'qemu-native:do_populate_sysroot' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'do_compile'  Name.Variable
+'['           Punctuation
+'noexec'      Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'1'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/addtask_statement.txt
+++ b/tests/snippets/bitbake/addtask_statement.txt
@@ -1,0 +1,49 @@
+---input---
+addtask install after do_compile before do_package
+deltask do_configure
+addhandler my_eventhandler
+EXPORT_FUNCTIONS do_install do_compile
+my_eventhandler[eventmask] = "bb.event.RecipePreFinalise"
+
+---tokens---
+'addtask'     Keyword
+' '           Text.Whitespace
+'install'     Name
+' '           Text.Whitespace
+'after'       Keyword
+' '           Text.Whitespace
+'do_compile'  Name
+' '           Text.Whitespace
+'before'      Keyword
+' '           Text.Whitespace
+'do_package'  Name
+'\n'          Text.Whitespace
+
+'deltask'     Keyword
+' '           Text.Whitespace
+'do_configure' Name
+'\n'          Text.Whitespace
+
+'addhandler'  Keyword
+' '           Text.Whitespace
+'my_eventhandler' Name
+'\n'          Text.Whitespace
+
+'EXPORT_FUNCTIONS' Keyword
+' '           Text.Whitespace
+'do_install'  Name
+' '           Text.Whitespace
+'do_compile'  Name
+'\n'          Text.Whitespace
+
+'my_eventhandler' Name.Variable
+'['           Punctuation
+'eventmask'   Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'bb.event.RecipePreFinalise' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/assignments.txt
+++ b/tests/snippets/bitbake/assignments.txt
@@ -1,0 +1,95 @@
+---input---
+SUMMARY = "hello"
+DESCRIPTION ?= "Default description"
+RDEPENDS ??= ""
+PV := "1.0+git${SRCPV}"
+CFLAGS += "-O2"
+EXTRA_OEMAKE =+ "V=1"
+PATH .= ":/usr/local/bin"
+PATH =. "/opt/bin:"
+export CCACHE_DIR = "/var/cache/ccache"
+
+---tokens---
+'SUMMARY'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'hello'       Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'DESCRIPTION' Name.Variable
+' '           Text.Whitespace
+'?='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'Default description' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'RDEPENDS'    Name.Variable
+' '           Text.Whitespace
+'??='         Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PV'          Name.Variable
+' '           Text.Whitespace
+':='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'1.0+git'     Literal.String.Double
+'${'          Literal.String.Interpol
+'SRCPV'       Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'CFLAGS'      Name.Variable
+' '           Text.Whitespace
+'+='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'-O2'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'EXTRA_OEMAKE' Name.Variable
+' '           Text.Whitespace
+'=+'          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'V=1'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PATH'        Name.Variable
+' '           Text.Whitespace
+'.='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+':/usr/local/bin' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PATH'        Name.Variable
+' '           Text.Whitespace
+'=.'          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'/opt/bin:'   Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'export '     Keyword.Type
+'CCACHE_DIR'  Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'/var/cache/ccache' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/comments_strings.txt
+++ b/tests/snippets/bitbake/comments_strings.txt
@@ -1,0 +1,47 @@
+---input---
+# This is a top-level comment
+SUMMARY = "Hello \
+world"
+SECTION = 'examples'
+HOMEPAGE = "https://example.com/${BPN}"
+# trailing comment
+
+---tokens---
+'# This is a top-level comment' Comment.Single
+'\n'          Text.Whitespace
+
+'SUMMARY'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'Hello '      Literal.String.Double
+'\\\n'        Literal.String.Escape
+
+'world'       Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SECTION'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Single
+'examples'    Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text.Whitespace
+
+'HOMEPAGE'    Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'https://example.com/' Literal.String.Double
+'${'          Literal.String.Interpol
+'BPN'         Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'# trailing comment' Comment.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/inherit_include_require.txt
+++ b/tests/snippets/bitbake/inherit_include_require.txt
@@ -1,0 +1,57 @@
+---input---
+inherit autotools pkgconfig
+inherit_defer ${PYTHON_PN}-setuptools
+include conf/distro/${DISTRO}.conf
+include_all conf/multilib.conf
+require recipes-core/images/core-image-minimal.bb
+inherit \
+    cmake \
+    systemd
+
+---tokens---
+'inherit'     Keyword.Namespace
+' '           Text.Whitespace
+'autotools'   Literal.String
+' '           Text.Whitespace
+'pkgconfig'   Literal.String
+'\n'          Text.Whitespace
+
+'inherit_defer' Keyword.Namespace
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'PYTHON_PN'   Name.Variable
+'}'           Literal.String.Interpol
+'-setuptools' Literal.String
+'\n'          Text.Whitespace
+
+'include'     Keyword.Namespace
+' '           Text.Whitespace
+'conf/distro/' Literal.String
+'${'          Literal.String.Interpol
+'DISTRO'      Name.Variable
+'}'           Literal.String.Interpol
+'.conf'       Literal.String
+'\n'          Text.Whitespace
+
+'include_all' Keyword.Namespace
+' '           Text.Whitespace
+'conf/multilib.conf' Literal.String
+'\n'          Text.Whitespace
+
+'require'     Keyword.Namespace
+' '           Text.Whitespace
+'recipes-core/images/core-image-minimal.bb' Literal.String
+'\n'          Text.Whitespace
+
+'inherit'     Keyword.Namespace
+' '           Text.Whitespace
+'\\\n'        Text
+
+'    '        Text.Whitespace
+'cmake'       Literal.String
+' '           Text.Whitespace
+'\\\n'        Text
+
+'    '        Text.Whitespace
+'systemd'     Literal.String
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/interpolation.txt
+++ b/tests/snippets/bitbake/interpolation.txt
@@ -1,0 +1,91 @@
+---input---
+S = "${WORKDIR}/${BPN}-${PV}"
+PN_PYTHON = "${@d.getVar('PN').replace('-', '_')}"
+PACKAGECONFIG = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}"
+
+---tokens---
+'S'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'WORKDIR'     Name.Variable
+'}'           Literal.String.Interpol
+'/'           Literal.String.Double
+'${'          Literal.String.Interpol
+'BPN'         Name.Variable
+'}'           Literal.String.Interpol
+'-'           Literal.String.Double
+'${'          Literal.String.Interpol
+'PV'          Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PN_PYTHON'   Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${@'         Literal.String.Interpol
+'d'           Name
+'.'           Operator
+'getVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'PN'          Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'.'           Operator
+'replace'     Name
+'('           Punctuation
+"'"           Literal.String.Single
+'-'           Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'_'           Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PACKAGECONFIG' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${@'         Literal.String.Interpol
+'bb'          Name
+'.'           Operator
+'utils'       Name
+'.'           Operator
+'contains'    Name
+'('           Punctuation
+"'"           Literal.String.Single
+'DISTRO_FEATURES' Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'systemd'     Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'systemd'     Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+'d'           Name
+')'           Punctuation
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/overrides.txt
+++ b/tests/snippets/bitbake/overrides.txt
@@ -1,0 +1,58 @@
+---input---
+FILES:${PN}-doc = "${docdir}"
+RDEPENDS:${PN}:append:class-target = " bash"
+SRC_URI:remove = "file://broken.patch"
+SRC_URI:append:qemux86 = " file://qemu.cfg"
+VAR := "immediate"
+
+---tokens---
+'FILES'       Name.Variable
+':${PN}-doc'  Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'docdir'      Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'RDEPENDS'    Name.Variable
+':${PN}:append:class-target' Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+' bash'       Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SRC_URI'     Name.Variable
+':remove'     Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'file://broken.patch' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SRC_URI'     Name.Variable
+':append:qemux86' Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+' file://qemu.cfg' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'VAR'         Name.Variable
+' '           Text.Whitespace
+':='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'immediate'   Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/python_function.txt
+++ b/tests/snippets/bitbake/python_function.txt
@@ -1,0 +1,100 @@
+---input---
+python do_check() {
+    bb.warn("checking %s" % d.getVar('PN'))
+}
+
+fakeroot python () {
+    d.setVar('FOO', 'bar')
+}
+
+def my_helper(d):
+    return d.getVar('PN') + '-helper'
+
+
+---tokens---
+'python'      Keyword
+' do_check'   Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text
+'bb'          Name
+'.'           Operator
+'warn'        Name
+'('           Punctuation
+'"'           Literal.String.Double
+'checking '   Literal.String.Double
+'%s'          Literal.String.Interpol
+'"'           Literal.String.Double
+' '           Text
+'%'           Operator
+' '           Text
+'d'           Name
+'.'           Operator
+'getVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'PN'          Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'fakeroot '   Keyword.Type
+'python'      Keyword
+' () '        Text
+'{\n'         Punctuation
+
+'    '        Text
+'d'           Name
+'.'           Operator
+'setVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'FOO'         Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'bar'         Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'def'         Keyword
+' '           Text.Whitespace
+'my_helper'   Name.Function
+'('           Punctuation
+'d'           Name
+')'           Punctuation
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text
+'return'      Keyword
+' '           Text
+'d'           Name
+'.'           Operator
+'getVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'PN'          Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+' '           Text
+'+'           Operator
+' '           Text
+"'"           Literal.String.Single
+'-helper'     Literal.String.Single
+"'"           Literal.String.Single
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/shell_function.txt
+++ b/tests/snippets/bitbake/shell_function.txt
@@ -1,0 +1,65 @@
+---input---
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/hello ${D}${bindir}/hello
+}
+
+fakeroot do_rootfs() {
+    echo "building rootfs"
+}
+
+---tokens---
+'do_install'  Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'install'     Text
+' '           Text.Whitespace
+'-d'          Text
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'D'           Name.Variable
+'}'           Literal.String.Interpol
+'${'          Literal.String.Interpol
+'bindir'      Name.Variable
+'}'           Literal.String.Interpol
+'\n    '      Text.Whitespace
+'install'     Text
+' '           Text.Whitespace
+'-m'          Text
+' '           Text.Whitespace
+'0755'        Literal.Number
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'B'           Name.Variable
+'}'           Literal.String.Interpol
+'/hello'      Text
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'D'           Name.Variable
+'}'           Literal.String.Interpol
+'${'          Literal.String.Interpol
+'bindir'      Name.Variable
+'}'           Literal.String.Interpol
+'/hello'      Text
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'fakeroot '   Keyword.Type
+'do_rootfs'   Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'echo'        Name.Builtin
+' '           Text.Whitespace
+'"building rootfs"' Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/varflags.txt
+++ b/tests/snippets/bitbake/varflags.txt
@@ -1,0 +1,41 @@
+---input---
+do_install[depends] = "qemu-native:do_populate_sysroot"
+do_compile[noexec] = "1"
+do_fetch[postfuncs] += "do_extra_fetch"
+
+---tokens---
+'do_install'  Name.Variable
+'['           Punctuation
+'depends'     Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'qemu-native:do_populate_sysroot' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'do_compile'  Name.Variable
+'['           Punctuation
+'noexec'      Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'1'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'do_fetch'    Name.Variable
+'['           Punctuation
+'postfuncs'   Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'+='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'do_extra_fetch' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace


### PR DESCRIPTION
BitBake is the build engine used by the Yocto Project / OpenEmbedded [1] to evaluate recipes (``*.bb``, ``*.bbclass``, ``*.bbappend``, ``*.inc`` and ``*.conf``). Add a dedicated lexer that highlights:

  - comments and line continuations
  - all assignment operators (``=``, ``?=``, ``??=``, ``:=``, ``+=``, ``=+``, ``.=``, ``=.``) with optional ``export`` prefix and OE override chains (e.g. ``FILES:${PN}-doc``, ``RDEPENDS:${PN}:append:class-target``)
  - varflag assignments (``VAR[flag] = "value"``)
  - ``${VAR}`` and ``${@python_expr}`` interpolations
  - ``inherit`` / ``include`` / ``require`` directives
  - ``addtask`` / ``deltask`` / ``addhandler`` / ``EXPORT_FUNCTIONS`` statements (with the ``after`` / ``before`` keywords)
  - shell task bodies delegated to ``BashLexer``
  - ``python``, ``fakeroot python``, anonymous ``python () { ... }`` task bodies and top-level ``def`` blocks delegated to ``PythonLexer``

The lexer registers the ``bitbake`` alias and the ``*.bbclass`` / ``*.bbappend`` filename patterns. ``*.bb`` is intentionally not claimed because it is already used by ``BlitzBasicLexer``; the same applies to the ``text/x-bb`` MIME type. Snippet tests covering each construct and a representative example file are included.

[1] https://www.yoctoproject.org/

Co-authored-by: codex/claude opus 4.7 (xhigh)