### PR TITLE
Add 'yml' as an alias for the YAML lexer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Version 2.21.0
 
   * C++: Add C23/C++26 attributes (#3084)
   * JavaScript: Highlight the ``arguments`` object (#3146)
+  * YAML: Add ``yml`` alias (#3169)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -596,7 +596,7 @@ LEXERS = {
     'XtendLexer': ('pygments.lexers.jvm', 'Xtend', ('xtend',), ('*.xtend',), ('text/x-xtend',)),
     'XtlangLexer': ('pygments.lexers.lisp', 'xtlang', ('extempore',), ('*.xtm',), ()),
     'YamlJinjaLexer': ('pygments.lexers.templates', 'YAML+Jinja', ('yaml+jinja', 'salt', 'sls'), ('*.sls', '*.yaml.j2', '*.yml.j2', '*.yaml.jinja2', '*.yml.jinja2'), ('text/x-yaml+jinja', 'text/x-sls')),
-    'YamlLexer': ('pygments.lexers.data', 'YAML', ('yaml',), ('*.yaml', '*.yml'), ('text/x-yaml',)),
+    'YamlLexer': ('pygments.lexers.data', 'YAML', ('yaml', 'yml'), ('*.yaml', '*.yml'), ('text/x-yaml',)),
     'YangLexer': ('pygments.lexers.yang', 'YANG', ('yang',), ('*.yang',), ('application/yang',)),
     'YaraLexer': ('pygments.lexers.yara', 'YARA', ('yara', 'yar'), ('*.yar',), ('text/x-yara',)),
     'ZeekLexer': ('pygments.lexers.dsls', 'Zeek', ('zeek', 'bro'), ('*.zeek', '*.bro'), ()),

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -35,7 +35,7 @@ class YamlLexer(ExtendedRegexLexer):
 
     name = 'YAML'
     url = 'http://yaml.org/'
-    aliases = ['yaml']
+    aliases = ['yaml', 'yml']
     filenames = ['*.yaml', '*.yml']
     mimetypes = ['text/x-yaml']
     version_added = '0.11'


### PR DESCRIPTION
Fixes #3169.

The YAML lexer already lists `*.yml` in its `filenames`, so `.yml` files are recognized as YAML — but `yml` was not in its `aliases`, so referring to the lexer by that short name (e.g. in a ```` ```yml ```` Markdown code fence) failed with `ClassNotFound`.

highlight.js, Prism, Rouge and GitHub-flavoured Markdown all accept `yml` for YAML, so this is a common expectation; tools built on Pygments (e.g. mkdocs/Zensical) inherit the gap.

This adds `'yml'` to `YamlLexer.aliases` and regenerates `pygments/lexers/_mapping.py`.

- Verified `get_lexer_by_name("yml")` resolves to the YAML lexer and highlights correctly (it raised `ClassNotFound` before).
- Confirmed no other lexer already claims the `yml` alias.
- `tests/test_basic_api.py` (which validates that every alias resolves and is unique) passes: 2445 passed.
- Added a `CHANGES` entry.

*AI disclosure: prepared with the assistance of an AI tool (Claude Code); I verified the change and test results and take responsibility for the contribution.*
