### PR TITLE
Exclude tests directory from source distribution

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -65,6 +65,8 @@ Version 2.21.0
 - RawTokenFormatter: fix a crash when ``error_color`` is set (#3215)
 - Groff formatter: don't duplicate a character when word-wrapping (``wrap``)
   a token that is not at the end of a line (#3201)
+- Exclude the ``tests`` directory from the source distribution to reduce its
+  size
 
 Version 2.20.0
 --------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ pygmentize = "pygments.cmdline:main"
 [tool.hatch.build.targets.wheel]
 packages = ["pygments"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["/tests"]
+
 [tool.hatch.version]
 path = "pygments/__init__.py"
 


### PR DESCRIPTION
## Summary

Closes #3219

The sdist (source distribution) uploaded to PyPI currently bundles the entire `tests/` directory (2350+ files), which then gets pulled into downstream rebuilds such as conda-forge/miniforge, triggering malware scanners on some test fixture files (e.g. `.odin` files). The wheel is already scoped correctly via `[tool.hatch.build.targets.wheel] packages = ["pygments"]`, but no equivalent exclusion existed for the sdist target.

This adds `[tool.hatch.build.targets.sdist] exclude = ["/tests"]` to `pyproject.toml` to drop the tests directory from the sdist.

## Test plan

- [x] Built sdist before the change with `python -m build --sdist`: 2350 files under `tests/`, 2787 files total.
- [x] Built sdist after the change: 0 files under `tests/`, 437 files total.
- [x] Confirmed `pygments/__init__.py` and the rest of the package are still present in the sdist.
- [x] Confirmed the wheel build is unaffected (it was already excluding `tests/`).