### PR TITLE
Clojure: recognize named, octal and unicode character literals as a single token

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -39,6 +39,8 @@ Version 2.21.0
   * Swift: Keep ``func`` a keyword in ``class func`` type methods (#1125)
   * Mathematica: Recognize ``\[Name]`` named-character escapes such as
     ``\[Nu]`` instead of emitting an ``Error`` token (#3097)
+  * Clojure: Recognize named, octal and unicode character literals such as
+    ``\space`` and ``\o377`` as a single token (#979)
 
 - Fix catastrophic backtracking in ``looks_like_xml`` (#2931, #3112)
 - Improve monokai theme colors (#3100)

--- a/pygments/lexers/jvm.py
+++ b/pygments/lexers/jvm.py
@@ -911,7 +911,8 @@ class ClojureLexer(RegexLexer):
             # strings, symbols and characters
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String),
             (r"'" + valid_name, String.Symbol),
-            (r"\\(.|[a-z]+)", String.Char),
+            (r"\\(?:newline|space|tab|formfeed|backspace|return"
+             r"|u[0-9a-fA-F]{4}|o[0-7]{1,3}|.)", String.Char),
 
             # keywords
             (r'::?#?' + valid_name, String.Symbol),

--- a/tests/snippets/clojure/test_characters.txt
+++ b/tests/snippets/clojure/test_characters.txt
@@ -1,0 +1,31 @@
+---input---
+(str \a \A \1 \( \space \newline \tab \formfeed \backspace \return \u00ff \o377)
+
+---tokens---
+'('           Punctuation
+'str '        Name.Builtin
+'\\a'         Literal.String.Char
+' '           Text.Whitespace
+'\\A'         Literal.String.Char
+' '           Text.Whitespace
+'\\1'         Literal.String.Char
+' '           Text.Whitespace
+'\\('         Literal.String.Char
+' '           Text.Whitespace
+'\\space'     Literal.String.Char
+' '           Text.Whitespace
+'\\newline'   Literal.String.Char
+' '           Text.Whitespace
+'\\tab'       Literal.String.Char
+' '           Text.Whitespace
+'\\formfeed'  Literal.String.Char
+' '           Text.Whitespace
+'\\backspace' Literal.String.Char
+' '           Text.Whitespace
+'\\return'    Literal.String.Char
+' '           Text.Whitespace
+'\\u00ff'     Literal.String.Char
+' '           Text.Whitespace
+'\\o377'      Literal.String.Char
+')'           Punctuation
+'\n'          Text.Whitespace


### PR DESCRIPTION
Fixes #979.

`ClojureLexer` splits named, octal, and unicode character literals into two tokens. For example `\space` lexes as `String.Char '\s'` followed by `Name.Variable 'pace'`, instead of a single character literal.

The cause is the rule `(r"\(.|[a-z]+)", String.Char)`: the `.` alternative always matches first, so the `[a-z]+` branch is dead and multi-character names are never matched as a unit.

The fix replaces it with an ordered alternation covering the six named literals (`newline`, `space`, `tab`, `formfeed`, `backspace`, `return`), unicode `\uNNNN` (4 hex digits), octal `\oNNN` (1–3 octal digits), and finally the single-character fallback:

```python
(r"\(?:newline|space|tab|formfeed|backspace|return"
 r"|u[0-9a-fA-F]{4}|o[0-7]{1,3}|.)", String.Char),
```

Now each of these lexes as a single `String.Char`:

```
\a  \A  \1  \(  \space  \newline  \tab  \formfeed  \backspace  \return  ÿ  \o377
```

Single-character literals are unchanged, and literals stop correctly at delimiters (e.g. `\newline)` → `\newline` + `)`).

Added a snippet test (`tests/snippets/clojure/test_characters.txt`) and a `CHANGES` entry. The existing Clojure example-file goldens are unchanged.
