### PR TITLE
Allow transparent in style color definitions

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -27,7 +27,7 @@ __all__ = ['HtmlFormatter']
 
 
 def webify(color):
-    if color.startswith('calc') or color.startswith('var'):
+    if color == 'transparent' or color.startswith('calc') or color.startswith('var'):
         return color
     else:
         # Check if the color can be shortened from 6 to 3 characters

--- a/pygments/style.py
+++ b/pygments/style.py
@@ -74,6 +74,8 @@ class StyleMeta(type):
                     return col[0] * 2 + col[1] * 2 + col[2] * 2
             elif text == '':
                 return ''
+            elif text == 'transparent':
+                return text
             elif text.startswith('var') or text.startswith('calc'):
                 return text
             assert False, f"wrong color format {text!r}"

--- a/tests/test_html_formatter.py
+++ b/tests/test_html_formatter.py
@@ -17,6 +17,7 @@ import pytest
 from pygments.formatters import HtmlFormatter, NullFormatter
 from pygments.lexers import PythonLexer
 from pygments.style import Style
+from pygments.token import Name
 from pygments.util import html_escape
 
 TESTDIR = path.dirname(path.abspath(__file__))
@@ -189,6 +190,23 @@ def test_get_style_defs_contains_style_specific_line_numbers_styles():
         'span.linenos.special '
         '{ color: #00ff00; background-color: #ffffff; padding-left: 5px; padding-right: 5px; }'
     )
+
+
+def test_get_style_defs_allows_transparent_color():
+    class TransparentStyle(Style):
+        styles = {
+            Name: 'transparent bg:transparent border:transparent',
+        }
+
+    ndef = TransparentStyle.style_for_token(Name)
+    assert ndef['color'] == 'transparent'
+    assert ndef['bgcolor'] == 'transparent'
+    assert ndef['border'] == 'transparent'
+
+    assert (
+        '.n { color: transparent; background-color: transparent; '
+        'border: 1px solid transparent } /* Name */'
+    ) in HtmlFormatter(style=TransparentStyle).get_style_defs()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
﻿## Summary

Fixes #3170 by allowing the CSS `transparent` keyword in style color definitions.

## What changed

- Allowed exact `transparent` style color values in `StyleMeta.colorformat()`.
- Preserved `transparent` when emitting HTML CSS instead of treating it as a hex value.
- Added a regression test covering foreground, background, and border style color output.
- No new dependencies.

## Why

Previously, defining a style such as `Name: "transparent"` failed with `AssertionError: wrong color format 'transparent'`. Since Pygments already passes through CSS-specific `var(...)` and `calc(...)` color values for HTML output, this keeps the change narrow by accepting only the `transparent` keyword rather than broadening validation to arbitrary named colors or RGBA formats.

## Tests

- [x] `tox -- tests/test_html_formatter.py::test_get_style_defs_allows_transparent_color`
- [x] `tox -- tests/test_html_formatter.py`
- [x] `tox -e check`
- [x] `tox`

Closes #3170
