### PR TITLE
C#: recognize interpolated verbatim strings (#2685)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,8 @@ Version 2.21.0
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * C#: Recognize interpolated verbatim strings with either ``$@`` or ``@$``
+    prefixes (#2685)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/dotnet.py
+++ b/pygments/lexers/dotnet.py
@@ -97,6 +97,7 @@ class CSharpLexer(RegexLexer):
                 (r'[()\[\];:,.]', Punctuation),
                 (r'[{}]', Punctuation),
                 (r'\$*"{3,}.*?"{3,}', String),
+                (r'(?:\$@|@\$)"(""|[^"])*"', String),
                 (r'@"(""|[^"])*"', String),
                 (r'\$?"(\\\\|\\[^\\]|[^"\\\n])*["\n]', String),
                 (r"'\\.'|'[^\\]'", String.Char),

--- a/tests/snippets/csharp/2685.txt
+++ b/tests/snippets/csharp/2685.txt
@@ -1,0 +1,22 @@
+---input---
+Console.WriteLine($@"C:\Users\{username}\Desktop");
+Console.WriteLine(@$"C:\Users\{username}\Desktop");
+
+---tokens---
+'Console'     Name
+'.'           Punctuation
+'WriteLine'   Name
+'('           Punctuation
+'$@"C:\\Users\\{username}\\Desktop"' Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace
+
+'Console'     Name
+'.'           Punctuation
+'WriteLine'   Name
+'('           Punctuation
+'@$"C:\\Users\\{username}\\Desktop"' Literal.String
+')'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
C# interpolated verbatim strings allow both `$@"..."` and `@$"..."`, but the lexer left one prefix character as an `Error` token. Recognize both forms as strings and cover the reported examples with a golden lexer test.

Fixes #2685
