### PR TITLE
Add missing word boundary to GoogleSqlLexer 'set' keyword

### DIFF
--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -951,7 +951,7 @@ class GoogleSqlLexer(RegexLexer):
             (r'\?', Name.Variable),  # For demonstrating prepared statements
 
             # Exceptions; these words tokenize differently in different contexts.
-            (r'\b(set)(?!\s*\()', Keyword),
+            (r'\b(set)\b(?!\s*\()', Keyword),
             (r'\b(character)(\s+)(set)\b', bygroups(Keyword, Whitespace, Keyword)),
 
             # Constants, types, keywords, functions, operators

--- a/tests/snippets/googlesql/test_leading_substring_set_not_keyword.txt
+++ b/tests/snippets/googlesql/test_leading_substring_set_not_keyword.txt
@@ -1,0 +1,8 @@
+---input---
+select settings
+
+---tokens---
+'select'      Keyword
+' '           Text.Whitespace
+'settings'    Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
GoogleSqlLexer's keyword pattern for `set` lacks a trailing `\b`, so an identifier like `settings` is lexed as the keyword `set` followed by `tings` instead of a single name. The fix adds the missing word boundary.

This is the same fix merged in #3110 for the adjacent lexer; GoogleSql was the case left unmirrored, which the maintainer noted as still-unfixed. Existing suite stays green (796 passed).