### PR TITLE
YAML: recognize non-breaking spaces

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,7 +35,8 @@ Version 2.21.0
     rather than the start of a heredoc (#760)
   * Kotlin: Don't let a nullable type marker (``?``) consume the following
     character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
-  * YAML: Add ``yml`` alias (#3169)
+  * YAML: Add ``yml`` alias (#3169), recognize non-breaking spaces as valid
+    scalar content (#2827)
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)

--- a/CHANGES
+++ b/CHANGES
@@ -15,40 +15,56 @@ Version 2.21.0
 
 - Updated lexers:
 
+  * Bash: Fix coloured keyword at the beginning of a name (#2926)
   * Boogie: Add missing Boogie and Civl Verifier keywords (#3156)
-  * C++: Add C23/C++26 attributes (#3084)
-  * D: Allow non-ASCII (Unicode) identifiers (#1088)
+  * Clojure: Recognize named, octal and unicode character literals such as
+    ``\space`` and ``\o377`` as a single token (#979)
   * CUDA: Derive from the C++ lexer instead of C to highlight C++
     constructs such as ``template``, ``class`` and ``namespace`` (#3127)
-  * Markdown: Highlight bold-italics (``***...***`` and ``___...___``) (#3067)
-  * WebAssembly: Recognize sign-extension operators (#2991, #3160)
+  * C++: Add C23/C++26 attributes (#3084)
   * C++: Highlight a function following a namespace body (#2928)
+  * C#: Recognize interpolated verbatim strings with either ``$@`` or ``@$``
+    prefixes (#2685)
+  * D: Allow non-ASCII (Unicode) identifiers (#1088)
   * JavaScript: Highlight the ``arguments`` object (#3146)
+  * Jsonnet: Recognize colons in array slice expressions (#2828)
+  * JSX: Allow apostrophes in element text (#2816)
+  * Kotlin: Support companion objects without an explicit name (#2525)
+  * Kotlin: Don't let a nullable type marker (``?``) consume the following
+    character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
+  * Kusto: Recognize member-access dots in dynamic objects (#2779)
+  * Markdown: Highlight bold-italics (``***...***`` and ``___...___``) (#3067)
+  * Markdown, reStructuredText, TiddlyWiki5: Fix wrong token offsets for
+    embedded code blocks (#3133)
+  * Mathematica: Recognize ``\[Name]`` named-character escapes such as
+    ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
   * MATLAB, Octave, Scilab: Allow ``...`` line continuations in function
     definition signatures (#659)
-  * Tcl: Stop ``$name`` variable references at a dash (#1720)
-  * TypeScript: Only treat ``module`` as a keyword when followed by
-    whitespace, so identifiers like ``modules`` and ``module.exports``
-    are highlighted correctly (#2823)
   * Ruby: Don't duplicate the body of an unterminated heredoc (#2998)
   * Ruby: Treat ``<<`` after ``)``, ``]`` or ``}`` as the shift operator
     rather than the start of a heredoc (#760)
-  * Kotlin: Don't let a nullable type marker (``?``) consume the following
-    character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
+  * SCSS: Recognize variable references in property values (#2818)
+  * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
+  * Tcl: Stop ``$name`` variable references at a dash (#1720)
+  * TeX: Recognize LaTeX math environments as math (#3034)
+  * TypeScript: Only treat ``module`` as a keyword when followed by
+    whitespace, so identifiers like ``modules`` and ``module.exports``
+    are highlighted correctly (#2823)
   * YAML: Add ``yml`` alias (#3169), recognize non-breaking spaces as valid
     scalar content (#2827)
-  * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
-  * Mathematica: Recognize ``\[Name]`` named-character escapes such as
-    ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Vala: Recognize verbatim strings before ordinary quoted strings (#2861)
+  * Vala: Recognize conditional compilation directives (#2858)
+  * WebAssembly: Recognize sign-extension operators (#2991, #3160)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)
 - Improve handling of non-string types in ``html_escape`` to fix broken clients (#3090, #3086)
-- Fix wrong token offsets for embedded code blocks in the Markdown, reStructuredText
-  and TiddlyWiki5 lexers (#3133)
 - LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
   options when ``escapeinside`` is set, so blank lines are no longer stripped
   under ``stripnl=false`` (#2975)
+- RawTokenFormatter: fix a crash when ``error_color`` is set (#3215)
+- Groff formatter: don't duplicate a character when word-wrapping (``wrap``)
+  a token that is not at the end of a line (#3201)
 
 Version 2.20.0
 --------------

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -349,10 +349,8 @@ class YamlLexer(ExtendedRegexLexer):
             (r'[ ]+$', Whitespace),
             # line breaks are ignored
             (r'\n+', Whitespace),
-            # non-breaking spaces are a part of the value
-            (r'\xa0+', Name.Variable),
             # other whitespaces are a part of the value
-            (r'[ ]+', Name.Variable),
+            (r'[ \xa0]+', Name.Variable),
         ],
 
         # single-quoted scalars

--- a/pygments/lexers/data.py
+++ b/pygments/lexers/data.py
@@ -349,6 +349,8 @@ class YamlLexer(ExtendedRegexLexer):
             (r'[ ]+$', Whitespace),
             # line breaks are ignored
             (r'\n+', Whitespace),
+            # non-breaking spaces are a part of the value
+            (r'\xa0+', Name.Variable),
             # other whitespaces are a part of the value
             (r'[ ]+', Name.Variable),
         ],
@@ -403,7 +405,7 @@ class YamlLexer(ExtendedRegexLexer):
             # line breaks are ignored
             (r'\n+', Whitespace, 'plain-scalar-in-block-context-new-line'),
             # other whitespaces are a part of the value
-            (r'[ ]+', Literal.Scalar.Plain),
+            (r'[ \xa0]+', Literal.Scalar.Plain),
             # regular non-whitespace characters
             (r'(?::(?!\s)|[^\s:])+', Literal.Scalar.Plain),
         ],
@@ -420,7 +422,7 @@ class YamlLexer(ExtendedRegexLexer):
             # line breaks are ignored
             (r'\n+', Whitespace),
             # other whitespaces are a part of the value
-            (r'[ ]+', Name.Variable),
+            (r'[ \xa0]+', Name.Variable),
             # regular non-whitespace characters
             (r'[^\s,:?\[\]{}]+', Name.Variable),
         ],

--- a/tests/snippets/yaml/2827.txt
+++ b/tests/snippets/yaml/2827.txt
@@ -1,0 +1,11 @@
+---input---
+foo: bar baz
+
+---tokens---
+'foo'         Name.Tag
+':'           Punctuation
+' '           Text.Whitespace
+'bar'         Literal.Scalar.Plain
+'\xa0'        Literal.Scalar.Plain
+'baz'         Literal.Scalar.Plain
+'\n'          Text.Whitespace


### PR DESCRIPTION
YAML permits U+00A0 in scalar content, but the lexer emitted an `Error` token for it. This recognizes non-breaking spaces in block, flow, and quoted scalars and adds a golden regression test.

Fixes #2827
