### PR TITLE
Python lexer: add support for 3.15 'sentinel' built-in

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -242,9 +242,10 @@ class PythonLexer(RegexLexer):
                 'hasattr', 'hash', 'hex', 'id', 'input', 'int', 'isinstance',
                 'issubclass', 'iter', 'len', 'list', 'locals', 'map', 'max',
                 'memoryview', 'min', 'next', 'object', 'oct', 'open', 'ord', 'pow',
-                'print', 'property', 'range', 'repr', 'reversed', 'round', 'set',
-                'setattr', 'slice', 'sorted', 'staticmethod', 'str', 'sum', 'super',
-                'tuple', 'type', 'vars', 'zip'), prefix=r'(?<!\.)', suffix=r'\b'),
+                'print', 'property', 'range', 'repr', 'reversed', 'round', 'sentinel',
+                'set', 'setattr', 'slice', 'sorted', 'staticmethod', 'str', 'sum',
+                'super', 'tuple', 'type', 'vars', 'zip'), prefix=r'(?<!\.)',
+                suffix=r'\b'),
              Name.Builtin),
             (r'(?<!\.)(self|Ellipsis|NotImplemented|cls)\b', Name.Builtin.Pseudo),
             (words((

--- a/tests/snippets/python/test_sentinel_builtin.txt
+++ b/tests/snippets/python/test_sentinel_builtin.txt
@@ -1,0 +1,8 @@
+# Tests that 'sentinel' is recognized as a built-in
+
+---input---
+sentinel
+
+---tokens---
+'sentinel'    Name.Builtin
+'\n'          Text.Whitespace


### PR DESCRIPTION
Adds the built-in 'sentinel' coming in Python 3.15 as per PEP 661, https://peps.python.org/pep-0661/