### PR TITLE
Vala: recognize conditional compilation directives

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@ Version 2.21.0
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Vala: Recognize conditional compilation directives (#2858)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/c_like.py
+++ b/pygments/lexers/c_like.py
@@ -194,6 +194,7 @@ class ValaLexer(RegexLexer):
     tokens = {
         'whitespace': [
             (r'^\s*#if\s+0', Comment.Preproc, 'if0'),
+            (r'^\s*#(?:if|elif|else|endif)\b[^\n]*', Comment.Preproc),
             (r'\n', Whitespace),
             (r'\s+', Whitespace),
             (r'\\\n', Text),  # line continuation

--- a/tests/snippets/vala/2858.txt
+++ b/tests/snippets/vala/2858.txt
@@ -1,0 +1,82 @@
+---input---
+int main (string[] args) {
+   #if COND
+     message ("COND IS DEFINED");
+   #elif OTHER_COND
+     message ("OTHER_COND IS DEFINED");
+   #else
+     message ("COND IS NOT DEFINED");
+   #endif
+   return 0;
+}
+
+---tokens---
+'int'         Keyword.Type
+' '           Text.Whitespace
+'main'        Name
+' '           Text.Whitespace
+'('           Punctuation
+'string'      Keyword.Type
+'['           Punctuation
+']'           Punctuation
+' '           Text.Whitespace
+'args'        Name
+')'           Punctuation
+' '           Text.Whitespace
+'{'           Punctuation
+'\n'          Text.Whitespace
+
+'   #if COND' Comment.Preproc
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'message'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'"'           Literal.String
+'COND IS DEFINED' Literal.String
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'   #elif OTHER_COND' Comment.Preproc
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'message'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'"'           Literal.String
+'OTHER_COND IS DEFINED' Literal.String
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'   #else'    Comment.Preproc
+'\n'          Text.Whitespace
+
+'     '       Text.Whitespace
+'message'     Name
+' '           Text.Whitespace
+'('           Punctuation
+'"'           Literal.String
+'COND IS NOT DEFINED' Literal.String
+'"'           Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'   #endif'   Comment.Preproc
+'\n'          Text.Whitespace
+
+'   '         Text.Whitespace
+'return'      Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
The Vala lexer only special-cased `#if 0`, so valid `#if`, `#elif`, `#else`, and `#endif` lines emitted `Error` tokens for `#`. This recognizes those lines as preprocessor directives and adds a golden regression snippet based on the report.

Fixes #2858.
