### PR TITLE
[Bug] Fix hexdump regex to only match valid hex digits

### DIFF
--- a/pygments/lexers/hexdump.py
+++ b/pygments/lexers/hexdump.py
@@ -39,7 +39,7 @@ class HexdumpLexer(RegexLexer):
     url = 'https://en.wikipedia.org/wiki/Hex_dump'
     version_added = '2.1'
 
-    hd = r'[0-9A-Ha-h]'
+    hd = r'[0-9A-Fa-f]'
 
     tokens = {
         'root': [


### PR DESCRIPTION
Fixes the character range in the hexdump lexer regex from `[0-9A-Ha-h]` to `[0-9A-Fa-f]`.

The letters G, H, g, h are not valid hexadecimal digits and were incorrectly included in the pattern.

Fixes #2847