### PR TITLE
Add HOCON lexer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ Other contributors, listed alphabetically, are:
 * Oliver Kopp - Friendly grayscale style
 * Adam Koprowski -- Opa lexer
 * Benjamin Kowarsch -- Modula-2 lexer
+* Jakub Kozłowski -- HOCON lexer
 * Domen Kožar -- Nix lexer
 * Oleh Krekel -- Emacs Lisp lexer
 * Alexander Kriegisch -- Kconfig and AspectJ lexers

--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 2.21.0
 
   * BitBake (#3103)
   * CEL (#3048)
+  * HOCON
   * PureScript (#1077, #3054)
 
 - Updated lexers:

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -213,6 +213,7 @@ LEXERS = {
     'HaskellLexer': ('pygments.lexers.haskell', 'Haskell', ('haskell', 'hs'), ('*.hs',), ('text/x-haskell',)),
     'HaxeLexer': ('pygments.lexers.haxe', 'Haxe', ('haxe', 'hxsl', 'hx'), ('*.hx', '*.hxsl'), ('text/haxe', 'text/x-haxe', 'text/x-hx')),
     'HexdumpLexer': ('pygments.lexers.hexdump', 'Hexdump', ('hexdump',), (), ()),
+    'HoconLexer': ('pygments.lexers.hocon', 'HOCON', ('hocon',), ('*.conf',), ('application/hocon',)),
     'HsailLexer': ('pygments.lexers.asm', 'HSAIL', ('hsail', 'hsa'), ('*.hsail',), ('text/x-hsail',)),
     'HspecLexer': ('pygments.lexers.haskell', 'Hspec', ('hspec',), ('*Spec.hs',), ()),
     'HtmlDjangoLexer': ('pygments.lexers.templates', 'HTML+Django/Jinja', ('html+django', 'html+jinja', 'htmldjango'), ('*.html.j2', '*.htm.j2', '*.xhtml.j2', '*.html.jinja2', '*.htm.jinja2', '*.xhtml.jinja2'), ('text/html+django', 'text/html+jinja')),

--- a/pygments/lexers/hocon.py
+++ b/pygments/lexers/hocon.py
@@ -1,0 +1,165 @@
+"""
+    pygments.lexers.hocon
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for the HOCON configuration format.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+from pygments.lexer import RegexLexer, bygroups, default, include, words
+from pygments.token import Comment, Keyword, Name, Number, Operator, \
+    Punctuation, String, Whitespace
+
+__all__ = ['HoconLexer']
+
+
+class HoconLexer(RegexLexer):
+    """
+    Lexer for the `HOCON <https://github.com/lightbend/config/blob/main/HOCON.md>`_
+    (Human-Optimized Config Object Notation) configuration format used by the
+    Lightbend Config library and tools built on it (Akka/Pekko, Play, Lagom,
+    Scala Steward, ...).
+
+    Whether an unquoted token is a key or a string value is positional in
+    HOCON, so the lexer tracks a ``value`` state that begins after a
+    key/value separator (``=``, ``:``, ``+=``) and ends at a newline or
+    a structural delimiter.
+    """
+
+    name = 'HOCON'
+    aliases = ['hocon']
+    filenames = ['*.conf']
+    mimetypes = ['application/hocon']
+    url = 'https://github.com/lightbend/config/blob/main/HOCON.md'
+    version_added = '2.21'
+
+    _duration_size = (
+        r'ns|us|ms|s|m|h|d|w|y'
+        r'|nano(?:second)?s?|micro(?:second)?s?|milli(?:second)?s?'
+        r'|second(?:s)?|minute(?:s)?|hour(?:s)?|day(?:s)?|week(?:s)?'
+        r'|month(?:s)?|year(?:s)?|mo'
+        r'|[KMGTPEZY]i?B?|[kmgtpezy]B?|B|byte(?:s)?'
+    )
+
+    tokens = {
+        'whitespace_inline': [
+            (r'[ \t]+', Whitespace),
+        ],
+        'comments': [
+            (r'(#|//)[^\r\n]*', Comment.Single),
+        ],
+        'string': [
+            (r'"""', String.Double, 'multistring'),
+            (r'"', String.Double, 'qstring'),
+        ],
+        'multistring': [
+            # HOCON multi-line strings do not interpret escapes; the closing
+            # delimiter is ``"""`` and any extra trailing ``"`` characters
+            # belong to the string value.
+            (r'[^"]+', String.Double),
+            (r'"""(?!")', String.Double, '#pop'),
+            (r'"', String.Double),
+        ],
+        'qstring': [
+            (r'\\.', String.Escape),
+            (r'[^"\\\r\n]+', String.Double),
+            (r'"', String.Double, '#pop'),
+        ],
+        'substitution': [
+            (r'\$\{\??', String.Interpol, 'substitution_body'),
+        ],
+        'substitution_body': [
+            (r'\}', String.Interpol, '#pop'),
+            (r'[^${}"\s.]+', Name.Variable),
+            (r'\.', Punctuation),
+            (r'[ \t]+', Whitespace),
+        ],
+        'constants': [
+            (words(('true', 'false', 'null', 'yes', 'no', 'on', 'off'),
+                   suffix=r'(?![\w-])'),
+             Keyword.Constant),
+        ],
+        'numbers': [
+            # Number with an optional duration/size suffix. Recognising the
+            # suffix here keeps unquoted strings like ``3 days`` lexing as
+            # a number followed by a duration unit.
+            (r'(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)'
+             r'([ \t]*)'
+             r'(' + _duration_size + r')(?![\w-])',
+             bygroups(Number, Whitespace, Keyword.Type)),
+            (r'-?(?:0|[1-9]\d*)\.\d+(?:[eE][+-]?\d+)?', Number.Float),
+            (r'-?(?:0|[1-9]\d*)(?:[eE][+-]?\d+)?', Number.Integer),
+        ],
+        'include_args': [
+            (r'[ \t]+', Whitespace),
+            (words(('required', 'url', 'file', 'classpath'),
+                   suffix=r'(?=\s*\()'),
+             Keyword.Namespace),
+            (r'[()]', Punctuation),
+            include('string'),
+            (r'[\r\n]', Whitespace, '#pop'),
+        ],
+        'root': [
+            (r'\s+', Whitespace),
+            include('comments'),
+            (r'\b(include)\b', Keyword.Namespace, 'include_args'),
+            (r'\{', Punctuation, 'object'),
+            (r'\}', Punctuation),
+            (r'\[', Punctuation, 'array'),
+            include('key'),
+        ],
+        'object': [
+            (r'\s+', Whitespace),
+            include('comments'),
+            (r'\}', Punctuation, '#pop'),
+            (r'\{', Punctuation, 'object'),
+            include('key'),
+        ],
+        'array': [
+            (r'\s+', Whitespace),
+            include('comments'),
+            (r'\]', Punctuation, '#pop'),
+            # Inside an array each comma- or newline-separated entry is a
+            # value, so jump straight into ``value`` state.
+            default('value'),
+        ],
+        'key': [
+            (r'"', String.Double, ('value_sep', 'qstring')),
+            # Bare path key: dotted identifier-ish run. Stop at whitespace,
+            # separators, or structural punctuation so the value rules below
+            # take over on the next iteration.
+            (r'[^\s${}\[\],:=+#"]+', Name.Attribute, 'value_sep'),
+        ],
+        'value_sep': [
+            (r'[ \t]+', Whitespace),
+            (r'\+=|[=:]', Operator, ('#pop', 'value')),
+            # ``foo { ... }`` — the separator before ``{`` is optional, and
+            # any other unmatched character (e.g. a newline or closing
+            # brace) means the key had no value and we should hand back
+            # control to the surrounding state.
+            default('#pop'),
+        ],
+        'value': [
+            include('whitespace_inline'),
+            include('comments'),
+            (r'[\r\n]+', Whitespace, '#pop'),
+            (r',', Punctuation, '#pop'),
+            (r'\{', Punctuation, 'object'),
+            (r'\[', Punctuation, 'array'),
+            include('substitution'),
+            include('string'),
+            include('constants'),
+            include('numbers'),
+            # Unquoted value text. HOCON forbids many characters here;
+            # treating each run as ``String`` is good enough for
+            # highlighting and folds value concatenation into one token.
+            (r'[^\s${}\[\],:=+#"/]+', String),
+            (r'/(?!/)', String),
+            (r'\+(?!=)', String),
+            # Anything else (a closing ``]`` or ``}``) ends the value; let
+            # the surrounding state consume it.
+            default('#pop'),
+        ],
+    }

--- a/tests/snippets/hocon/test_basic.txt
+++ b/tests/snippets/hocon/test_basic.txt
@@ -1,0 +1,66 @@
+---input---
+# A comment
+// Another comment
+host = "localhost"
+port = 8080
+active = true
+fallback = ${?OVERRIDE_HOST}
+url = ${server.host}":"${server.port}
+
+---tokens---
+'# A comment' Comment.Single
+'\n'          Text.Whitespace
+
+'// Another comment' Comment.Single
+'\n'          Text.Whitespace
+
+'host'        Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'localhost'   Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'port'        Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'8080'        Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'active'      Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'true'        Keyword.Constant
+'\n'          Text.Whitespace
+
+'fallback'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'${?'         Literal.String.Interpol
+'OVERRIDE_HOST' Name.Variable
+'}'           Literal.String.Interpol
+'\n'          Text.Whitespace
+
+'url'         Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'server'      Name.Variable
+'.'           Punctuation
+'host'        Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+':'           Literal.String.Double
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'server'      Name.Variable
+'.'           Punctuation
+'port'        Name.Variable
+'}'           Literal.String.Interpol
+'\n'          Text.Whitespace

--- a/tests/snippets/hocon/test_durations_and_sizes.txt
+++ b/tests/snippets/hocon/test_durations_and_sizes.txt
@@ -1,0 +1,41 @@
+---input---
+timeout = 30 seconds
+retry = 250ms
+buffer = 5 MiB
+window = 2 d
+
+---tokens---
+'timeout'     Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'30'          Literal.Number
+' '           Text.Whitespace
+'seconds'     Keyword.Type
+'\n'          Text.Whitespace
+
+'retry'       Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'250'         Literal.Number
+'ms'          Keyword.Type
+'\n'          Text.Whitespace
+
+'buffer'      Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'5'           Literal.Number
+' '           Text.Whitespace
+'MiB'         Keyword.Type
+'\n'          Text.Whitespace
+
+'window'      Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'2'           Literal.Number
+' '           Text.Whitespace
+'d'           Keyword.Type
+'\n'          Text.Whitespace

--- a/tests/snippets/hocon/test_includes.txt
+++ b/tests/snippets/hocon/test_includes.txt
@@ -1,0 +1,35 @@
+---input---
+include "application.conf"
+include required(file("local.conf"))
+include url("https://example.com/config")
+
+---tokens---
+'include'     Keyword.Namespace
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'application.conf' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'include'     Keyword.Namespace
+' '           Text.Whitespace
+'required'    Keyword.Namespace
+'('           Punctuation
+'file'        Keyword.Namespace
+'('           Punctuation
+'"'           Literal.String.Double
+'local.conf'  Literal.String.Double
+'"'           Literal.String.Double
+')'           Punctuation
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'include'     Keyword.Namespace
+' '           Text.Whitespace
+'url'         Keyword.Namespace
+'('           Punctuation
+'"'           Literal.String.Double
+'https://example.com/config' Literal.String.Double
+'"'           Literal.String.Double
+')'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/hocon/test_multiline_string.txt
+++ b/tests/snippets/hocon/test_multiline_string.txt
@@ -1,0 +1,19 @@
+---input---
+greeting = """
+hello "world"
+"""
+
+---tokens---
+'greeting'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"""'         Literal.String.Double
+'\nhello '    Literal.String.Double
+'"'           Literal.String.Double
+'world'       Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Literal.String.Double
+
+'"""'         Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/hocon/test_scala_steward.txt
+++ b/tests/snippets/hocon/test_scala_steward.txt
@@ -1,0 +1,79 @@
+---input---
+updates.cooldown = {
+  minimumAge = "3 days"
+}
+
+dependencyOverrides = [
+  {
+    dependency = { groupId = "com.my-company" },
+    cooldown = { minimumAge = "1 day" }
+  }
+]
+
+---tokens---
+'updates.cooldown' Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'minimumAge'  Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'3 days'      Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n\n'        Text.Whitespace
+
+'dependencyOverrides' Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'\n  '        Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'dependency'  Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'groupId'     Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'com.my-company' Literal.String.Double
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'}'           Punctuation
+','           Punctuation
+'\n    '      Text.Whitespace
+'cooldown'    Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'{'           Punctuation
+' '           Text.Whitespace
+'minimumAge'  Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'1 day'       Literal.String.Double
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'  '          Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+']'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
## Summary

HOCON (Human-Optimized Config Object Notation) is the JSON-superset configuration format used by the Lightbend Config library and a wide range of JVM tooling built on top of it (Akka/Pekko, Play, Lagom, sbt plugins, Scala Steward, ...). It does not currently have a Pygments lexer; users tend to fall back to ``properties``, which loses substitutions, durations, includes, multi-line strings, and the key/value distinction.

This PR adds a dedicated ``HoconLexer`` covering:

- line comments (``#`` and ``//``)
- quoted and triple-quoted multi-line strings (``"""..."""``)
- substitutions ``${path}`` and optional substitutions ``${?path}``, with dotted path expressions
- ``include`` directives, including ``required(...)`` / ``url(...)`` / ``file(...)`` / ``classpath(...)`` wrappers and nestings such as ``include required(file("..."))``
- numbers with optional duration / period / size suffixes (``30 seconds``, ``250ms``, ``5 MiB``, ``2 d``) so unquoted values like ``minimumAge = 3 days`` lex naturally
- ``true`` / ``false`` / ``null`` (and the YAML-ish synonyms ``yes`` / ``no`` / ``on`` / ``off`` accepted by the reference parser)
- assignment operators ``=``, ``:``, ``+=``
- dotted path keys, with key-vs-value disambiguated positionally via a ``value`` state pushed on a key/value separator and popped at a newline, comma, or closing brace/bracket

The lexer registers the ``hocon`` alias, the ``*.conf`` filename pattern, and the ``application/hocon`` MIME type.

Example:

<img width="900" height="1500" alt="hocon-preview" src="https://github.com/user-attachments/assets/447aabc6-b99b-464b-83ba-2a4b67beca46" />

## Test plan

- [x] ``pytest tests/snippets/hocon/`` — 5 snippet tests pass (basic config, durations and sizes, includes, multi-line strings, real-world Scala Steward configuration)
- [x] ``pytest tests/test_basic_api.py`` — no regressions
- [x] ``regexlint pygments.lexers.hocon`` — clean
- [x] ``ruff check pygments/lexers/hocon.py`` — clean
- [x] ``scripts/gen_mapfiles.py`` re-run to register the lexer
- [x] AUTHORS and CHANGES updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)