### PR TITLE
Mathematica: recognize \[Name] named-character escapes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -37,6 +37,8 @@ Version 2.21.0
     character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
   * YAML: Add ``yml`` alias (#3169)
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
+  * Mathematica: Recognize ``\[Name]`` named-character escapes such as
+    ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/algebra.py
+++ b/pygments/lexers/algebra.py
@@ -177,6 +177,9 @@ class MathematicaLexer(RegexLexer):
         'root': [
             (r'(?s)\(\*.*?\*\)', Comment),
 
+            # Named character escapes, e.g. \[Nu], \[CapitalAlpha].
+            (r'\\\[[A-Za-z][A-Za-z0-9]*\]', String.Escape),
+
             (r'([a-zA-Z]+[A-Za-z0-9]*`)', Name.Namespace),
             (r'([A-Za-z0-9]*_+[A-Za-z0-9]*)', Name.Variable),
             (r'#\d*', Name.Variable),

--- a/tests/snippets/mathematica/test_named_character.txt
+++ b/tests/snippets/mathematica/test_named_character.txt
@@ -1,0 +1,15 @@
+# Named-character escapes such as \[Nu] must not produce Error tokens.
+# See https://github.com/pygments/pygments/issues/3097
+
+---input---
+(45*\[Nu])/32
+
+---tokens---
+'('           Punctuation
+'45'          Literal.Number.Integer
+'*'           Operator
+'\\[Nu]'      Literal.String.Escape
+')'           Punctuation
+'/'           Operator
+'32'          Literal.Number.Integer
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #3097.

## Summary

Since 2.20, highlighting valid Mathematica/Wolfram code that contains a named-character escape such as `\[Nu]` produces a `Token.Error`, which surfaces as a Sphinx `misc.highlighting_failure` warning. For example, lexing `(45*\[Nu])/32` yielded `(Token.Error, \)` followed by `[`, `Nu`, `]` tokenized separately.

The `MathematicaLexer` (in `pygments/lexers/algebra.py`) had no rule for the `\[Name]` named-character escape syntax, so the leading backslash was left unmatched and emitted as an `Error` token.

## Fix

Add a rule to the lexer's `root` state that matches `\[Name]` named-character escapes (e.g. `\[Nu]`, `\[CapitalAlpha]`) and tokenizes each as a single `String.Escape` token instead of an `Error`.

```python
# Named character escapes, e.g. \[Nu], \[CapitalAlpha].
(r'\\\[[A-Za-z][A-Za-z0-9]*\]', String.Escape),
```

## Tests

- Added `tests/snippets/mathematica/test_named_character.txt`, a golden snippet test for the issue's reproducer `(45*\[Nu])/32`. It fails on the pristine lexer (records `'\\' Error`) and passes with the fix (`'\\[Nu]' Literal.String.Escape`).
- Full golden suite (`tests/snippets/` + `tests/examplefiles/`) and the rest of `tests/` pass; `ruff check --ignore UP031 .`, `scripts/check_sources.py`, and `regexlint` are clean.
- Added a `CHANGES` entry under "Updated lexers".

Disclosure: prepared with AI assistance; reviewed and verified locally.