### PR TITLE
JavaScript: highlight the `arguments` object (#3146)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Version 2.21.0
 - Updated lexers:
 
   * C++: Add C23/C++26 attributes (#3084)
+  * JavaScript: Highlight the ``arguments`` object (#3146)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -102,7 +102,7 @@ class JavascriptLexer(RegexLexer):
              r'Number|Object|RegExp|String|Promise|Proxy|decodeURI|'
              r'decodeURIComponent|encodeURI|encodeURIComponent|'
              r'eval|isFinite|isNaN|parseFloat|parseInt|DataView|'
-             r'document|window|globalThis|global|Symbol|Intl|'
+             r'document|window|globalThis|global|arguments|Symbol|Intl|'
              r'WeakSet|WeakMap|Set|Map|Reflect|JSON|Atomics|'
              r'Int(?:8|16|32)Array|BigInt64Array|Float32Array|Float64Array|'
              r'Uint8ClampedArray|Uint(?:8|16|32)Array|BigUint64Array)\b', Name.Builtin),

--- a/tests/snippets/javascript/test_arguments_object.txt
+++ b/tests/snippets/javascript/test_arguments_object.txt
@@ -1,0 +1,22 @@
+---input---
+function f() {
+    return arguments;
+}
+
+---tokens---
+'function'    Keyword.Declaration
+' '           Text.Whitespace
+'f'           Name.Other
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'arguments'   Name.Builtin
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #3146.

`arguments` is the implicit array-like object available inside every non-arrow function in JavaScript, but the lexer currently tokenizes it as a plain `Name.Other`, so it is not highlighted.

This adds `arguments` to the lexer's list of predefined built-in identifiers (`Name.Builtin`), alongside the other special globals it already recognizes such as `globalThis`, `window`, `document` and `global`. (`arguments` is not a reserved keyword — despite the issue title — so `Name.Builtin` is the consistent category rather than `Keyword`.)

### Before
```
'arguments'   Name.Other
```
### After
```
'arguments'   Name.Builtin
```

A snippet test (`tests/snippets/javascript/test_arguments_object.txt`) and a CHANGES entry are included. `make check` / snippet and basic-API test suites pass locally.