### PR TITLE
Groff formatter: don't duplicate a character when word-wrapping

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,8 @@ Version 2.21.0
 - LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
   options when ``escapeinside`` is set, so blank lines are no longer stripped
   under ``stripnl=false`` (#2975)
+- Groff formatter: don't duplicate a character when word-wrapping (``wrap``)
+  a token that is not at the end of a line (#3201)
 
 Version 2.20.0
 --------------

--- a/pygments/formatters/groff.py
+++ b/pygments/formatters/groff.py
@@ -104,7 +104,7 @@ class GroffFormatter(Formatter):
                 newline += (chunk + '\n' + space)
             remainder = length % self.wrap
             if remainder > 0:
-                newline += line[-remainder-1:]
+                newline += line[length-remainder:]
                 self._linelen = remainder
         elif self._linelen + length > self.wrap:
             newline = ('\n' + space) + line

--- a/tests/test_groff_formatter.py
+++ b/tests/test_groff_formatter.py
@@ -78,3 +78,16 @@ def test_inheritance_custom_tokens():
 
 .fi"""
     assert highlight("ab", ToyLexer(), GroffFormatter(style=ToyStyle)) == expected
+
+
+def test_wrap_does_not_duplicate_characters():
+    # A piece longer than ``wrap`` that does not end in a newline must not
+    # have a character duplicated when it is soft-wrapped. The tail slice used
+    # to reach one character too far to the left when there was no trailing
+    # newline, repeating the last character of the preceding full chunk.
+    fmt = GroffFormatter(wrap=4)
+    assert fmt._wrap_line("abcdefghij") == "abcd\nefgh\nij"
+
+    # A piece that does end in a newline still keeps that trailing newline.
+    fmt = GroffFormatter(wrap=4)
+    assert fmt._wrap_line("123456\n") == "1234\n56\n"


### PR DESCRIPTION
### The bug

`GroffFormatter` with the `wrap` option duplicates a character whenever a token longer than `wrap` is not at the end of a line:

```python
>>> from pygments.formatters import GroffFormatter
>>> GroffFormatter(wrap=4)._wrap_line("abcdefghij")
'abcd\nefgh\nhij'          # reconstructs to 'abcdefghhij' (11 chars); the 'h' is duplicated
```

Rendering real code shows it too: highlighting `abcdefghij = 1` with `GroffFormatter(wrap=4)` emits the identifier as `abcdefghhij`.

### Root cause

`_wrap_line` emits `floor(length / wrap)` full-width chunks and then appends the leftover characters with:

```python
remainder = length % self.wrap
if remainder > 0:
    newline += line[-remainder-1:]
```

The `-1` is there to also carry along the single trailing newline. That is only correct when `line` actually ends in `\n`. But `_wrap_line` is called per token piece (from `value.splitlines(True)` in `format_unencoded`), and a mid-line piece has no trailing newline. For such a piece the negative slice `line[-remainder-1:]` reaches one character too far to the left, so the last character of the preceding full-width chunk is repeated in the remainder.

### Fix

Slice from `length - remainder`, i.e. `floor(length / wrap) * wrap`, the exact offset where the full-width chunk loop stopped:

```python
newline += line[length-remainder:]
```

This returns precisely the remaining `remainder` content characters plus any trailing newline (since `length` excludes a trailing `\n`), so it is correct whether or not the piece ends in a newline. Lines that do end in `\n` are unchanged.

### Test

Added `test_wrap_does_not_duplicate_characters` to `tests/test_groff_formatter.py` (which had no `wrap` coverage). It asserts `_wrap_line("abcdefghij") == "abcd\nefgh\nij"` (fails before the fix with a trailing `hij`) and that a newline-terminated piece keeps its trailing newline. The existing groff tests still pass.

I can add a `CHANGES` entry referencing this PR number if you'd like.