### PR TITLE
Fix C++ integer literal suffix tokenisation (#1847)

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -36,7 +36,7 @@ class CFamilyLexer(RegexLexer):
     # This includes decimal separators matching.
     _decpart = r'\d(\'?\d)*'
     # Integer literal suffix (e.g. 'ull' or 'll').
-    _intsuffix = r'(([uU]?[zZ])|([zZ][uU])|([uU][lL]{0,2})|([lL]{1,2}[uU]?))?'
+    _intsuffix = r'(([uU][zZ])|([zZ][uU]?)|([uU][lL]{0,2})|([lL]{1,2}[uU]?))?'
 
     # Identifier regex with C and C++ Universal Character Name (UCN) support.
     _ident = r'(?!\d)(?:[\w$]|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8})+'

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -93,7 +93,7 @@ class CFamilyLexer(RegexLexer):
             (r'(-)?(' + _decpart + r'\.' + _decpart + r'|\.' + _decpart + r'|' +
              _decpart + r')[eE][+-]?' + _decpart + r'[fFlL]?', Number.Float),
             (r'(-)?((' + _decpart + r'\.(' + _decpart + r')?|\.' +
-             _decpart + r')[fFlL]?)|(' + _decpart + r'[fFlL])', Number.Float),
+             _decpart + r')[fFlL]?)|(' + _decpart + r'[fF])', Number.Float),
             (r'(-)?0[xX]' + _hexpart + _intsuffix, Number.Hex),
             (r'(-)?0[bB][01](\'?[01])*' + _intsuffix, Number.Bin),
             (r'(-)?0(\'?[0-7])+' + _intsuffix, Number.Oct),

--- a/tests/examplefiles/cpp/example2.cpp
+++ b/tests/examplefiles/cpp/example2.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <iostream>
+#include <cstddef>
 
 int main() {
     char *_str      = "a normal string";
@@ -15,6 +16,18 @@ int main() {
 as a delimiter)"""";
 
     std::cout << R_str << std::endl;
+
+    long i1 = 12l;
+    long i2 = 12L;
+
+    std::size_t i3 = 12z;
+    std::size_t i4 = 12Z;
+
+    float f1 = 12f;
+    float f2 = 12F;
+
+    long double d1 = 12.0l;
+    long double d2 = 12.0L;
 
     return 0;
 }

--- a/tests/examplefiles/cpp/example2.cpp.output
+++ b/tests/examplefiles/cpp/example2.cpp.output
@@ -9,6 +9,12 @@
 '<iostream>'  Comment.PreprocFile
 '\n'          Comment.Preproc
 
+'#'           Comment.Preproc
+'include'     Comment.Preproc
+' '           Text.Whitespace
+'<cstddef>'   Comment.PreprocFile
+'\n'          Comment.Preproc
+
 '\n'          Text.Whitespace
 
 'int'         Keyword.Type
@@ -132,6 +138,112 @@
 ':'           Operator
 ':'           Operator
 'endl'        Name
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'long'        Keyword.Type
+' '           Text.Whitespace
+'i1'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12l'         Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'long'        Keyword.Type
+' '           Text.Whitespace
+'i2'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12L'         Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'std'         Name
+':'           Operator
+':'           Operator
+'size_t'      Keyword.Type
+' '           Text.Whitespace
+'i3'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12z'         Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'std'         Name
+':'           Operator
+':'           Operator
+'size_t'      Keyword.Type
+' '           Text.Whitespace
+'i4'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12Z'         Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'float'       Keyword.Type
+' '           Text.Whitespace
+'f1'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12f'         Literal.Number.Float
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'float'       Keyword.Type
+' '           Text.Whitespace
+'f2'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12F'         Literal.Number.Float
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'long'        Keyword.Type
+' '           Text.Whitespace
+'double'      Keyword.Type
+' '           Text.Whitespace
+'d1'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12.0l'       Literal.Number.Float
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'long'        Keyword.Type
+' '           Text.Whitespace
+'double'      Keyword.Type
+' '           Text.Whitespace
+'d2'          Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'12.0L'       Literal.Number.Float
 ';'           Punctuation
 '\n'          Text.Whitespace
 


### PR DESCRIPTION
Fixes #1847 

Fixes incorrect tokenisation of C++ integer literals.

12l was tokenised as Literal.Number.Float and 12z was not recognised as a valid integer literal.

Also added some lexer tests.
