### PR TITLE
Kusto: highlight object member access (#2779)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,7 @@ Version 2.21.0
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Kusto: Recognize member-access dots in dynamic objects (#2779)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/kusto.py
+++ b/pygments/lexers/kusto.py
@@ -36,7 +36,7 @@ KUSTO_KEYWORDS = [
 # https://github.com/microsoft/Kusto-Query-Language/blob/master/src/Kusto.Language/Syntax/SyntaxFacts.cs
 KUSTO_PUNCTUATION = [
     "(", ")", "[", "]", "{", "}", "|", "<|", "+", "-", "*", "/",
-    "%", ".." "!", "<", "<=", ">", ">=", "=", "==", "!=", "<>",
+    "%", ".", "..", "!", "<", "<=", ">", ">=", "=", "==", "!=", "<>",
     ":", ";", ",", "=~", "!~", "?", "=>",
 ]
 
@@ -56,10 +56,10 @@ class KustoLexer(RegexLexer):
             (r"\s+", Whitespace),
             (words(KUSTO_KEYWORDS, suffix=r"\b"), Keyword),
             (r"//.*", Comment),
-            (words(KUSTO_PUNCTUATION), Punctuation),
-            (r"[^\W\d]\w*", Name),
             # Numbers can take the form 1, .1, 1., 1.1, 1.1111, etc.
             (r"\d+[.]\d*|[.]\d+", Number.Float),
+            (words(KUSTO_PUNCTUATION), Punctuation),
+            (r"[^\W\d]\w*", Name),
             (r"\d+", Number.Integer),
             (r"'", String, "single_string"),
             (r'"', String, "double_string"),

--- a/tests/snippets/kusto/test_kusto.txt
+++ b/tests/snippets/kusto/test_kusto.txt
@@ -4,6 +4,9 @@ StormEvents
 | where State == "FLORIDA"
 | count
 
+resources
+| project owner=tags.owner
+
 ---tokens---
 'StormEvents' Name
 '\n'          Text.Whitespace
@@ -26,8 +29,7 @@ StormEvents
 '01'          Literal.Number.Integer
 ')'           Punctuation
 ' '           Text.Whitespace
-'.'           Error
-'.'           Error
+'..'          Punctuation
 ' '           Text.Whitespace
 'datetime'    Keyword
 '('           Punctuation
@@ -56,4 +58,18 @@ StormEvents
 '|'           Punctuation
 ' '           Text.Whitespace
 'count'       Keyword
+'\n\n'        Text.Whitespace
+
+'resources'   Name
+'\n'          Text.Whitespace
+
+'|'           Punctuation
+' '           Text.Whitespace
+'project'     Keyword
+' '           Text.Whitespace
+'owner'       Name
+'='           Punctuation
+'tags'        Name
+'.'           Punctuation
+'owner'       Name
 '\n'          Text.Whitespace


### PR DESCRIPTION
Kusto member access such as `tags.owner` currently emits an `Error` token for the dot because `.` is missing from the punctuation table. This adds both dot punctuation forms, preserves leading-dot floats by matching numbers first, and adds a golden regression case.

Fixes #2779
