### PR TITLE
Documentation and comment fixes

### DIFF
--- a/doc/docs/api.rst
+++ b/doc/docs/api.rst
@@ -58,7 +58,8 @@ The base lexer class from which all lexers are derived is:
 .. autoclass:: Lexer
    :members: __init__, add_filter, get_tokens, get_tokens_unprocessed, analyse_text
 
-There are several base class derived from ``Lexer`` you can use to build your lexer from:
+There are several base classes derived from ``Lexer`` you can use to build your
+lexer from:
 
 .. autoclass:: pygments.lexer.RegexLexer
 .. autoclass:: pygments.lexer.ExtendedRegexLexer

--- a/doc/docs/cmdline.rst
+++ b/doc/docs/cmdline.rst
@@ -10,7 +10,7 @@ You can use Pygments from the shell, provided you installed the
     $ pygmentize test.py
     print "Hello World"
 
-will print the file test.py to standard output, using the Python lexer
+will print the file ``test.py`` to standard output, using the Python lexer
 (inferred from the file name extension) and the terminal formatter (because
 you didn't give an explicit formatter name).
 
@@ -26,11 +26,11 @@ detect the maximum number of colors that the terminal supports. The difference
 between color formatters for 16 and 256 colors is immense, but there is a less
 noticeable difference between color formatters for 256 and 16 million colors.
 
-Here's the process of how it detects the maxiumum number of colors
+Here's the process of how it detects the maximum number of colors
 supported by your terminal. If the ``COLORTERM`` environment variable is set to
 either ``truecolor`` or ``24bit``, it will use a 16 million color representation
 (like ``terminal16m``). Next, it will try to find ``256`` is anywhere in the
-environment variable ``TERM``, which it will use a 256-color representaion
+environment variable ``TERM``, which it will use a 256-color representation
 (such as ``terminal256``).  When neither of those are found, it falls back to a
 the 16 color representation (like ``terminal``).
 
@@ -38,9 +38,9 @@ If you want HTML output::
 
     $ pygmentize -f html -l python -o test.html test.py
 
-As you can see, the -l option explicitly selects a lexer. As seen above, if you
-give an input file name and it has an extension that Pygments recognizes, you can
-omit this option.
+As you can see, the ``-l`` option explicitly selects a lexer. As seen above, if
+you give an input file name and it has an extension that Pygments recognizes,
+you can omit this option.
 
 The ``-o`` option gives an output file name. If it is not given, output is
 written to stdout.
@@ -134,7 +134,7 @@ follows::
 
     $ pygmentize -g setup.py
 
-Note though, that this option is not very relaiable, and probably should be
+Note though, that this option is not very reliable, and probably should be
 used only if Pygments is not able to guess the correct lexer from the file's
 extension.
 

--- a/doc/docs/unicode.rst
+++ b/doc/docs/unicode.rst
@@ -18,7 +18,7 @@ data using this encoding.
 
 You can override the encoding using the `encoding` or `inencoding` lexer
 options.  If you have the `chardet`_ library installed and set the encoding to
-``chardet`` if will analyse the text and use the encoding it thinks is the
+``chardet`` it will analyse the text and use the encoding it thinks is the
 right one automatically:
 
 .. sourcecode:: python

--- a/pygments/lexers/_lua_builtins.py
+++ b/pygments/lexers/_lua_builtins.py
@@ -181,7 +181,7 @@ if __name__ == '__main__':  # pragma: no cover
 
     # you can't generally find out what module a function belongs to if you
     # have only its name. Because of this, here are some callback functions
-    # that recognize if a gioven function belongs to a specific module
+    # that recognize if a given function belongs to a specific module
     def module_callbacks():
         def is_in_coroutine_module(name):
             return name.startswith('coroutine.')


### PR DESCRIPTION
These are just fixes for some typos I found when reading through the documentation and source. Additionally, adjusted the formatting a little bit in [doc/docs/cmdline.rst](https://github.com/pygments/pygments/blob/master/doc/docs/cmdline.rst) so that it is more consistent throughout the file.