### PR TITLE
Swift: keep `func` a keyword in `class func` methods

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -34,6 +34,7 @@ Version 2.21.0
   * Kotlin: Don't let a nullable type marker (``?``) consume the following
     character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
   * YAML: Add ``yml`` alias (#3169)
+  * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/objective.py
+++ b/pygments/lexers/objective.py
@@ -436,6 +436,12 @@ class SwiftLexer(RegexLexer):
              r'|__FILE__|__FUNCTION__|__LINE__|_'
              r'|#(?:file|line|column|function))\b', Keyword.Constant),
             (r'import\b', Keyword.Declaration, 'module'),
+            (r'(class)(\s+)(func)(\s+)([a-zA-Z_]\w*)',
+             bygroups(Keyword.Declaration, Whitespace, Keyword.Declaration,
+                      Whitespace, Name.Function)),
+            (r'(class)(\s+)(var)(\s+)([a-zA-Z_]\w*)',
+             bygroups(Keyword.Declaration, Whitespace, Keyword.Declaration,
+                      Whitespace, Name.Variable)),
             (r'(class|enum|extension|struct|protocol)(\s+)([a-zA-Z_]\w*)',
              bygroups(Keyword.Declaration, Whitespace, Name.Class)),
             (r'(func)(\s+)([a-zA-Z_]\w*)',

--- a/tests/examplefiles/swift/test.swift.output
+++ b/tests/examplefiles/swift/test.swift.output
@@ -47,9 +47,9 @@
 '    '        Text.Whitespace
 'class'       Keyword.Declaration
 ' '           Text.Whitespace
-'func'        Name.Class
+'func'        Keyword.Declaration
 ' '           Text.Whitespace
-'unarchiveFromFile' Name
+'unarchiveFromFile' Name.Function
 '('           Punctuation
 'file'        Name
 ' '           Text.Whitespace

--- a/tests/snippets/swift/test_class_method.txt
+++ b/tests/snippets/swift/test_class_method.txt
@@ -1,0 +1,50 @@
+---input---
+func plain() {}
+class func typeMethod() {}
+public class func publicTypeMethod() {}
+class Named {}
+
+---tokens---
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'plain'       Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'typeMethod'  Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'public'      Keyword.Declaration
+' '           Text.Whitespace
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'func'        Keyword.Declaration
+' '           Text.Whitespace
+'publicTypeMethod' Name.Function
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text
+
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'Named'       Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'}'           Punctuation
+'\n'          Text


### PR DESCRIPTION
`class func`/`class var` are type-member modifiers, but the lexer's class-name rule grabbed the word after `class`, so `func` got tagged as a type name instead of a keyword. Fixed with a negative lookahead so those fall through to the keyword rules. `class Foo` still works.

Heads up on scope: I only excluded the modifier keywords instead of handling `class`/`static` modifiers properly, and the lookahead's on the whole `class|enum|...` group. Kept it to one rule, can go broader if you want.

Test added (fails before, passes after) + CHANGES.

Fixes #1125.
