### PR TITLE
docs: fix filterdevelopment.rst (uncolor typo + sentence case)

### DIFF
--- a/doc/docs/filterdevelopment.rst
+++ b/doc/docs/filterdevelopment.rst
@@ -69,7 +69,7 @@ You can also use the `simplefilter` decorator from the `pygments.filter` module:
 
 You can instantiate this filter by calling `uncolor(classtoo=True)`, the same
 way that you would have instantiated the previous filter by calling
-`UncolorFilter(classtoo=True)`. Indeed, The decorator automatically ensures that
+`UncolorFilter(classtoo=True)`. Indeed, the decorator automatically ensures that
 `uncolor` is a class which subclasses an internal filter class. The class
-`uncolo` uses the decorated function as a method for filtering.  (That's why
+`uncolor` uses the decorated function as a method for filtering.  (That's why
 there is a `self` argument that you probably won't end up using in the method.)


### PR DESCRIPTION
## Summary

- Fix documentation typo: `uncolo` → `uncolor` (reported in #2990).
- Fix prose: "Indeed, The decorator" → "Indeed, the decorator" after the comma.

## Note

There is an open PR (#3105) that only addresses the `uncolo` typo. This change adds the sentence-case fix as well; if #3105 lands first, I am happy to rebase to keep only the capitalization change.

Fixes #2990

Made with [Cursor](https://cursor.com)