### PR TITLE
JSX: Allow apostrophes in element text (#2816)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Version 2.21.0
   * WebAssembly: Recognize sign-extension operators (#2991, #3160)
   * C++: Highlight a function following a namespace body (#2928)
   * JavaScript: Highlight the ``arguments`` object (#3146)
+  * JSX: Allow apostrophes in element text (#2816)
   * MATLAB, Octave, Scilab: Allow ``...`` line continuations in function
     definition signatures (#659)
   * Tcl: Stop ``$name`` variable references at a dash (#1720)

--- a/pygments/lexers/jsx.py
+++ b/pygments/lexers/jsx.py
@@ -74,6 +74,7 @@ class JsxLexer(JavascriptLexer):
         "root": [
             include("jsx"),
             inherit,
+            (r"'", Text),
         ],
     **_JSX_RULES}
 
@@ -96,5 +97,6 @@ class TsxLexer(TypeScriptLexer):
         "root": [
             include("jsx"),
             inherit,
+            (r"'", Text),
         ],
     **_JSX_RULES}

--- a/tests/snippets/jsx/test_apostrophe_text.txt
+++ b/tests/snippets/jsx/test_apostrophe_text.txt
@@ -1,0 +1,35 @@
+---input---
+const View = () => <div>I'm the Block view component!</div>;
+
+---tokens---
+'const'       Keyword.Declaration
+' '           Text.Whitespace
+'View'        Name.Other
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'('           Punctuation
+')'           Punctuation
+' '           Text.Whitespace
+'=>'          Punctuation
+' '           Text.Whitespace
+'<'           Punctuation
+'div'         Name.Tag
+'>'           Punctuation
+'I'           Name.Other
+"'"           Text
+'m'           Name.Other
+' '           Text.Whitespace
+'the'         Name.Other
+' '           Text.Whitespace
+'Block'       Name.Other
+' '           Text.Whitespace
+'view'        Name.Other
+' '           Text.Whitespace
+'component'   Name.Other
+'!'           Operator
+'</'          Punctuation
+'div'         Name.Tag
+'>'           Punctuation
+';'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
JSX element text currently falls through to the inherited JavaScript rules, so an apostrophe in a contraction becomes an `Error` token and strict consumers such as Sphinx reject valid JSX. This adds a text fallback after normal JavaScript and TypeScript string handling, with a golden regression fixture.

Fixes #2816
