### PR TITLE
TeX: recognize math environments (#3034)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Version 2.21.0
 - LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
   options when ``escapeinside`` is set, so blank lines are no longer stripped
   under ``stripnl=false`` (#2975)
+- Recognize LaTeX math environments as math in the TeX lexer (#3034)
 
 Version 2.20.0
 --------------

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -305,6 +305,9 @@ class TexLexer(RegexLexer):
             (r'[&_^]', Name.Builtin),
         ],
         'root': [
+            (r'(\\begin)(\{)((?:display)?math|equation\*?|align\*?)(\})',
+             bygroups(Keyword, Name.Builtin, Name.Builtin, Name.Builtin),
+             'environmentmath'),
             (r'\\\[', String.Backtick, 'displaymath'),
             (r'\\\(', String, 'inlinemath'),
             (r'\$\$', String.Backtick, 'displaymath'),
@@ -330,6 +333,11 @@ class TexLexer(RegexLexer):
             (r'\\\]', String, '#pop'),
             (r'\$\$', String, '#pop'),
             (r'\$', Name.Builtin),
+            include('math'),
+        ],
+        'environmentmath': [
+            (r'(\\end)(\{)((?:display)?math|equation\*?|align\*?)(\})',
+             bygroups(Keyword, Name.Builtin, Name.Builtin, Name.Builtin), '#pop'),
             include('math'),
         ],
         'command': [

--- a/tests/test_markup.py
+++ b/tests/test_markup.py
@@ -6,7 +6,11 @@
     :license: BSD, see LICENSE for details.
 """
 
-from pygments.lexers.markup import MarkdownLexer, RstLexer, TiddlyWiki5Lexer
+import pytest
+
+from pygments.lexers.markup import (
+    MarkdownLexer, RstLexer, TexLexer, TiddlyWiki5Lexer)
+from pygments.token import Name, Operator
 
 
 def assert_token_offsets(lexer, text):
@@ -47,3 +51,15 @@ def test_rst_code_block_offsets():
 
 def test_tiddlywiki_code_block_offsets():
     assert_token_offsets(TiddlyWiki5Lexer(), TIDDLYWIKI_CODE)
+
+
+@pytest.mark.parametrize('environment', [
+    'math', 'displaymath', 'equation', 'equation*', 'align', 'align*',
+])
+def test_tex_math_environments(environment):
+    tokens = list(TexLexer().get_tokens(
+        rf'\begin{{{environment}}}x+1\end{{{environment}}}'
+    ))
+
+    assert (Name.Builtin, 'x') in tokens
+    assert (Operator, '+') in tokens


### PR DESCRIPTION
LaTeX math environments such as `equation` and `align` were lexed as ordinary text, unlike `$...$` and `\[...\]`. Enter a math state for the standard `math`, `displaymath`, `equation`, and `align` environments (including starred forms), with regression coverage.

Fixes #3034.
