### PR TITLE
Add `union` as a class keyword (C# 15)

### DIFF
--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -134,7 +134,7 @@ class CSharpLexer(RegexLexer):
                 (r'(global)(::)', bygroups(Keyword, Punctuation)),
                 (r'(bool|byte|char|decimal|double|dynamic|float|int|long|object|'
                  r'sbyte|short|string|uint|ulong|ushort|var)\b\??', Keyword.Type),
-                (r'(class|struct)(\s+)', bygroups(Keyword, Whitespace), 'class'),
+                (r'(class|struct|union)(\s+)', bygroups(Keyword, Whitespace), 'class'),
                 (r'(namespace|using)(\s+)', bygroups(Keyword, Whitespace), 'namespace'),
                 (cs_ident, Name),
             ],


### PR DESCRIPTION
C# 15 introduces `union` as a new class keyword (see [here](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/union)).