### PR TITLE
Fix whitespace after backlash

### DIFF
--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -47,7 +47,7 @@ class CFamilyLexer(RegexLexer):
     # are embedded in larger regexes, that can cause the stuff*? to
     # match more than it would have if the regex had been used in
     # a standalone way ...
-    _comment_single = r'//(?:.|(?<=\\)\n)*\n'
+    _comment_single = r'//(?:\\[^\S\n]*\n|[^\n])*\n'
     _comment_multiline = r'/(?:\\\n)?[*](?:[^*]|[*](?!(?:\\\n)?/))*[*](?:\\\n)?/'
 
     # Regex to match optional comments
@@ -73,7 +73,7 @@ class CFamilyLexer(RegexLexer):
              bygroups(Whitespace, Name.Label, Whitespace, Punctuation)),
             (r'\n', Whitespace),
             (r'[^\S\n]+', Whitespace),
-            (r'\\\n', Text),  # line continuation
+            (r'\\[^\S\n]*\n', Text),  # line continuation
             (_comment_single, Comment.Single),
             (_comment_multiline, Comment.Multiline),
             # Open until EOF, so no ending delimiter
@@ -190,11 +190,11 @@ class CFamilyLexer(RegexLexer):
             (r'('+_ws1+r')(include)('+_ws1+r')(<[^>]+>)([^\n]*)',
                 bygroups(using(this), Comment.Preproc, using(this),
                          Comment.PreprocFile, Comment.Single)),
-            (r'[^/\n]+', Comment.Preproc),
+            (r'[^/\\\n]+', Comment.Preproc),
             (r'/[*](.|\n)*?[*]/', Comment.Multiline),
             (r'//.*?\n', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
-            (r'(?<=\\)\n', Comment.Preproc),
+            (r'\\[^\S\n]*\n', Comment.Preproc),
             (r'\n', Comment.Preproc, '#pop'),
         ],
         'if0': [

--- a/tests/snippets/cpp/test_backslash_whitespace_continuation.txt
+++ b/tests/snippets/cpp/test_backslash_whitespace_continuation.txt
@@ -1,0 +1,32 @@
+---input---
+int x = 0;
+
+// a comment \ 
+x += 10;
+
+#define TEST \ 
+x += 20;
+
+---tokens---
+'int'         Keyword.Type
+' '           Text.Whitespace
+'x'           Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'// a comment \\ \nx += 10;\n' Comment.Single
+
+'\n'          Text.Whitespace
+
+'#'           Comment.Preproc
+'define TEST ' Comment.Preproc
+'\\ \n'       Comment.Preproc
+
+'x += 20;'    Comment.Preproc
+'\n'          Comment.Preproc


### PR DESCRIPTION
Fixes #2258 

Handles C/C++ line continuations when whitespace appears between the backslash and newline.

Previously, comments and macros using:

// comment \ 
#define TEST \ 

were incorrectly tokenised.

Updated the lexer regexes and added tests for comment and macro continuations.