### PR TITLE
Fix f-string comment parsing in Python 3.12+

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -188,6 +188,8 @@ class PythonLexer(RegexLexer):
             include('name'),
         ],
         'expr-inside-fstring': [
+            (r'#[^\n]*', Comment.Single),
+            (r'\n', Whitespace, '#pop'),
             (r'[{([]', Punctuation, 'expr-inside-fstring-inner'),
             # without format specifier
             (r'(=\s*)?'         # debug (https://bugs.python.org/issue36817)

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -189,7 +189,7 @@ class PythonLexer(RegexLexer):
         ],
         'expr-inside-fstring': [
             (r'#[^\n]*', Comment.Single),
-            (r'\n', Whitespace, '#pop'),
+            (r'\n', Whitespace),
             (r'[{([]', Punctuation, 'expr-inside-fstring-inner'),
             # without format specifier
             (r'(=\s*)?'         # debug (https://bugs.python.org/issue36817)


### PR DESCRIPTION
## PR Description
### Summary
Fixes #2937 - Python f-string comment parsing for Python 3.12+

### Problem
Python 3.12+ allows # comments inside f-string expressions, where comments extend to the end of line. However, Pygments incorrectly recognized } inside comments as the end of the f-string expression.
<img width="1358" height="178" alt="屏幕截图 2026-05-16 213639" src="https://github.com/user-attachments/assets/aa4ef58d-8f58-437c-b1dd-6643ddcc05c1" />

### Changes Made
Modified pygments/lexers/python.py in the expr-inside-fstring state:

```
'expr-inside-fstring': [
    (r'#[^\n]*', Comment.Single),     # Match # comment to end of line
    (r'\n', Whitespace),       # Return to parent state on newline
    # ... existing rules
],
```

### Result
<img width="1354" height="248" alt="屏幕截图 2026-05-16 223619" src="https://github.com/user-attachments/assets/069d3ffd-0ebd-4f5c-851f-46393a0ff9a5" />

### Related Issues
#2937