### PR TITLE
Smithy: fix text blocks and add missing syntax

### DIFF
--- a/pygments/lexers/smithy.py
+++ b/pygments/lexers/smithy.py
@@ -31,7 +31,7 @@ class SmithyLexer(RegexLexer):
     simple_shapes = (
         'use', 'byte', 'short', 'integer', 'long', 'float', 'document',
         'double', 'bigInteger', 'bigDecimal', 'boolean', 'blob', 'string',
-        'timestamp',
+        'timestamp', 'enum', 'intEnum',  # enum/intEnum are IDL 2.0 shapes
     )
 
     aggregate_shapes = (
@@ -44,8 +44,9 @@ class SmithyLexer(RegexLexer):
             (r'///.*$', Comment.Multiline),
             (r'//.*$', Comment),
             (r'@[0-9a-zA-Z\.#-]*', Name.Decorator),
+            (r'(:=)', Name.Decorator),  # inline structure / operation shape operator
             (r'(=)', Name.Decorator),
-            (r'^(\$version)(:)(.+)',
+            (r'^(\$[A-Za-z_][A-Za-z0-9_]*)(:)(.+)',
                 bygroups(Keyword.Declaration, Name.Decorator, Name.Class)),
             (r'^(namespace)(\s+' + identifier + r')\b',
                 bygroups(Keyword.Declaration, Name.Class)),
@@ -60,6 +61,9 @@ class SmithyLexer(RegexLexer):
                          Whitespace, Name.Decorator)),
             (r"(true|false|null)", Keyword.Constant),
             (r"(-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?)", Number),
+            (r'\b(with|for)\b', Keyword.Declaration),  # mixin / resource binding keywords
+            # Target elision: the leading "$" marks an elided member, e.g. "$id"
+            (r'(\$)(' + identifier + r')', bygroups(Name.Decorator, Name.Variable.Class)),
             (identifier + ":", Name.Label),
             (identifier, Name.Variable.Class),
             (r'\[', Text, "#push"),
@@ -68,7 +72,9 @@ class SmithyLexer(RegexLexer):
             (r'\)', Text, "#pop"),
             (r'\{', Text, "#push"),
             (r'\}', Text, "#pop"),
-            (r'"{3}(\\\\|\n|\\")*"{3}', String.Doc),
+            # Text block: """...""", spanning escapes, lone 1-2 quotes, and any
+            # other character up to the closing triple quote.
+            (r'"""(?:\\.|"{1,2}(?!")|[^"\\])*"""', String.Doc),
             (r'"(\\\\|\n|\\"|[^"])*"', String.Double),
             (r"'(\\\\|\n|\\'|[^'])*'", String.Single),
             (r'[:,]+', Punctuation),

--- a/tests/snippets/smithy/test_control_statement.txt
+++ b/tests/snippets/smithy/test_control_statement.txt
@@ -1,0 +1,14 @@
+---input---
+$version: "2.0"
+$operationInputSuffix: "Request"
+
+---tokens---
+'$version'    Keyword.Declaration
+':'           Name.Decorator
+' "2.0"'      Name.Class
+'\n'          Text.Whitespace
+
+'$operationInputSuffix' Keyword.Declaration
+':'           Name.Decorator
+' "Request"'  Name.Class
+'\n'          Text.Whitespace

--- a/tests/snippets/smithy/test_enum.txt
+++ b/tests/snippets/smithy/test_enum.txt
@@ -1,0 +1,45 @@
+---input---
+enum Suit {
+    DIAMOND
+    CLUB
+}
+
+intEnum FaceCard {
+    JACK = 11
+    QUEEN = 12
+}
+
+---tokens---
+'enum'        Keyword.Declaration
+' Suit'       Name.Class
+' '           Text.Whitespace
+'{'           Text
+'\n    '      Text.Whitespace
+'DIAMOND'     Name.Variable.Class
+'\n    '      Text.Whitespace
+'CLUB'        Name.Variable.Class
+'\n'          Text.Whitespace
+
+'}'           Text
+'\n\n'        Text.Whitespace
+
+'intEnum'     Keyword.Declaration
+' FaceCard'   Name.Class
+' '           Text.Whitespace
+'{'           Text
+'\n    '      Text.Whitespace
+'JACK'        Name.Variable.Class
+' '           Text.Whitespace
+'='           Name.Decorator
+' '           Text.Whitespace
+'11'          Literal.Number
+'\n    '      Text.Whitespace
+'QUEEN'       Name.Variable.Class
+' '           Text.Whitespace
+'='           Name.Decorator
+' '           Text.Whitespace
+'12'          Literal.Number
+'\n'          Text.Whitespace
+
+'}'           Text
+'\n'          Text.Whitespace

--- a/tests/snippets/smithy/test_inline_operation.txt
+++ b/tests/snippets/smithy/test_inline_operation.txt
@@ -1,0 +1,28 @@
+---input---
+operation GetUser {
+    input := {
+        userId: String
+    }
+}
+
+---tokens---
+'operation'   Keyword.Declaration
+' GetUser'    Name.Class
+' '           Text.Whitespace
+'{'           Text
+'\n    '      Text.Whitespace
+'input'       Name.Variable.Class
+' '           Text.Whitespace
+':='          Name.Decorator
+' '           Text.Whitespace
+'{'           Text
+'\n        '  Text.Whitespace
+'userId:'     Name.Label
+' '           Text.Whitespace
+'String'      Name.Variable.Class
+'\n    '      Text.Whitespace
+'}'           Text
+'\n'          Text.Whitespace
+
+'}'           Text
+'\n'          Text.Whitespace

--- a/tests/snippets/smithy/test_mixins_and_elision.txt
+++ b/tests/snippets/smithy/test_mixins_and_elision.txt
@@ -1,0 +1,32 @@
+---input---
+structure UserDetails for User with [BaseMixin] {
+    $id
+    name: String
+}
+
+---tokens---
+'structure'   Keyword.Declaration
+' UserDetails' Name.Class
+' '           Text.Whitespace
+'for'         Keyword.Declaration
+' '           Text.Whitespace
+'User'        Name.Variable.Class
+' '           Text.Whitespace
+'with'        Keyword.Declaration
+' '           Text.Whitespace
+'['           Text
+'BaseMixin'   Name.Variable.Class
+']'           Text
+' '           Text.Whitespace
+'{'           Text
+'\n    '      Text.Whitespace
+'$'           Name.Decorator
+'id'          Name.Variable.Class
+'\n    '      Text.Whitespace
+'name:'       Name.Label
+' '           Text.Whitespace
+'String'      Name.Variable.Class
+'\n'          Text.Whitespace
+
+'}'           Text
+'\n'          Text.Whitespace

--- a/tests/snippets/smithy/test_textblock.txt
+++ b/tests/snippets/smithy/test_textblock.txt
@@ -1,0 +1,16 @@
+---input---
+@documentation("""
+    A text block with "interior" quotes and a {"json": "value"}.
+    """)
+string Documented
+
+---tokens---
+'@documentation' Name.Decorator
+'('           Text
+'"""\n    A text block with "interior" quotes and a {"json": "value"}.\n    """' Literal.String.Doc
+')'           Text
+'\n'          Text.Whitespace
+
+'string'      Keyword.Declaration
+' Documented' Name.Class
+'\n'          Text.Whitespace


### PR DESCRIPTION
The Smithy lexer in pygments predates Smithy 2.0, and so it was missing support for the new syntax added by it. This fixes those gaps:

  - enum / intEnum are now recognized as shape keywords
  - the with and for keywords (mixins and resource binding)
  - the := inline operator for operation input/output shapes
  - target elision, e.g. $id inside a structure
  - control statements other than $version (e.g. $operationInputSuffix); the rule was hardcoded to $version

Additionally, this fixes text blocks, which had no branch for ordinary characters. That made it so any block containing actual text failed to match and got shredded into a run of String.Double tokens, with words from the body leaking out as identifiers.

([smithy docs for reference](https://smithy.io))