### PR TITLE
Improve BashSessionLexer

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -244,7 +244,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
             (?:\[.*?\]|\(\S+\)\s*)?
             (?:
                 # Shell name such as "sh-3.2"
-                |sh\S*?
+                |(?:ba|z)?sh\S*?
                 # Common "user@host[:path]"-style prompt fragments.
                 |\w+\S+[@:]\S+(?:\s+\S+)?
                 # Busybox puts the path before the sigil, e.g. "/var/log #"

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -244,8 +244,6 @@ class BashSessionLexer(ShellSessionBaseLexer):
                 # Prompt may start with a bracketed/parenthesized prefix, e.g. "[venv]" or "(main)".
                 (?:\[.*?\]|\(\S+\)\s*)?
                 (?:
-                    # Empty/userless prompt body
-                    |
                     # A plain whitespace body before the final prompt sigil.
                     \s
                     # Shell name such as "sh-3.2"
@@ -256,7 +254,7 @@ class BashSessionLexer(ShellSessionBaseLexer):
                     |[a-z0-9~/]+
                     # Bracketed host-style prompt fragments.
                     |\[\S+[@:][^\n]+\].+
-                )
+                )?
             )
             # Final prompt sigil and optional surrounding whitespace.
             \s*[$#%❯]\s*

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -241,11 +241,8 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _ps1rgx = re.compile(r'''
         ^(
             (?:
-                # Prompt may start with a bracketed prefix, e.g. "[venv]".
-                (?:\[.*?\])
-                |
-                # Prompt may start with a parenthesized prefix, e.g. "(venv)".
-                (?:\(\S+\))?
+                # Prompt may start with a bracketed/parenthesized prefix, e.g. "[venv]" or "(main)".
+                (?:\[.*?\]|\(\S+\)\s*)?
                 (?:
                     # Empty/userless prompt body
                     |

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -235,9 +235,36 @@ class BashSessionLexer(ShellSessionBaseLexer):
     _example = "console/example.sh-session"
 
     _innerLexerCls = BashLexer
-    _ps1rgx = re.compile(
-        r'^((?:(?:\[.*?\])|(?:\(\S+\))?(?:| |sh\S*?|\w+\S+[@:]\S+(?:\s+\S+)' \
-        r'?|\[\S+[@:][^\n]+\].+))\s*[$#%❯]\s*)(.*\n?)')
+    # Prompt detection for interactive shell sessions.
+    # Group 1 captures the full prompt prefix and Group 2 captures
+    # the command text that follows on the same line.
+    _ps1rgx = re.compile(r'''
+        ^(
+            (?:
+                # Prompt may start with a bracketed prefix, e.g. "[venv]".
+                (?:\[.*?\])
+                |
+                # Prompt may start with a parenthesized prefix, e.g. "(venv)".
+                (?:\(\S+\))?
+                (?:
+                    # Empty/userless prompt body
+                    |
+                    # A plain whitespace body before the final prompt sigil.
+                    \s
+                    # Shell name such as "sh-3.2"
+                    |sh\S*?
+                    # Common "user@host[:path]"-style prompt fragments.
+                    |\w+\S+[@:]\S+(?:\s+\S+)?
+                    # Bracketed host-style prompt fragments.
+                    |\[\S+[@:][^\n]+\].+
+                )
+            )
+            # Final prompt sigil and optional surrounding whitespace.
+            \s*[$#%❯]\s*
+        )
+        # Command entered at the prompt (optionally ending in a newline).
+        (.*\n?)
+    ''', re.VERBOSE)
     _ps2 = '> '
 
 

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -244,8 +244,6 @@ class BashSessionLexer(ShellSessionBaseLexer):
                 # Prompt may start with a bracketed/parenthesized prefix, e.g. "[venv]" or "(main)".
                 (?:\[.*?\]|\(\S+\)\s*)?
                 (?:
-                    # A plain whitespace body before the final prompt sigil.
-                    \s
                     # Shell name such as "sh-3.2"
                     |sh\S*?
                     # Common "user@host[:path]"-style prompt fragments.

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -255,6 +255,8 @@ class BashSessionLexer(ShellSessionBaseLexer):
                     |sh\S*?
                     # Common "user@host[:path]"-style prompt fragments.
                     |\w+\S+[@:]\S+(?:\s+\S+)?
+                    # Busybox puts the path before the sigil, e.g. "/var/log #"
+                    |[a-z0-9~/]+
                     # Bracketed host-style prompt fragments.
                     |\[\S+[@:][^\n]+\].+
                 )

--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -240,20 +240,18 @@ class BashSessionLexer(ShellSessionBaseLexer):
     # the command text that follows on the same line.
     _ps1rgx = re.compile(r'''
         ^(
+            # Prompt may start with a bracketed/parenthesized prefix, e.g. "[venv]" or "(main)".
+            (?:\[.*?\]|\(\S+\)\s*)?
             (?:
-                # Prompt may start with a bracketed/parenthesized prefix, e.g. "[venv]" or "(main)".
-                (?:\[.*?\]|\(\S+\)\s*)?
-                (?:
-                    # Shell name such as "sh-3.2"
-                    |sh\S*?
-                    # Common "user@host[:path]"-style prompt fragments.
-                    |\w+\S+[@:]\S+(?:\s+\S+)?
-                    # Busybox puts the path before the sigil, e.g. "/var/log #"
-                    |[a-z0-9~/]+
-                    # Bracketed host-style prompt fragments.
-                    |\[\S+[@:][^\n]+\].+
-                )?
-            )
+                # Shell name such as "sh-3.2"
+                |sh\S*?
+                # Common "user@host[:path]"-style prompt fragments.
+                |\w+\S+[@:]\S+(?:\s+\S+)?
+                # Busybox puts the path before the sigil, e.g. "/var/log #"
+                |[a-z0-9~/]+
+                # Bracketed host-style prompt fragments.
+                |\[\S+[@:][^\n]+\].+
+            )?
             # Final prompt sigil and optional surrounding whitespace.
             \s*[$#%❯]\s*
         )

--- a/tests/examplefiles/console/example.sh-session
+++ b/tests/examplefiles/console/example.sh-session
@@ -16,4 +16,5 @@ root@host:~#
 sh-3.1$ # on hardy
 sh$ # on etch
 (virtualenv-name)user@host:~$ ls -a
+[main] user@host:~$ ls -a
 

--- a/tests/examplefiles/console/example.sh-session
+++ b/tests/examplefiles/console/example.sh-session
@@ -17,4 +17,5 @@ sh-3.1$ # on hardy
 sh$ # on etch
 (virtualenv-name)user@host:~$ ls -a
 [main] user@host:~$ ls -a
+/var/log # pwd
 

--- a/tests/examplefiles/console/example.sh-session
+++ b/tests/examplefiles/console/example.sh-session
@@ -18,4 +18,7 @@ sh$ # on etch
 (virtualenv-name)user@host:~$ ls -a
 [main] user@host:~$ ls -a
 /var/log # pwd
+/usr/lib # /usr/bin/id
+uid=0(root) gid=0(root)
+/usr/lib # 
 

--- a/tests/examplefiles/console/example.sh-session.output
+++ b/tests/examplefiles/console/example.sh-session.output
@@ -59,3 +59,5 @@
 ' '           Text.Whitespace
 '-a'          Text
 '\n'          Text.Whitespace
+
+'[main] user@host:~$ ls -a\n' Generic.Output

--- a/tests/examplefiles/console/example.sh-session.output
+++ b/tests/examplefiles/console/example.sh-session.output
@@ -65,3 +65,11 @@
 '/var/log # ' Generic.Prompt
 'pwd'         Name.Builtin
 '\n'          Text.Whitespace
+
+'/usr/lib # ' Generic.Prompt
+'/usr/bin/id' Text
+'\n'          Text.Whitespace
+
+'uid=0(root) gid=0(root)\n' Generic.Output
+
+'/usr/lib # \n' Generic.Prompt

--- a/tests/examplefiles/console/example.sh-session.output
+++ b/tests/examplefiles/console/example.sh-session.output
@@ -61,3 +61,7 @@
 '\n'          Text.Whitespace
 
 '[main] user@host:~$ ls -a\n' Generic.Output
+
+'/var/log # ' Generic.Prompt
+'pwd'         Name.Builtin
+'\n'          Text.Whitespace

--- a/tests/snippets/console/test_comment_after_prompt.txt
+++ b/tests/snippets/console/test_comment_after_prompt.txt
@@ -1,6 +1,6 @@
 ---input---
-$# comment
+$ # comment
 
 ---tokens---
-'$'           Generic.Prompt
+'$ '          Generic.Prompt
 '# comment\n' Comment.Single


### PR DESCRIPTION
This pull-request is split in different commits to make it easier to review, feel free to squash it before merging it.

Long story short, I noticed that the shell sessions on https://dustri.org/b/running-the-packaged-arr-stack-on-alpine.html weren't looking good highlight-wise, so I wanted to improve BashSessionLexer. Because the regex was a tad cryptic, I spent some time tidying things up before piling more stuff on top of it.