### PR TITLE
Fix HtmlFormatter crash when filename=None

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -429,7 +429,7 @@ class HtmlFormatter(Formatter):
         self.noclobber_cssfile = get_bool_opt(options, 'noclobber_cssfile', False)
         self.tagsfile = self._decodeifneeded(options.get('tagsfile', ''))
         self.tagurlformat = self._decodeifneeded(options.get('tagurlformat', ''))
-        self.filename = html_escape(self._decodeifneeded(options.get('filename', '')))
+        self.filename = html_escape(self._decodeifneeded(options.get('filename', '') or ''))
         self.wrapcode = get_bool_opt(options, 'wrapcode', False)
         self.span_element_openers = {}
         self.debug_token_types = get_bool_opt(options, 'debug_token_types', False)

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -257,6 +257,14 @@ def test_filename():
     assert re.search("<span class=\"filename\">test.py</span><pre>", html)
 
 
+def test_filename_none():
+    fmt = HtmlFormatter(filename=None)
+    assert fmt.filename == ''
+    outfile = StringIO()
+    fmt.format(tokensource, outfile)
+    assert '<span class="filename">' not in outfile.getvalue()
+
+
 def test_debug_token_types():
     fmt_nod_token_types = HtmlFormatter(debug_token_types=False)
     outfile_nod_token_types = StringIO()


### PR DESCRIPTION
- Fix `HtmlFormatter.__init__` crash when `filename=None` is passed explicitly
- `options.get('filename', '')` returns `None` (not `''`) when caller passes `filename=None`, causing `html_escape(None)` to raise `AttributeError`
- Adding `or ''` handles both absent key and explicit `None`

Libraries like `pymdownx.highlight` pass `filename=None` when no filename is specified. This worked in 2.19.2 but crashes in 2.20.0 due to the `html_escape` wrapping added in that release.

Fixes #3077