### PR TITLE
C++: highlight a function following a namespace body (#2928)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Version 2.21.0
 - Updated lexers:
 
   * C++: Add C23/C++26 attributes (#3084)
+  * C++: Highlight a function following a namespace body (#2928)
   * JavaScript: Highlight the ``arguments`` object (#3146)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -449,10 +449,15 @@ class CppLexer(CFamilyLexer):
             inherit
         ],
         'namespace': [
-            (r'[;{]', Punctuation, ('#pop', 'root')),
+            (r';', Punctuation, ('#pop', 'root')),
+            (r'\{', Punctuation, ('#pop', 'namespace-body')),
             (r'inline\b', Keyword.Reserved),
             (CFamilyLexer._ident, Name.Namespace),
             include('statement')
+        ],
+        'namespace-body': [
+            (r'\}', Punctuation, '#pop'),
+            include('root'),
         ],
         'annotation': [
             (r'\]\]', Punctuation, '#pop'),

--- a/tests/examplefiles/cpp/namespace.cpp.output
+++ b/tests/examplefiles/cpp/namespace.cpp.output
@@ -133,7 +133,7 @@
 'FlyString'   Name
 '&'           Operator
 ' '           Text.Whitespace
-'local_name'  Name
+'local_name'  Name.Function
 '('           Punctuation
 ')'           Punctuation
 ' '           Text.Whitespace

--- a/tests/snippets/cpp/test_function_after_namespace.txt
+++ b/tests/snippets/cpp/test_function_after_namespace.txt
@@ -1,0 +1,18 @@
+---input---
+namespace {}
+void fn();
+
+---tokens---
+'namespace'   Keyword
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'void'        Keyword.Type
+' '           Text.Whitespace
+'fn'          Name.Function
+'('           Punctuation
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #2928.

## The bug

A function declaration/definition placed immediately after a `namespace ... {}` block has its name highlighted as `Name` instead of `Name.Function`:

```cpp
namespace {}
void fn();
```

Before this PR, `fn` is tokenized as `Token.Name`. As the issue notes, adding a `;` after the (invalid) `namespace {};` "fixes" it — a strong hint that the lexer state stack is the culprit.

## Root cause

The `CppLexer` `namespace` state opened a namespace body with `('#pop', 'root')`, lexing the body's contents in a fresh `root` frame:

```python
'namespace': [
    (r'[;{]', Punctuation, ('#pop', 'root')),
    ...
],
```

But `root` has **no rule for a closing `}`** — it falls through to `default('statement')`, which pushes a `statement` frame that is never popped. The lexer is then stuck in `statement`, and the function-declaration patterns (which live only in `root`) can no longer match. Every following function name is lexed as a plain `Name` until some later `;` happens to pop the stray frame — which is exactly why `namespace {};` (with the trailing semicolon) restores correct highlighting.

## The fix

Give the namespace body its own `namespace-body` state that includes `root` for its contents but pops on its own closing `}`, returning to the enclosing context cleanly. The `;` form (namespace alias / empty declaration, e.g. `namespace o = std;`) keeps the existing `('#pop', 'root')` behavior.

```python
'namespace': [
    (r';', Punctuation, ('#pop', 'root')),
    (r'\{', Punctuation, ('#pop', 'namespace-body')),
    (r'inline\b', Keyword.Reserved),
    (CFamilyLexer._ident, Name.Namespace),
    include('statement')
],
'namespace-body': [
    (r'\}', Punctuation, '#pop'),
    include('root'),
],
```

## Before / after

| input | `fn` before | `fn` after |
|---|---|---|
| `namespace {}` then `void fn();` | `Name` | `Name.Function` |
| `namespace N {}` then `void fn();` | `Name` | `Name.Function` |
| `namespace N { int x; }` then `void fn();` | `Name` | `Name.Function` |
| `namespace A { namespace B {} }` then `void fn();` | `Name` | `Name.Function` |
| `namespace {};` then `void fn();` (semicolon workaround) | `Name.Function` | `Name.Function` (unchanged) |
| `void fn();` (no namespace) | `Name.Function` | `Name.Function` (unchanged) |

## Tests

- Adds `tests/snippets/cpp/test_function_after_namespace.txt`, proven to fail without the fix and pass with it (verified via `git stash` of the source change).
- Updates the existing `namespace.cpp` example golden: a member function defined inside a class inside a namespace body (`const FlyString& local_name() const {...}`) is now correctly `Name.Function` — the only line that changes in that file, confirming the fix is surgical.
- Full test suite: `5260 passed, 16 skipped` (the 16 skips are the pre-existing optional-dependency `tests/contrast` group, unrelated). `ruff check` clean on the changed source.
