### PR TITLE
Remove redundant validation on already escaped filename field

### DIFF
--- a/pygments/formatters/html.py
+++ b/pygments/formatters/html.py
@@ -416,7 +416,7 @@ class HtmlFormatter(Formatter):
         self.noclobber_cssfile = get_bool_opt(options, 'noclobber_cssfile', False)
         self.tagsfile = self._decodeifneeded(options.get('tagsfile', ''))
         self.tagurlformat = self._decodeifneeded(options.get('tagurlformat', ''))
-        self.filename = html_escape(self._decodeifneeded(options.get('filename', '') or ''))
+        self.filename = html_escape(self._decodeifneeded(options.get('filename', '')))
         self.wrapcode = get_bool_opt(options, 'wrapcode', False)
         self.span_element_openers = {}
         self.debug_token_types = get_bool_opt(options, 'debug_token_types', False)


### PR DESCRIPTION
Hi,

Just a quick PR to address my comment on closed issue https://github.com/pygments/pygments/issues/3077#issuecomment-4380341716.

As a reminder , the comment:

> Hi all,
> 
> Sorry to raise again this topic, just read it now, but I think there is an overlap between #3076 and #3077, and their resolutions.
> 
> @pellepim, the solution in PR #3090 wasn't merged at the time of your analysis. So, regarding PR #3016, ` or '')` in `self.filename = html.escape(self._decodeifneeded(options.get('filename') or ''))` will work but is redondant to the `html_escape` solution and respond only to the filename issue, not to other escaped fields. Also, it will not handle other type of values, like `int` (see lepture/shibuya/issues/113). I did the same mistake in #3078, amended by PR #3090 to address it.
> 
> I use zensical rather than mkdocs, but I am fairly sure that this is the same thing. superfences swallows the exception silently and the raw backtick markup passes through to the Markdown block parser, which renders it as inline < code > with the language hint visible as text.
> 
> Correct and a good catch, didn't saw this relationship.
> 
> So #3090 will handle it in this case.
> 
> **Proposals to fix the redondant fix** @Anteru , @birkenfeld :
> - Revert commit b6f6dab78e13652741d5e5811b4256b4dcb5fcd8. Will also remove the test.
> - A new PR to remove ` or '')` on escaped filename field. We can let the test which is correct.
> 
> Best regards. 

 _Originally posted by @styx0x6 in [#3077](https://github.com/pygments/pygments/issues/3077#issuecomment-4380341716)_

