### PR TITLE
Fix RawTokenFormatter crash when error_color is set

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ Version 2.21.0
 - LaTeX formatter: honor the wrapped lexer's ``stripnl`` and other input
   options when ``escapeinside`` is set, so blank lines are no longer stripped
   under ``stripnl=false`` (#2975)
+- RawTokenFormatter: fix a crash when ``error_color`` is set (#3215)
 
 Version 2.20.0
 --------------

--- a/pygments/formatters/other.py
+++ b/pygments/formatters/other.py
@@ -106,7 +106,7 @@ class RawTokenFormatter(Formatter):
             for ttype, value in tokensource:
                 line = b"%r\t%r\n" % (ttype, value)
                 if ttype is Token.Error:
-                    write(colorize(self.error_color, line))
+                    write(colorize(self.error_color, line.decode()).encode())
                 else:
                     write(line)
         else:

--- a/tests/test_raw_token.py
+++ b/tests/test_raw_token.py
@@ -66,3 +66,18 @@ def test_invalid_raw_token():
         highlight(b"Token.Text\t'\xff'", RawTokenLexer(), RawTokenFormatter())
         == b"Token.Text\t'\\xff'\n"
     )
+
+
+def test_raw_token_error_color():
+    # ``error_color`` wraps Error tokens in an ANSI color. The output stream is
+    # binary, so the colorized line must stay bytes (regression test for the
+    # ``str``/``bytes`` mix that crashed the formatter).
+    from pygments.console import codes
+
+    out = highlight("$", PythonLexer(), RawTokenFormatter(error_color="red"))
+    assert out == (
+        codes["red"].encode()
+        + b"Token.Error\t'$'\n"
+        + codes["reset"].encode()
+        + b"Token.Text.Whitespace\t'\\n'\n"
+    )


### PR DESCRIPTION
`RawTokenFormatter` crashes with `TypeError` whenever `error_color` is set and the token stream contains an `Error` token.

The formatter writes a binary stream and builds each line as bytes:

```python
line = b"%r\t%r\n" % (ttype, value)
if ttype is Token.Error:
    write(colorize(self.error_color, line))
```

`colorize` (in `pygments/console.py`) is a str-only helper (`codes[color_key] + text + codes["reset"]`), so passing the bytes `line` raises `TypeError: can only concatenate str (not "bytes") to str`. The output was switched to bytes for Python 3 support, but this branch was never updated, so the whole `error_color` path is dead for Error tokens.

Repro:

```python
from pygments import highlight
from pygments.lexers import PythonLexer
from pygments.formatters import RawTokenFormatter

highlight("$", PythonLexer(), RawTokenFormatter(error_color="red"))
# TypeError: can only concatenate str (not "bytes") to str
```

Fix: decode the line for `colorize` and re-encode the result so the output stays bytes. The raw stream is ASCII by construction (`%r` escapes non-ASCII), so the round-trip is lossless:

```python
write(colorize(self.error_color, line.decode()).encode())
```

Non-error output is byte-for-byte unchanged. Added a regression test in `tests/test_raw_token.py` that fails before this change (TypeError) and passes after, checking the Error line is wrapped in the color codes while the following line is untouched.
