### PR TITLE
Kotlin: support anonymous companion objects (#2525)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Version 2.21.0
   * Ruby: Don't duplicate the body of an unterminated heredoc (#2998)
   * Ruby: Treat ``<<`` after ``)``, ``]`` or ``}`` as the shift operator
     rather than the start of a heredoc (#760)
+  * Kotlin: Support companion objects without an explicit name (#2525)
   * Kotlin: Don't let a nullable type marker (``?``) consume the following
     character, so ``Foo?,`` and ``a?:b`` tokenize correctly (#2964)
   * YAML: Add ``yml`` alias (#3169)

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -1183,6 +1183,7 @@ class KotlinLexer(RegexLexer):
             (r'' + kt_id + r'(\?(?![.:]))?', Name)
         ],
         'class': [
+            (r'\{', Punctuation, '#pop'),
             (kt_id, Name.Class, '#pop')
         ],
         'variable': [

--- a/tests/snippets/kotlin/test_anonymous_companion_object.txt
+++ b/tests/snippets/kotlin/test_anonymous_companion_object.txt
@@ -1,0 +1,40 @@
+---input---
+class MyClass {
+    companion object {
+        fun create(): MyClass = MyClass()
+    }
+}
+
+---tokens---
+'class'       Keyword.Declaration
+' '           Text.Whitespace
+'MyClass'     Name.Class
+' '           Text.Whitespace
+'{'           Punctuation
+'\n    '      Text.Whitespace
+'companion'   Keyword.Declaration
+' '           Text.Whitespace
+'object'      Keyword.Declaration
+' '           Text.Whitespace
+'{'           Punctuation
+'\n        '  Text.Whitespace
+'fun'         Keyword.Declaration
+' '           Text.Whitespace
+'create'      Name.Function
+'('           Punctuation
+')'           Punctuation
+':'           Punctuation
+' '           Text.Whitespace
+'MyClass'     Name
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'MyClass'     Name
+'('           Punctuation
+')'           Punctuation
+'\n    '      Text.Whitespace
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Anonymous Kotlin companion objects enter the lexer’s class-name state even though no name follows, so the opening `{` was emitted as an Error token. Let that state consume the brace directly and add a golden regression fixture for the reported example.

Fixes #2525
