### PR TITLE
INI: fix quoted continuation values with colons

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ Version 2.21.0
 - Updated lexers:
 
   * Boogie: Add missing Boogie and Civl Verifier keywords (#3156)
+  * INI: Don't treat quoted continuation values containing colons as keys (#2844)
   * C++: Add C23/C++26 attributes (#3084)
   * D: Allow non-ASCII (Unicode) identifiers (#1088)
   * CUDA: Derive from the C++ lexer instead of C to highlight C++

--- a/pygments/lexers/configs.py
+++ b/pygments/lexers/configs.py
@@ -44,7 +44,7 @@ class IniLexer(RegexLexer):
             (r'\s+', Whitespace),
             (r'[;#].*', Comment.Single),
             (r'(\[.*?\])([ \t]*)$', bygroups(Keyword, Whitespace)),
-            (r'''(.*?)([ \t]*)([=:])([ \t]*)(["'])''',
+            (r'''(?![ \t]*["'])(.*?)([ \t]*)([=:])([ \t]*)(["'])''',
              bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String),
              "quoted_value"),
             (r'(.*?)([ \t]*)([=:])([ \t]*)([^;#\n]*)(\\)(\s+)',

--- a/tests/snippets/ini/test_quoted_entries.txt
+++ b/tests/snippets/ini/test_quoted_entries.txt
@@ -3,6 +3,9 @@
     key 1 = "value1"
     key 2 = "value2" # comment
     key 3 = "value3 ; value 3bis" ; comment
+    key 4 = [
+        'value4:',
+    ]
 
 ---tokens---
 '[section]'   Keyword
@@ -34,4 +37,16 @@
 '"'           Literal.String
 ' '           Text.Whitespace
 '; comment'   Comment.Single
+'\n    '      Text.Whitespace
+'key 4'       Name.Attribute
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Literal.String
+'\n        '  Text.Whitespace
+"'value4"     Name.Attribute
+':'           Operator
+"',"          Literal.String
+'\n    '      Text.Whitespace
+']'           Name.Attribute
 '\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #2844. The INI lexer's quoted-value rule was also matching indented continuation lines beginning with a quote, causing a colon inside the value to end it early and the following comma to become an `Error` token. Excluding quote-prefixed continuation lines keeps the existing quoted assignment handling while allowing the reported multiline value to tokenize without errors.
