### PR TITLE
[Bug] Fail on invalid -L values

### DIFF
--- a/pygments/cmdline.py
+++ b/pygments/cmdline.py
@@ -206,14 +206,14 @@ def main_inner(parser, argns):
             parser.print_help(sys.stderr)
             return 2
 
-        # print version
-        if not argns.json:
-            main(['', '-V'])
         allowed_types = {'lexer', 'formatter', 'filter', 'style'}
         largs = [arg.rstrip('s') for arg in argns.L]
         if any(arg not in allowed_types for arg in largs):
             parser.print_help(sys.stderr)
-            return 0
+            return 2
+        # print version
+        if not argns.json:
+            main(['', '-V'])
         if not largs:
             largs = allowed_types
         if not argns.json:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -162,6 +162,7 @@ def test_L_opt():
     o = check_success('-L', 'lexer')
     assert 'Lexers' in o and 'Formatters' not in o
     check_success('-L', 'lexers')
+    check_failure('-L', 'invalid-kind', code=2)
 
 
 def test_O_opt():


### PR DESCRIPTION
## Summary

Make `pygmentize -L <invalid-kind>` return the established usage-error status `2` instead of reporting success.

The validation now happens before printing the version/listing header, so invalid input produces usage on stderr, no stdout, and a failure exit code. Valid `-L`, `-L lexer`, and `-L lexers` behavior is unchanged.

## Regression coverage

The existing `test_L_opt` now exercises an invalid listing kind through the shared `check_failure` helper.

Before the source change, the new assertion observed exit `0`; afterward it observes exit `2`.

## Validation

- Focused regression: **1 passed**
- `tests/test_cmdline.py`: **30 passed**
- Ruff on both changed files: **passed**
- Direct subprocess reproduction: exit `2`, empty stdout, usage on stderr
- `git diff --check`: **passed**

The full tox matrix was not run. No lexer, formatter, public signature, dependency, lockfile, or workflow change is included.