### PR TITLE
Add TextWithCommentLexer for plain text with hash comments

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -528,6 +528,7 @@ LEXERS = {
     'TerraformLexer': ('pygments.lexers.configs', 'Terraform', ('terraform', 'tf', 'hcl'), ('*.tf', '*.hcl'), ('application/x-tf', 'application/x-terraform')),
     'TexLexer': ('pygments.lexers.markup', 'TeX', ('tex', 'latex'), ('*.tex', '*.aux', '*.toc'), ('text/x-tex', 'text/x-latex')),
     'TextLexer': ('pygments.lexers.special', 'Text only', ('text',), ('*.txt',), ('text/plain',)),
+    'TextWithCommentLexer': ('pygments.lexers.textfmts', 'Text with comments', ('text-with-comments',), (), ()),
     'ThingsDBLexer': ('pygments.lexers.thingsdb', 'ThingsDB', ('ti', 'thingsdb'), ('*.ti',), ()),
     'ThriftLexer': ('pygments.lexers.dsls', 'Thrift', ('thrift',), ('*.thrift',), ('application/x-thrift',)),
     'TiddlyWiki5Lexer': ('pygments.lexers.markup', 'tiddler', ('tid',), ('*.tid',), ('text/vnd.tiddlywiki',)),

--- a/pygments/lexers/textfmts.py
+++ b/pygments/lexers/textfmts.py
@@ -17,7 +17,7 @@ from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
 from pygments.util import ClassNotFound
 
 __all__ = ['IrcLogsLexer', 'TodotxtLexer', 'HttpLexer', 'GettextLexer',
-           'NotmuchLexer', 'KernelLogLexer']
+           'NotmuchLexer', 'KernelLogLexer', 'TextWithCommentLexer']
 
 
 class IrcLogsLexer(RegexLexer):
@@ -433,4 +433,26 @@ class KernelLogLexer(RegexLexer):
             include('base'),
             (r'.+\n', Generic.Error, '#pop')
         ]
+    }
+
+
+class TextWithCommentLexer(RegexLexer):
+    """
+    Lexer that highlights ``#`` comments but displays everything else as text.
+    Useful for example for ``.gitignore`` files, interactive git rebasing sessions,
+    or just config-style files.
+    Note that the ``#`` character has to be preceded by a whitespace character.
+    """
+    name = 'Text with comments'
+    aliases = ['text-with-comments']
+    url = ''
+    version_added = '2.21'
+
+    tokens = {
+        'root': [
+            (r'^(#.*)(\n?)', bygroups(Comment.Single, Text.Whitespace)),
+            (r'([^\n]*?[ \t])(#.*)(\n?)', bygroups(Text, Comment.Single, Text.Whitespace)),
+            (r'\n', Text.Whitespace),
+            (r'[^\n]+', Text),
+        ],
     }

--- a/tests/snippets/text-with-comments/test_comments.txt
+++ b/tests/snippets/text-with-comments/test_comments.txt
@@ -1,0 +1,28 @@
+---input---
+text # inline comment
+# full line comment
+#full line comment
+text#invalid inline comment
+text #inline comment
+text# invalid inline comment
+
+---tokens---
+'text '       Text
+'# inline comment' Comment.Single
+'\n'          Text.Whitespace
+
+'# full line comment' Comment.Single
+'\n'          Text.Whitespace
+
+'#full line comment' Comment.Single
+'\n'          Text.Whitespace
+
+'text#invalid inline comment' Text
+'\n'          Text.Whitespace
+
+'text '       Text
+'#inline comment' Comment.Single
+'\n'          Text.Whitespace
+
+'text# invalid inline comment' Text
+'\n'          Text.Whitespace


### PR DESCRIPTION
Adds a minimal `TextWithCommentLexer` that highlights `#` comments while treating everything else as plain text.

**Possible use cases:**
This lexer provides minimal useful highlighting for files that are essentially plain text but use `#` for annotations — especially in terminal-based editors and preview tools.

### `.gitignore`
Line-based files where only comments need visual separation from content.
<img width="196" height="140" alt="gitignore_example" src="https://github.com/user-attachments/assets/677dc39b-6716-4fb7-afb7-32014820acb6" />


### `git rebase -i`
The instructions are `#` comments, the rest is user-editable content. Highlighting comments helps distinguish actionable lines from help text.
<img width="460" height="170" alt="rebase_example" src="https://github.com/user-attachments/assets/153a3723-c70f-4508-8e9e-e381a8ce7901" />


### Notes and scratch files
Quick TODO files where `#` marks section headers or meta-notes vs. actual content. Inline `#` comments annotate individual lines.
<img width="533" height="140" alt="notes_example" src="https://github.com/user-attachments/assets/bcfa89e8-4b9b-4f73-bdc4-c6ea7d585b58" />


**Changes:**
  - `pygments/lexers/textfmts.py` — new `TextWithCommentLexer` class
  - `tests/snippets/text-with-comments/test_comments.txt` — golden test
  - `pygments/lexers/_mapping.py` — regenerated mapping
