### PR TITLE
Simplify redundant whitespace regexes to \s+

### DIFF
--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -285,7 +285,7 @@ class HsailLexer(RegexLexer):
             (r'[=<>{}\[\]()*.,:;!]|x\b', Punctuation)
         ],
         'whitespace': [
-            (r'(\n|\s)+', Whitespace),
+            (r'\s+', Whitespace),
         ],
         'comments': [
             (r'/\*.*?\*/', Comment.Multiline),
@@ -396,7 +396,7 @@ class LlvmLexer(RegexLexer):
             (r'[=<>{}\[\]()*.,!]|x\b', Punctuation)
         ],
         'whitespace': [
-            (r'(\n|\s+)+', Whitespace),
+            (r'\s+', Whitespace),
             (r';.*?\n', Comment),
             (r'/\*', Comment, 'c-comment'),
         ],

--- a/pygments/lexers/numbair.py
+++ b/pygments/lexers/numbair.py
@@ -58,6 +58,6 @@ class NumbaIRLexer(RegexLexer):
         ],
 
         'whitespace': [
-            (r'(\n|\s)+', Whitespace),
+            (r'\s+', Whitespace),
         ],
     }

--- a/pygments/lexers/ptx.py
+++ b/pygments/lexers/ptx.py
@@ -55,7 +55,7 @@ class PtxLexer(RegexLexer):
 
         ],
         'whitespace': [
-            (r'(\n|\s+)+', Whitespace),
+            (r'\s+', Whitespace),
             (r'//.*?\n', Comment)
         ],
 

--- a/pygments/lexers/slash.py
+++ b/pygments/lexers/slash.py
@@ -161,7 +161,7 @@ class SlashLanguageLexer(ExtendedRegexLexer):
             (r'\.',                     Operator),
             (r'::',                     Operator),
             (r':',                      Operator),
-            (r'(\s|\n)+',               Whitespace),
+            (r'\s+',                    Whitespace),
             (r'[a-z_][a-zA-Z0-9_\']*',  Name.Variable),
         ],
     }


### PR DESCRIPTION
Several lexers matched whitespace with a nested/redundant quantifier over an alternation, e.g. (\n|\s+)+, (\n|\s)+ or (\s|\n)+. Since \s already matches \n in re.MULTILINE, the \n branch, the outer quantifier and the capturing group are all redundant: each pattern is equivalent to plain \s+, but does more work (an alternation, a group and a needless second quantifier) both when matching a whitespace run and when failing at a non-whitespace position.

Replace them with \s+ in a bunch of lexers. The rules yield a bare Whitespace token and never read the group (no bygroups), so tokenisation is unchanged.

On dumb local microbenchmark (import re, timeit; re.compile; match), it speeds the matching by 25%-33%.