### PR TITLE
Python lexer: add support for type statements

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -227,6 +227,12 @@ class PythonLexer(RegexLexer):
                                        # pattern matching (but None/True/False is ok)
              r'|'.join(k for k in keyword.kwlist if k[0].islower()) + r')\b))',
              bygroups(Text, Keyword), 'soft-keywords-inner'),
+            # `type` soft keyword
+            (r'(^[ \t]*)'                    # beginning of line + indentation
+             r'(type)\b'                     # the keyword 'type' followed by
+             r'([ \t]+)(' + uni_name + r')'  # the type alias name
+             r'(?=[ \t]*(?:[^\n]*)?=)',      # followed by an eventual assignment
+             bygroups(Text, Keyword, Text, Name.Class)),
         ],
         'soft-keywords-inner': [
             # optional `_` keyword

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -231,7 +231,7 @@ class PythonLexer(RegexLexer):
             (r'(^[ \t]*)'                    # beginning of line + indentation
              r'(type)\b'                     # the keyword 'type' followed by
              r'([ \t]+)(' + uni_name + r')'  # the type alias name
-             r'(?=[ \t]*(?:[^\n]*)?=)',      # followed by an eventual assignment
+             r'(?=[^\n]*=)',                 # followed by an eventual assignment
              bygroups(Text, Keyword, Text, Name.Class)),
         ],
         'soft-keywords-inner': [

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -228,10 +228,9 @@ class PythonLexer(RegexLexer):
              r'|'.join(k for k in keyword.kwlist if k[0].islower()) + r')\b))',
              bygroups(Text, Keyword), 'soft-keywords-inner'),
             # `type` soft keyword
-            (r'(^[ \t]*)'                    # beginning of line + indentation
-             r'(type)\b'                     # the keyword 'type' followed by
-             r'([ \t]+)(' + uni_name + r')'  # the type alias name
-             r'(?=[^\n]*=)',                 # followed by an eventual assignment
+            (r'(^[ \t]*)'                     # beginning of line + indentation
+             r'(type)\b'                      # the keyword 'type' followed by
+             r'([ \t]+)(' + uni_name + r')',  # the type alias name
              bygroups(Text, Keyword, Text, Name.Class)),
         ],
         'soft-keywords-inner': [

--- a/tests/snippets/python/test_soft_kwd_type.txt
+++ b/tests/snippets/python/test_soft_kwd_type.txt
@@ -1,0 +1,76 @@
+---input---
+type alias = int | str
+
+type Pair[L: int, R: (int, str)] = tuple[L, R]
+
+print(type(alias))
+
+type = 3
+
+---tokens---
+'type'        Keyword
+' '           Text
+'alias'       Name.Class
+' '           Text
+'='           Operator
+' '           Text
+'int'         Name.Builtin
+' '           Text
+'|'           Operator
+' '           Text
+'str'         Name.Builtin
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'type'        Keyword
+' '           Text
+'Pair'        Name.Class
+'['           Punctuation
+'L'           Name
+':'           Punctuation
+' '           Text
+'int'         Name.Builtin
+','           Punctuation
+' '           Text
+'R'           Name
+':'           Punctuation
+' '           Text
+'('           Punctuation
+'int'         Name.Builtin
+','           Punctuation
+' '           Text
+'str'         Name.Builtin
+')'           Punctuation
+']'           Punctuation
+' '           Text
+'='           Operator
+' '           Text
+'tuple'       Name.Builtin
+'['           Punctuation
+'L'           Name
+','           Punctuation
+' '           Text
+'R'           Name
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'print'       Name.Builtin
+'('           Punctuation
+'type'        Name.Builtin
+'('           Punctuation
+'alias'       Name
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'type'        Name.Builtin
+' '           Text
+'='           Operator
+' '           Text
+'3'           Literal.Number.Integer
+'\n'          Text.Whitespace

--- a/tests/snippets/python/test_soft_kwd_type.txt
+++ b/tests/snippets/python/test_soft_kwd_type.txt
@@ -1,7 +1,9 @@
 ---input---
 type alias = int | str
 
-type Pair[L: int, R: (int, str)] = tuple[L, R]
+type Pair[
+    L: int, R: (int, str)
+] = tuple[L, R]
 
 print(type(alias))
 
@@ -27,6 +29,9 @@ type = 3
 ' '           Text
 'Pair'        Name.Class
 '['           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text
 'L'           Name
 ':'           Punctuation
 ' '           Text
@@ -42,6 +47,8 @@ type = 3
 ' '           Text
 'str'         Name.Builtin
 ')'           Punctuation
+'\n'          Text.Whitespace
+
 ']'           Punctuation
 ' '           Text
 '='           Operator


### PR DESCRIPTION
Highlights the soft keyword 'type' as a keyword instead of a built-in in scenarios that look like type statements, added in Python 3.12 (https://docs.python.org/3/reference/simple_stmts.html#the-type-statement).

Using the theme 'dracula', before the change `type` always has the same colour:

<img width="373" height="129" alt="Screenshot 2026-05-02 at 13 39 33" src="https://github.com/user-attachments/assets/eb54b60d-415e-4f18-93a6-c47e749e48fa" />

After the change, `type` has the colour of a keyword and the type alias is coloured like a class name (inspiration taken from how VS Code highlights type statements):

<img width="373" height="129" alt="Screenshot 2026-05-02 at 13 39 47" src="https://github.com/user-attachments/assets/03e89573-160d-4a46-9161-fc33ac1f693b" />

(This is the snippet of code used in the test I added.)

P.S. I know pygments isn't supposed to _validate_ code. The regex I used to check if `type` is supposed to be highlightd like a keyword is something like “we're at the beginning of the line, we see the keyword, then whitespace, then a valid name, then further down the line we find an equals sign”. I think this is _enough_ while not being too restrictive, but I could be wrong.