### PR TITLE
Recognise a double-quoted bash here-doc delimiter, and anchor the terminator

### DIFF
--- a/pygments/lexers/shell.py
+++ b/pygments/lexers/shell.py
@@ -70,7 +70,7 @@ class BashLexer(RegexLexer):
             (r'(\b\w+)(\s*)(\+?=)', bygroups(Name.Variable, Whitespace, Operator)),
             (r'[\[\]{}()=]', Operator),
             (r'<<<', Operator),  # here-string
-            (r'<<-?\s*(\'?)\\?(\w+)[\w\W]+?\2', String),
+            (r'<<-?\s*([\'"]?)\\?(\w+)[\w\W]+?^[ \t]*\2$', String),
             (r'&&|\|\|', Operator),
         ],
         'data': [

--- a/tests/snippets/bash/test_heredoc_quoted_delimiter.txt
+++ b/tests/snippets/bash/test_heredoc_quoted_delimiter.txt
@@ -1,0 +1,10 @@
+---input---
+cat <<"EOF"
+$not_expanded
+EOF
+
+---tokens---
+'cat'         Text
+' '           Text.Whitespace
+'<<"EOF"\n$not_expanded\nEOF' Literal.String
+'\n'          Text.Whitespace

--- a/tests/snippets/bash/test_heredoc_terminator_is_a_whole_line.txt
+++ b/tests/snippets/bash/test_heredoc_terminator_is_a_whole_line.txt
@@ -1,0 +1,20 @@
+---input---
+cat <<EOF
+See the EOFs below for details
+EOF
+rm -rf "$dir"
+
+---tokens---
+'cat'         Text
+' '           Text.Whitespace
+'<<EOF\nSee the EOFs below for details\nEOF' Literal.String
+'\n'          Text.Whitespace
+
+'rm'          Text
+' '           Text.Whitespace
+'-rf'         Text
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'$dir'        Name.Variable
+'"'           Literal.String.Double
+'\n'          Text.Whitespace


### PR DESCRIPTION
> **AI disclosure:** this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, ran the repro, wrote the tests, and wrote this description; the human account holder reviews every change and is accountable for it. Everything below is real and re-runnable from the diff — it was just done by the AI, not a person. Please review it as unsupervised AI output, and tell me if that's not something you want here.

`BashLexer`'s here-doc rule handles three of bash's four delimiter forms and misses one:

```python
(r'<<-?\s*(\'?)\\?(\w+)[\w\W]+?\2', String),
```

`(\'?)` covers `<<'EOF'`, `\\?` covers `<<\EOF`, and the bare `<<EOF` needs neither — but there's no branch for a **double-quoted** delimiter, so `<<"EOF"` fails the rule entirely and the body is lexed as live code.

```
<<EOF      body is one String token: True
<<'EOF'    body is one String token: True
<<"EOF"    body is one String token: False   <-- 
<<\EOF     body is one String token: True
```

`man bash`, Here Documents: *"If any part of word is quoted, the delimiter is the result of quote removal on word, and the lines in the here-document are not expanded."* Quoting a delimiter with `"` is the idiomatic way to embed a foreign-language body verbatim; `gh search code '<<"EOF"' --language=shell` finds it in yadm, pi-apps, and libtool's `ltmain.sh` among others. The cascade is the bad part — an awk body's `"` characters then pair up across lines, so `String.Double` spans newlines and the rest of the file mis-highlights.

While fixing it I hit a second defect in the same rule: **the terminator is unanchored**, so `\2` matches inside a word.

```bash
cat <<EOF
See the EOFs below for details
EOF
rm -rf "$dir"
```
The here-doc ends inside `EOFs`, and the prose that follows is lexed as code — `for` becomes `Token.Keyword`. `man bash` again: read *"until a line containing only delimiter (with no trailing blanks) is seen"*.

## The fix

```python
(r'<<-?\s*([\'"]?)\\?(\w+)[\w\W]+?^[ \t]*\2$', String),
```

- `['"]?` rather than a new group keeps the numbering, so `\2` still refers to the delimiter.
- `^...$` works because `RegexLexer.flags` defaults to `re.MULTILINE`.
- `[ \t]*` rather than `\t*` is deliberate: `examplefiles/bash/stripheredoc.sh` terminates a `<<-` here-doc with a **space**-indented `EOF`. Real bash strips only tabs there, so that file isn't legal bash — but over-acceptance is exactly what the Validation section sanctions, and `\t*` regresses that test. (I found this because the test went red, not by inspection.)

**Not a "not strict enough" report.** Per `doc/docs/contributing.rst`, accepting illegal code is fine — nothing here is about rejecting more. Both defects are the other category: valid, idiomatic bash whose body is lexed as the wrong token type, cascading into the rest of the file.

I left the identical rules in `TcshLexer` (`shell.py:591`) and `FishShellLexer` (`:814`) alone. Tcsh has the same two defects and is worth its own PR. Fish's copy looks like dead code — fish has no here-documents — so touching it would be cleanup, not a fix.

## Testing

`tests/snippets/` has samples for 141 languages and **none for bash**, which is why this went unnoticed; `examplefiles/bash/` only uses `<<EOF`/`<<-EOF`. (Amusingly, Pygments bundles `ltmain.sh`, and current libtool's `ltmain.sh` does use `<<"EOF"` — the bundled copy predates it.) Golden files are regenerated from current behaviour, so they encode the buggy tokens as expected and structurally can't catch this.

Added `tests/snippets/bash/` with two samples, goldens generated via `--update-goldens`. Both fail before the fix. Full suite: **5318 passed, 16 skipped** (5316 before, +2 mine) — no golden file changed.

