### PR TITLE
Vala: recognize verbatim strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@ Version 2.21.0
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Vala: Recognize verbatim strings before ordinary quoted strings (#2861)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -201,10 +201,10 @@ class ValaLexer(RegexLexer):
             (r'/(\\\n)?[*][\s\S]*?[*](\\\n)?/', Comment.Multiline),
         ],
         'statements': [
+            (r'(?s)""".*?"""', String),  # verbatim strings
             (r'[L@]?"', String, 'string'),
             (r"L?'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])'",
              String.Char),
-            (r'(?s)""".*?"""', String),  # verbatim strings
             (r'(\d+\.\d*|\.\d+|\d+)[eE][+-]?\d+[lL]?', Number.Float),
             (r'(\d+\.\d*|\.\d+|\d+[fF])[fF]?', Number.Float),
             (r'0x[0-9a-fA-F]+[Ll]?', Number.Hex),

--- a/tests/snippets/vala/verbatim-string.txt
+++ b/tests/snippets/vala/verbatim-string.txt
@@ -1,0 +1,15 @@
+---input---
+string verbatim = """This is a so-called "verbatim string".
+   Verbatim strings don't process escape sequences, such as \n, \t, \\, etc.
+   They may contain quotes and may span multiple lines.""";
+
+---tokens---
+'string'      Keyword.Type
+' '           Text.Whitespace
+'verbatim'    Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"""This is a so-called "verbatim string".\n   Verbatim strings don\'t process escape sequences, such as \\n, \\t, \\\\, etc.\n   They may contain quotes and may span multiple lines."""' Literal.String
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Vala's ordinary quote rule matched the first `"` of a triple-quoted verbatim string, making its contents fall back to ordinary code tokens and producing errors for valid backslashes. Match the existing verbatim-string rule first so the full multiline value is emitted as one string token; the reported example is covered by a golden test.

Fixes #2861
