### PR TITLE
Vala: recognize regex literals after opening parentheses

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,9 @@ Version 2.21.0
 
 - Updated lexers:
 
+  * Vala: Recognize regular expression literals after an opening parenthesis
+    (#2860)
+
   * Boogie: Add missing Boogie and Civl Verifier keywords (#3156)
   * C++: Add C23/C++26 attributes (#3084)
   * D: Allow non-ASCII (Unicode) identifiers (#1088)

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -201,6 +201,8 @@ class ValaLexer(RegexLexer):
             (r'/(\\\n)?[*][\s\S]*?[*](\\\n)?/', Comment.Multiline),
         ],
         'statements': [
+            (r'(\()(\s*)(/(?:\\.|[^/\\\n])*/[ismxo]*)',
+             bygroups(Punctuation, Whitespace, String.Regex)),
             (r'[L@]?"', String, 'string'),
             (r"L?'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])'",
              String.Char),

--- a/tests/snippets/vala/2860.txt
+++ b/tests/snippets/vala/2860.txt
@@ -1,0 +1,48 @@
+---input---
+string email = "tux@kernel.org";
+if (/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.match(email)) {
+    stdout.printf("Valid email address\n");
+}
+
+---tokens---
+'string'      Keyword.Type
+' '           Text.Whitespace
+'email'       Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String
+'tux@kernel.org' Literal.String
+'"'           Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+'/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,4}$/i' Literal.String.Regex
+'.'           Punctuation
+'match'       Name
+'('           Punctuation
+'email'       Name
+')'           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'stdout'      Name
+'.'           Punctuation
+'printf'      Name
+'('           Punctuation
+'"'           Literal.String
+'Valid email address' Literal.String
+'\\n'         Literal.String.Escape
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Vala regex literals inside conditions were split into operators and names, producing Error tokens for valid characters such as `@`. Recognize slash-delimited regex literals after an opening parenthesis and add the reported example as a lexer fixture.

Fixes #2860
