### PR TITLE
docs: fix typo in filterdevelopment.rst

### DIFF
--- a/doc/docs/filterdevelopment.rst
+++ b/doc/docs/filterdevelopment.rst
@@ -71,5 +71,5 @@ You can instantiate this filter by calling `uncolor(classtoo=True)`, the same
 way that you would have instantiated the previous filter by calling
 `UncolorFilter(classtoo=True)`. Indeed, The decorator automatically ensures that
 `uncolor` is a class which subclasses an internal filter class. The class
-`uncolo` uses the decorated function as a method for filtering.  (That's why
+`uncolor` uses the decorated function as a method for filtering.  (That's why
 there is a `self` argument that you probably won't end up using in the method.)


### PR DESCRIPTION
Correct the spelling of 'uncolo' to 'uncolor' in filterdevelopment.rst

Close: #2990 