### PR TITLE
Add a lexer for Morrowind scripting (mwscript)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Version 2.21.0
   * BitBake (#3103)
   * Caddyfile (#3225)
   * CEL (#3048)
+  * MWScript (Morrowind scripting)
   * PureScript (#1077, #3054)
 
 - Updated lexers:

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -304,6 +304,7 @@ LEXERS = {
     'MIPSLexer': ('pygments.lexers.mips', 'MIPS', ('mips',), ('*.mips', '*.MIPS'), ()),
     'MOOCodeLexer': ('pygments.lexers.scripting', 'MOOCode', ('moocode', 'moo'), ('*.moo',), ('text/x-moocode',)),
     'MSDOSSessionLexer': ('pygments.lexers.shell', 'MSDOS Session', ('doscon',), (), ()),
+    'MWScriptLexer': ('pygments.lexers.mwscript', 'MWScript', ('mwscript', 'morrowind'), ('*.mwscript',), ('text/x-mwscript',)),
     'Macaulay2Lexer': ('pygments.lexers.macaulay2', 'Macaulay2', ('macaulay2',), ('*.m2',), ()),
     'MakefileLexer': ('pygments.lexers.make', 'Makefile', ('make', 'makefile', 'mf', 'bsdmake'), ('*.mak', '*.mk', 'Makefile', 'makefile', 'Makefile.*', 'GNUmakefile'), ('text/x-makefile',)),
     'MakoCssLexer': ('pygments.lexers.templates', 'CSS+Mako', ('css+mako',), (), ('text/css+mako',)),

--- a/pygments/lexers/mwscript.py
+++ b/pygments/lexers/mwscript.py
@@ -1,0 +1,209 @@
+"""
+    pygments.lexers.mwscript
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Lexer for Morrowind scripting (mwscript), the scripting language used by
+    the Elder Scrolls III: Morrowind Construction Set and OpenMW.
+
+    :copyright: Copyright 2006-present by the Pygments team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, bygroups, words
+from pygments.token import Comment, Keyword, Name, Number, Operator, \
+    Punctuation, String, Whitespace
+
+__all__ = ['MWScriptLexer']
+
+
+class MWScriptLexer(RegexLexer):
+    """
+    For Morrowind scripting (mwscript) source code, the scripting language
+    used by the Elder Scrolls III: Morrowind Construction Set and OpenMW.
+    """
+
+    name = 'MWScript'
+    aliases = ['mwscript', 'morrowind']
+    filenames = ['*.mwscript']
+    mimetypes = ['text/x-mwscript']
+    url = 'https://en.uesp.net/wiki/Morrowind_Mod:Scripting_Basics'
+    version_added = '2.21'
+
+    # Morrowind scripting is case-insensitive for keywords and functions.
+    flags = re.IGNORECASE | re.MULTILINE
+
+    # Flow-control and structural keywords.
+    keywords = (
+        'begin', 'end', 'if', 'elseif', 'else', 'endif', 'while', 'endwhile',
+        'return', 'set', 'to',
+    )
+
+    # Variable type declarations.
+    types = ('short', 'long', 'float')
+
+    # Special variables, globals and event locals that scripts can read.
+    pseudo = (
+        'player', 'playersavegameid', 'companion', 'day', 'dayspassed',
+        'gamehour', 'month', 'pcrace', 'pcvampire', 'pcwerewolf', 'pcskipequip',
+        'stayoutside', 'onactivate', 'ondeath', 'onknockout', 'onmurder',
+        'onpcadd', 'onpcdrop', 'onpcequip', 'onpchitme', 'onpcrepair',
+        'onpcsoulgemuse', 'onrepair', 'timescale', 'year',
+    )
+
+    # A representative set of built-in script functions and commands.
+    builtins = (
+        'activate', 'additem', 'addsoulgem', 'addspell', 'addtolevcreature',
+        'addtolevitem', 'addtopic', 'aiactivate', 'aiescort', 'aiescortcell',
+        'aifollow', 'aifollowcell', 'aitravel', 'aiwander', 'becomewerewolf',
+        'betacomment', 'cast', 'cellchanged', 'cellupdate', 'centeroncell',
+        'centeronexterior', 'changeweather', 'choice', 'clearforcejump',
+        'clearforcemovejump', 'clearforcerun', 'clearforcesneak',
+        'clearinfoactor', 'createmaps', 'disable', 'disablelevitation',
+        'disableplayercontrols', 'disableplayerfighting',
+        'disableplayerjumping', 'disableplayerlooking', 'disableplayermagic',
+        'disableplayerviewswitch', 'disableteleporting', 'disablevanitymode',
+        'dontsaveobject', 'drop', 'dropsoulgem', 'enable', 'enablebirthmenu',
+        'enableclassmenu', 'enableinventorymenu', 'enablelevelupmenu',
+        'enablelevitation', 'enablemagicmenu', 'enablemapmenu',
+        'enablenamemenu', 'enableplayercontrols', 'enableplayerfighting',
+        'enableplayerjumping', 'enableplayerlooking', 'enableplayermagic',
+        'enableplayerviewswitch', 'enableracemenu', 'enablerest',
+        'enablestatreviewmenu', 'enablestatsmenu', 'enableteleporting',
+        'enablevanitymode', 'equip', 'explodespell', 'face', 'fadein',
+        'fadeout', 'fadeto', 'fall', 'filljournal', 'fillmap', 'fixme',
+        'forcegreeting', 'forcejump', 'forcemovejump', 'forcerun', 'forcesneak',
+        'getacrobatics', 'getagility', 'getaipackagedone', 'getalarm',
+        'getalchemy', 'getalteration', 'getangle', 'getarmorbonus', 'getarmorer',
+        'getarmortype', 'getathletics', 'getattackbonus', 'getattacked',
+        'getaxe', 'getblightdisease', 'getblindness', 'getblock',
+        'getbluntweapon', 'getbuttonpressed', 'getcastpenalty', 'getchameleon',
+        'getcollidingactor', 'getcollidingpc', 'getcommondisease',
+        'getconjuration', 'getcurrentaipackage', 'getcurrenttime',
+        'getcurrentweather', 'getdeadcount', 'getdefendbonus', 'getdestruction',
+        'getdetected', 'getdisabled', 'getdisposition', 'getdistance',
+        'geteffect', 'getenchant', 'getendurance', 'getfactionreaction',
+        'getfatigue', 'getfight', 'getflee', 'getflying', 'getforcejump',
+        'getforcemovejump', 'getforcerun', 'getforcesneak', 'gethandtohand',
+        'gethealth', 'gethealthgetratio', 'getheavyarmor', 'gethello',
+        'getillusion', 'getintelligence', 'getinterior', 'getinvisible',
+        'getitemcount', 'getjournalindex', 'getlevel', 'getlightarmor',
+        'getlineofsight', 'getlos', 'getlocked', 'getlongblade', 'getluck',
+        'getmagicka', 'getmarksman', 'getmasserphase', 'getmediumarmor',
+        'getmercantile', 'getmysticism', 'getparalysis', 'getpccell',
+        'getpccrimelevel', 'getpcfacrep', 'getpcinjail', 'getpcjumping',
+        'getpcrank', 'getpcrunning', 'getpcsleep', 'getpcsneaking',
+        'getpctraveling', 'getpcvisionbonus', 'getpersonality',
+        'getplayercontrolsdisabled', 'getplayerfightingdisabled',
+        'getplayerjumpingdisabled', 'getplayerlookingdisabled',
+        'getplayermagicdisabled', 'getplayerviewswitch', 'getpos', 'getrace',
+        'getreputation', 'getresistblight', 'getresistcorprus',
+        'getresistdisease', 'getresistfire', 'getresistfrost',
+        'getresistmagicka', 'getresistnormalweapons', 'getresistparalysis',
+        'getresistpoison', 'getresistshock', 'getrestoration', 'getscale',
+        'getsecondspassed', 'getsecundaphase', 'getsecurity', 'getshortblade',
+        'getsilence', 'getsneak', 'getsoundplaying', 'getspear',
+        'getspeechcraft', 'getspeed', 'getspell', 'getspelleffects',
+        'getspellreadied', 'getsquareroot', 'getstandingactor', 'getstandingpc',
+        'getstartingangle', 'getstartingpos', 'getstrength', 'getsuperjump',
+        'getswimspeed', 'gettarget', 'getunarmored', 'getvanitymodedisabled',
+        'getwaterbreathing', 'getwaterlevel', 'getwaterwalking',
+        'getweapondrawn', 'getweapontype', 'getwerewolfkills', 'getwillpower',
+        'getwindspeed', 'goodbye', 'gotojail', 'hasitemequipped', 'hassoulgem',
+        'help', 'hitattemptonme', 'hitonme', 'hurtcollidingactor',
+        'hurtstandingactor', 'iswerewolf', 'journal', 'lock', 'loopgroup',
+        'lowerrank', 'menumode', 'menutest', 'messagebox', 'modacrobatics',
+        'modagility', 'modalarm', 'modalchemy', 'modalteration', 'modarmorbonus',
+        'modarmorer', 'modathletics', 'modattackbonus', 'modaxe', 'modblindness',
+        'modblock', 'modbluntweapon', 'modcastpenalty', 'modchameleon',
+        'modconjuration', 'modcurrentfatigue', 'modcurrenthealth',
+        'modcurrentmagicka', 'moddefendbonus', 'moddestruction', 'moddisposition',
+        'modenchant', 'modendurance', 'modfactionreaction', 'modfatigue',
+        'modfight', 'modflee', 'modflying', 'modhandtohand', 'modhealth',
+        'modheavyarmor', 'modhello', 'modillusion', 'modintelligence',
+        'modinvisible', 'modlightarmor', 'modlongblade', 'modluck', 'modmagicka',
+        'modmarksman', 'modmediumarmor', 'modmercantile', 'modmysticism',
+        'modparalysis', 'modpccrimelevel', 'modpcfacrep', 'modpcvisionbonus',
+        'modpersonality', 'modregion', 'modreputation', 'modresistblight',
+        'modresistcorprus', 'modresistdisease', 'modresistfire',
+        'modresistfrost', 'modresistmagicka', 'modresistnormalweapons',
+        'modresistparalysis', 'modresistpoison', 'modresistshock',
+        'modrestoration', 'modscale', 'modsecurity', 'modshortblade',
+        'modsilence', 'modsneak', 'modspear', 'modspeechcraft', 'modspeed',
+        'modstrength', 'modsuperjump', 'modswimspeed', 'modunarmored',
+        'modwaterbreathing', 'modwaterlevel', 'modwaterwalking', 'modwillpower',
+        'move', 'moveonetoone', 'moveworld', 'payfine', 'payfinethief',
+        'pcclearexpelled', 'pcexpell', 'pcexpelled', 'pcforce1stperson',
+        'pcforce3rdperson', 'pcget3rdperson', 'pcjoinfaction', 'pclowerrank',
+        'pcraiserank', 'placeatme', 'placeatpc', 'placeitem', 'placeitemcell',
+        'playbink', 'playgroup', 'playloopsound3d', 'playloopsound3dvp',
+        'playsound', 'playsound3d', 'playsound3dvp', 'playsoundvp', 'position',
+        'positioncell', 'purgetextures', 'raiserank', 'random', 'removeeffects',
+        'removefromlevcreature', 'removefromlevitem', 'removeitem',
+        'removesoulgem', 'removespell', 'removespelleffects', 'repairedonme',
+        'resetactors', 'resurrect', 'rotate', 'rotateworld', 'samefaction',
+        'say', 'saydone', 'scriptrunning', 'setacrobatics', 'setagility',
+        'setalarm', 'setalchemy', 'setalteration', 'setangle', 'setarmorbonus',
+        'setarmorer', 'setathletics', 'setatstart', 'setattackbonus', 'setaxe',
+        'setblindness', 'setblock', 'setbluntweapon', 'setcastpenalty',
+        'setchameleon', 'setconjuration', 'setdefendbonus', 'setdelete',
+        'setdestruction', 'setdisposition', 'setenchant', 'setendurance',
+        'setfactionreaction', 'setfatigue', 'setfight', 'setflee', 'setflying',
+        'sethandtohand', 'sethealth', 'setheavyarmor', 'sethello',
+        'setillusion', 'setintelligence', 'setinvisible', 'setjournalindex',
+        'setlevel', 'setlightarmor', 'setlongblade', 'setluck', 'setmagicka',
+        'setmarksman', 'setmediumarmor', 'setmercantile', 'setmysticism',
+        'setparalysis', 'setpccrimelevel', 'setpcfacrep', 'setpcvisionbonus',
+        'setpersonality', 'setpos', 'setreputation', 'setresistblight',
+        'setresistcorprus', 'setresistdisease', 'setresistfire',
+        'setresistfrost', 'setresistmagicka', 'setresistnormalweapons',
+        'setresistparalysis', 'setresistpoison', 'setresistshock',
+        'setrestoration', 'setscale', 'setsecurity', 'setshortblade',
+        'setsilence', 'setsneak', 'setspear', 'setspeechcraft', 'setspeed',
+        'setstrength', 'setsuperjump', 'setswimspeed', 'setunarmored',
+        'setwaterbreathing', 'setwaterlevel', 'setwaterwalking',
+        'setwerewolfacrobatics', 'setwillpower', 'show', 'showanim', 'showgroup',
+        'showmap', 'showrestmenu', 'showscenegraph', 'showtargets', 'showvars',
+        'skipanim', 'startcombat', 'startscript', 'stopcelltest', 'stopcombat',
+        'stopscript', 'stopsound', 'streammusic', 'testcells',
+        'testinteriorcells', 'testmodels', 'testthreadcells', 'toggleai',
+        'toggleborders', 'togglecollision', 'togglecollisionboxes',
+        'togglecollisiongrid', 'togglecombatstats', 'toggledebugtext',
+        'toggledialoguestats', 'togglefogofwar', 'togglefullhelp', 'togglegodmode',
+        'togglegrid', 'togglekillstats', 'togglelights', 'toggleloadfade',
+        'togglemagicstats', 'togglemenus', 'togglepathgrid', 'togglescriptoutput',
+        'togglescripts', 'togglesky', 'togglestats', 'toggletexturestring',
+        'togglevanitymode', 'togglewater', 'togglewireframe', 'toggleworld',
+        'turnmoonred', 'turnmoonwhite', 'undowerewolf', 'unlock', 'usedonme',
+        'wakeuppc', 'xbox',
+    )
+
+    tokens = {
+        'root': [
+            (r'[^\S\n]+', Whitespace),
+            (r'\n', Whitespace),
+            (r';[^\n]*', Comment.Single),
+            # Closing quote optional so an unterminated string (common while
+            # editing) is highlighted as a string instead of an Error token.
+            (r'"[^"\n]*"?', String.Double),
+            # ``begin <name>`` starts a script; highlight the script name.
+            (r'\b(begin)\b([^\S\n]+)([\w.]+)',
+             bygroups(Keyword, Whitespace, Name.Namespace)),
+            (words(keywords, suffix=r'\b'), Keyword),
+            (words(types, suffix=r'\b'), Keyword.Type),
+            (words(pseudo, suffix=r'\b'), Name.Builtin.Pseudo),
+            (words(builtins, suffix=r'\b'), Name.Builtin),
+            (r'->|==|!=|<=|>=|[<>+\-*/=]', Operator),
+            (r'\d+\.\d+', Number.Float),
+            (r'\d+', Number.Integer),
+            (r'[(),.]', Punctuation),
+            (r'[a-zA-Z_]\w*', Name),
+        ],
+    }
+
+    def analyse_text(text):
+        # Scripts are delimited by ``begin <name>`` ... ``end``.
+        if re.search(r'(?im)^\s*begin\s+\w', text) and \
+                re.search(r'(?im)^\s*end\b', text):
+            return 0.2

--- a/tests/examplefiles/mwscript/example.mwscript
+++ b/tests/examplefiles/mwscript/example.mwscript
@@ -1,0 +1,48 @@
+begin TrickChestScript
+short OpenAttempt
+
+; Check for the player attempting to open the chest. Use the OpenAttempt variable as
+; putting all the code into the OnActivate if statement becomes difficult for more
+; complex scripts.
+if ( OnActivate == 1 )
+    set OpenAttempt to 1
+end if
+
+; Stop the script if not trying to open the chest
+if ( OpenAttempt == 0 )
+    return
+endif
+
+; Check the player for the 'secret' key, which is 10 pillows
+if ( player->GetItemCount, "misc_uni_pillow_01" >= 10 )
+
+    Activate        ; Open the container normally
+    Set OpenAttempt to 0
+    MessageBox, "The chest opens mysteriously..."
+
+; The player doesn't have 10 pillows, activate trap
+else
+    PlaySound3D, "Heavy Armor Hit"      ; Play ominous sound
+    Set OpenAttempt to 0
+
+    ; Cast trap on player depending on level
+    if ( player->GetLevel < 10 )
+        Cast, "poisontrap_10", Player
+    elseif ( player->GetLevel < 25 )
+        Cast, "poisontrap_50", Player
+    elseif ( player->GetLevel < 50 )
+        Cast, "poisontrap_150", Player
+    else
+        Cast, "poisontrap_250", Player
+    endif
+    
+endif
+
+short Value
+while ( Value < 10 )    
+    set Value to ( Value + 1 )
+endwhile
+MessageBox, "Value:%d", Value
+
+
+end

--- a/tests/examplefiles/mwscript/example.mwscript.output
+++ b/tests/examplefiles/mwscript/example.mwscript.output
@@ -1,0 +1,314 @@
+'begin'       Keyword
+' '           Text.Whitespace
+'TrickChestScript' Name.Namespace
+'\n'          Text.Whitespace
+
+'short'       Keyword.Type
+' '           Text.Whitespace
+'OpenAttempt' Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'; Check for the player attempting to open the chest. Use the OpenAttempt variable as' Comment.Single
+'\n'          Text.Whitespace
+
+'; putting all the code into the OnActivate if statement becomes difficult for more' Comment.Single
+'\n'          Text.Whitespace
+
+'; complex scripts.' Comment.Single
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'OnActivate'  Name.Builtin.Pseudo
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'set'         Keyword
+' '           Text.Whitespace
+'OpenAttempt' Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'end'         Keyword
+' '           Text.Whitespace
+'if'          Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'; Stop the script if not trying to open the chest' Comment.Single
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'OpenAttempt' Name
+' '           Text.Whitespace
+'=='          Operator
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'return'      Keyword
+'\n'          Text.Whitespace
+
+'endif'       Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"; Check the player for the 'secret' key, which is 10 pillows" Comment.Single
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'player'      Name.Builtin.Pseudo
+'->'          Operator
+'GetItemCount' Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"misc_uni_pillow_01"' Literal.String.Double
+' '           Text.Whitespace
+'>='          Operator
+' '           Text.Whitespace
+'10'          Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Activate'    Name.Builtin
+'        '    Text.Whitespace
+'; Open the container normally' Comment.Single
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Set'         Keyword
+' '           Text.Whitespace
+'OpenAttempt' Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'MessageBox'  Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"The chest opens mysteriously..."' Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+"; The player doesn't have 10 pillows, activate trap" Comment.Single
+'\n'          Text.Whitespace
+
+'else'        Keyword
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'PlaySound3D' Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"Heavy Armor Hit"' Literal.String.Double
+'      '      Text.Whitespace
+'; Play ominous sound' Comment.Single
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'Set'         Keyword
+' '           Text.Whitespace
+'OpenAttempt' Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'; Cast trap on player depending on level' Comment.Single
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'player'      Name.Builtin.Pseudo
+'->'          Operator
+'GetLevel'    Name.Builtin
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'10'          Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'Cast'        Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"poisontrap_10"' Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'Player'      Name.Builtin.Pseudo
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'elseif'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'player'      Name.Builtin.Pseudo
+'->'          Operator
+'GetLevel'    Name.Builtin
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'25'          Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'Cast'        Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"poisontrap_50"' Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'Player'      Name.Builtin.Pseudo
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'elseif'      Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'player'      Name.Builtin.Pseudo
+'->'          Operator
+'GetLevel'    Name.Builtin
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'50'          Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'Cast'        Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"poisontrap_150"' Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'Player'      Name.Builtin.Pseudo
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'else'        Keyword
+'\n'          Text.Whitespace
+
+'        '    Text.Whitespace
+'Cast'        Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"poisontrap_250"' Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'Player'      Name.Builtin.Pseudo
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'endif'       Keyword
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'\n'          Text.Whitespace
+
+'endif'       Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'short'       Keyword.Type
+' '           Text.Whitespace
+'Value'       Name
+'\n'          Text.Whitespace
+
+'while'       Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'Value'       Name
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'10'          Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'    '        Text.Whitespace
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'set'         Keyword
+' '           Text.Whitespace
+'Value'       Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'Value'       Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'1'           Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'endwhile'    Keyword
+'\n'          Text.Whitespace
+
+'MessageBox'  Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"Value:%d"'  Literal.String.Double
+','           Punctuation
+' '           Text.Whitespace
+'Value'       Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'end'         Keyword
+'\n'          Text.Whitespace

--- a/tests/snippets/mwscript/test_basic.txt
+++ b/tests/snippets/mwscript/test_basic.txt
@@ -1,0 +1,154 @@
+---input---
+begin TestScript
+
+short DaysPassed
+float Gold
+
+set DaysPassed to 0
+set Gold to ( Gold + 100.5 )
+
+while ( Gold < 100000 )
+    player->AddItem, Gold_001, 100
+    set Gold to Gold + 100
+endwhile
+
+if ( DaysPassed <= 3 )
+    MessageBox, "Not enough time has passed"
+endif
+
+set objectID.varName to 100
+
+end
+
+---tokens---
+'begin'       Keyword
+' '           Text.Whitespace
+'TestScript'  Name.Namespace
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'short'       Keyword.Type
+' '           Text.Whitespace
+'DaysPassed'  Name.Builtin.Pseudo
+'\n'          Text.Whitespace
+
+'float'       Keyword.Type
+' '           Text.Whitespace
+'Gold'        Name
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'set'         Keyword
+' '           Text.Whitespace
+'DaysPassed'  Name.Builtin.Pseudo
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'0'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'set'         Keyword
+' '           Text.Whitespace
+'Gold'        Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'Gold'        Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'100.5'       Literal.Number.Float
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'while'       Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'Gold'        Name
+' '           Text.Whitespace
+'<'           Operator
+' '           Text.Whitespace
+'100000'      Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'player'      Name.Builtin.Pseudo
+'->'          Operator
+'AddItem'     Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'Gold_001'    Name
+','           Punctuation
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'set'         Keyword
+' '           Text.Whitespace
+'Gold'        Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'Gold'        Name
+' '           Text.Whitespace
+'+'           Operator
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'endwhile'    Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'if'          Keyword
+' '           Text.Whitespace
+'('           Punctuation
+' '           Text.Whitespace
+'DaysPassed'  Name.Builtin.Pseudo
+' '           Text.Whitespace
+'<='          Operator
+' '           Text.Whitespace
+'3'           Literal.Number.Integer
+' '           Text.Whitespace
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'    '        Text.Whitespace
+'MessageBox'  Name.Builtin
+','           Punctuation
+' '           Text.Whitespace
+'"Not enough time has passed"' Literal.String.Double
+'\n'          Text.Whitespace
+
+'endif'       Keyword
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'set'         Keyword
+' '           Text.Whitespace
+'objectID'    Name
+'.'           Punctuation
+'varName'     Name
+' '           Text.Whitespace
+'to'          Keyword
+' '           Text.Whitespace
+'100'         Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'end'         Keyword
+'\n'          Text.Whitespace


### PR DESCRIPTION
mwscript is the scripting language used by the Elder Scrolls III: Morrowind Construction Set and OpenMW. The lexer handles the case-insensitive syntax: begin/end script blocks, short/long/float declarations, the -> reference operator and . local-variable access, comparison/arithmetic operators, ; comments, quoted object IDs, and a comprehensive set of built-in functions, special variables and globals.

It's pretty niche, but since I'm part of the OpenMW project, I'm biased toward its inclusion in pygments :P