### PR TITLE
Require a word break after `SET` as a MySQL keyword

### DIFF
--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -764,7 +764,7 @@ class MySqlLexer(RegexLexer):
             (r'[!%&*+/:<=>^|~-]+', Operator),
 
             # Exceptions; these words tokenize differently in different contexts.
-            (r'\b(set)(?!\s*\()', Keyword),
+            (r'\b(set)\b(?!\s*\()', Keyword),
             (r'\b(character)(\s+)(set)\b', bygroups(Keyword, Whitespace, Keyword)),
             # In all other known cases, "SET" is tokenized by MYSQL_DATATYPES.
 

--- a/tests/snippets/mysql/test_leading_substring_set_not_keyword.txt
+++ b/tests/snippets/mysql/test_leading_substring_set_not_keyword.txt
@@ -1,0 +1,8 @@
+---input---
+select settings
+
+---tokens---
+'select'      Keyword
+' '           Text.Whitespace
+'settings'    Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
Per a bug report in the Mycli project:

 * https://github.com/dbcli/mycli/issues/1872

`SET` is tokenizing as a `Keyword` even when part of a `Name` in `MySqlLexer`.

The fix proposed is to require a word break after `SET`, and before the negative lookahead assertion.

There is an identical construct in `GoogleSqlLexer`, which is not changed.