### PR TITLE
feat(lexer): add BicepLexer for Azure Bicep deployment files

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -53,6 +53,7 @@ LEXERS = {
     'BefungeLexer': ('pygments.lexers.esoteric', 'Befunge', ('befunge',), ('*.befunge',), ('application/x-befunge',)),
     'BerryLexer': ('pygments.lexers.berry', 'Berry', ('berry', 'be'), ('*.be',), ('text/x-berry', 'application/x-berry')),
     'BibTeXLexer': ('pygments.lexers.bibtex', 'BibTeX', ('bibtex', 'bib'), ('*.bib',), ('text/x-bibtex',)),
+    'BicepLexer': ('pygments.lexers.configs', 'Bicep', ('bicep',), ('*.bicep', '*.bicepparam'), ()),
     'BlitzBasicLexer': ('pygments.lexers.basic', 'BlitzBasic', ('blitzbasic', 'b3d', 'bplus'), ('*.bb', '*.decls'), ('text/x-bb',)),
     'BlitzMaxLexer': ('pygments.lexers.basic', 'BlitzMax', ('blitzmax', 'bmax'), ('*.bmx',), ('text/x-bmx',)),
     'BlueprintLexer': ('pygments.lexers.blueprint', 'Blueprint', ('blueprint',), ('*.blp',), ('text/x-blueprint',)),

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -22,7 +22,8 @@ __all__ = ['IniLexer', 'SystemdLexer', 'DesktopLexer', 'RegeditLexer', 'Properti
            'NginxConfLexer', 'LighttpdConfLexer', 'DockerLexer',
            'TerraformLexer', 'TermcapLexer', 'TerminfoLexer',
            'PkgConfigLexer', 'PacmanConfLexer', 'AugeasLexer', 'TOMLLexer',
-           'NestedTextLexer', 'SingularityLexer', 'UnixConfigLexer']
+           'NestedTextLexer', 'SingularityLexer', 'UnixConfigLexer',
+           'BicepLexer']
 
 
 class IniLexer(RegexLexer):
@@ -1429,5 +1430,157 @@ class UnixConfigLexer(RegexLexer):
             (r'[0-9]+', Number),
             (r'((?!\n)[a-zA-Z0-9\_\-\s\(\),]){2,}', Text),
             (r'[^:\n]+', String),
+        ],
+    }
+
+
+class BicepLexer(RegexLexer):
+    """
+    Lexer for Azure Bicep declarative deployment files.
+
+    Bicep is a domain-specific language for declarative deployment of
+    Azure resources. Source files use the ``.bicep`` extension; parameter
+    files use ``.bicepparam``. Keywords are scoped tightly to the
+    resource-graph grammar; everything else is identifier-or-expression.
+    """
+
+    name = 'Bicep'
+    aliases = ['bicep']
+    filenames = ['*.bicep', '*.bicepparam']
+    url = 'https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/'
+    version_added = '2.20'
+
+    declarations = (
+        'param', 'var', 'resource', 'module', 'output', 'targetScope',
+        'type', 'func', 'metadata', 'extends', 'using', 'extension',
+        'import', 'provider',
+    )
+
+    statement_keywords = ('if', 'else', 'for', 'in')
+
+    builtin_constants = ('true', 'false', 'null')
+
+    builtin_types = (
+        'string', 'int', 'bool', 'array', 'object',
+        'secureString', 'secureObject', 'sys',
+    )
+
+    # Keep the function list short on purpose. Bicep ships hundreds of
+    # functions across the `sys`, `az`, and resource-specific namespaces;
+    # the curated list below covers the ones that show up most often in
+    # tutorials, so they highlight as Name.Builtin instead of plain text
+    # without us pretending to know every function in the language.
+    builtin_functions = (
+        'concat', 'format', 'replace', 'split', 'toLower', 'toUpper',
+        'substring', 'trim', 'length', 'empty', 'contains', 'first',
+        'last', 'min', 'max', 'range', 'union', 'intersection', 'json',
+        'string', 'int', 'bool', 'array', 'createObject', 'items',
+        'resourceId', 'subscriptionResourceId', 'tenantResourceId',
+        'managementGroupResourceId', 'resourceGroup', 'subscription',
+        'tenant', 'managementGroup', 'environment', 'deployment',
+        'reference', 'getSecret', 'listKeys', 'list',
+        'base64', 'base64ToString', 'uri', 'uriComponent',
+        'utcNow', 'dateTimeAdd', 'guid', 'newGuid',
+        'loadTextContent', 'loadFileAsBase64', 'loadJsonContent',
+        'loadYamlContent', 'pickZones', 'cidrSubnet', 'cidrHost',
+    )
+
+    tokens = {
+        'root': [
+            include('comments'),
+            include('whitespace'),
+
+            # Decorators e.g. @description('...'), @secure().
+            (r'(@)([a-zA-Z_]\w*)', bygroups(Punctuation, Name.Decorator)),
+
+            # Top-level declaration keywords introduce a name binding.
+            (words(declarations, prefix=r'\b', suffix=r'\b'),
+             Keyword.Declaration),
+
+            (words(statement_keywords, prefix=r'\b', suffix=r'\b'),
+             Keyword),
+
+            (words(builtin_constants, prefix=r'\b', suffix=r'\b'),
+             Keyword.Constant),
+
+            (words(builtin_types, prefix=r'\b', suffix=r'\b'),
+             Keyword.Type),
+
+            (words(builtin_functions, prefix=r'\b', suffix=r'\b'),
+             Name.Builtin),
+
+            include('strings'),
+            include('numbers'),
+
+            # Resource API version on a resource declaration:
+            #   resource foo 'Microsoft.Network/virtualNetworks@2023-04-01'
+            # The whole single-quoted form is handled in 'strings'; nothing
+            # extra needed here.
+
+            include('punctuation'),
+            include('operators'),
+
+            (r'[a-zA-Z_]\w*', Name),
+        ],
+
+        'whitespace': [
+            (r'\s+', Whitespace),
+        ],
+
+        'comments': [
+            (r'//[^\n]*', Comment.Single),
+            (r'/\*', Comment.Multiline, 'block-comment'),
+        ],
+
+        'block-comment': [
+            (r'[^*/]+', Comment.Multiline),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline),
+        ],
+
+        'strings': [
+            # Triple-quoted multiline string: '''...'''
+            (r"'''", String, 'multiline-string'),
+
+            # Single-quoted string with optional ${...} interpolation.
+            (r"'", String, 'string'),
+        ],
+
+        'string': [
+            (r"\\.", String.Escape),
+            (r"\$\{", String.Interpol, 'interpol'),
+            (r"'", String, '#pop'),
+            (r"[^'\\$]+", String),
+            (r"\$", String),
+        ],
+
+        'multiline-string': [
+            (r"'''", String, '#pop'),
+            (r"\$\{", String.Interpol, 'interpol'),
+            (r"[^'\\$]+", String),
+            (r"'", String),
+            (r"\$", String),
+            (r"\\.", String.Escape),
+        ],
+
+        'interpol': [
+            (r"\}", String.Interpol, '#pop'),
+            include('root'),
+        ],
+
+        'numbers': [
+            (r'\d+\.\d+', Number.Float),
+            (r'\d+', Number.Integer),
+        ],
+
+        'punctuation': [
+            (r'[\[\](){}]', Punctuation),
+            (r'[,;.]', Punctuation),
+        ],
+
+        'operators': [
+            # Multi-char operators first so '==' isn't mis-tokenised as '='.
+            (r'==|!=|<=|>=|&&|\|\||\?\?|=>|\.\.|\?\.|::', Operator),
+            (r'[=+\-*/%<>!|&?:^]', Operator),
         ],
     }

--- a/tests/snippets/bicep/test_basic.txt
+++ b/tests/snippets/bicep/test_basic.txt
@@ -1,0 +1,119 @@
+---input---
+@description('A simple resource')
+param location string = resourceGroup().location
+
+var prefix = 'demo'
+// short comment
+/* block
+   comment */
+
+resource sa 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: '${prefix}storage'
+  location: location
+  sku: { name: 'Standard_LRS' }
+}
+
+output id string = sa.id
+
+
+---tokens---
+'@'           Punctuation
+'description' Name.Decorator
+'('           Punctuation
+"'"           Literal.String
+'A simple resource' Literal.String
+"'"           Literal.String
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'param'       Keyword.Declaration
+' '           Text.Whitespace
+'location'    Name
+' '           Text.Whitespace
+'string'      Keyword.Type
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'resourceGroup' Name.Builtin
+'('           Punctuation
+')'           Punctuation
+'.'           Punctuation
+'location'    Name
+'\n\n'        Text.Whitespace
+
+'var'         Keyword.Declaration
+' '           Text.Whitespace
+'prefix'      Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String
+'demo'        Literal.String
+"'"           Literal.String
+'\n'          Text.Whitespace
+
+'// short comment' Comment.Single
+'\n'          Text.Whitespace
+
+'/*'          Comment.Multiline
+' block\n   comment ' Comment.Multiline
+'*/'          Comment.Multiline
+'\n\n'        Text.Whitespace
+
+'resource'    Keyword.Declaration
+' '           Text.Whitespace
+'sa'          Name
+' '           Text.Whitespace
+"'"           Literal.String
+'Microsoft.Storage/storageAccounts@2023-01-01' Literal.String
+"'"           Literal.String
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'name'        Name
+':'           Operator
+' '           Text.Whitespace
+"'"           Literal.String
+'${'          Literal.String.Interpol
+'prefix'      Name
+'}'           Literal.String.Interpol
+'storage'     Literal.String
+"'"           Literal.String
+'\n  '        Text.Whitespace
+'location'    Name
+':'           Operator
+' '           Text.Whitespace
+'location'    Name
+'\n  '        Text.Whitespace
+'sku'         Name
+':'           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'name'        Name
+':'           Operator
+' '           Text.Whitespace
+"'"           Literal.String
+'Standard_LRS' Literal.String
+"'"           Literal.String
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'output'      Keyword.Declaration
+' '           Text.Whitespace
+'id'          Name
+' '           Text.Whitespace
+'string'      Keyword.Type
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'sa'          Name
+'.'           Punctuation
+'id'          Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
## What

Adds a `BicepLexer` for Azure Bicep, the declarative deployment language for Azure resources, claiming `*.bicep` and `*.bicepparam`.

Closes #2938.

## Coverage

- Top-level declaration keywords: `param`, `var`, `resource`, `module`, `output`, `targetScope`, `type`, `func`, `metadata`, `extension` / `provider`, `import`, `extends`, `using`
- Statement keywords: `if`, `else`, `for`, `in`
- Built-in types: `string`, `int`, `bool`, `array`, `object`, the `secure*` variants, the `sys` namespace marker
- Constants: `true`, `false`, `null`
- Curated function namespace (the most-used sys / resource / string / file-loading functions get `Name.Builtin`). Bicep ships hundreds of functions across `sys`, `az`, and resource-specific namespaces; the curated list trades long-tail coverage for predictability rather than pretending to know every function. Anything not on the list still highlights as `Name`.
- Decorators (`@description`, `@secure`, etc.)
- Single-quoted strings, triple-quoted multiline strings, and `${...}` interpolation that pops into the root state for nested expressions
- Single-line `//` and block `/* */` comments
- Multi-character operators (`==`, `!=`, `<=`, `>=`, `&&`, `||`, `??`, `=>`, `..`, `?.`, `::`) tokenised before the single-char fallback

Resource API-version literals (e.g. `'Microsoft.Storage/storageAccounts@2023-01-01'`) work via the ordinary single-quoted string path; no special case needed.

## Files

- `pygments/lexers/configs.py`: add `BicepLexer` class, append to `__all__`
- `pygments/lexers/_mapping.py`: register between `BibTeXLexer` and `BlitzBasicLexer` (alphabetical) with filenames `*.bicep`, `*.bicepparam`
- `tests/snippets/bicep/test_basic.txt`: golden snippet test covering decorators, declarations, types, a curated builtin function (`resourceGroup`), single-line + block comments, a resource declaration with API-version literal, string interpolation, and an output binding

## Test plan

- [x] `pytest tests/snippets/bicep/` -> 1 passed
- [x] `pytest tests/snippets/terraform/` -> 10 passed (untouched)
- [x] `pytest tests/test_basic_api.py` -> 2445 passed
- [x] Manual visual check on a real `.bicep` file: decorators, keywords, types, strings, interpolation all render distinct

## Reference

- Bicep language docs: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
- Built-in functions index: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions

Closes #2938