### PR TITLE
Remove redundant duplicate regexes in several lexers

### DIFF
--- a/pygments/lexers/ada.py
+++ b/pygments/lexers/ada.py
@@ -37,7 +37,6 @@ class AdaLexer(RegexLexer):
         'root': [
             (r'[^\S\n]+', Text),
             (r'--.*?\n', Comment.Single),
-            (r'[^\S\n]+', Text),
             (r'function|procedure|entry', Keyword.Declaration, 'subprogram'),
             (r'(subtype|type)(\s+)(\w+)',
              bygroups(Keyword.Declaration, Text, Keyword.Type), 'type_def'),

--- a/pygments/lexers/basic.py
+++ b/pygments/lexers/basic.py
@@ -457,7 +457,6 @@ class QBasicLexer(RegexLexer):
             (r'\-?\d*\.\d+[@|#]?', Number.Float),
             (r'\-?\d+[@|#]', Number.Float),
             (r'\-?\d+#?', Number.Integer.Long),
-            (r'\-?\d+#?', Number.Integer),
             (r'!=|==|:=|\.=|<<|>>|[-~+/\\*%=<>&^|?:!.]', Operator),
             (r'[\[\]{}(),;]', Punctuation),
             (r'[\w]+', Name.Variable.Global),

--- a/pygments/lexers/eiffel.py
+++ b/pygments/lexers/eiffel.py
@@ -30,7 +30,6 @@ class EiffelLexer(RegexLexer):
         'root': [
             (r'[^\S\n]+', Whitespace),
             (r'--.*?$', Comment.Single),
-            (r'[^\S\n]+', Whitespace),
             # Please note that keyword and operator are case insensitive.
             (r'(?i)(true|false|void|current|result|precursor)\b', Keyword.Constant),
             (r'(?i)(not|xor|implies|or)\b', Operator.Word),

--- a/pygments/lexers/factor.py
+++ b/pygments/lexers/factor.py
@@ -247,8 +247,6 @@ class FactorLexer(RegexLexer):
             (r'(PREDICATE:)(\s+)(\S+)(\s+)(<)(\s+)(\S+)',
              bygroups(Keyword, Whitespace, Name.Class, Whitespace,
                  Punctuation, Whitespace, Name.Class)),
-            (r'(C:)(\s+)(\S+)(\s+)(\S+)',
-             bygroups(Keyword, Whitespace, Name.Function, Whitespace, Name.Class)),
             (r'(INSTANCE:)(\s+)(\S+)(\s+)(\S+)',
              bygroups(Keyword, Whitespace, Name.Class, Whitespace, Name.Class)),
             (r'(SLOT:)(\s+)(\S+)', bygroups(Keyword, Whitespace, Name.Function)),

--- a/pygments/lexers/fantom.py
+++ b/pygments/lexers/fantom.py
@@ -245,7 +245,6 @@ class FantomLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'(\s*)(\w+)(\s*)(=)', bygroups(Whitespace, Name, Whitespace, Operator)),
             (r'\}', Punctuation, '#pop'),
-            (r'\s+', Whitespace),
             (r'.', Text)
         ],
     }

--- a/pygments/lexers/futhark.py
+++ b/pygments/lexers/futhark.py
@@ -79,7 +79,6 @@ class FutharkLexer(RegexLexer):
             (r'"', String, 'string'),
             #  Special
             (r'\[[a-zA-Z_\d]*\]', Keyword.Type),
-            (r'\(\)', Name.Builtin),
         ],
         'character': [
             # Allows multi-chars, incorrectly.

--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -249,8 +249,6 @@ class KalLexer(RegexLexer):
                 bygroups(Keyword, Whitespace, Keyword)),
             (r'(?<![.$])(inherits)(\s+)(from)?\b',
                 bygroups(Keyword, Whitespace, Keyword)),
-            (r'(?<![.$])(for)(\s+)(parallel|series)?\b',
-                bygroups(Keyword, Whitespace, Keyword)),
             (words((
                 'in', 'of', 'while', 'until', 'break', 'return', 'continue',
                 'when', 'if', 'unless', 'else', 'otherwise', 'throw', 'raise',

--- a/pygments/lexers/unicon.py
+++ b/pygments/lexers/unicon.py
@@ -35,7 +35,6 @@ class UniconLexer(RegexLexer):
         'root': [
             (r'[^\S\n]+', Text),
             (r'#.*?\n', Comment.Single),
-            (r'[^\S\n]+', Text),
             (r'class|method|procedure', Keyword.Declaration, 'subprogram'),
             (r'(record)(\s+)(\w+)',
              bygroups(Keyword.Declaration, Text, Keyword.Type), 'type_def'),
@@ -180,7 +179,6 @@ class IconLexer(RegexLexer):
         'root': [
             (r'[^\S\n]+', Text),
             (r'#.*?\n', Comment.Single),
-            (r'[^\S\n]+', Text),
             (r'class|method|procedure', Keyword.Declaration, 'subprogram'),
             (r'(record)(\s+)(\w+)',
              bygroups(Keyword.Declaration, Text, Keyword.Type), 'type_def'),


### PR DESCRIPTION
Each of these rules was an exact duplicate of an earlier pattern within the same RegexLexer state. They were found with the following python script:

```python
from pygments.lexers import get_all_lexers, find_lexer_class
from pygments.lexer import RegexLexer

report = []
seen_classes = set()

for name, aliases, filenames, mimetypes in get_all_lexers(plugins=False):
    cls = find_lexer_class(name)
    if cls is None or cls in seen_classes:
        continue
    if not (isinstance(cls, type) and issubclass(cls, RegexLexer)):
        continue
    seen_classes.add(cls)
    # look only at tokens literally defined on THIS class (not inherited)
    toks = cls.__dict__.get('tokens')
    if not toks:
        continue
    for state, rules in toks.items():
        seen = {}
        for idx, tdef in enumerate(rules):
            if not (type(tdef) is tuple):
                continue
            pat = tdef[0]
            if not isinstance(pat, str):
                continue
            if pat in seen:
                report.append((cls.__module__.split('.')[-1], cls.__name__,
                               state, pat, seen[pat], idx))
            else:
                seen[pat] = idx

for mod, clsname, state, pat, first, dup in report:
    print(f"{mod}.py {clsname} state={state!r} rule#{dup} dup of #{first}: {pat!r}")
print(f"\nTotal in-source duplicate regexes: {len(report)}")
```