### PR TITLE
Fix(C/C++): Add support for multi-character literals

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -83,7 +83,7 @@ class CFamilyLexer(RegexLexer):
             include('keywords'),
             include('types'),
             (r'([LuU]|u8)?(")', bygroups(String.Affix, String), 'string'),
-            (r"([LuU]|u8)?(')(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])(')",
+            (r"([LuU]|u8)?(')((?:\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])+)(')",
              bygroups(String.Affix, String.Char, String.Char, String.Char)),
 
              # Hexadecimal floating-point literals (C11, C++17)

--- a/tests/examplefiles/c/multichar_literal.c
+++ b/tests/examplefiles/c/multichar_literal.c
@@ -1,0 +1,7 @@
+/*
+ * Multi-character literals
+ */
+
+int a = 'A';
+int ab = 'ab12';
+int abcd = 'ABCD';

--- a/tests/examplefiles/c/multichar_literal.c.output
+++ b/tests/examplefiles/c/multichar_literal.c.output
@@ -1,0 +1,40 @@
+'/*\n * Multi-character literals\n */' Comment.Multiline
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'a'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'A'           Literal.String.Char
+"'"           Literal.String.Char
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'ab'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'ab12'        Literal.String.Char
+"'"           Literal.String.Char
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'int'         Keyword.Type
+' '           Text.Whitespace
+'abcd'        Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'ABCD'        Literal.String.Char
+"'"           Literal.String.Char
+';'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/c/test_multichar_literal.txt
+++ b/tests/snippets/c/test_multichar_literal.txt
@@ -1,0 +1,15 @@
+---input---
+int foo = 'ABCD';
+
+---tokens---
+'int'         Keyword.Type
+' '           Text.Whitespace
+'foo'         Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+"'"           Literal.String.Char
+'ABCD'        Literal.String.Char
+"'"           Literal.String.Char
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary
Fixes #3116 

The C/C++ lexer only matched single-character char literals. Added a `+` quantifier to the char literal regex to support multi-character literals like `'ABCD'`, which is valid C and C++ syntax.

## Changes
- c_cpp.py: updated char literal regex from single character match to one-or-more characters
- Added example file multichar_literal.c with test cases
- Added expected output multichar_literal.c.output
- Added snippet test test_multichar_literal.txt