### PR TITLE
Ruby: treat << after ), ], } as the shift operator, not a heredoc

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,8 @@ Version 2.21.0
     whitespace, so identifiers like ``modules`` and ``module.exports``
     are highlighted correctly (#2823)
   * Ruby: Don't duplicate the body of an unterminated heredoc (#2998)
+  * Ruby: Treat ``<<`` after ``)``, ``]`` or ``}`` as the shift operator
+    rather than the start of a heredoc (#760)
   * Kotlin: Don't let a nullable type marker (``?``) consume the following
     character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
   * YAML: Add ``yml`` alias (#3169)

--- a/pygments/lexers/ruby.py
+++ b/pygments/lexers/ruby.py
@@ -253,7 +253,7 @@ class RubyLexer(ExtendedRegexLexer):
              Name.Builtin),
             (r'__(FILE|LINE)__\b', Name.Builtin.Pseudo),
             # normal heredocs
-            (r'(?<!\w)(<<[-~]?)(["`\']?)([a-zA-Z_]\w*)(\2)(.*?\n)',
+            (r'(?<![\w)\]}])(<<[-~]?)(["`\']?)([a-zA-Z_]\w*)(\2)(.*?\n)',
              heredoc_callback),
             # empty string heredocs
             (r'(<<[-~]?)("|\')()(\2)(.*?\n)', heredoc_callback),

--- a/tests/snippets/ruby/test_shift_operator.txt
+++ b/tests/snippets/ruby/test_shift_operator.txt
@@ -1,0 +1,9 @@
+---input---
+[]<<a
+
+---tokens---
+'['           Operator
+']'           Operator
+'<<'          Operator
+'a'           Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #760.

The bareword heredoc rule in `RubyLexer` used a `(?<!\w)` lookbehind. That rejects `a<<b` (word char before `<<`), but `)`, `]` and `}` are not word characters, so `<<` immediately after a closing bracket was wrongly started as a heredoc. After a closing `)`/`]`/`}` the parser is in an expression-end state, so `<<` there is the left-shift/append operator.

Example — `[]<<a` before:

```
Operator '['
Operator ']'
Operator '<<'
String.Heredoc ''
String.Delimiter 'a'
String.Heredoc ''
```

after:

```
Operator '['
Operator ']'
Operator '<<'
Name 'a'
```

The fix extends the lookbehind to `(?<![\w)\]}])` on the "normal heredocs" rule only. Verified that genuine heredocs are unaffected, including ones that legitimately follow `(` or `[` (e.g. `foo(<<A)`, `[<<A]`), as well as `<<~` / `<<-` forms.

Added a snippet test `tests/snippets/ruby/test_shift_operator.txt` and a `CHANGES` entry.

Scope: this targets the `)`/`]`/`}` case from the issue. Two related cases are intentionally left for separate follow-ups — `<<` after a string literal (`"foo"<<bar`) and the empty-delimiter `<<""` heredoc rule — since they involve different rules and tradeoffs.
