### PR TITLE
Python: distinguish exception chaining from imports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,40 +15,56 @@ Version 2.21.0
 
 - Updated lexers:
 
+  * Bash: Fix coloured keyword at the beginning of a name (#2926)
   * Boogie: Add missing Boogie and Civl Verifier keywords (#3156)
-  * C++: Add C23/C++26 attributes (#3084)
-  * D: Allow non-ASCII (Unicode) identifiers (#1088)
+  * Clojure: Recognize named, octal and unicode character literals such as
+    ``\space`` and ``\o377`` as a single token (#979)
   * CUDA: Derive from the C++ lexer instead of C to highlight C++
     constructs such as ``template``, ``class`` and ``namespace`` (#3127)
-  * Markdown: Highlight bold-italics (``***...***`` and ``___...___``) (#3067)
-  * Python: Distinguish exception chaining from import statements (#2880)
-  * WebAssembly: Recognize sign-extension operators (#2991, #3160)
+  * C++: Add C23/C++26 attributes (#3084)
   * C++: Highlight a function following a namespace body (#2928)
+  * C#: Recognize interpolated verbatim strings with either ``$@`` or ``@$``
+    prefixes (#2685)
+  * D: Allow non-ASCII (Unicode) identifiers (#1088)
   * JavaScript: Highlight the ``arguments`` object (#3146)
+  * Jsonnet: Recognize colons in array slice expressions (#2828)
+  * JSX: Allow apostrophes in element text (#2816)
+  * Kotlin: Support companion objects without an explicit name (#2525)
+  * Kotlin: Don't let a nullable type marker (``?``) consume the following
+    character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
+  * Kusto: Recognize member-access dots in dynamic objects (#2779)
+  * Markdown: Highlight bold-italics (``***...***`` and ``___...___``) (#3067)
+  * Markdown, reStructuredText, TiddlyWiki5: Fix wrong token offsets for
+    embedded code blocks (#3133)
+  * Mathematica: Recognize ``\[Name]`` named-character escapes such as
+    ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
   * MATLAB, Octave, Scilab: Allow ``...`` line continuations in function
     definition signatures (#659)
-  * Tcl: Stop ``$name`` variable references at a dash (#1720)
-  * TypeScript: Only treat ``module`` as a keyword when followed by
-    whitespace, so identifiers like ``modules`` and ``module.exports``
-    are highlighted correctly (#2823)
+  * Python: Distinguish exception chaining from import statements (#2880)
   * Ruby: Don't duplicate the body of an unterminated heredoc (#2998)
   * Ruby: Treat ``<<`` after ``)``, ``]`` or ``}`` as the shift operator
     rather than the start of a heredoc (#760)
-  * Kotlin: Don't let a nullable type marker (``?``) consume the following
-    character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
-  * YAML: Add ``yml`` alias (#3169)
+  * SCSS: Recognize variable references in property values (#2818)
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
-  * Mathematica: Recognize ``\[Name]`` named-character escapes such as
-    ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Tcl: Stop ``$name`` variable references at a dash (#1720)
+  * TeX: Recognize LaTeX math environments as math (#3034)
+  * TypeScript: Only treat ``module`` as a keyword when followed by
+    whitespace, so identifiers like ``modules`` and ``module.exports``
+    are highlighted correctly (#2823)
+  * YAML: Add ``yml`` alias (#3169)
+  * Vala: Recognize verbatim strings before ordinary quoted strings (#2861)
+  * Vala: Recognize conditional compilation directives (#2858)
+  * WebAssembly: Recognize sign-extension operators (#2991, #3160)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)
 - Improve handling of non-string types in ``html_escape`` to fix broken clients (#3090, #3086)
-- Fix wrong token offsets for embedded code blocks in the Markdown, reStructuredText
-  and TiddlyWiki5 lexers (#3133)
 - LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
   options when ``escapeinside`` is set, so blank lines are no longer stripped
   under ``stripnl=false`` (#2975)
+- RawTokenFormatter: fix a crash when ``error_color`` is set (#3215)
+- Groff formatter: don't duplicate a character when word-wrapping (``wrap``)
+  a token that is not at the end of a line (#3201)
 
 Version 2.20.0
 --------------

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ Version 2.21.0
   * CUDA: Derive from the C++ lexer instead of C to highlight C++
     constructs such as ``template``, ``class`` and ``namespace`` (#3127)
   * Markdown: Highlight bold-italics (``***...***`` and ``___...___``) (#3067)
+  * Python: Distinguish exception chaining from import statements (#2880)
   * WebAssembly: Recognize sign-extension operators (#2991, #3160)
   * C++: Highlight a function following a namespace body (#2928)
   * JavaScript: Highlight the ``arguments`` object (#3146)

--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -119,10 +119,12 @@ class PythonLexer(RegexLexer):
             (r'^(lazy)((?:\s|\\\s)+)(import)((?:\s|\\\s)+)',
              bygroups(Keyword.Namespace, Whitespace, Keyword.Namespace, Whitespace),
              'import'),
-            (r'(from)((?:\s|\\\s)+)', bygroups(Keyword.Namespace, Whitespace),
-             'fromimport'),
+            (r'(from)((?:\s|\\\s)+)(?=(?:\.*' + uni_name + r'|\.+)'
+             r'(?:\s*\.\s*' + uni_name + r')*\s+import\b)',
+             bygroups(Keyword.Namespace, Whitespace), 'fromimport'),
             (r'(import)((?:\s|\\\s)+)', bygroups(Keyword.Namespace, Whitespace),
              'import'),
+            (r'from\b', Keyword),
             include('expr'),
         ],
         'expr': [

--- a/tests/examplefiles/python/linecontinuation.py.output
+++ b/tests/examplefiles/python/linecontinuation.py.output
@@ -49,9 +49,12 @@
 'path'        Name
 '\n'          Text.Whitespace
 
-'from'        Keyword.Namespace
-' \\\n        ' Text.Whitespace
-'os'          Name.Namespace
+'from'        Keyword
+' '           Text
+'\\\n'        Text
+
+'        '    Text
+'os'          Name
 ' '           Text
 '\\\n'        Text
 

--- a/tests/snippets/python/test_exception_chaining.txt
+++ b/tests/snippets/python/test_exception_chaining.txt
@@ -1,0 +1,38 @@
+# Regression test for exception chaining being recognized as an import (#2880)
+
+---input---
+try:
+    raise Exception
+except Exception as error:
+    raise RuntimeError from error
+
+---tokens---
+'try'         Keyword
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text
+'raise'       Keyword
+' '           Text
+'Exception'   Name.Exception
+'\n'          Text.Whitespace
+
+'except'      Keyword
+' '           Text
+'Exception'   Name.Exception
+' '           Text
+'as'          Keyword
+' '           Text
+'error'       Name
+':'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text
+'raise'       Keyword
+' '           Text
+'RuntimeError' Name.Exception
+' '           Text
+'from'        Keyword
+' '           Text
+'error'       Name
+'\n'          Text.Whitespace


### PR DESCRIPTION
`raise ... from error` currently enters the import lexer state, highlighting `from` and the cause as a namespace import. This only enters that state when an `import` keyword follows, preserving absolute and relative imports while tokenizing exception chaining correctly.

Fixes #2880.
