### PR TITLE
Fix regex_opt emitting redundant character classes for duplicate words

### DIFF
--- a/pygments/regexopt.py
+++ b/pygments/regexopt.py
@@ -98,5 +98,5 @@ def regex_opt(strings, prefix='', suffix=''):
 
     *prefix* and *suffix* are pre- and appended to the final regex.
     """
-    strings = sorted(strings)
+    strings = sorted(set(strings))
     return prefix + regex_opt_inner(strings, '(') + suffix

--- a/tests/test_regexopt.py
+++ b/tests/test_regexopt.py
@@ -100,3 +100,29 @@ def test_same_length_suffix_grouping():
     assert rex.groups == 2
     groups = rex.match('am').groups()
     assert groups == ('a', 'm')
+
+
+def test_duplicates():
+    # duplicate words must not produce a redundant character class like [ss]
+    opt = regex_opt(('as', 'abstract', 'and', 'as', 'break'))
+    print(opt)
+    assert '[ss]' not in opt
+    rex = re.compile(opt)
+    assert rex.match('as')
+    assert rex.match('abstract')
+    assert rex.match('and')
+    assert rex.match('break')
+    assert not rex.match('x')
+    assert rex.groups == 1
+
+
+def test_duplicate_single_chars():
+    # duplicate one-character words must be collapsed in the character class
+    opt = regex_opt(('a', 'a', 'b'))
+    print(opt)
+    assert opt.count('a') == 1
+    rex = re.compile(opt)
+    assert rex.match('a')
+    assert rex.match('b')
+    assert not rex.match('c')
+    assert rex.groups == 1


### PR DESCRIPTION
regex_opt() sorted its input but never deduplicated it. When a word list contained duplicates (e.g. the Boo lexer keyword list has 'as' twice), the duplicate one-character remainders left after prefix-stripping were fed into make_charset, producing a redundant character class such as [ss]. This triggered a W117 "Overlap in character class" lint warning (surfaced in pygments/pygments#3189).

Deduplicate the input with sorted(set(strings)) and add regression tests.