### PR TITLE
Remove superfluous parentheses from PostgresExplainLexer

### DIFF
--- a/pygments/lexers/sql.py
+++ b/pygments/lexers/sql.py
@@ -390,8 +390,8 @@ class PostgresExplainLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'(:|\(|\)|ms|kB|->|\.\.|\,|\/|=|%|text)', Punctuation),
-            (r'(\s+)', Whitespace),
+            (r':|\(|\)|ms|kB|->|\.\.|\,|\/|=|%|text', Punctuation),
+            (r'\s+', Whitespace),
 
             # This match estimated cost and effectively measured counters with ANALYZE
             # Then, we move to instrumentation state
@@ -407,7 +407,7 @@ class PostgresExplainLexer(RegexLexer):
              Comment.Single),
 
             (r'(hit|read|dirtied|written|write|time|calls|records|bytes|allocated|used|output|format)(=)', bygroups(Comment.Single, Operator)),
-            (r'(shared|temp|local)', Keyword.Pseudo),
+            (r'shared|temp|local', Keyword.Pseudo),
 
             # We move to sort state in order to emphasize specific keywords (especially disk access)
             (r'(Sort Method)(: )', bygroups(Comment.Preproc, Punctuation), 'sort'),
@@ -453,26 +453,26 @@ class PostgresExplainLexer(RegexLexer):
             (words(_postgres_builtins.EXPLAIN_KEYWORDS, suffix=r'\b'), Keyword),
 
             # join keywords
-            (r'((Right|Left|Full|Semi|Anti) Join)', Keyword.Type),
-            (r'(Parallel |Async |Finalize |Partial )', Comment.Preproc),
+            (r'(Right|Left|Full|Semi|Anti) Join', Keyword.Type),
+            (r'Parallel |Async |Finalize |Partial ', Comment.Preproc),
             (r'Backward', Comment.Preproc),
-            (r'(Intersect|Except|Hash)', Comment.Preproc),
+            (r'Intersect|Except|Hash', Comment.Preproc),
 
             (r'(CTE)( )(\w*)?', bygroups(Comment, Whitespace, Name.Variable)),
 
 
             # Treat "on" and "using" as a punctuation
-            (r'(on|using)', Punctuation, 'object_name'),
+            (r'on|using', Punctuation, 'object_name'),
 
 
             # strings
             (r"'(''|[^'])*'", String.Single),
             # numbers
             (r'-?\d+\.\d+', Number.Float),
-            (r'(-?\d+)', Number.Integer),
+            (r'-?\d+', Number.Integer),
 
             # boolean
-            (r'(true|false)', Name.Constant),
+            (r'true|false', Name.Constant),
             # explain header
             (r'\s*QUERY PLAN\s*\n\s*-+', Comment.Single),
             # Settings
@@ -492,7 +492,7 @@ class PostgresExplainLexer(RegexLexer):
             # the first opening paren is matched by the 'caller'
             (r'\(', Punctuation, '#push'),
             (r'\)', Punctuation, '#pop'),
-            (r'(never executed)', Name.Exception),
+            (r'never executed', Name.Exception),
             (r'[^)(]+', Comment),
         ],
         'object_name': [
@@ -504,7 +504,7 @@ class PostgresExplainLexer(RegexLexer):
             # if object_name is parenthesized, mark opening paren as
             # punctuation, call 'expression', and exit state
             (r'\(', Punctuation, 'expression'),
-            (r'(on)', Punctuation),
+            (r'on', Punctuation),
             # matches possibly schema-qualified table and column names
             (r'\w+(\.\w+)*( USING \S+| \w+ USING \S+)', Name.Variable),
             (r'\"?\w+\"?(?:\.\"?\w+\"?)?', Name.Variable),
@@ -537,16 +537,16 @@ class PostgresExplainLexer(RegexLexer):
         'instrumentation': [
             (r'=|\.\.', Punctuation),
             (r' +', Whitespace),
-            (r'(rows|width|time|loops)', Name.Class),
+            (r'rows|width|time|loops', Name.Class),
             (r'\d+\.\d+', Number.Float),
-            (r'(\d+)', Number.Integer),
+            (r'\d+', Number.Integer),
             (r'\)', Punctuation, '#pop'),
         ],
         'conflict': [
             (r'(Resolution: )(\w+)', bygroups(Comment.Preproc, Name.Variable)),
-            (r'(Arbiter \w+:)', Comment.Preproc, 'object_name'),
-            (r'(Filter: )', Comment.Preproc, 'predicate'),
-            (r'(Tuples: )', Comment.Preproc, 'predicate'),
+            (r'Arbiter \w+:', Comment.Preproc, 'object_name'),
+            (r'Filter: ', Comment.Preproc, 'predicate'),
+            (r'Tuples: ', Comment.Preproc, 'predicate'),
         ],
         'setting': [
             (r'([a-z_]*?)(\s*)(=)(\s*)(\'.*?\')', bygroups(Name.Attribute, Whitespace, Operator, Whitespace, String)),
@@ -559,9 +559,9 @@ class PostgresExplainLexer(RegexLexer):
         ],
         'sort': [
             (r':|kB', Punctuation),
-            (r'(quicksort|top-N|heapsort|Average|Memory|Peak)', Comment.Prepoc),
-            (r'(external|merge|Disk|sort)', Name.Exception),
-            (r'(\d+)', Number.Integer),
+            (r'quicksort|top-N|heapsort|Average|Memory|Peak', Comment.Prepoc),
+            (r'external|merge|Disk|sort', Name.Exception),
+            (r'\d+', Number.Integer),
             (r' +', Whitespace),
         ],
     }


### PR DESCRIPTION
Unfortunately, I don't think there's an easy way to have a regexlinter check for that :/