### PR TITLE
Jsonnet: recognize array slice colons (#2828)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Version 2.21.0
   * WebAssembly: Recognize sign-extension operators (#2991, #3160)
   * C++: Highlight a function following a namespace body (#2928)
   * JavaScript: Highlight the ``arguments`` object (#3146)
+  * Jsonnet: Recognize colons in array slice expressions (#2828)
   * MATLAB, Octave, Scilab: Allow ``...`` line continuations in function
     definition signatures (#659)
   * Tcl: Stop ``$name`` variable references at a dash (#1720)

--- a/pygments/lexers/jsonnet.py
+++ b/pygments/lexers/jsonnet.py
@@ -57,9 +57,7 @@ class JsonnetLexer(RegexLexer):
             (r'\|\|\|(.|\n)*\|\|\|', String),
             # Jsonnet has no integers, only an IEEE754 64-bit float
             (r'[+-]?[0-9]+(.[0-9])?', Number.Float),
-            # Omit : despite spec because it appears to be used as a field
-            # separator
-            (r'[!$~+\-&|^=<>*/%]', Operator),
+            (r'[!$~+\-&|^=<>*/%:]', Operator),
             (r'\{', Punctuation, 'object'),
             (r'\[', Punctuation, 'array'),
             (r'local\b', Keyword, ('local_name')),

--- a/tests/snippets/jsonnet/test_array_slice.txt
+++ b/tests/snippets/jsonnet/test_array_slice.txt
@@ -1,0 +1,63 @@
+---input---
+{
+  local numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  even_numbers: numbers[1::2],
+}
+
+---tokens---
+'{'           Punctuation
+'\n  '        Text.Whitespace
+'local'       Keyword
+' '           Text.Whitespace
+'numbers'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'['           Punctuation
+'1'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'2'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'3'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'4'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'5'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'6'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'7'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'8'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'9'           Literal.Number.Float
+','           Punctuation
+' '           Text.Whitespace
+'10'          Literal.Number.Float
+']'           Punctuation
+','           Punctuation
+'\n  '        Text.Whitespace
+''            Text
+'even_numbers' Name.Variable
+':'           Punctuation
+' '           Text.Whitespace
+'numbers'     Name.Variable
+'['           Punctuation
+'1'           Literal.Number.Float
+':'           Operator
+':'           Operator
+'2'           Literal.Number.Float
+']'           Punctuation
+','           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Jsonnet array slice colons currently fall through to `Error` tokens. This adds `:` to the lexer’s operator rule and covers the reported stride syntax with a golden lexer fixture.

Fixes #2828
