### PR TITLE
Add Night Owl style by Sarah Drasner

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -166,6 +166,7 @@ Other contributors, listed alphabetically, are:
 * Kurt McKee -- Tera Term macro lexer, PostgreSQL updates, MySQL overhaul, JSON lexer
 * Joe Eli McIlvain -- Savi lexer
 * Lukas Meuser -- BBCode formatter, Lua lexer
+* Bruno Mesquita -- Night Owl style
 * Cat Miller -- Pig lexer
 * Paul Miller -- LiveScript lexer
 * Hong Minhee -- HTTP lexer

--- a/pygments/styles/_mapping.py
+++ b/pygments/styles/_mapping.py
@@ -30,6 +30,7 @@ STYLES = {
     'MonokaiStyle': ('pygments.styles.monokai', 'monokai', ()),
     'MurphyStyle': ('pygments.styles.murphy', 'murphy', ()),
     'NativeStyle': ('pygments.styles.native', 'native', ()),
+    'NightOwlStyle': ('pygments.styles.night_owl', 'night-owl', ()),
     'NordDarkerStyle': ('pygments.styles.nord', 'nord-darker', ()),
     'NordStyle': ('pygments.styles.nord', 'nord', ()),
     'OneDarkStyle': ('pygments.styles.onedark', 'one-dark', ()),

--- a/pygments/styles/night_owl.py
+++ b/pygments/styles/night_owl.py
@@ -1,0 +1,143 @@
+"""
+    pygments.styles.night_owl
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Pygments version of the `Night Owl` theme by Sarah Drasner.
+    Based on https://github.com/sdras/night-owl-vscode-theme.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.style import Style
+from pygments.token import Comment, Error, Generic, Keyword, Name, Number, \
+    Operator, Punctuation, String, Text, Token, Whitespace
+
+
+__all__ = ['NightOwlStyle']
+
+
+# Night Owl color palette
+background  = '#011627'
+foreground  = '#d6deeb'
+selection   = '#1d3b53'
+cyan        = '#7fdbca'
+blue        = '#82aaff'
+purple      = '#c792ea'
+green       = '#addb67'
+yellow      = '#ecc48d'
+orange      = '#f78c6c'
+red         = '#ef5350'
+comment     = '#637777'
+pink        = '#ff869a'
+
+
+class NightOwlStyle(Style):
+    """
+    Night Owl theme by Sarah Drasner.
+
+    A theme for the night owls amongst us. Fine-tuned for those of us who
+    like to code late into the night. Color choices have also taken into
+    consideration what is accessible to those with color blindness and in
+    low-light circumstances.
+
+    Based on the VS Code Night Owl theme:
+    https://github.com/sdras/night-owl-vscode-theme
+
+    .. versionadded:: 2.19
+    """
+
+    name = 'night-owl'
+
+    background_color = background
+    highlight_color = selection
+    line_number_color = comment
+    line_number_background_color = background
+    line_number_special_color = foreground
+    line_number_special_background_color = selection
+
+    styles = {
+        Token:                  foreground,
+        Whitespace:             foreground,
+        Text:                   foreground,
+
+        # Comments
+        Comment:                'italic ' + comment,
+        Comment.Multiline:      'italic ' + comment,
+        Comment.Preproc:        cyan,
+        Comment.Single:         'italic ' + comment,
+        Comment.Special:        'italic ' + comment,
+
+        # Keywords
+        Keyword:                'italic ' + purple,
+        Keyword.Constant:       'italic ' + purple,
+        Keyword.Declaration:    'italic ' + purple,
+        Keyword.Namespace:      'italic ' + purple,
+        Keyword.Reserved:       'italic ' + purple,
+        Keyword.Type:           cyan,
+
+        # Names
+        Name:                   foreground,
+        Name.Attribute:         yellow,
+        Name.Builtin:           cyan,
+        Name.Builtin.Pseudo:    'italic ' + blue,
+        Name.Class:             yellow,
+        Name.Constant:          orange,
+        Name.Decorator:         blue,
+        Name.Entity:            orange,
+        Name.Exception:         red,
+        Name.Function:          blue,
+        Name.Function.Magic:    cyan,
+        Name.Label:             foreground,
+        Name.Namespace:         foreground,
+        Name.Other:             foreground,
+        Name.Property:          cyan,
+        Name.Tag:               pink,
+        Name.Variable:          foreground,
+        Name.Variable.Class:    yellow,
+        Name.Variable.Global:   orange,
+        Name.Variable.Instance: yellow,
+
+        # Literals
+        Number:                 orange,
+        Number.Float:           orange,
+        Number.Hex:             orange,
+        Number.Integer:         orange,
+        Number.Oct:             orange,
+
+        # Strings
+        String:                 green,
+        String.Affix:           cyan,
+        String.Char:            green,
+        String.Doc:             'italic ' + comment,
+        String.Escape:          yellow,
+        String.Heredoc:         green,
+        String.Interpol:        cyan,
+        String.Other:           green,
+        String.Regex:           cyan,
+        String.Symbol:          cyan,
+
+        # Operators
+        Operator:               cyan,
+        Operator.Word:          'italic ' + purple,
+
+        # Punctuation
+        Punctuation:            foreground,
+
+        # Errors
+        Error:                  red,
+
+        # Generic tokens (used by diffs, prompts, etc.)
+        Generic:                foreground,
+        Generic.Deleted:        red,
+        Generic.Emph:           'italic',
+        Generic.Error:          red,
+        Generic.Heading:        'bold ' + blue,
+        Generic.Inserted:       green,
+        Generic.Output:         comment,
+        Generic.Prompt:         'bold ' + cyan,
+        Generic.Strong:         'bold',
+        Generic.EmphStrong:     'bold italic',
+        Generic.Subheading:     'bold ' + cyan,
+        Generic.Traceback:      red,
+    }


### PR DESCRIPTION
## Summary

Adds a Pygments port of the popular [Night Owl VS Code theme](https://github.com/sdras/night-owl-vscode-theme) by Sarah Drasner. After this change, `'night-owl'` is available via `pygments.styles.get_all_styles()` and selectable as a style name (e.g. `HtmlFormatter(style='night-owl')`).

## Why

Night Owl is one of the most popular dark editor themes, designed specifically for low-light coding sessions. Its color choices were carefully picked with **color-blind accessibility** in mind. Several other community ports of Night Owl exist (Sublime, Vim, etc.), but Pygments has been missing one.

## Changes

- **`pygments/styles/night_owl.py`** — new `NightOwlStyle` class.
- **`pygments/styles/_mapping.py`** — registers `NightOwlStyle` as `'night-owl'`.

## Color palette

| Token | Color |
|---|---|
| Background | `#011627` |
| Foreground | `#d6deeb` |
| Keywords (italic) | `#c792ea` |
| Functions / Decorators | `#82aaff` |
| Strings | `#addb67` |
| Numbers / Constants | `#f78c6c` |
| Types / Operators / Builtins | `#7fdbca` |
| Comments (italic) | `#637777` |
| Errors | `#ef5350` |

## Verification

```python
>>> from pygments.styles import get_all_styles, get_style_by_name
>>> 'night-owl' in list(get_all_styles())
True
>>> get_style_by_name('night-owl').background_color
'#011627'
```

Highlighting via `HtmlFormatter(style='night-owl')` was confirmed to produce valid output for Python source.

## Notes

- Style name uses the `'night-owl'` slug (kebab-case), matching conventions used by `one-dark`, `gruvbox-dark`, `solarized-dark`, etc.
- Class is named `NightOwlStyle` per existing naming conventions.