### PR TITLE
Twig: allow uppercase letters at the start of identifiers

### DIFF
--- a/pygments/lexers/templates.py
+++ b/pygments/lexers/templates.py
@@ -2168,7 +2168,7 @@ class TwigLexer(RegexLexer):
     # Note that a backslash is included in the following two patterns
     # PHP uses a backslash as a namespace separator
     _ident_char = r'[\\\w-]|[^\x00-\x7f]'
-    _ident_begin = r'(?:[\\_a-z]|[^\x00-\x7f])'
+    _ident_begin = r'(?:[\\_a-zA-Z]|[^\x00-\x7f])'
     _ident_end = r'(?:' + _ident_char + ')*'
     _ident_inner = _ident_begin + _ident_end
 

--- a/tests/snippets/twig/test_uppercase_variable_names.txt
+++ b/tests/snippets/twig/test_uppercase_variable_names.txt
@@ -1,0 +1,18 @@
+---input---
+{{ MediaHelper.background(content.media, mediaRenderOptions) }}
+
+---tokens---
+'{{'          Comment.Preproc
+' '           Text
+'MediaHelper' Name.Variable
+'.background' Name.Variable
+'('           Operator
+'content'     Name.Variable
+'.media'      Name.Variable
+','           Operator
+' '           Text
+'mediaRenderOptions' Name.Variable
+')'           Operator
+' '           Text
+'}}'          Comment.Preproc
+'\n'          Other


### PR DESCRIPTION
## Summary

The Twig lexer emitted an `Error` token for the first character of any
identifier that starts with an uppercase letter, so valid Twig like

```twig
{{ MediaHelper.background(content.media, mediaRenderOptions) }}
```

was mis-lexed — the leading `M` became `Token.Error`.

## Root cause

In `TwigLexer` the leading-character class only allowed lowercase ASCII
letters:

```python
_ident_char  = r'[\\w-]|[^\x00-\x7f]'
_ident_begin = r'(?:[\_a-z]|[^\x00-\x7f])'   # no A-Z
```

`_ident_begin` is used for the first character of variable, attribute,
filter and tag names, while `_ident_char` (used for the remaining
characters) already allows `\w`. As a result `mediaHelper` lexed fine
but `MediaHelper` did not.

## Fix

Add `A-Z` to the leading character class:

```python
_ident_begin = r'(?:[\_a-zA-Z]|[^\x00-\x7f])'
```

Digits remain excluded from the first position, as before.

## Tests

Added `tests/snippets/twig/test_uppercase_variable_names.txt` covering the
reported example; `MediaHelper` and `mediaRenderOptions` now lex as
`Name.Variable`. The full test suite, `tox -e check` and `regexlint` are
green locally.

Fixes #2965.

(This is a focused redo of the Twig change from the closed #3061, without
the unrelated ASN.1 edits that PR also bundled.)
