### PR TITLE
LaTeX formatter: honor wrapped lexer options in LatexEmbeddedLexer (#2975)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,9 @@ Version 2.21.0
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)
 - Improve handling of non-string types in ``html_escape`` to fix broken clients (#3090, #3086)
+- LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
+  options when ``escapeinside`` is set, so blank lines are no longer stripped
+  under ``stripnl=false`` (#2975)
 
 Version 2.20.0
 --------------

--- a/pygments/formatters/latex.py
+++ b/pygments/formatters/latex.py
@@ -449,7 +449,15 @@ class LatexEmbeddedLexer(Lexer):
         self.left = left
         self.right = right
         self.lang = lang
-        Lexer.__init__(self, **options)
+        # Inherit the wrapped lexer's options so that wrapping is
+        # transparent: input-preprocessing options such as ``stripnl``,
+        # ``stripall``, ``ensurenl`` and ``tabsize`` are applied by
+        # ``Lexer.get_tokens`` on *this* lexer, so they must match the
+        # wrapped lexer or its settings are silently overridden by our
+        # defaults (e.g. ``stripnl=False`` would be ignored, stripping
+        # leading/trailing blank lines). Options passed explicitly to this
+        # lexer still take precedence.
+        Lexer.__init__(self, **{**lang.options, **options})
 
     def get_tokens_unprocessed(self, text):
         # find and remove all the escape tokens (replace with an empty string)

--- a/tests/test_latex_formatter.py
+++ b/tests/test_latex_formatter.py
@@ -105,3 +105,24 @@ def test_embedded_lexer():
         (Token.Escape, '$1 + z^2$'),
         (Token.Generic.Output, '\n'),
     ]
+
+
+def test_embedded_lexer_inherits_options():
+    # gh-2975: wrapping a lexer in LatexEmbeddedLexer (as the command line
+    # does when `escapeinside` is set) must not override the wrapped lexer's
+    # input-preprocessing options such as `stripnl`. Previously the wrapper
+    # was built with default options, so `stripnl=False` was ignored and
+    # leading/trailing blank lines were stripped anyway.
+    from pygments.lexers.special import TextLexer
+
+    inner = TextLexer(stripnl=False)
+    wrapped = LatexEmbeddedLexer('|', '|', inner)
+    assert wrapped.stripnl is False
+
+    src = '\nLINE\n'
+    # The blank leading line survives, exactly as with the unwrapped lexer.
+    assert list(wrapped.get_tokens(src)) == list(inner.get_tokens(src))
+    assert list(wrapped.get_tokens(src))[0][1].startswith('\n')
+
+    # An option passed explicitly to the wrapper still takes precedence.
+    assert LatexEmbeddedLexer('|', '|', inner, stripnl=True).stripnl is True


### PR DESCRIPTION
Fixes #2975.

## The bug

When the LaTeX formatter's `escapeinside` option is used, blank leading/trailing lines are stripped even with `stripnl=false`:

```console
$ printf '\nLINE\n' > f.txt

$ pygmentize -f latex -l text -P stripnl=false f.txt
\begin{Verbatim}[commandchars=\\\{\}]

LINE
\end{Verbatim}

$ pygmentize -f latex -l text -P stripnl=false -P escapeinside='||' f.txt
\begin{Verbatim}[commandchars=\\\{\},codes={\catcode`\$=3\catcode`\^=7\catcode`\_=8\relax}]
LINE                       # <-- the blank line is gone
\end{Verbatim}
```

Only the `escapeinside` invocation drops the blank line; the plain one keeps it.

## Root cause

Setting `escapeinside` makes `cmdline.py` wrap the user's lexer:

```python
# pygments/cmdline.py
lexer = LatexEmbeddedLexer(left, right, lexer)
```

`LatexEmbeddedLexer` is itself a `Lexer`, but its constructor built the base with **no** options:

```python
def __init__(self, left, right, lang, **options):
    ...
    Lexer.__init__(self, **options)   # options is empty from cmdline
```

so the wrapper always got the base defaults (`stripnl=True`, `stripall=False`, `ensurenl=True`, `tabsize=0`). `Lexer.get_tokens` runs `_preprocess_lexer_input` (which applies `stripnl`/`stripall`/`tabsize`/`ensurenl`) on **this** lexer before delegating to the wrapped lexer's `get_tokens_unprocessed` — so the wrapped lexer's own `stripnl=False` was silently overridden by the wrapper's default `stripnl=True`.

```python
inner   = TextLexer(stripnl=False)
wrapped = LatexEmbeddedLexer('|', '|', inner)
inner.stripnl    # False
wrapped.stripnl  # True  <-- overrides the wrapped lexer
```

## The fix

Build the wrapper's base `Lexer` with the wrapped lexer's options so wrapping is transparent, mirroring how `DelegatingLexer` already shares `**options` with its sub-lexers:

```python
Lexer.__init__(self, **{**lang.options, **options})
```

Options passed explicitly to the wrapper still take precedence (`{**lang.options, **options}`), so nothing regresses for the default `stripnl=True` case.

After the fix, both invocations produce identical blank-line handling:

| invocation | before | after |
|---|---|---|
| `stripnl=false` (no escapeinside) | blank line kept | blank line kept |
| `stripnl=false` + `escapeinside` | blank line **stripped** | blank line **kept** |

## Regression test

`tests/test_latex_formatter.py::test_embedded_lexer_inherits_options` asserts the wrapper inherits `stripnl` from the wrapped lexer, that the resulting token stream equals the unwrapped lexer's (blank line preserved), and that an explicit option to the wrapper still wins.

Proven to guard the bug (stash the source fix → test FAILs on `wrapped.stripnl is False`; restore → PASSes):

```
# with fix
tests/test_latex_formatter.py::test_embedded_lexer_inherits_options PASSED

# source fix stashed
tests/test_latex_formatter.py::test_embedded_lexer_inherits_options FAILED
    +  where True = <pygments.lexers.LatexEmbeddedLexer>.stripnl
```

## Verification

- `tests/test_latex_formatter.py`: 3 passed, 1 skipped (skip = `test_valid_output`, needs a `latex` binary — pre-existing).
- `tests/test_cmdline.py`: 30 passed (this is the `escapeinside` wrapping path).
- Wider run `test_latex_formatter.py test_html_formatter.py test_basic_api.py test_util.py`: 2488 passed, 9 skipped, no regressions.
- `ruff check` on the changed files introduces no new warnings (the 2 pre-existing `UP031` hits are on the unrelated `linenos` block and are present on `master` too).

Diff is +33/−1 across `pygments/formatters/latex.py`, `tests/test_latex_formatter.py`, and a `CHANGES` entry.
