### PR TITLE
Simplify single-character regex alternations to character classes

### DIFF
--- a/pygments/lexers/amdgpu.py
+++ b/pygments/lexers/amdgpu.py
@@ -45,7 +45,7 @@ class AMDGPULexer(RegexLexer):
                 'lit', 'unorm'), suffix=r'\b'), Name.Attribute),
             (r'(label_[a-z0-9]+)', Keyword),
             (r'(_L[0-9]*)', Name.Variable),
-            (r'(s|v)_[a-z0-9_]+', Keyword),
+            (r'[sv]_[a-z0-9_]+', Keyword),
             (r'(v[0-9.]+|vcc|exec|v)', Name.Variable),
             (r's[0-9.]+|s', Name.Variable),
             (r'[0-9]+\.[^0-9]+', Number.Float),

--- a/pygments/lexers/asm.py
+++ b/pygments/lexers/asm.py
@@ -258,7 +258,7 @@ class HsailLexer(RegexLexer):
     # Numeric Constant
     float = r'((\d+\.)|(\d*\.\d+))[eE][+-]?\d+'
     hexfloat = r'0[xX](([0-9a-fA-F]+\.[0-9a-fA-F]*)|([0-9a-fA-F]*\.[0-9a-fA-F]+))[pP][+-]?\d+'
-    ieeefloat = r'0((h|H)[0-9a-fA-F]{4}|(f|F)[0-9a-fA-F]{8}|(d|D)[0-9a-fA-F]{16})'
+    ieeefloat = r'0(?:[hH][0-9a-fA-F]{4}|[fF][0-9a-fA-F]{8}|[dD][0-9a-fA-F]{16})'
 
     tokens = {
         'root': [

--- a/pygments/lexers/business.py
+++ b/pygments/lexers/business.py
@@ -285,7 +285,7 @@ class ABAPLexer(RegexLexer):
             (r'(\s+)([\w\-]+)([=\-]>)([\w\-~]+)',
              bygroups(Whitespace, Name.Variable, Operator, Name.Function)),
             # call methodnames returning style
-            (r'(?<=(=|-)>)([\w\-~]+)(?=\()', Name.Function),
+            (r'(?<=[=-]>)([\w\-~]+)(?=\()', Name.Function),
 
             # text elements
             (r'(TEXT)(-)(\d{3})',

--- a/pygments/lexers/cplint.py
+++ b/pygments/lexers/cplint.py
@@ -36,7 +36,7 @@ class CplintLexer(PrologLexer):
                     'finite')), Name.Builtin),
             # annotations of atoms
             (r'([a-z]+)(:)', bygroups(String.Atom, Punctuation)),
-            (r':(-|=)|::?|~=?|=>', Operator),
+            (r':[-=]|::?|~=?|=>', Operator),
             (r'\?', Name.Builtin),
             inherit,
         ],

--- a/pygments/lexers/dsls.py
+++ b/pygments/lexers/dsls.py
@@ -287,7 +287,7 @@ class ZeekLexer(RegexLexer):
             # operator.
             (r'/(?=.*/)', String.Regex, 'regex'),
 
-            (r'(T|F)\b', Keyword.Constant),
+            (r'[TF]\b', Keyword.Constant),
 
             # Port
             (r'\d{1,5}/(udp|tcp|icmp|unknown)\b', Number),

--- a/pygments/lexers/esoteric.py
+++ b/pygments/lexers/esoteric.py
@@ -218,7 +218,7 @@ class CapDLLexer(RegexLexer):
 
             # Literals
             (r'0[xX][\da-fA-F]+', Number.Hex),
-            (r'\d+(\.\d+)?(k|M)?', Number),
+            (r'\d+(\.\d+)?[kM]?', Number),
             (words(('bits',), suffix=r'\b'), Number),
             (words(('cspace', 'vspace', 'reply_slot', 'caller_slot',
                     'ipc_buffer_slot'), suffix=r'\b'), Number),

--- a/pygments/lexers/graphics.py
+++ b/pygments/lexers/graphics.py
@@ -335,11 +335,11 @@ class PostScriptLexer(RegexLexer):
             # Numbers
             (r'<[0-9A-Fa-f]+>' + delimiter_end, Number.Hex),
             # Slight abuse: use Oct to signify any explicit base system
-            (r'[0-9]+\#(\-|\+)?([0-9]+\.?|[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)'
-             r'((e|E)[0-9]+)?' + delimiter_end, Number.Oct),
-            (r'(\-|\+)?([0-9]+\.?|[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)((e|E)[0-9]+)?'
+            (r'[0-9]+\#[+-]?([0-9]+\.?|[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)'
+             r'([eE][0-9]+)?' + delimiter_end, Number.Oct),
+            (r'[+-]?([0-9]+\.?|[0-9]*\.[0-9]+|[0-9]+\.[0-9]*)([eE][0-9]+)?'
              + delimiter_end, Number.Float),
-            (r'(\-|\+)?[0-9]+' + delimiter_end, Number.Integer),
+            (r'[+-]?[0-9]+' + delimiter_end, Number.Integer),
 
             # References
             (rf'\/{valid_name}', Name.Variable),

--- a/pygments/lexers/html.py
+++ b/pygments/lexers/html.py
@@ -141,7 +141,7 @@ class DtdLexer(RegexLexer):
 
         'common': [
             (r'\s+', Text),
-            (r'(%|&)[^;]*;', Name.Entity),
+            (r'[%&][^;]*;', Name.Entity),
             ('<!--', Comment, 'comment'),
             (r'[(|)*,?+]', Operator),
             (r'"[^"]*"', String.Double),

--- a/pygments/lexers/idl.py
+++ b/pygments/lexers/idl.py
@@ -259,7 +259,7 @@ class IDLLexer(RegexLexer):
             (r'\b(mod|lt|le|eq|ne|ge|gt|not|and|or|xor)\b', Operator),
             (r'"[^\"]*"', String.Double),
             (r"'[^\']*'", String.Single),
-            (r'\b[+\-]?([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)(D|E)?([+\-]?[0-9]+)?\b',
+            (r'\b[+\-]?([0-9]*\.[0-9]+|[0-9]+\.[0-9]*)[DE]?([+\-]?[0-9]+)?\b',
              Number.Float),
             (r'\b\'[+\-]?[0-9A-F]+\'X(U?(S?|L{1,2})|B)\b', Number.Hex),
             (r'\b\'[+\-]?[0-7]+\'O(U?(S?|L{1,2})|B)\b', Number.Oct),

--- a/pygments/lexers/javascript.py
+++ b/pygments/lexers/javascript.py
@@ -860,8 +860,8 @@ class ObjectiveJLexer(RegexLexer):
             (r'\n', Whitespace, '#pop'),
         ],
         'statements': [
-            (r'(L|@)?"', String, 'string'),
-            (r"(L|@)?'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])'",
+            (r'[L@]?"', String, 'string'),
+            (r"[L@]?'(\\.|\\[0-7]{1,3}|\\x[a-fA-F0-9]{1,2}|[^\\\'\n])'",
              String.Char),
             (r'"(\\\\|\\[^\\]|[^"\\])*"', String.Double),
             (r"'(\\\\|\\[^\\]|[^'\\])*'", String.Single),

--- a/pygments/lexers/kuin.py
+++ b/pygments/lexers/kuin.py
@@ -302,8 +302,8 @@ class KuinLexer(RegexLexer):
             (r"'(?:\\.|.)+?'", String.Char),
 
             # Operator
-            (r'(?:\.|\$(?:>|<)?)', Operator),
-            (r'(?:\^)', Operator),
+            (r'(?:\.|\$[<>]?)', Operator),
+            (r'\^', Operator),
             (r'(?:\+|-|!|##?)', Operator),
             (r'(?:\*|/|%)', Operator),
             (r'(?:~)', Operator),

--- a/pygments/lexers/lisp.py
+++ b/pygments/lexers/lisp.py
@@ -1627,7 +1627,7 @@ class NewLispLexer(RegexLexer):
             (r'\[text\]*', String, "tagstring"),
 
             # 'special' operators...
-            (r"('|:)", Operator),
+            (r"[':]", Operator),
 
             # highlight the builtins
             (words(builtins, suffix=r'\b'),

--- a/pygments/lexers/nit.py
+++ b/pygments/lexers/nit.py
@@ -52,7 +52,7 @@ class NitLexer(RegexLexer):
             (r'(\'[^\'\\]\')|(\'\\.\')', String.Char),
             (r'[0-9]+', Number.Integer),
             (r'[0-9]*.[0-9]+', Number.Float),
-            (r'0(x|X)[0-9A-Fa-f]+', Number.Hex),
+            (r'0[xX][0-9A-Fa-f]+', Number.Hex),
             (r'[a-z]\w*', Name),
             (r'_\w+', Name.Variable.Instance),
             (r'==|!=|<==>|>=|>>|>|<=|<<|<|\+|-|=|/|\*|%|\+=|-=|!|@', Operator),

--- a/pygments/lexers/prolog.py
+++ b/pygments/lexers/prolog.py
@@ -115,7 +115,7 @@ class LogtalkLexer(RegexLexer):
             (r'0b[01]+', Number.Bin),
             (r'0o[0-7]+', Number.Oct),
             (r'0x[0-9a-fA-F]+', Number.Hex),
-            (r'\d+\.?\d*((e|E)(\+|-)?\d+)?', Number),
+            (r'\d+\.?\d*(?:[eE][+-]?\d+)?', Number),
             # Variables
             (r'([A-Z_][a-zA-Z0-9_]*)', Name.Variable),
             # Event handlers
@@ -145,7 +145,7 @@ class LogtalkLexer(RegexLexer):
             (r'\blogtalk_make\b', Keyword),
             # Database
             (r'(clause|retract(all)?)(?=[(])', Keyword),
-            (r'a(bolish|ssert(a|z))(?=[(])', Keyword),
+            (r'a(bolish|ssert[az])(?=[(])', Keyword),
             # Control constructs
             (r'(ca(ll|tch)|throw)(?=[(])', Keyword),
             (r'(fa(il|lse)|true|(instantiation|system)_error)\b', Keyword),
@@ -282,7 +282,7 @@ class LogtalkLexer(RegexLexer):
             (r'0b[01]+', Number.Bin),
             (r'0o[0-7]+', Number.Oct),
             (r'0x[0-9a-fA-F]+', Number.Hex),
-            (r'\d+\.?\d*((e|E)(\+|-)?\d+)?', Number),
+            (r'\d+\.?\d*(?:[eE][+-]?\d+)?', Number),
             # Variables
             (r'([A-Z_][a-zA-Z0-9_]*)', Name.Variable),
             # Atoms

--- a/pygments/lexers/r.py
+++ b/pygments/lexers/r.py
@@ -108,7 +108,7 @@ class SLexer(RegexLexer):
              r'letters|LETTERS|Inf|TRUE|FALSE|NaN|pi|\.\.(\.|[0-9]+))'
              r'(?![\w.])',
              Keyword.Constant),
-            (r'(T|F)\b', Name.Builtin.Pseudo),
+            (r'[TF]\b', Name.Builtin.Pseudo),
         ],
         'numbers': [
             # hex number

--- a/pygments/lexers/sas.py
+++ b/pygments/lexers/sas.py
@@ -136,7 +136,7 @@ class SASLexer(RegexLexer):
         ],
         # Special highlight for proc, data, quit, run
         'proc-data': [
-            (r'(^|;)\s*(proc \w+|data|run|quit)[\s;]',
+            (r'[^;]\s*(proc \w+|data|run|quit)[\s;]',
              Keyword.Reserved),
         ],
         # Special highlight cards and datalines
@@ -151,9 +151,9 @@ class SASLexer(RegexLexer):
             (r'\n?^\s*%?put ', Keyword, 'log-messages'),
         ],
         'log-messages': [
-            (r'NOTE(:|-).*', Generic, '#pop'),
-            (r'WARNING(:|-).*', Generic.Emph, '#pop'),
-            (r'ERROR(:|-).*', Generic.Error, '#pop'),
+            (r'NOTE[:-].*', Generic, '#pop'),
+            (r'WARNING[:-].*', Generic.Emph, '#pop'),
+            (r'ERROR[:-].*', Generic.Error, '#pop'),
             include('general'),
         ],
         'general': [


### PR DESCRIPTION
Replace single-character alternations like (a|b) and (?:a|b) with the equivalent character class [ab] across several lexers.

While technically a character class compiles to a single IN op in CPython's sre engine, whereas an alternation compiles to a slower BRANCH, there is no measurable performance improvements, even from removing the useless capture groups. The change is purely cosmetic, as reading regexps is tedious enough as it is without the need to add useless grouping.

This was found via `git grep '(.|.)' | grep -v bygroup`