### PR TITLE
Speed up line-scanning regexes with [^\n]* instead of lazy .*?

### DIFF
--- a/pygments/lexers/ada.py
+++ b/pygments/lexers/ada.py
@@ -36,7 +36,7 @@ class AdaLexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Text),
-            (r'--.*?\n', Comment.Single),
+            (r'--[^\n]*\n', Comment.Single),
             (r'[^\S\n]+', Text),
             (r'function|procedure|entry', Keyword.Declaration, 'subprogram'),
             (r'(subtype|type)(\s+)(\w+)',

--- a/pygments/lexers/algebra.py
+++ b/pygments/lexers/algebra.py
@@ -210,7 +210,7 @@ class MuPADLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'/\*', Comment.Multiline, 'comment'),
             (r'"(?:[^"\\]|\\.)*"', String),
             (r'\(|\)|\[|\]|\{|\}', Punctuation),

--- a/pygments/lexers/amdgpu.py
+++ b/pygments/lexers/amdgpu.py
@@ -34,7 +34,7 @@ class AMDGPULexer(RegexLexer):
             (r'[\r\n]+', Text),
             (r'(([a-z_0-9])*:([a-z_0-9])*)', Name.Attribute),
             (r'(\[|\]|\(|\)|,|\:|\&)', Text),
-            (r'([;#]|//).*?\n', Comment.Single),
+            (r'([;#]|//)[^\n]*\n', Comment.Single),
             (r'((s_)?(scratch|ds|buffer|flat|image)_[a-z0-9_]+)', Keyword.Reserved),
             (r'(_lo|_hi)', Name.Variable),
             (r'(vmcnt|lgkmcnt|expcnt)', Name.Attribute),

--- a/pygments/lexers/ampl.py
+++ b/pygments/lexers/ampl.py
@@ -29,7 +29,7 @@ class AmplLexer(RegexLexer):
         'root': [
             (r'\n', Text),
             (r'\s+', Whitespace),
-            (r'#.*?\n', Comment.Single),
+            (r'#[^\n]*\n', Comment.Single),
             (r'/[*][\s\S]*?[*]/', Comment.Multiline),
             (words((
                 'call', 'cd', 'close', 'commands', 'data', 'delete', 'display',

--- a/pygments/lexers/arturo.py
+++ b/pygments/lexers/arturo.py
@@ -73,8 +73,8 @@ class ArturoLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r';.*?$', Comment.Single),
-            (r'^((\s#!)|(#!)).*?$', Comment.Hashbang),
+            (r';[^\n]*$', Comment.Single),
+            (r'^((\s#!)|(#!))[^\n]*$', Comment.Hashbang),
 
             # Constants
             (words(('false', 'true', 'maybe'),      # boolean

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -57,9 +57,9 @@ class GasLexer(RegexLexer):
             (number, Number.Integer),
             (register, Name.Variable),
             (r'[\r\n]+', Whitespace, '#pop'),
-            (r'([;#]|//).*?\n', Comment.Single, '#pop'),
+            (r'([;#]|//)[^\n]*\n', Comment.Single, '#pop'),
             (r'/[*].*?[*]/', Comment.Multiline),
-            (r'/[*].*?\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
+            (r'/[*][^\n]*\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -83,9 +83,9 @@ class GasLexer(RegexLexer):
             ('$'+number, Number.Integer),
             (r"$'(.|\\')'", String.Char),
             (r'[\r\n]+', Whitespace, '#pop'),
-            (r'([;#]|//).*?\n', Comment.Single, '#pop'),
+            (r'([;#]|//)[^\n]*\n', Comment.Single, '#pop'),
             (r'/[*].*?[*]/', Comment.Multiline),
-            (r'/[*].*?\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
+            (r'/[*][^\n]*\n[\w\W]*?[*]/', Comment.Multiline, '#pop'),
 
             include('punctuation'),
             include('whitespace')
@@ -93,7 +93,7 @@ class GasLexer(RegexLexer):
         'whitespace': [
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r'([;#]|//).*?\n', Comment.Single),
+            (r'([;#]|//)[^\n]*\n', Comment.Single),
             (r'/[*][\w\W]*?[*]/', Comment.Multiline)
         ],
         'punctuation': [
@@ -289,7 +289,7 @@ class HsailLexer(RegexLexer):
         ],
         'comments': [
             (r'/\*.*?\*/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
         ],
         'keyword': [
             # Types
@@ -397,7 +397,7 @@ class LlvmLexer(RegexLexer):
         ],
         'whitespace': [
             (r'\s+', Whitespace),
-            (r';.*?\n', Comment),
+            (r';[^\n]*\n', Comment),
             (r'/\*', Comment, 'c-comment'),
         ],
         'c-comment': [
@@ -789,7 +789,7 @@ class NasmLexer(RegexLexer):
         ],
         'preproc': [
             (r'[^;\n]+', Comment.Preproc),
-            (r';.*?\n', Comment.Single, '#pop'),
+            (r';[^\n]*\n', Comment.Single, '#pop'),
             (r'\n', Comment.Preproc, '#pop'),
         ],
         'whitespace': [
@@ -891,7 +891,7 @@ class TasmLexer(RegexLexer):
         ],
         'preproc': [
             (r'[^;\n]+', Comment.Preproc),
-            (r';.*?\n', Comment.Single, '#pop'),
+            (r';[^\n]*\n', Comment.Single, '#pop'),
             (r'\n', Comment.Preproc, '#pop'),
         ],
         'whitespace': [
@@ -1032,7 +1032,7 @@ class Dasm16Lexer(RegexLexer):
 
         'instruction-line' : [
             (r'[\r\n]+', Whitespace, '#pop'),
-            (r';.*?$', Comment, '#pop'),
+            (r';[^\n]*$', Comment, '#pop'),
             include('whitespace')
         ],
 
@@ -1053,6 +1053,6 @@ class Dasm16Lexer(RegexLexer):
         'whitespace': [
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r';.*?\n', Comment)
+            (r';[^\n]*\n', Comment)
         ],
     }

--- a/pygments/lexers/automation.py
+++ b/pygments/lexers/automation.py
@@ -30,8 +30,8 @@ class AutohotkeyLexer(RegexLexer):
         'root': [
             (r'^(\s*)(/\*)', bygroups(Text, Comment.Multiline), 'incomment'),
             (r'^(\s*)(\()', bygroups(Text, Generic), 'incontinuation'),
-            (r'\s+;.*?$', Comment.Single),
-            (r'^;.*?$', Comment.Single),
+            (r'\s+;[^\n]*$', Comment.Single),
+            (r'^;[^\n]*$', Comment.Single),
             (r'[]{}(),;[]', Punctuation),
             (r'(in|is|and|or|not)\b', Operator.Word),
             (r'\%[a-zA-Z_#@$][\w#@$]*\%', Name.Variable),

--- a/pygments/lexers/bare.py
+++ b/pygments/lexers/bare.py
@@ -57,7 +57,7 @@ class BareLexer(RegexLexer):
              bygroups(Keyword, Whitespace, Name, Whitespace), 'typedef'),
             (r'(enum)(\s+)([A-Z][a-zA-Z0-9]+)(\s+\{)',
              bygroups(Keyword, Whitespace, Name.Class, Whitespace), 'enum'),
-            (r'#.*?$', Comment),
+            (r'#[^\n]*$', Comment),
             (r'\s+', Whitespace),
         ],
         'struct': [
@@ -76,7 +76,7 @@ class BareLexer(RegexLexer):
         ],
         'typedef': [
             (r'\[\]', Text),
-            (r'#.*?$', Comment, '#pop'),
+            (r'#[^\n]*$', Comment, '#pop'),
             (r'(\[)(\d+)(\])', bygroups(Text, Literal, Text)),
             (r'<|>', Text),
             (r'\(', Text, 'union'),
@@ -95,7 +95,7 @@ class BareLexer(RegexLexer):
             (r'([A-Z][A-Z0-9_]*)(\s*=\s*)(\d+)',
              bygroups(Name.Attribute, Text, Literal)),
             (r'([A-Z][A-Z0-9_]*)', bygroups(Name.Attribute)),
-            (r'#.*?$', Comment),
+            (r'#[^\n]*$', Comment),
             (r'\s+', Whitespace),
         ],
     }

--- a/pygments/lexers/basic.py
+++ b/pygments/lexers/basic.py
@@ -47,7 +47,7 @@ class BlitzMaxLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'(\.\.)(\n)', bygroups(Text, Whitespace)),  # Line continuation
             # Comments
-            (r"'.*?\n", Comment.Single),
+            (r"'[^\n]*\n", Comment.Single),
             (r'([ \t]*)\bRem\n[\s\S]*?\s*\bEnd([ \t]*)Rem', Comment.Multiline),
             # Data types
             ('"', String.Double, 'string'),
@@ -130,7 +130,7 @@ class BlitzBasicLexer(RegexLexer):
             # Text
             (r'\s+', Whitespace),
             # Comments
-            (r";.*?\n", Comment.Single),
+            (r";[^\n]*\n", Comment.Single),
             # Data types
             ('"', String.Double, 'string'),
             # Numbers

--- a/pygments/lexers/berry.py
+++ b/pygments/lexers/berry.py
@@ -55,7 +55,7 @@ class BerryLexer(RegexLexer):
         'whitespace': [
             (r'\s+', Whitespace),
             (r'#-[\s\S]*?-#', Comment.Multiline),
-            (r'#.*?$', Comment.Single)
+            (r'#[^\n]*$', Comment.Single)
         ],
         'keywords': [
             (words((

--- a/pygments/lexers/bibtex.py
+++ b/pygments/lexers/bibtex.py
@@ -154,6 +154,6 @@ class BSTLexer(RegexLexer):
         ],
         'whitespace': [
             (r'\s+', Whitespace),
-            ('%.*?$', Comment.Single),
+            (r'%[^\n]*$', Comment.Single),
         ],
     }

--- a/pygments/lexers/blueprint.py
+++ b/pygments/lexers/blueprint.py
@@ -49,7 +49,7 @@ class BlueprintLexer(RegexLexer):
         ],
         "whitespace": [
             (r"\s+", Whitespace),
-            (r"//.*?\n", Comment.Single),
+            (r"//[^\n]*\n", Comment.Single),
             (r"/\*", Comment.Multiline, "comment-multiline"),
         ],
         "comment-multiline": [

--- a/pygments/lexers/boa.py
+++ b/pygments/lexers/boa.py
@@ -79,7 +79,7 @@ class BoaLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'#.*?$', Comment.Single),
+            (r'#[^\n]*$', Comment.Single),
             (r'/\*.*?\*/', Comment.Multiline),
             (reserved, Keyword.Reserved),
             (built_in_functions, Name.Function),

--- a/pygments/lexers/business.py
+++ b/pygments/lexers/business.py
@@ -256,7 +256,7 @@ class ABAPLexer(RegexLexer):
         'common': [
             (r'\s+', Whitespace),
             (r'^\*.*$', Comment.Single),
-            (r'\".*?\n', Comment.Single),
+            (r'\"[^\n]*\n', Comment.Single),
             (r'##\w+', Comment.Special),
         ],
         'variable-names': [

--- a/pygments/lexers/c_cpp.py
+++ b/pygments/lexers/c_cpp.py
@@ -192,7 +192,7 @@ class CFamilyLexer(RegexLexer):
                          Comment.PreprocFile, using(this), Comment.Single)),
             (r'[^/\n]+', Comment.Preproc),
             (r'/[*][\s\S]*?[*]/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single, '#pop'),
+            (r'//[^\n]*\n', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
             (r'(?<=\\)\n', Comment.Preproc),
             (r'\n', Comment.Preproc, '#pop'),
@@ -201,7 +201,7 @@ class CFamilyLexer(RegexLexer):
             (r'^\s*#if.*?(?<!\\)\n', Comment.Preproc, '#push'),
             (r'^\s*#el(?:se|if).*\n', Comment.Preproc, '#pop'),
             (r'^\s*#endif.*?(?<!\\)\n', Comment.Preproc, '#pop'),
-            (r'.*?\n', Comment),
+            (r'[^\n]*\n', Comment),
         ],
         'classname': [
             include('whitespace'),

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -105,7 +105,7 @@ class ClayLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Whitespace),
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'/(\\\n)?[*][\s\S]*?[*](\\\n)?/', Comment.Multiline),
             (words(('public', 'private', 'import', 'as', 'record', 'variant',
                     'instance', 'define', 'overload', 'default',
@@ -268,7 +268,7 @@ class ValaLexer(RegexLexer):
             (r'^\s*#if.*?(?<!\\)\n', Comment.Preproc, '#push'),
             (r'^\s*#el(?:se|if).*\n', Comment.Preproc, '#pop'),
             (r'^\s*#endif.*?(?<!\\)\n', Comment.Preproc, '#pop'),
-            (r'.*?\n', Comment),
+            (r'[^\n]*\n', Comment),
         ],
         'class': [
             (r'[a-zA-Z_]\w*', Name.Class, '#pop')

--- a/pygments/lexers/capnproto.py
+++ b/pygments/lexers/capnproto.py
@@ -26,7 +26,7 @@ class CapnProtoLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'#.*?$', Comment.Single),
+            (r'#[^\n]*$', Comment.Single),
             (r'@[0-9a-zA-Z]*', Name.Decorator),
             (r'=', Literal, 'expression'),
             (r':', Name.Class, 'type'),

--- a/pygments/lexers/codeql.py
+++ b/pygments/lexers/codeql.py
@@ -33,7 +33,7 @@ class CodeQLLexer(RegexLexer):
         'root': [
             # Whitespace and comments
             (r'\s+', Whitespace),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
             (r'/\*', Comment.Multiline, 'multiline-comments'),
 
              # Keywords

--- a/pygments/lexers/console.py
+++ b/pygments/lexers/console.py
@@ -55,7 +55,7 @@ class PyPyLogLexer(RegexLexer):
 
     tokens = {
         "root": [
-            (r"\[\w+\] \{jit-log-.*?$", Keyword, "jit-log"),
+            (r"\[\w+\] \{jit-log-[^\n]*$", Keyword, "jit-log"),
             (r"\[\w+\] \{jit-backend-counts$", Keyword, "jit-backend-counts"),
             include("extra-stuff"),
         ],
@@ -120,6 +120,6 @@ class PyPyLogLexer(RegexLexer):
         ],
         "extra-stuff": [
             (r"\s+", Whitespace),
-            (r"#.*?$", Comment),
+            (r"#[^\n]*$", Comment),
         ],
     }

--- a/pygments/lexers/d.py
+++ b/pygments/lexers/d.py
@@ -109,7 +109,7 @@ class DLexer(RegexLexer):
             (r'q"\(', String, 'delimited_parenthesis'),
             (r'q"<', String, 'delimited_angle'),
             (r'q"\{', String, 'delimited_curly'),
-            (r'q"([^\W\d]\w*)\n.*?\n\1"', String),
+            (r'q"([^\W\d]\w*)\n[^\n]*\n\1"', String),
             (r'q"(.).*?\1"', String),
             # -- TokenString
             (r'q\{', String, 'token_string'),

--- a/pygments/lexers/dalvik.py
+++ b/pygments/lexers/dalvik.py
@@ -102,7 +102,7 @@ class SmaliLexer(RegexLexer):
             (r'[ZBSCIJFDV\[]+', Keyword.Type),
         ],
         'comment': [
-            (r'#.*?\n', Comment),
+            (r'#[^\n]*\n', Comment),
         ],
     }
 

--- a/pygments/lexers/dylan.py
+++ b/pygments/lexers/dylan.py
@@ -114,7 +114,7 @@ class DylanLexer(RegexLexer):
             (r'\s+', Whitespace),
 
             # single line comment
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
 
             # lid header
             (r'([a-z0-9-]+)(:)([ \t]*)(.*(?:\n[ \t].+)*)',

--- a/pygments/lexers/eiffel.py
+++ b/pygments/lexers/eiffel.py
@@ -29,7 +29,7 @@ class EiffelLexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Whitespace),
-            (r'--.*?$', Comment.Single),
+            (r'--[^\n]*$', Comment.Single),
             (r'[^\S\n]+', Whitespace),
             # Please note that keyword and operator are case insensitive.
             (r'(?i)(true|false|void|current|result|precursor)\b', Keyword.Constant),

--- a/pygments/lexers/fantom.py
+++ b/pygments/lexers/fantom.py
@@ -45,9 +45,9 @@ class FantomLexer(RegexLexer):
     tokens = {
         'comments': [
             (r'(?s)/\*.*?\*/', Comment.Multiline),           # Multiline
-            (r'//.*?$', Comment.Single),                    # Single line
+            (r'//[^\n]*$', Comment.Single),                    # Single line
             # TODO: highlight references in fandocs
-            (r'\*\*.*?$', Comment.Special),                 # Fandoc
+            (r'\*\*[^\n]*$', Comment.Special),                 # Fandoc
             (r'#.*$', Comment.Single)                       # Shell-style
         ],
         'literals': [

--- a/pygments/lexers/forth.py
+++ b/pygments/lexers/forth.py
@@ -35,7 +35,7 @@ class ForthLexer(RegexLexer):
         'root': [
             (r'\s+', Whitespace),
             # All comment types
-            (r'\\.*?$', Comment.Single),
+            (r'\\[^\n]*$', Comment.Single),
             (r'\([\s].*?\)', Comment.Single),
             # defining words. The next word is a new command name
             (r'(:|variable|constant|value|buffer:)(\s+)',

--- a/pygments/lexers/foxpro.py
+++ b/pygments/lexers/foxpro.py
@@ -43,7 +43,7 @@ class FoxProLexer(RegexLexer):
             # before matching string literals.
             (r'(?<=\w)\[[0-9, ]+\]', Text),
             (r'\'[^\'\n]*\'|"[^"\n]*"|\[[^]*]\]', String),
-            (r'(^\s*\*|&&|&amp;&amp;).*?\n', Comment.Single),
+            (r'(^\s*\*|&&|&amp;&amp;)[^\n]*\n', Comment.Single),
 
             (r'(ABS|ACLASS|ACOPY|ACOS|ADATABASES|ADBOBJECTS|ADDBS|'
              r'ADDPROPERTY|ADEL|ADIR|ADLLS|ADOCKSTATE|AELEMENT|AERROR|'
@@ -343,7 +343,7 @@ class FoxProLexer(RegexLexer):
             (r'.', Text),
         ],
         'newline': [
-            (r'\*.*?$', Comment.Single, '#pop'),
+            (r'\*[^\n]*$', Comment.Single, '#pop'),
             (r'(ACCEPT|ACTIVATE\s*MENU|ACTIVATE\s*POPUP|ACTIVATE\s*SCREEN|'
              r'ACTIVATE\s*WINDOW|APPEND|APPEND\s*FROM|APPEND\s*FROM\s*ARRAY|'
              r'APPEND\s*GENERAL|APPEND\s*MEMO|ASSIST|AVERAGE|BLANK|BROWSE|'

--- a/pygments/lexers/graphics.py
+++ b/pygments/lexers/graphics.py
@@ -408,7 +408,7 @@ class AsymptoteLexer(RegexLexer):
     version_added = '1.2'
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/\*.*?\*/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/\*.*?\*/)+'
 
     tokens = {
         'whitespace': [

--- a/pygments/lexers/graphviz.py
+++ b/pygments/lexers/graphviz.py
@@ -29,7 +29,7 @@ class GraphvizLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Whitespace),
-            (r'(#|//).*?$', Comment.Single),
+            (r'(#|//)[^\n]*$', Comment.Single),
             (r'/(\\\n)?[*][\s\S]*?[*](\\\n)?/', Comment.Multiline),
             (r'(?i)(node|edge|graph|digraph|subgraph|strict)\b', Keyword),
             (r'--|->', Operator),

--- a/pygments/lexers/hare.py
+++ b/pygments/lexers/hare.py
@@ -25,7 +25,7 @@ class HareLexer(RegexLexer):
     mimetypes = ['text/x-hare']
     version_added = '2.19'
 
-    _ws = r'(?:\s|//.*?\n|/[*].*?[*]/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/[*].*?[*]/)+'
     _ws1 = r'\s*(?:/[*].*?[*]/\s*)?'
 
     tokens = {
@@ -34,7 +34,7 @@ class HareLexer(RegexLexer):
             (r'@[a-z]+', Comment.Preproc),
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
         ],
         'statements': [
             (r'"', String, 'string'),

--- a/pygments/lexers/haskell.py
+++ b/pygments/lexers/haskell.py
@@ -45,7 +45,7 @@ class HaskellLexer(RegexLexer):
             # Whitespace:
             (r'\s+', Whitespace),
             # (r'--\s*|.*$', Comment.Doc),
-            (r'--(?![!#$%&*+./<=>?@^|_~:\\]).*?$', Comment.Single),
+            (r'--(?![!#$%&*+./<=>?@^|_~:\\])[^\n]*$', Comment.Single),
             (r'\{-', Comment.Multiline, 'comment'),
             # Lexemes:
             #  Identifiers
@@ -114,7 +114,7 @@ class HaskellLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'[' + uni.Lu + r']\w*', Keyword.Type),
             (r'(_[\w\']+|[' + uni.Ll + r'][\w\']*)', Name.Function),
-            (r'--(?![!#$%&*+./<=>?@^|_~:\\]).*?$', Comment.Single),
+            (r'--(?![!#$%&*+./<=>?@^|_~:\\])[^\n]*$', Comment.Single),
             (r'\{-', Comment.Multiline, 'comment'),
             (r',', Punctuation),
             (r'[:!#$%&*+.\\/<=>?@^|~-]+', Operator),
@@ -316,7 +316,7 @@ class AgdaLexer(RegexLexer):
              bygroups(Whitespace, Name.Function, Whitespace,
                       Operator.Word, Whitespace)),
             # Comments
-            (r'--(?![!#$%&*+./<=>?@^|_~:\\]).*?$', Comment.Single),
+            (r'--(?![!#$%&*+./<=>?@^|_~:\\])[^\n]*$', Comment.Single),
             (r'\{-', Comment.Multiline, 'comment'),
             # Holes
             (r'\{!', Comment.Directive, 'hole'),

--- a/pygments/lexers/hdl.py
+++ b/pygments/lexers/hdl.py
@@ -29,7 +29,7 @@ class VerilogLexer(RegexLexer):
     version_added = '1.4'
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/[*].*?[*]/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/[*].*?[*]/)+'
 
     tokens = {
         'root': [
@@ -119,7 +119,7 @@ class VerilogLexer(RegexLexer):
         'macro': [
             (r'[^/\n]+', Comment.Preproc),
             (r'/[*][\s\S]*?[*]/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single, '#pop'),
+            (r'//[^\n]*\n', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
             (r'(?<=\\)\n', Comment.Preproc),
             (r'\n', Whitespace, '#pop'),
@@ -156,7 +156,7 @@ class SystemVerilogLexer(RegexLexer):
     version_added = '1.5'
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/[*].*?[*]/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/[*].*?[*]/)+'
 
     tokens = {
         'root': [
@@ -359,7 +359,7 @@ class SystemVerilogLexer(RegexLexer):
         'macro': [
             (r'[^/\n]+', Comment.Preproc),
             (r'/[*][\s\S]*?[*]/', Comment.Multiline),
-            (r'//.*?$', Comment.Single, '#pop'),
+            (r'//[^\n]*$', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
             (r'(?<=\\)\n', Comment.Preproc),
             (r'\n', Whitespace, '#pop'),
@@ -386,7 +386,7 @@ class VhdlLexer(RegexLexer):
         'root': [
             (r'\s+', Whitespace),
             (r'(\\)(\n)', bygroups(String.Escape, Whitespace)),  # line continuation
-            (r'--.*?$', Comment.Single),
+            (r'--[^\n]*$', Comment.Single),
             (r'/(\\\n)?[*][\s\S]*?[*](\\\n)?/', Comment.Multiline),
             (r"'(U|X|0|1|Z|W|L|H|-)'", String.Char),
             (r'[~!%^&*+=|?:<>/-]', Operator),

--- a/pygments/lexers/installers.py
+++ b/pygments/lexers/installers.py
@@ -257,12 +257,12 @@ class SourcesListLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Whitespace),
-            (r'#.*?$', Comment),
+            (r'#[^\n]*$', Comment),
             (r'^(deb(?:-src)?)(\s+)',
              bygroups(Keyword, Whitespace), 'distribution')
         ],
         'distribution': [
-            (r'#.*?$', Comment, '#pop'),
+            (r'#[^\n]*$', Comment, '#pop'),
             (r'\$\(ARCH\)', Name.Variable),
             (r'[^\s$[]+', String),
             (r'\[', String.Other, 'escaped-distribution'),
@@ -276,7 +276,7 @@ class SourcesListLexer(RegexLexer):
             (r'\$', String.Other)
         ],
         'components': [
-            (r'#.*?$', Comment, '#pop:2'),
+            (r'#[^\n]*$', Comment, '#pop:2'),
             (r'$', Text, '#pop:2'),
             (r'\s+', Whitespace),
             (r'\S+', Keyword.Pseudo),

--- a/pygments/lexers/lean.py
+++ b/pygments/lexers/lean.py
@@ -38,7 +38,7 @@ class Lean3Lexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'/--', String.Doc, 'docstring'),
             (r'/-', Comment, 'comment'),
-            (r'--.*?$', Comment.Single),
+            (r'--[^\n]*$', Comment.Single),
             (words((
                     'forall', 'fun', 'Pi', 'from', 'have', 'show', 'assume', 'suffices',
                     'let', 'if', 'else', 'then', 'in', 'with', 'calc', 'match',

--- a/pygments/lexers/make.py
+++ b/pygments/lexers/make.py
@@ -85,7 +85,7 @@ class BaseMakefileLexer(RegexLexer):
             # special variables
             (r'\$[<@$+%?|*]', Keyword),
             (r'\s+', Whitespace),
-            (r'#.*?\n', Comment),
+            (r'#[^\n]*\n', Comment),
             (r'((?:un)?export)(\s+)(?=[\w${}\t -]+\n)',
              bygroups(Keyword, Whitespace), 'export'),
             (r'(?:un)?export\s+', Keyword),
@@ -118,7 +118,7 @@ class BaseMakefileLexer(RegexLexer):
         ],
         'block-header': [
             (r'[,|]', Punctuation),
-            (r'#.*?\n', Comment, '#pop'),
+            (r'#[^\n]*\n', Comment, '#pop'),
             (r'\\\n', Text),  # line continuation
             (r'\$\(', Keyword, 'expansion'),
             (r'[a-zA-Z_]+', Name),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -300,7 +300,7 @@ class TexLexer(RegexLexer):
 
     tokens = {
         'general': [
-            (r'%.*?\n', Comment),
+            (r'%[^\n]*\n', Comment),
             (r'[{}]', Name.Builtin),
             (r'[&_^]', Name.Builtin),
         ],

--- a/pygments/lexers/matlab.py
+++ b/pygments/lexers/matlab.py
@@ -26,7 +26,7 @@ __all__ = ['MatlabLexer', 'MatlabSessionLexer', 'OctaveLexer', 'ScilabLexer']
 # the signature, which is valid in all three languages.
 _deffunc = [
     (r'[ \t]+', Whitespace),
-    (r'\.\.\..*?\n', Comment),  # line continuation
+    (r'\.\.\.[^\n]*\n', Comment),  # line continuation
     # output argument(s): `[a, b] =` (may span continuations) or `y =`
     (r'(\[)([^\]]*)(\])([ \t]*)(=)',
      bygroups(Punctuation, Text, Punctuation, Whitespace, Punctuation)),
@@ -39,7 +39,7 @@ _deffunc = [
 ]
 
 _deffunc_args = [
-    (r'\.\.\..*?\n', Comment),  # line continuation
+    (r'\.\.\.[^\n]*\n', Comment),  # line continuation
     (r'\)', Punctuation, '#pop:2'),
     (r'[^)\n.]+', Text),
     (r'[.\n]', Text),
@@ -2754,7 +2754,7 @@ class MatlabLexer(RegexLexer):
             return 0.2
 
 
-line_re  = re.compile('.*?\n')
+line_re  = re.compile('[^\n]*\n')
 
 
 class MatlabSessionLexer(Lexer):
@@ -3251,7 +3251,7 @@ class ScilabLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'^\s*function\b', Keyword, 'deffunc'),
 
             (words((

--- a/pygments/lexers/meson.py
+++ b/pygments/lexers/meson.py
@@ -36,7 +36,7 @@ class MesonLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'#.*?$', Comment),
+            (r'#[^\n]*$', Comment),
             (r"'''.*'''", String.Single),
             (r'[1-9][0-9]*', Number.Integer),
             (r'0o[0-7]+', Number.Oct),

--- a/pygments/lexers/minecraft.py
+++ b/pygments/lexers/minecraft.py
@@ -332,7 +332,7 @@ class MCSchemaLexer(RegexLexer):
     tokens = {
         'commentsandwhitespace': [
             (r'\s+', Whitespace),
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'/\*.*?\*/', Comment.Multiline)
         ],
         'slashstartsregex': [

--- a/pygments/lexers/ml.py
+++ b/pygments/lexers/ml.py
@@ -484,7 +484,7 @@ class OpaLexer(RegexLexer):
         # factorizing these rules, because they are inserted many times
         'comments': [
             (r'/\*', Comment, 'nested-comment'),
-            (r'//.*?$', Comment),
+            (r'//[^\n]*$', Comment),
         ],
         'comments-and-spaces': [
             include('comments'),
@@ -811,7 +811,7 @@ class ReasonLexer(RegexLexer):
             (r'false|true|\(\)|\[\]', Name.Builtin.Pseudo),
             (r'\b([A-Z][\w\']*)(?=\s*\.)', Name.Namespace, 'dotted'),
             (r'\b([A-Z][\w\']*)', Name.Class),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
             (r'\/\*(?!/)', Comment.Multiline, 'comment'),
             (r'\b({})\b'.format('|'.join(keywords)), Keyword),
             (r'({})'.format('|'.join(keyopts[::-1])), Operator.Word),

--- a/pygments/lexers/mosel.py
+++ b/pygments/lexers/mosel.py
@@ -402,7 +402,7 @@ class MoselLexer(RegexLexer):
         'root': [
             (r'\n', Text),
             (r'\s+', Text.Whitespace),
-            (r'!.*?\n', Comment.Single),
+            (r'![^\n]*\n', Comment.Single),
             (r'\(![\s\S]*?!\)', Comment.Multiline),
             (words((
                 'and', 'as', 'break', 'case', 'count', 'declarations', 'do',

--- a/pygments/lexers/nit.py
+++ b/pygments/lexers/nit.py
@@ -27,7 +27,7 @@ class NitLexer(RegexLexer):
     version_added = '2.0'
     tokens = {
         'root': [
-            (r'#.*?$', Comment.Single),
+            (r'#[^\n]*$', Comment.Single),
             (words((
                 'package', 'module', 'import', 'class', 'abstract', 'interface',
                 'universal', 'enum', 'end', 'fun', 'type', 'init', 'redef',

--- a/pygments/lexers/parasail.py
+++ b/pygments/lexers/parasail.py
@@ -34,7 +34,7 @@ class ParaSailLexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Text),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
             (r'\b(and|or|xor)=', Operator.Word),
             (r'\b(and(\s+then)?|or(\s+else)?|xor|rem|mod|'
              r'(is|not)\s+null)\b',

--- a/pygments/lexers/pawn.py
+++ b/pygments/lexers/pawn.py
@@ -28,7 +28,7 @@ class SourcePawnLexer(RegexLexer):
     version_added = '1.6'
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/\*.*?\*/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/\*.*?\*/)+'
     #: only one /* */ style comment
     _ws1 = r'\s*(?:/[*].*?[*]/\s*)*'
 
@@ -72,7 +72,7 @@ class SourcePawnLexer(RegexLexer):
         'macro': [
             (r'[^/\n]+', Comment.Preproc),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single, '#pop'),
+            (r'//[^\n]*\n', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
             (r'(?<=\\)\n', Comment.Preproc),
             (r'\n', Comment.Preproc, '#pop'),
@@ -80,7 +80,7 @@ class SourcePawnLexer(RegexLexer):
         'if0': [
             (r'^\s*#if.*?(?<!\\)\n', Comment.Preproc, '#push'),
             (r'^\s*#endif.*?(?<!\\)\n', Comment.Preproc, '#pop'),
-            (r'.*?\n', Comment),
+            (r'[^\n]*\n', Comment),
         ]
     }
 
@@ -139,7 +139,7 @@ class PawnLexer(RegexLexer):
     version_added = '2.0'
 
     #: optional Comment or Whitespace
-    _ws = r'(?:\s|//.*?\n|/[*][\w\W]*?[*]/)+'
+    _ws = r'(?:\s|//[^\n]*\n|/[*][\w\W]*?[*]/)+'
     #: only one /* */ style comment
     _ws1 = r'\s*(?:/[*].*?[*]/\s*)*'
 
@@ -183,7 +183,7 @@ class PawnLexer(RegexLexer):
         'macro': [
             (r'[^/\n]+', Comment.Preproc),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
-            (r'//.*?\n', Comment.Single, '#pop'),
+            (r'//[^\n]*\n', Comment.Single, '#pop'),
             (r'/', Comment.Preproc),
             (r'(?<=\\)\n', Comment.Preproc),
             (r'\n', Comment.Preproc, '#pop'),
@@ -191,7 +191,7 @@ class PawnLexer(RegexLexer):
         'if0': [
             (r'^\s*#if.*?(?<!\\)\n', Comment.Preproc, '#push'),
             (r'^\s*#endif.*?(?<!\\)\n', Comment.Preproc, '#pop'),
-            (r'.*?\n', Comment),
+            (r'[^\n]*\n', Comment),
         ]
     }
 

--- a/pygments/lexers/praat.py
+++ b/pygments/lexers/praat.py
@@ -117,8 +117,8 @@ class PraatLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'(\s+)(#.*?$)',  bygroups(Whitespace, Comment.Single)),
-            (r'^#.*?$',        Comment.Single),
+            (r'(\s+)(#[^\n]*$)',  bygroups(Whitespace, Comment.Single)),
+            (r'^#[^\n]*$',        Comment.Single),
             (r';[^\n]*',       Comment.Single),
             (r'\s+',           Whitespace),
 
@@ -271,7 +271,7 @@ class PraatLexer(RegexLexer):
             (r'[^\'"\n]+',  String),
         ],
         'old_form': [
-            (r'(\s+)(#.*?$)',  bygroups(Whitespace, Comment.Single)),
+            (r'(\s+)(#[^\n]*$)',  bygroups(Whitespace, Comment.Single)),
             (r'\s+', Whitespace),
 
             (r'(optionmenu|choice)([ \t]+)(\S+)(:)([ \t]+)',

--- a/pygments/lexers/prolog.py
+++ b/pygments/lexers/prolog.py
@@ -105,7 +105,7 @@ class LogtalkLexer(RegexLexer):
             # Directives
             (r'^\s*:-\s', Punctuation, 'directive'),
             # Comments
-            (r'%.*?\n', Comment),
+            (r'%[^\n]*\n', Comment),
             (r'/\*[\s\S]*?\*/', Comment),
             # Whitespace
             (r'\n', Text),
@@ -297,7 +297,7 @@ class LogtalkLexer(RegexLexer):
             # Punctuation
             (r'[()\[\],.|]', Text),
             # Comments
-            (r'%.*?\n', Comment),
+            (r'%[^\n]*\n', Comment),
             (r'/\*[\s\S]*?\*/', Comment),
             # Whitespace
             (r'\n', Text),

--- a/pygments/lexers/promql.py
+++ b/pygments/lexers/promql.py
@@ -140,7 +140,7 @@ class PromQLLexer(RegexLexer):
             (r"-?[0-9]+\.[0-9]+", Number.Float),
             (r"-?[0-9]+", Number.Integer),
             # Comments
-            (r"#.*?$", Comment.Single),
+            (r"#[^\n]*$", Comment.Single),
             # Operators
             (r"(\+|\-|\*|\/|\%|\^)", Operator),
             (r"==|!=|>=|<=|<|>", Operator),

--- a/pygments/lexers/ptx.py
+++ b/pygments/lexers/ptx.py
@@ -56,7 +56,7 @@ class PtxLexer(RegexLexer):
         ],
         'whitespace': [
             (r'\s+', Whitespace),
-            (r'//.*?\n', Comment)
+            (r'//[^\n]*\n', Comment)
         ],
 
         'keyword': [

--- a/pygments/lexers/purescript.py
+++ b/pygments/lexers/purescript.py
@@ -37,7 +37,7 @@ class PureScriptLexer(RegexLexer):
             # Whitespace
             (r'\s+', Whitespace),
             # Single-line comments
-            (r'--.*?$', Comment.Single),
+            (r'--[^\n]*$', Comment.Single),
             # Multi-line comments
             (r'\{-', Comment.Multiline, 'comment'),
             # Lexemes:
@@ -113,7 +113,7 @@ class PureScriptLexer(RegexLexer):
             (r"\b(class|type)(?!')\b", Keyword.Reserved),
             (r'[' + uni.Lu + r']\w*', Keyword.Type),
             (r'(_[\w\']+|[' + uni.Ll + r'][\w\']*)', Name.Function),
-            (r'--.*?$', Comment.Single),
+            (r'--[^\n]*$', Comment.Single),
             (r'\{-', Comment.Multiline, 'comment'),
             (r',', Punctuation),
             (r'\.\.', Punctuation),

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -1032,7 +1032,7 @@ class DgLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Text),
-            (r'#.*?$', Comment.Single),
+            (r'#[^\n]*$', Comment.Single),
 
             (r'(?i)0b[01]+', Number.Bin),
             (r'(?i)0o[0-7]+', Number.Oct),

--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -17,7 +17,7 @@ from pygments.token import Text, Comment, Operator, Keyword, Name, String, \
 __all__ = ['RConsoleLexer', 'SLexer', 'RdLexer']
 
 
-line_re  = re.compile('.*?\n')
+line_re  = re.compile('[^\n]*\n')
 
 
 class RConsoleLexer(Lexer):

--- a/pygments/lexers/rego.py
+++ b/pygments/lexers/rego.py
@@ -38,7 +38,7 @@ class RegoLexer(RegexLexer):
         'root': [
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r'#.*?$', Comment.Single),
+            (r'#[^\n]*$', Comment.Single),
             (words(reserved_words, suffix=r'\b'), Keyword),
             (words(builtins, suffix=r'\b'), Name.Builtin),
             (r'[a-zA-Z_][a-zA-Z0-9_]*', Name),

--- a/pygments/lexers/rell.py
+++ b/pygments/lexers/rell.py
@@ -44,7 +44,7 @@ class RellLexer(RegexLexer):
                 'module', 'not', 'offset', 'or', 'override', 'return', 'update',
                 'val', 'var', 'when', 'while'), suffix=r'\b'),
              Keyword.Reserved),
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
             (r'"(\\\\|\\"|[^"])*"', String.Double),
             (r'\'(\\\\|\\\'|[^\\\'])*\'', String.Single),

--- a/pygments/lexers/resource.py
+++ b/pygments/lexers/resource.py
@@ -32,7 +32,7 @@ class ResourceLexer(RegexLexer):
     flags = re.MULTILINE | re.IGNORECASE
     tokens = {
         'root': [
-            (r'//.*?$', Comment),
+            (r'//[^\n]*$', Comment),
             (r'"', String, 'string'),
             (r'-?\d+', Number.Integer),
             (r'[,{}]', Operator),

--- a/pygments/lexers/rust.py
+++ b/pygments/lexers/rust.py
@@ -74,8 +74,8 @@ class RustLexer(RegexLexer):
             # Whitespace and Comments
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r'//!.*?\n', String.Doc),
-            (r'///(\n|[^/].*?\n)', String.Doc),
+            (r'//![^\n]*\n', String.Doc),
+            (r'///(\n|[^/][^\n]*\n)', String.Doc),
             (r'//(.*?)\n', Comment.Single),
             (r'/\*\*(\n|[^/*])', String.Doc, 'doccomment'),
             (r'/\*!', String.Doc, 'doccomment'),

--- a/pygments/lexers/savi.py
+++ b/pygments/lexers/savi.py
@@ -45,10 +45,10 @@ class SaviLexer(RegexLexer):
     tokens = {
       "root": [
         # Line Comment
-        (r'//.*?$', Comment.Single),
+        (r'//[^\n]*$', Comment.Single),
 
         # Doc Comment
-        (r'::.*?$', Comment.Single),
+        (r'::[^\n]*$', Comment.Single),
 
         # Capability Operator
         (r'(\')(\w+)(?=[^\'])', bygroups(Operator, Name)),

--- a/pygments/lexers/sieve.py
+++ b/pygments/lexers/sieve.py
@@ -72,7 +72,7 @@ class SieveLexer(RegexLexer):
              Name.Tag, 'text'),
         ],
         'text': [
-            (r'[^.].*?\n', String),
+            (r'[^.][^\n]*\n', String),
             (r'^\.', Punctuation, "#pop"),
         ]
     }

--- a/pygments/lexers/slash.py
+++ b/pygments/lexers/slash.py
@@ -67,7 +67,7 @@ class SlashLanguageLexer(ExtendedRegexLexer):
             (r"'[a-zA-Z0-9_]+",         String),
             (r'%r{',                    String.Regex,       move_state("regexp")),
             (r'/\*.*?\*/',              Comment.Multiline),
-            (r"(#|//).*?\n",            Comment.Single),
+            (r"(#|//)[^\n]*\n",            Comment.Single),
             (r'-?[0-9]+e[+-]?[0-9]+',   Number.Float),
             (r'-?[0-9]+\.[0-9]+(e[+-]?[0-9]+)?', Number.Float),
             (r'-?[0-9]+',               Number.Integer),

--- a/pygments/lexers/sophia.py
+++ b/pygments/lexers/sophia.py
@@ -54,7 +54,7 @@ class SophiaLexer(RegexLexer):
             (r'(true|false)\b', Keyword.Constant),
             (r'\b([A-Z][\w\']*)(?=\s*\.)', Name.Class, 'dotted'),
             (r'\b([A-Z][\w\']*)', Name.Function),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
             (r'\/\*(?!/)', Comment.Multiline, 'comment'),
 
             (r'0[xX][\da-fA-F][\da-fA-F_]*', Number.Hex),

--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -58,7 +58,7 @@ __all__ = ['GoogleSqlLexer', 'PostgresLexer', 'PlPgsqlLexer',
            'PostgresConsoleLexer', 'PostgresExplainLexer', 'SqlLexer',
            'TransactSqlLexer', 'MySqlLexer', 'SqliteConsoleLexer', 'RqlLexer']
 
-line_re  = re.compile('.*?\n')
+line_re  = re.compile('[^\n]*\n')
 sqlite_prompt_re = re.compile(r'^(?:sqlite|   ...)>(?= )')
 
 language_re = re.compile(r"\s+LANGUAGE\s+'?(\w+)'?", re.IGNORECASE)
@@ -278,7 +278,7 @@ re_psql_command = re.compile(r'(\s*)(\\.+?)(\s+)$')
 re_error = re.compile(r'(ERROR|FATAL):')
 re_message = re.compile(
     r'((?:DEBUG|INFO|NOTICE|WARNING|ERROR|'
-    r'FATAL|HINT|DETAIL|CONTEXT|LINE [0-9]+):)(.*?\n)')
+    r'FATAL|HINT|DETAIL|CONTEXT|LINE [0-9]+):)([^\n]*\n)')
 
 
 class lookahead:

--- a/pygments/lexers/tablegen.py
+++ b/pygments/lexers/tablegen.py
@@ -118,7 +118,7 @@ class TableGenLexer(RegexLexer):
             (r'\s+', Whitespace),
 
             (r'/\*', Comment.Multiline, 'comment'),
-            (r'//.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
             (r'#(define|ifdef|ifndef|else|endif)', Comment.Preproc),
 
             # Binary/hex numbers. Note that these take priority over names,

--- a/pygments/lexers/unicon.py
+++ b/pygments/lexers/unicon.py
@@ -34,7 +34,7 @@ class UniconLexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Text),
-            (r'#.*?\n', Comment.Single),
+            (r'#[^\n]*\n', Comment.Single),
             (r'[^\S\n]+', Text),
             (r'class|method|procedure', Keyword.Declaration, 'subprogram'),
             (r'(record)(\s+)(\w+)',
@@ -179,7 +179,7 @@ class IconLexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Text),
-            (r'#.*?\n', Comment.Single),
+            (r'#[^\n]*\n', Comment.Single),
             (r'[^\S\n]+', Text),
             (r'class|method|procedure', Keyword.Declaration, 'subprogram'),
             (r'(record)(\s+)(\w+)',

--- a/pygments/lexers/usd.py
+++ b/pygments/lexers/usd.py
@@ -65,7 +65,7 @@ class UsdLexer(RegexLexer):
         _keywords(TYPES, Keyword.Type) +
         [
             (r"[(){}\[\]]", Punctuation),
-            ("#.*?$", Comment.Single),
+            (r"#[^\n]*$", Comment.Single),
             (",", Punctuation),
             (";", Punctuation),  # ";"s are allowed to combine separate metadata lines
             ("=", Operator),

--- a/pygments/lexers/webassembly.py
+++ b/pygments/lexers/webassembly.py
@@ -80,7 +80,7 @@ class WatLexer(RegexLexer):
             (words(builtins), Name.Builtin, 'arguments'),
             (words(['i32', 'i64', 'f32', 'f64']), Keyword.Type),
             (r'\$[A-Za-z0-9!#$%&\'*+./:<=>?@\\^_`|~-]+', Name.Variable), # yes, all of the are valid in identifiers
-            (r';;.*?$', Comment.Single),
+            (r';;[^\n]*$', Comment.Single),
             (r'\(;', Comment.Multiline, 'nesting_comment'),
             (r'[+-]?0x[\dA-Fa-f](_?[\dA-Fa-f])*(.([\dA-Fa-f](_?[\dA-Fa-f])*)?)?([pP][+-]?[\dA-Fa-f](_?[\dA-Fa-f])*)?', Number.Float),
             (r'[+-]?\d.\d(_?\d)*[eE][+-]?\d(_?\d)*', Number.Float),

--- a/pygments/lexers/x10.py
+++ b/pygments/lexers/x10.py
@@ -53,7 +53,7 @@ class X10Lexer(RegexLexer):
     tokens = {
         'root': [
             (r'[^\S\n]+', Text),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
             (r'/\*[\s\S]*?\*/', Comment.Multiline),
             (r'\b({})\b'.format('|'.join(keywords)), Keyword),
             (r'\b({})\b'.format('|'.join(types)), Keyword.Type),

--- a/pygments/lexers/yang.py
+++ b/pygments/lexers/yang.py
@@ -76,7 +76,7 @@ class YangLexer(RegexLexer):
             (r"'(?:\\'|[^'])*?'", String.Single),
 
             (r'/\*', Comment, 'comments'),
-            (r'//.*?$', Comment),
+            (r'//[^\n]*$', Comment),
 
             #match BNF stmt for `node-identifier` with [ prefix ":"]
             (r'(?:^|(?<=[\s{};]))([\w.-]+)(:)([\w.-]+)(?=[\s{};])',

--- a/pygments/lexers/yara.py
+++ b/pygments/lexers/yara.py
@@ -30,8 +30,8 @@ class YaraLexer(RegexLexer):
     tokens = {
         'root': [
             (r'\s+', Whitespace),
-            (r'//.*?$', Comment.Single),
-            (r'\#.*?$', Comment.Single),
+            (r'//[^\n]*$', Comment.Single),
+            (r'\#[^\n]*$', Comment.Single),
             (r'/\*', Comment.Multiline, 'comment'),
             (words(('rule', 'private', 'global', 'import', 'include'),
                    prefix=r'\b', suffix=r'\b'),

--- a/pygments/lexers/zig.py
+++ b/pygments/lexers/zig.py
@@ -73,7 +73,7 @@ class ZigLexer(RegexLexer):
         'root': [
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
-            (r'//.*?\n', Comment.Single),
+            (r'//[^\n]*\n', Comment.Single),
 
             # Keywords
             statement_keywords,


### PR DESCRIPTION
Many lexers match to end-of-line with the lazy idioms .*?\n / .*?$ (line comments, line continuations, etc.). Lazy .*? advances one character at a time, whereas [^\n]* consumes the line in a single character-class scan. In isolation on microbenchmarks [^\n]*\n is ~3.4x faster than //.*?\n, and on comment-heavy input the affected lexers (zig, ada, prolog, hare, yara, ...) lex ~20% faster end to end.

Under re.MULTILINE without re.DOTALL (the RegexLexer default), . never matches \n, so .*?\n and .*?$ are exactly equivalent to [^\n]*\n and [^\n]*$. Lexers using re.DOTALL/re.S are left untouched.

This was a mechanical change, then tediously manually reviewed, and the testsuite wasn't touched, so it shouldn't™ break anything.