### PR TITLE
SCSS: Recognize variables in property values

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -31,6 +31,7 @@ Version 2.21.0
     whitespace, so identifiers like ``modules`` and ``module.exports``
     are highlighted correctly (#2823)
   * Ruby: Don't duplicate the body of an unterminated heredoc (#2998)
+  * SCSS: Recognize variable references in property values (#2818)
   * Ruby: Treat ``<<`` after ``)``, ``]`` or ``}`` as the shift operator
     rather than the start of a heredoc (#760)
   * Kotlin: Don't let a nullable type marker (``?``) consume the following

--- a/pygments/lexers/css.py
+++ b/pygments/lexers/css.py
@@ -362,6 +362,7 @@ common_sass_tokens = {
         (r'\.', Name.Class, 'class'),
         (r'\#', Name.Namespace, 'id'),
         (r'[\w-]+', Name.Tag),
+        (r'\$[\w-]+', Name.Variable),
         (r'#\{', String.Interpol, 'interpolation'),
         (r'&', Keyword),
         (r'[~^*!&\[\]()<>|+=@:;,./?-]', Operator),

--- a/tests/snippets/scss/2818.txt
+++ b/tests/snippets/scss/2818.txt
@@ -1,0 +1,39 @@
+---input---
+$border-radius:               1rem;
+.searchButton.btn.btn-secondary {
+    border-radius: 0 $border-radius $border-radius 0;
+}
+
+---tokens---
+'$border-radius' Name.Variable
+':'           Operator
+'               ' Text.Whitespace
+'1'           Literal.Number.Integer
+'rem'         Keyword.Type
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'.'           Name.Class
+'searchButton' Name.Class
+'.'           Name.Class
+'btn'         Name.Class
+'.'           Name.Class
+'btn-secondary' Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'border-radius' Name.Tag
+':'           Name.Decorator
+' '           Text.Whitespace
+'0'           Name.Tag
+' '           Text.Whitespace
+'$border-radius' Name.Variable
+' '           Text.Whitespace
+'$border-radius' Name.Variable
+' '           Text.Whitespace
+'0'           Name.Tag
+';'           Operator
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #2818. SCSS variable references used in property values were falling through the selector state as `Error` tokens; recognize them as `Name.Variable` and cover the reported snippet with a golden lexer test.