### PR TITLE
Add vimscript and viml as aliases for vim

### DIFF
--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -569,7 +569,7 @@ LEXERS = {
     'VerifpalLexer': ('pygments.lexers.verifpal', 'Verifpal', ('verifpal',), ('*.vp',), ('text/x-verifpal',)),
     'VerilogLexer': ('pygments.lexers.hdl', 'verilog', ('verilog', 'v'), ('*.v',), ('text/x-verilog',)),
     'VhdlLexer': ('pygments.lexers.hdl', 'vhdl', ('vhdl',), ('*.vhdl', '*.vhd'), ('text/x-vhdl',)),
-    'VimLexer': ('pygments.lexers.textedit', 'VimL', ('vim',), ('*.vim', '.vimrc', '.exrc', '.gvimrc', '_vimrc', '_exrc', '_gvimrc', 'vimrc', 'gvimrc'), ('text/x-vim',)),
+    'VimLexer': ('pygments.lexers.textedit', 'VimL', ('vim', 'vimscript', 'viml'), ('*.vim', '.vimrc', '.exrc', '.gvimrc', '_vimrc', '_exrc', '_gvimrc', 'vimrc', 'gvimrc'), ('text/x-vim',)),
     'VisualPrologGrammarLexer': ('pygments.lexers.vip', 'Visual Prolog Grammar', ('visualprologgrammar',), ('*.vipgrm',), ()),
     'VisualPrologLexer': ('pygments.lexers.vip', 'Visual Prolog', ('visualprolog',), ('*.pro', '*.cl', '*.i', '*.pack', '*.ph'), ()),
     'VueLexer': ('pygments.lexers.html', 'Vue', ('vue',), ('*.vue',), ()),

--- a/pygments/lexers/textedit.py
+++ b/pygments/lexers/textedit.py
@@ -115,7 +115,7 @@ class VimLexer(RegexLexer):
     Lexer for VimL script files.
     """
     name = 'VimL'
-    aliases = ['vim']
+    aliases = ['vim', 'vimscript', 'viml']
     filenames = ['*.vim', '.vimrc', '.exrc', '.gvimrc',
                  '_vimrc', '_exrc', '_gvimrc', 'vimrc', 'gvimrc']
     mimetypes = ['text/x-vim']


### PR DESCRIPTION
As per wikipedia (https://en.wikipedia.org/wiki/Vim_(text_editor)#Vim_script):

> Vim script (also called Vimscript or VimL) is the scripting language built
into Vim.