### PR TITLE
Add Lateralus lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -288,5 +288,6 @@ Other contributors, listed alphabetically, are:
 * Markus Meyer, Nextron Systems -- YARA lexer
 * Hannes Römer -- Mojo lexer
 * Jan Frederik Schaefer -- PDDL lexer
+* bad-antics -- Lateralus lexer
 
 Many thanks for all contributions!

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Version 2.21.0
 ---------------
 (not released yet)
 
+- New lexers:
+
+  * Lateralus
+
 Version 2.20.0
 --------------
 (released March 29th, 2026)

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -274,6 +274,7 @@ LEXERS = {
     'LassoJavascriptLexer': ('pygments.lexers.templates', 'JavaScript+Lasso', ('javascript+lasso', 'js+lasso'), (), ('application/x-javascript+lasso', 'text/x-javascript+lasso', 'text/javascript+lasso')),
     'LassoLexer': ('pygments.lexers.javascript', 'Lasso', ('lasso', 'lassoscript'), ('*.lasso', '*.lasso[89]'), ('text/x-lasso',)),
     'LassoXmlLexer': ('pygments.lexers.templates', 'XML+Lasso', ('xml+lasso',), (), ('application/xml+lasso',)),
+    'LateralusLexer': ('pygments.lexers.lateralus', 'Lateralus', ('lateralus', 'ltl'), ('*.ltl',), ('text/x-lateralus',)),
     'LdaprcLexer': ('pygments.lexers.ldap', 'LDAP configuration file', ('ldapconf', 'ldaprc'), ('.ldaprc', 'ldaprc', 'ldap.conf'), ('text/x-ldapconf',)),
     'LdifLexer': ('pygments.lexers.ldap', 'LDIF', ('ldif',), ('*.ldif',), ('text/x-ldif',)),
     'Lean3Lexer': ('pygments.lexers.lean', 'Lean', ('lean', 'lean3'), ('*.lean',), ('text/x-lean', 'text/x-lean3')),

--- a/pygments/lexers/lateralus.py
+++ b/pygments/lexers/lateralus.py
@@ -1,0 +1,131 @@
+"""
+    pygments.lexers.lateralus
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the Lateralus programming language.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.token import Comment, Keyword, Name, Number, Operator, \
+    Punctuation, String, Text, Whitespace
+
+__all__ = ['LateralusLexer']
+
+
+class LateralusLexer(RegexLexer):
+    """
+    Lexer for the Lateralus programming language, a statically typed,
+    pipeline-oriented language with algebraic data types, pattern matching,
+    and first-class effect capabilities.
+    """
+
+    name = 'Lateralus'
+    url = 'https://lateralus.dev'
+    aliases = ['lateralus', 'ltl']
+    filenames = ['*.ltl']
+    mimetypes = ['text/x-lateralus']
+    version_added = '2.21'
+
+    keywords = (
+        'fn', 'let', 'mut', 'match', 'if', 'else', 'elif', 'while', 'for',
+        'in', 'return', 'break', 'continue', 'import', 'export', 'module',
+        'pub', 'priv', 'struct', 'enum', 'impl', 'trait', 'where', 'type',
+        'const', 'static', 'async', 'await', 'spawn', 'guard', 'defer',
+        'use', 'as', 'self', 'Self', 'super', 'yield', 'do',
+    )
+
+    builtin_types = (
+        'int', 'i8', 'i16', 'i32', 'i64', 'i128',
+        'uint', 'u8', 'u16', 'u32', 'u64', 'u128',
+        'float', 'f32', 'f64',
+        'bool', 'str', 'char', 'bytes', 'any', 'never',
+        'list', 'map', 'set', 'tuple', 'Option', 'Result',
+        'Some', 'None', 'Ok', 'Err',
+    )
+
+    builtin_funcs = (
+        'print', 'println', 'eprint', 'eprintln', 'format', 'panic',
+        'assert', 'assert_eq', 'todo', 'unimplemented', 'unreachable',
+        'len', 'range', 'map', 'filter', 'reduce', 'fold', 'zip',
+        'enumerate', 'sort', 'sorted', 'reverse', 'sum', 'min', 'max',
+    )
+
+    tokens = {
+        'root': [
+            (r'\s+', Whitespace),
+            # Line comments
+            (r'//[^\n]*', Comment.Single),
+            # Doc comments
+            (r'///[^\n]*', Comment.Special),
+            # Nested block comments
+            (r'/\*', Comment.Multiline, 'block_comment'),
+            # Attribute decorators: @memo, @doc("..."), @foreign("c")
+            (r'@[A-Za-z_][A-Za-z0-9_]*', Name.Decorator),
+            # Capability annotations: #[caps(io, net)]
+            (r'#\[', Name.Decorator, 'attribute'),
+            # Keywords
+            (words(keywords, suffix=r'\b'), Keyword),
+            # Builtin types
+            (words(builtin_types, suffix=r'\b'), Keyword.Type),
+            # Boolean and null-ish literals
+            (words(('true', 'false', 'null'), suffix=r'\b'), Keyword.Constant),
+            # Builtin functions (followed by a call)
+            (words(builtin_funcs, suffix=r'\b'), Name.Builtin),
+            # Function definitions
+            (r'(fn)(\s+)([A-Za-z_][A-Za-z0-9_]*)',
+             bygroups(Keyword, Whitespace, Name.Function)),
+            # Type / struct / enum / trait definitions
+            (r'(struct|enum|trait|type|impl)(\s+)([A-Z][A-Za-z0-9_]*)',
+             bygroups(Keyword, Whitespace, Name.Class)),
+            # Module path: `foo::bar::baz`
+            (r'([A-Za-z_][A-Za-z0-9_]*)(::)',
+             bygroups(Name.Namespace, Punctuation)),
+            # ADT variants: uppercase-leading identifier in value position
+            (r'\b[A-Z][A-Za-z0-9_]*\b', Name.Class),
+            # Raw strings: r"...", r#"..."#
+            (r'r(#+)"(?:\\.|[^"\\])*"\1', String),
+            (r'r"(?:\\.|[^"\\])*"', String),
+            # Byte strings: b"..."
+            (r'b"(?:\\.|[^"\\])*"', String),
+            # Interpolated / regular strings
+            (r'"', String, 'string'),
+            # Char literals
+            (r"'(?:\\.|[^'\\])'", String.Char),
+            # Numeric literals with optional type suffixes
+            (r'\d[\d_]*\.\d[\d_]*(?:[eE][-+]?\d+)?'
+             r'(?:_?(?:f32|f64))?', Number.Float),
+            (r'0x[0-9a-fA-F_]+(?:_?(?:[iu](?:8|16|32|64|128)))?', Number.Hex),
+            (r'0o[0-7_]+(?:_?(?:[iu](?:8|16|32|64|128)))?', Number.Oct),
+            (r'0b[01_]+(?:_?(?:[iu](?:8|16|32|64|128)))?', Number.Bin),
+            (r'\d[\d_]*(?:_?(?:[iu](?:8|16|32|64|128)))?', Number.Integer),
+            # Pipeline operator (Lateralus's signature feature)
+            (r'\|>', Operator),
+            # Other operators
+            (r'(==|!=|<=|>=|->|=>|&&|\|\||<<|>>|::|\.\.=?|\?\?|'
+             r'[+\-*/%<>!=&|^~?])', Operator),
+            # Punctuation
+            (r'[{}()\[\];,.:]', Punctuation),
+            # Identifiers
+            (r'[A-Za-z_][A-Za-z0-9_]*', Name),
+        ],
+        'block_comment': [
+            (r'[^/*]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[/*]', Comment.Multiline),
+        ],
+        'string': [
+            (r'[^"\\{}]+', String),
+            (r'\\.', String.Escape),
+            (r'\{[^}]*\}', String.Interpol),
+            (r'"', String, '#pop'),
+        ],
+        'attribute': [
+            (r'[^\[\]]+', Name.Decorator),
+            (r'\[', Name.Decorator, '#push'),
+            (r'\]', Name.Decorator, '#pop'),
+        ],
+    }

--- a/tests/examplefiles/lateralus/fibonacci.ltl
+++ b/tests/examplefiles/lateralus/fibonacci.ltl
@@ -1,0 +1,22 @@
+// examples/fibonacci.ltl  -  Fibonacci demonstration
+
+module examples.fibonacci
+
+import io
+
+fn fib(n: int) -> int {
+    if n <= 0 { return 0 }
+    if n == 1 { return 1 }
+    return fib(n - 1) + fib(n - 2)
+}
+
+fn main() {
+    io.println("Fibonacci sequence:")
+    let mut i = 0
+    while i <= 15 {
+        io.println("fib(" + i as str + ") = " + fib(i) as str)
+        i += 1
+    }
+}
+
+main()

--- a/tests/examplefiles/lateralus/fibonacci.ltl.output
+++ b/tests/examplefiles/lateralus/fibonacci.ltl.output
@@ -1,0 +1,177 @@
+'// examples/fibonacci.ltl  -  Fibonacci demonstration' Comment.Single
+'\n\n'        Text.Whitespace
+
+'module'      Keyword
+' '           Text.Whitespace
+'examples'    Name
+'.'           Punctuation
+'fibonacci'   Name
+'\n\n'        Text.Whitespace
+
+'import'      Keyword
+' '           Text.Whitespace
+'io'          Name
+'\n\n'        Text.Whitespace
+
+'fn'          Keyword
+' '           Text.Whitespace
+'fib'         Name
+'('           Punctuation
+'n'           Name
+':'           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+'}'           Punctuation
+'\n    '      Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'n'           Name
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+'}'           Punctuation
+'\n    '      Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'fib'         Name
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+')'           Punctuation
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'fib'         Name
+'('           Punctuation
+'n'           Name
+' '           Text.Whitespace
+'-'           Operator
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'fn'          Keyword
+' '           Text.Whitespace
+'main'        Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'io'          Name
+'.'           Punctuation
+'println'     Name.Builtin
+'('           Punctuation
+'"'           Literal.String
+'Fibonacci sequence:' Literal.String
+'"'           Literal.String
+')'           Punctuation
+'\n    '      Text.Whitespace
+'let'         Keyword
+' '           Text.Whitespace
+'mut'         Keyword
+' '           Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n    '      Text.Whitespace
+'while'       Keyword
+' '           Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'15'          Literal.Number.Integer
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'io'          Name
+'.'           Punctuation
+'println'     Name.Builtin
+'('           Punctuation
+'"'           Literal.String
+'fib('        Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'str'         Keyword.Type
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+') = '        Literal.String
+'"'           Literal.String
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'fib'         Name
+'('           Punctuation
+'i'           Name
+')'           Punctuation
+' '           Text.Whitespace
+'as'          Keyword
+' '           Text.Whitespace
+'str'         Keyword.Type
+')'           Punctuation
+'\n        '  Text.Whitespace
+'i'           Name
+' '           Text.Whitespace
+'+'           Operator
+'='           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'main'        Name
+'('           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/lateralus/pipeline.txt
+++ b/tests/snippets/lateralus/pipeline.txt
@@ -1,0 +1,97 @@
+---input---
+fn square(x: int) -> int { x * x }
+
+fn main() {
+    let nums = [1, 2, 3, 4, 5]
+    let total = nums |> map(square) |> sum()
+    println("total = {total}")
+}
+
+---tokens---
+'fn'          Keyword
+' '           Text.Whitespace
+'square'      Name
+'('           Punctuation
+'x'           Name
+':'           Punctuation
+' '           Text.Whitespace
+'int'         Keyword.Type
+')'           Punctuation
+' '           Text.Whitespace
+'->'          Operator
+' '           Text.Whitespace
+'int'         Keyword.Type
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'*'           Operator
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'fn'          Keyword
+' '           Text.Whitespace
+'main'        Name
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'let'         Keyword
+' '           Text.Whitespace
+'nums'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'1'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'2'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'4'           Literal.Number.Integer
+','           Punctuation
+' '           Text.Whitespace
+'5'           Literal.Number.Integer
+']'           Punctuation
+'\n    '      Text.Whitespace
+'let'         Keyword
+' '           Text.Whitespace
+'total'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'nums'        Name
+' '           Text.Whitespace
+'|>'          Operator
+' '           Text.Whitespace
+'map'         Keyword.Type
+'('           Punctuation
+'square'      Name
+')'           Punctuation
+' '           Text.Whitespace
+'|>'          Operator
+' '           Text.Whitespace
+'sum'         Name.Builtin
+'('           Punctuation
+')'           Punctuation
+'\n    '      Text.Whitespace
+'println'     Name.Builtin
+'('           Punctuation
+'"'           Literal.String
+'total = '    Literal.String
+'{total}'     Literal.String.Interpol
+'"'           Literal.String
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Adds a lexer for **Lateralus**, a statically typed, pipeline-oriented programming language with algebraic data types, pattern matching, and first-class effect capabilities.

## Language info

- Homepage: https://lateralus.dev
- Reference implementation: https://github.com/bad-antics/lateralus-lang (MIT licensed)
- File extension: `.ltl`
- Aliases: `lateralus`, `ltl`

## What's included

- `pygments/lexers/lateralus.py` — `LateralusLexer` (RegexLexer). Covers keywords, builtin types and functions, attribute decorators (`@memo`), capability annotations (`#[caps(io, net)]`), nested block comments, raw/byte/interpolated strings, numeric literals with type suffixes (`42u64`, `3.14f32`, `0xFF_i32`), module paths (`foo::bar`), ADT variants, and the signature pipeline operator `|>`.
- `tests/examplefiles/lateralus/fibonacci.ltl` plus generated `.output` — real example from the Lateralus reference implementation's `examples/` directory, MIT licensed.
- `tests/snippets/lateralus/pipeline.txt` — small snippet exercising the pipeline operator.
- Entry in `pygments/lexers/_mapping.py` (regenerated via `scripts/gen_mapfiles.py`).
- Entry in `CHANGES` under 2.21.0 / New lexers.
- Entry in `AUTHORS`.

## Tests

- `pytest tests/snippets/lateralus/ tests/examplefiles/lateralus/` → 2 passed
- `pytest tests/test_basic_api.py tests/test_cmdline.py` → 2467 passed, 8 skipped (unchanged)
- Example file produces zero `Token.Error` tokens.

## Sample license

The `fibonacci.ltl` sample is copied from the Lateralus reference implementation under MIT. Happy to re-license as Pygments BSD for inclusion if preferred — just say the word.