### PR TITLE
BitBake: align the lexer with BitBake's own parser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,16 @@ Version 2.22.0
 --------------
 (not released yet)
 
+- Updated lexers:
+
+  * BitBake:
+    - Take the statement rules from BitBake's own parser, so the lexer
+      accepts exactly what BitBake accepts and marks what it rejects
+    - Lex nested ``${...}`` expansions, including those embedded in a
+      ``${@...}`` Python expression
+    - Recover at the end of a line from an unterminated string or
+      expansion instead of losing the rest of the file
+
 Version 2.21.0
 ---------------
 (released August 17th, 2026)

--- a/pygments/lexers/bitbake.py
+++ b/pygments/lexers/bitbake.py
@@ -14,10 +14,108 @@ import re
 from pygments.lexer import RegexLexer, bygroups, include, using, words
 from pygments.lexers.python import PythonLexer
 from pygments.lexers.shell import BashLexer
-from pygments.token import Comment, Keyword, Name, Operator, Punctuation, \
-    String, Text, Whitespace
+from pygments.token import Comment, Error, Keyword, Name, Operator, \
+    Punctuation, String, Text, Whitespace
 
 __all__ = ['BitBakeLexer']
+
+
+class _FragmentPythonLexer(PythonLexer):
+    """Lex a ``${@...}`` fragment without reporting its incompleteness.
+
+    An inline Python expression is handed over in pieces, split around any
+    ``${VAR}`` expansions embedded in it, so a piece routinely begins or ends
+    mid-string and is not valid Python on its own. The error would be an
+    artefact of the splitting rather than a defect in the metadata.
+
+    This is deliberately the only place errors are suppressed. Errors in
+    BitBake's own syntax, and in a complete shell or Python function body,
+    are reported.
+    """
+
+    def get_tokens_unprocessed(self, text, stack=('root',)):
+        for index, token, value in super().get_tokens_unprocessed(text, stack):
+            yield index, Text if token is Error else token, value
+
+
+# ---------------------------------------------------------------------------
+# Validity is decided by BitBake, never by this file.
+#
+# Each pattern is BitBake's own statement regex from ``bb.parse.parse_py``,
+# mechanically adapted, and used below only as a zero-width guard: a rule
+# fires when and only when BitBake's parser would accept the line. The token
+# spans are then chosen separately, which is the part a lexer is for.
+#
+# Three adaptations are applied, each because BitBake matches one
+# already-assembled logical line while a lexer sees raw file text:
+#
+#   \s   ->  [ \t]                 its \s can never meet a newline, because
+#                                  the file has already been split into lines
+#   .    ->  (?:[^\n]|\\[ \t]*\n)        continuations are joined before BitBake
+#                                  sees them, and inline here instead
+#   $    ->  [ \t]*$               the line is rstripped before matching, so
+#                                  the anchors tolerate trailing whitespace
+#
+# The last applies to every anchor including the ones inside the assignment
+# rule's negative lookaheads, which are what decide whether the quotes
+# balance. Do not hand-edit these; regenerate them and check that the
+# verdicts still agree with BitBake's on real metadata.
+_BB = {
+    'function start':
+        '^(?:(?:(?:python(?=(?:(?:[ \\t]|\\\\[ \\t]*\\n)|\\()))|(?:fakeroot(?=(?:[ \\t]|\\\\[ \\t]*\\n))))(?:[ \\t]|\\\\[ \\t]*\\n)*)*(?:[\\w\\.\\-\\+\\{\\}\\$:]+)?(?:[ \\t]|\\\\[ \\t]*\\n)*\\((?:[ \\t]|\\\\[ \\t]*\\n)*\\)(?:[ \\t]|\\\\[ \\t]*\\n)*\\{[ \\t]*$',
+    'def block':
+        '^def(?:[ \\t]|\\\\[ \\t]*\\n)+(?:\\w+)(?:[^\\n]|\\\\[ \\t]*\\n)*:',
+    'export':
+        '^export(?:[ \\t]|\\\\[ \\t]*\\n)+(?:[a-zA-Z0-9\\-_+.${}/~]+)[ \\t]*$',
+    'unset varflag':
+        '^unset(?:[ \\t]|\\\\[ \\t]*\\n)+(?:[a-zA-Z0-9\\-_+.${}/~]+)\\[(?:[a-zA-Z0-9\\-_+.][a-zA-Z0-9\\-_+.@]+)\\][ \\t]*$',
+    'unset':
+        '^unset(?:[ \\t]|\\\\[ \\t]*\\n)+(?:[a-zA-Z0-9\\-_+.${}/~]+)[ \\t]*$',
+    'addpylib':
+        '^addpylib(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'addfragments':
+        '^addfragments(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'inherit_defer':
+        '^inherit_defer(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'inherit':
+        '^inherit(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'include_all':
+        '^include_all(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'include':
+        '^include(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'require':
+        '^require(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'EXPORT_FUNCTIONS':
+        '^EXPORT_FUNCTIONS(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'addtask':
+        '^addtask(?:[ \\t]|\\\\[ \\t]*\\n)+(?:[^#\\n]+)(?:#(?:[^\\n]|\\\\[ \\t]*\\n)*|(?:[^\\n]|\\\\[ \\t]*\\n)*?)',
+    'deltask':
+        '^deltask(?:[ \\t]|\\\\[ \\t]*\\n)+(?:[^#\\n]+)(?:#(?:[^\\n]|\\\\[ \\t]*\\n)*|(?:[^\\n]|\\\\[ \\t]*\\n)*?)',
+    'addhandler':
+        '^addhandler(?:[ \\t]|\\\\[ \\t]*\\n)+(?:(?:[^\\n]|\\\\[ \\t]*\\n)+)',
+    'assignment':
+        '^(?:export(?:[ \\t]|\\\\[ \\t]*\\n)+)?(?:[a-zA-Z0-9\\-_+.${}/~:]*?)(?:\\[(?:[a-zA-Z0-9\\-_+.][a-zA-Z0-9\\-_+.@/]*)\\])?(?:(?:[ \\t]|\\\\[ \\t]*\\n)*)(?:(?::=)|(?:\\?\\?=)|(?:\\?=)|(?:\\+=)|(?:=\\+)|(?:=\\.)|(?:\\.=)|=)(?:(?:[ \\t]|\\\\[ \\t]*\\n)*)(?!\'[^\'\\n]*\'[^\'\\n]*\'[ \\t]*$)(?!\\"[^\\"\\n]*\\"[^\\"\\n]*\\"[ \\t]*$)(?:\'(?:(?:[^\\n]|\\\\[ \\t]*\\n)*)\'|"(?:(?:[^\\n]|\\\\[ \\t]*\\n)*)")[ \\t]*$',
+}
+
+
+def _guard(*names):
+    """A zero-width assertion that BitBake's parser would accept this line."""
+    # The anchor is hoisted out of the alternation rather than repeated in
+    # each branch, which regexlint flags as suspicious (W114).
+    return r'(?=^(?:%s))' % '|'.join(_BB[name].lstrip('^') for name in names)
+
+
+_G_FUNC = _guard('function start')
+_G_DEF = _guard('def block')
+_G_INCLUDE = _guard('inherit_defer', 'inherit', 'include_all', 'include',
+                    'require')
+_G_STATEMENT = _guard('addtask', 'deltask', 'addhandler', 'EXPORT_FUNCTIONS',
+                      'addpylib', 'addfragments')
+_G_ASSIGN = _guard('assignment')
+_G_VALUELESS = _guard('export', 'unset varflag', 'unset')
+
+# None of the guards capture, so they add nothing for ``bygroups`` to number.
+
 
 # A bare BitBake identifier (variable, function or flag name). Allows the
 # characters used by OE-Core variable names (digits, ``-``, ``.``, ``+``).
@@ -26,11 +124,23 @@ _IDENT = r'[A-Za-z_][A-Za-z0-9_\-.+]*'
 # Optional OE override chain such as ``:append``, ``:remove``, ``:class-target``
 # or ``:${PN}-doc``. Anchored so it only consumes ``:foo`` runs and never
 # eats the leading ``:`` of the ``:=`` assignment operator.
-_OVERRIDE = r'(?::[A-Za-z0-9_\-.+${}]+)*'
+_OVERRIDE = r'(?::[A-Za-z0-9_\-.+/~${}]+)*'
 
 # All BitBake variable assignment operators, ordered so that the longer
 # operators win the regex alternation.
 _ASSIGN = r'(?:\?\?=|\?=|:=|\+=|=\+|\.=|=\.|=)'
+
+# A variable or function name, matching what BitBake's own parser accepts
+# (``[a-zA-Z0-9\-_+.${}/~:]`` for variables, ``[\w.\-+{}$:]`` for
+# functions). Names may begin with a digit, may contain ``/`` as in
+# ``PREFERRED_PROVIDER_virtual/kernel``, and may embed an expansion as in
+# ``PREFERRED_PROVIDER_virtual/${SDK_PREFIX}libc``. The ``:`` introducing
+# an override chain is excluded, since ``_OVERRIDE`` consumes that.
+_NAME = r':?(?:\$\{[^{}\s]+\}|[A-Za-z0-9_\-.+/~${}])+'
+
+# A varflag name, which may also begin with a digit, as in
+# ``ESW_BRANCH[2024.1]``.
+_FLAG = r'[A-Za-z0-9_\-.+][A-Za-z0-9_\-.+@/]*'
 
 
 class BitBakeLexer(RegexLexer):
@@ -50,14 +160,19 @@ class BitBakeLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'[ \t]+', Whitespace),
+            (r'[ \t]+$', Whitespace),
             (r'\n', Whitespace),
-            (r'#.*$', Comment.Single),
+
+            # ``handle`` tests for a comment at column zero only, and only
+            # after joining continuations, so an indented ``#`` is not a
+            # comment and a comment ending in ``\`` swallows the line below.
+            (r'^#(?:[^\n]|\\[ \t]*\n)*', Comment.Single),
 
             # ``python [name]() { ... }`` blocks (also ``fakeroot python``).
             # Must be tried before the generic shell function rule so the
             # ``python`` keyword is not mistaken for a shell function name.
-            (r'(^(?:fakeroot[ \t]+)?)(python)((?:[ \t]+' + _IDENT + r')?)'
+            (_G_FUNC + r'(^(?:fakeroot[ \t]+)?)(python)((?:[ \t]+' + _NAME
+             + _OVERRIDE + r')?)'
              r'([ \t]*\([ \t]*\)[ \t]*)(\{[ \t]*\n)'
              r'((?:.*\n)*?)'
              r'(^\}[ \t]*$)',
@@ -65,7 +180,8 @@ class BitBakeLexer(RegexLexer):
                       Punctuation, using(PythonLexer), Punctuation)),
 
             # Shell task bodies: ``[fakeroot ]name[:override]() { ... }``.
-            (r'(^(?:fakeroot[ \t]+)?)(' + _IDENT + r')(' + _OVERRIDE + r')'
+            (_G_FUNC + r'(^(?:fakeroot[ \t]+)?)(' + _NAME + r')('
+             + _OVERRIDE + r')'
              r'([ \t]*\([ \t]*\)[ \t]*)(\{[ \t]*\n)'
              r'((?:.*\n)*?)'
              r'(^\}[ \t]*$)',
@@ -74,38 +190,62 @@ class BitBakeLexer(RegexLexer):
 
             # Top-level python ``def`` blocks; the body is any run of
             # indented or blank lines following the signature.
-            (r'^def[ \t]+' + _IDENT + r'[ \t]*\([^)]*\)[ \t]*:[ \t]*\n'
-             r'(?:[ \t]+.*\n|\n)+',
+            # BitBake's rule is ``def\s+(\w+).*:``, which validates little
+            # and does not require a body, so neither may this. The guard
+            # has already decided the line is a def.
+            (_G_DEF + r'^def[ \t]+(?:[^\n]|\\[ \t]*\n)*:(?:[^\n]|\\[ \t]*\n)*(?:\n|$)'
+             r'(?:[ \t]+.*\n|\n)*',
              using(PythonLexer)),
 
             # ``inherit`` / ``inherit_defer`` / ``include`` / ``include_all`` /
             # ``require`` directives. Longer keywords are listed first so the
             # regex alternation does not match the shorter prefix.
-            (r'^(inherit_defer|inherit|include_all|include|require)\b',
+            (_G_INCLUDE
+             + r'^(inherit_defer|inherit|include_all|include|require)\b',
              Keyword.Namespace, 'include-line'),
 
-            # ``addtask`` / ``deltask`` / ``addhandler`` / ``EXPORT_FUNCTIONS``.
-            (r'^(addtask|deltask|addhandler|EXPORT_FUNCTIONS)\b',
+            # ``addtask`` / ``deltask`` / ``addhandler`` / ``EXPORT_FUNCTIONS``
+            # / ``addpylib`` / ``addfragments``.
+            (_G_STATEMENT
+             + r'^(addtask|deltask|addhandler|EXPORT_FUNCTIONS|addpylib'
+             r'|addfragments)\b',
              Keyword, 'statement'),
 
-            # ``VAR[flag] = "value"`` (varflag assignment).
-            (r'^(' + _IDENT + r')(\[)(' + _IDENT + r')(\])([ \t]*)('
-             + _ASSIGN + r')',
-             bygroups(Name.Variable, Punctuation, Name.Attribute,
-                      Punctuation, Whitespace, Operator),
+            # ``VAR[flag] = "value"`` (varflag assignment). The variable may
+            # carry an override chain first, as in
+            # ``GOARM:arm:class-target[export] = "1"``.
+            (_G_ASSIGN + r'^(' + _NAME + r')(' + _OVERRIDE + r')(\[)('
+             + _FLAG + r')(\])'
+             r'([ \t]*)(' + _ASSIGN + r')',
+             bygroups(Name.Variable, Name.Decorator, Punctuation,
+                      Name.Attribute, Punctuation, Whitespace, Operator),
              'value'),
 
             # ``[export ]VAR[:override...] OP "value"`` assignments.
-            (r'^(export[ \t]+)?(' + _IDENT + r')(' + _OVERRIDE + r')'
+            (_G_ASSIGN + r'^(export[ \t]+)?(' + _NAME + r')('
+             + _OVERRIDE + r')'
              r'([ \t]*)(' + _ASSIGN + r')',
              bygroups(Keyword.Type, Name.Variable, Name.Decorator,
                       Whitespace, Operator),
              'value'),
 
-            # Anything else: consume runs of "boring" characters in one
-            # token, then fall back to a single character if needed.
-            (r'[^\s#${}\[\]:=+?.@\\"\']+', Text),
-            (r'.', Text),
+            # ``export VAR`` and ``unset VAR`` / ``unset VAR[flag]``, which
+            # carry no value. These follow the assignment rules so that
+            # ``export VAR = "value"`` is still matched as an assignment.
+            (_G_VALUELESS + r'^(export|unset)([ \t]+)(' + _NAME + r')(\[)('
+             + _FLAG + r')'
+             r'(\])([ \t]*)$',
+             bygroups(Keyword, Whitespace, Name.Variable, Punctuation,
+                      Name.Attribute, Punctuation, Whitespace)),
+            (_G_VALUELESS + r'^(export|unset)([ \t]+)(' + _NAME
+             + r')([ \t]*)$',
+             bygroups(Keyword, Whitespace, Name.Variable, Whitespace)),
+
+            # Nothing above matched, so BitBake's parser would reject this
+            # line. Report it. A documentation block that is wrong on
+            # purpose carries ``:force:``, which skips Sphinx's filter for
+            # that block and leaves the marking visible.
+            (r'(?:[^\n]|\\[ \t]*\n)+', Error),
         ],
 
         'include-line': [
@@ -113,7 +253,9 @@ class BitBakeLexer(RegexLexer):
             (r'\\\n', Text),
             (r'\n', Whitespace, '#pop'),
             include('interp'),
+            (r'\$', String),
             (r'[^\s$]+', String),
+            (r'[^\n]', String),
         ],
 
         'statement': [
@@ -122,45 +264,91 @@ class BitBakeLexer(RegexLexer):
             (r'\n', Whitespace, '#pop'),
             (words(('after', 'before'), suffix=r'\b'), Keyword),
             include('interp'),
+            (r'\$', Name),
             (r'[^\s$\\]+', Name),
+            (r'[^\n]', Name),
         ],
 
         'value': [
             (r'[ \t]+', Whitespace),
-            (r'\\\n', String.Escape),
+            # A backslash is special to BitBake only as the last
+            # character of a line, where it continues the statement.
+            # There are no escape sequences in a value, so treating
+            # \\\\ as an escaped pair would swallow the backslash that
+            # forms the continuation.
+            (r'\\[ \t]*\n', String.Escape),
             (r'\n', Whitespace, '#pop'),
             (r'"', String.Double, 'string-double'),
             (r"'", String.Single, 'string-single'),
             include('interp'),
+            (r'\$', String),
             (r'[^\s"\'$\\]+', String),
+            (r'[^\n]', String),
         ],
 
         'string-double': [
-            (r'\\\n', String.Escape),
-            (r'\\.', String.Escape),
+            # A backslash is special to BitBake only as the last
+            # character of a line, where it continues the statement.
+            # There are no escape sequences in a value, so treating
+            # \\\\ as an escaped pair would swallow the backslash that
+            # forms the continuation.
+            (r'\\[ \t]*\n', String.Escape),
             (r'"', String.Double, '#pop'),
             include('interp'),
-            (r'[^"\\$]+', String.Double),
+            (r'\$', String.Double),
+            (r'[^"\\$\n]+', String.Double),
+            (r'[^\n]', String.Double),
         ],
 
         'string-single': [
-            (r'\\\n', String.Escape),
-            (r'\\.', String.Escape),
+            # A backslash is special to BitBake only as the last
+            # character of a line, where it continues the statement.
+            # There are no escape sequences in a value, so treating
+            # \\\\ as an escaped pair would swallow the backslash that
+            # forms the continuation.
+            (r'\\[ \t]*\n', String.Escape),
             (r"'", String.Single, '#pop'),
             include('interp'),
-            (r"[^'\\$]+", String.Single),
+            (r'\$', String.Single),
+            (r"[^'\\$\n]+", String.Single),
+            (r'[^\n]', String.Single),
         ],
 
         'interp': [
             # ``${@ python expression }`` evaluated by BitBake at parse time.
             (r'\$\{@', String.Interpol, 'py-interp'),
-            # ``${VAR}`` variable expansion.
-            (r'(\$\{)([A-Za-z0-9_\-:.+/]+)(\})',
-             bygroups(String.Interpol, Name.Variable, String.Interpol)),
+            # ``${VAR}`` variable expansion, which may itself contain further
+            # expansions such as ``${TUNE_ARCH:tune-${DEFAULTTUNE}}``.
+            (r'\$\{', String.Interpol, 'var-interp'),
+        ],
+
+        'var-interp': [
+            (r'\}', String.Interpol, '#pop'),
+            (r'\\[ \t]*\n', String.Escape),
+            (r'\$\{@', String.Interpol, 'py-interp'),
+            (r'\$\{', String.Interpol, '#push'),
+            (r'[^${}\n\\]+', Name.Variable),
+            (r'\$', Name.Variable),
+            (r'[^\n]', Name.Variable),
         ],
 
         'py-interp': [
             (r'\}', String.Interpol, '#pop'),
-            (r'[^}]+', using(PythonLexer)),
+            (r'\\[ \t]*\n', String.Escape),
+            # ``${VAR}`` expansions embedded in the Python expression, as in
+            # ``${@bb.utils.contains('F', 'x', '${A}', '', d)}``.
+            (r'\$\{', String.Interpol, 'var-interp'),
+            # The backslash is excluded so that the continuation rule above
+            # gets the chance to match it. Swallowed here instead, the
+            # newline ends up matching nothing, the state stack unwinds
+            # mid-expression, and every following line of a multi-line
+            # ``${@...}`` is lexed at the top level and reported as invalid.
+            (r'[^${}\n\\]+', using(_FragmentPythonLexer)),
+            # A ``$`` that does not open an expansion belongs to the Python
+            # expression's own text, most often a regular-expression anchor
+            # inside a quoted string.
+            (r'\$', String),
+            (r'\{', using(_FragmentPythonLexer)),
+            (r'[^\n]', String),
         ],
     }

--- a/tests/snippets/bitbake/broken_input.txt
+++ b/tests/snippets/bitbake/broken_input.txt
@@ -1,0 +1,134 @@
+---input---
+fakeroot create_shar() {
+   cat << "EOF" > ${SDK_DEPLOY}/${TOOLCHAIN_OUTPUTNAME}.sh
+usage()
+{
+   echo "test"
+}
+EOF
+}
+SUMMARY = "this quote never closes
+PN = "recovered"
+COMPATIBLE_MACHINE = "^$"
+L = "${@'a'.replace('b', 'c')}"
+python do_broken() {
+    if True
+        pass ?? 3
+}
+
+---tokens---
+'fakeroot '   Keyword.Type
+'create_shar' Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'   '         Text.Whitespace
+'cat'         Text
+' '           Text.Whitespace
+'<'           Text
+'<'           Text
+' '           Text.Whitespace
+'"EOF"'       Literal.String.Double
+' '           Text.Whitespace
+'>'           Text
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'SDK_DEPLOY'  Name.Variable
+'}'           Literal.String.Interpol
+'/'           Text
+'${'          Literal.String.Interpol
+'TOOLCHAIN_OUTPUTNAME' Name.Variable
+'}'           Literal.String.Interpol
+'.sh'         Text
+'\n'          Text.Whitespace
+
+'usage'       Text
+'('           Operator
+')'           Operator
+'\n'          Text.Whitespace
+
+'{'           Operator
+'\n   '       Text.Whitespace
+'echo'        Name.Builtin
+' '           Text.Whitespace
+'"test"'      Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace
+
+'EOF'         Error
+'\n'          Text.Whitespace
+
+'}'           Error
+'\n'          Text.Whitespace
+
+'SUMMARY = "this quote never closes' Error
+'\n'          Text.Whitespace
+
+'PN'          Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'recovered'   Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'COMPATIBLE_MACHINE' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'^'           Literal.String.Double
+'$'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'L'           Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${@'         Literal.String.Interpol
+"'"           Literal.String.Single
+'a'           Literal.String.Single
+"'"           Literal.String.Single
+'.'           Operator
+'replace'     Name
+'('           Punctuation
+"'"           Literal.String.Single
+'b'           Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'c'           Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'python'      Keyword
+' do_broken'  Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text
+'if'          Keyword
+' '           Text
+'True'        Keyword.Constant
+'\n'          Text.Whitespace
+
+'        '    Text
+'pass'        Keyword
+' '           Text
+'?'           Error
+'?'           Error
+' '           Text
+'3'           Literal.Number.Integer
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/extended_names.txt
+++ b/tests/snippets/bitbake/extended_names.txt
@@ -1,0 +1,100 @@
+---input---
+3GTOOLS:microblaze ?= ""
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-yocto"
+PREFERRED_PROVIDER_virtual/nativesdk-${SDK_PREFIX}libc = "nativesdk-glibc"
+LICENSE:modules/freebsd/vmblock = "BSD-2-Clause"
+ESW_BRANCH[2024.1] = "xlnx_rel_v2024.1"
+GOARM:arm:class-target[export] = "1"
+
+python populate_packages:prepend () {
+    d.setVar('FOO', 'bar')
+}
+
+---tokens---
+'3GTOOLS'     Name.Variable
+':microblaze' Name.Decorator
+' '           Text.Whitespace
+'?='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PREFERRED_PROVIDER_virtual/kernel' Name.Variable
+' '           Text.Whitespace
+'?='          Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'linux-yocto' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'PREFERRED_PROVIDER_virtual/nativesdk-${SDK_PREFIX}libc' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'nativesdk-glibc' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'LICENSE'     Name.Variable
+':modules/freebsd/vmblock' Name.Decorator
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'BSD-2-Clause' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'ESW_BRANCH'  Name.Variable
+'['           Punctuation
+'2024.1'      Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'xlnx_rel_v2024.1' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'GOARM'       Name.Variable
+':arm:class-target' Name.Decorator
+'['           Punctuation
+'export'      Name.Attribute
+']'           Punctuation
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'1'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'python'      Keyword
+' populate_packages:prepend' Name.Function
+' () '        Text
+'{\n'         Punctuation
+
+'    '        Text
+'d'           Name
+'.'           Operator
+'setVar'      Name
+'('           Punctuation
+"'"           Literal.String.Single
+'FOO'         Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'bar'         Literal.String.Single
+"'"           Literal.String.Single
+')'           Punctuation
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/literal_dollar.txt
+++ b/tests/snippets/bitbake/literal_dollar.txt
@@ -1,0 +1,95 @@
+---input---
+COMPATIBLE_MACHINE = "^$"
+UPSTREAM_CHECK_GITTAGREGEX = "^v(?P<pver>\d+(\.\d+)+)$"
+SPDX_FILE_EXCLUDE_PATTERNS = "\\.patch$ \\.o$"
+
+do_deploy() {
+    DEST=$1
+    EFIPATH=$(echo "${EFIDIR}" | sed 's/\//\\/g')
+    install -d "$DEST"
+}
+
+---tokens---
+'COMPATIBLE_MACHINE' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'^'           Literal.String.Double
+'$'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'UPSTREAM_CHECK_GITTAGREGEX' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'^v(?P<pver>' Literal.String.Double
+'\\'          Literal.String.Double
+'d+('         Literal.String.Double
+'\\'          Literal.String.Double
+'.'           Literal.String.Double
+'\\'          Literal.String.Double
+'d+)+)'       Literal.String.Double
+'$'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SPDX_FILE_EXCLUDE_PATTERNS' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'\\'          Literal.String.Double
+'\\'          Literal.String.Double
+'.patch'      Literal.String.Double
+'$'           Literal.String.Double
+' '           Literal.String.Double
+'\\'          Literal.String.Double
+'\\'          Literal.String.Double
+'.o'          Literal.String.Double
+'$'           Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'\n'          Text.Whitespace
+
+'do_deploy'   Name.Function
+'() '         Text
+'{\n'         Punctuation
+
+'    '        Text.Whitespace
+'DEST'        Name.Variable
+'='           Operator
+'$1'          Name.Variable
+'\n    '      Text.Whitespace
+'EFIPATH'     Name.Variable
+'='           Operator
+'$('          Keyword
+'echo'        Name.Builtin
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'EFIDIR'      Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+' '           Text.Whitespace
+'|'           Punctuation
+' '           Text.Whitespace
+'sed'         Text
+' '           Text.Whitespace
+"'s/\\//\\\\/g'" Literal.String.Single
+')'           Keyword
+'\n    '      Text.Whitespace
+'install'     Text
+' '           Text.Whitespace
+'-d'          Text
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'$DEST'       Name.Variable
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'}'           Punctuation
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/nested_interpolation.txt
+++ b/tests/snippets/bitbake/nested_interpolation.txt
@@ -1,0 +1,79 @@
+---input---
+TUNE_ARCH = "${TUNE_ARCH:tune-${DEFAULTTUNE}}"
+EFI_CLASS = "${@bb.utils.contains('MACHINE_FEATURES', 'efi', '${EFI_PROVIDER}', '', d)}"
+SP_UUID = "${SPM_TEST${SP_INDEX}_UUID}"
+AFTER = "still highlighted"
+
+---tokens---
+'TUNE_ARCH'   Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'TUNE_ARCH:tune-' Name.Variable
+'${'          Literal.String.Interpol
+'DEFAULTTUNE' Name.Variable
+'}'           Literal.String.Interpol
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'EFI_CLASS'   Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${@'         Literal.String.Interpol
+'bb'          Name
+'.'           Operator
+'utils'       Name
+'.'           Operator
+'contains'    Name
+'('           Punctuation
+"'"           Literal.String.Single
+'MACHINE_FEATURES' Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'efi'         Literal.String.Single
+"'"           Literal.String.Single
+','           Punctuation
+' '           Text
+"'"           Literal.String.Single
+'${'          Literal.String.Interpol
+'EFI_PROVIDER' Name.Variable
+'}'           Literal.String.Interpol
+"'"           Literal.String.Single
+', '          Literal.String.Single
+"'"           Literal.String.Single
+"'"           Literal.String.Single
+', d)'        Literal.String.Single
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'SP_UUID'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'${'          Literal.String.Interpol
+'SPM_TEST'    Name.Variable
+'${'          Literal.String.Interpol
+'SP_INDEX'    Name.Variable
+'}'           Literal.String.Interpol
+'_UUID'       Name.Variable
+'}'           Literal.String.Interpol
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'AFTER'       Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'still highlighted' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/unterminated_recovery.txt
+++ b/tests/snippets/bitbake/unterminated_recovery.txt
@@ -1,0 +1,37 @@
+---input---
+SUMMARY = "unterminated because the expansion closes with a paren ${DB_DIR)/"
+RECOVERED = "this line is still an assignment"
+do_rootfs[recrdeptask] += "do_package_write_rpm
+ALSO_RECOVERED = "and so is this one"
+
+---tokens---
+'SUMMARY'     Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'unterminated because the expansion closes with a paren ' Literal.String.Double
+'${'          Literal.String.Interpol
+'DB_DIR)/"'   Name.Variable
+'\n'          Text.Whitespace
+
+'RECOVERED'   Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'this line is still an assignment' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace
+
+'do_rootfs[recrdeptask] += "do_package_write_rpm' Error
+'\n'          Text.Whitespace
+
+'ALSO_RECOVERED' Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'and so is this one' Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace

--- a/tests/snippets/bitbake/valueless_statements.txt
+++ b/tests/snippets/bitbake/valueless_statements.txt
@@ -1,0 +1,57 @@
+---input---
+export BUILD_SYS
+unset DISTRO_FEATURES
+unset do_configure[noexec]
+addpylib ${LAYERDIR}/lib oe
+addfragments conf/fragments BB_CONF_FRAGMENT_SUMMARY BB_CONF_FRAGMENT_DESCRIPTION OE_FRAGMENTS
+export CFLAGS = "-O2"
+
+---tokens---
+'export'      Keyword
+' '           Text.Whitespace
+'BUILD_SYS'   Name.Variable
+'\n'          Text.Whitespace
+
+'unset'       Keyword
+' '           Text.Whitespace
+'DISTRO_FEATURES' Name.Variable
+'\n'          Text.Whitespace
+
+'unset'       Keyword
+' '           Text.Whitespace
+'do_configure' Name.Variable
+'['           Punctuation
+'noexec'      Name.Attribute
+']'           Punctuation
+'\n'          Text.Whitespace
+
+'addpylib'    Keyword
+' '           Text.Whitespace
+'${'          Literal.String.Interpol
+'LAYERDIR'    Name.Variable
+'}'           Literal.String.Interpol
+'/lib'        Name
+' '           Text.Whitespace
+'oe'          Name
+'\n'          Text.Whitespace
+
+'addfragments' Keyword
+' '           Text.Whitespace
+'conf/fragments' Name
+' '           Text.Whitespace
+'BB_CONF_FRAGMENT_SUMMARY' Name
+' '           Text.Whitespace
+'BB_CONF_FRAGMENT_DESCRIPTION' Name
+' '           Text.Whitespace
+'OE_FRAGMENTS' Name
+'\n'          Text.Whitespace
+
+'export '     Keyword.Type
+'CFLAGS'      Name.Variable
+' '           Text.Whitespace
+'='           Operator
+' '           Text.Whitespace
+'"'           Literal.String.Double
+'-O2'         Literal.String.Double
+'"'           Literal.String.Double
+'\n'          Text.Whitespace


### PR DESCRIPTION
Pygments 2.21.0 shipped the BitBake lexer. Pointing it at the Yocto Project
and BitBake manuals, and at ~20,000 files of real metadata, showed that it
accepts a good deal that BitBake does not:

```bitbake
PV = 0.8.16~rc1
QB_SMP = "-smp 8". 
ARCHIVER_MODE[src] = "x"  # comment
```

BitBake rejects all three: an assignment's value must be quoted, and the 
closing quote must end the line, which rules out both trailing text and a
trailing comment. The lexer read all three as clean assignments. The cause
was structural rather than a set of missing cases: it matched a name and an
operator and then pushed a value state that accepted anything to end of
line, with no quote requirement and no anchor.

## The change

Rather than tightening the approximation, the decision about **which lines
are valid** is handed to BitBake. The statement patterns are taken from the 
compiled regexes in `bb.parse.parse_py` and used as zero-width guards, so a
rule fires only where BitBake's parser would accept the line.

That closes one direction completely: a rule cannot fire on a line BitBake
rejects, so the lexer cannot be too permissive. It does not close the other.
The rules that *consume* a line once a guard has approved it, and the states
that lex a value, a string, an expansion or a delegated function body, are 
ordinary hand-written Pygments rules. If one of them fails to consume a line
its guard accepted, the remainder reaches the fallback and is reported as an
error. So a spurious error on valid metadata remains possible, and is ruled
out by testing rather than by construction - see the numbers below.

Mirroring means inheriting the unevenness. BitBake's statements each have
their own regex and their own idea of how strict to be, so a trailing
comment is rejected after an assignment and accepted after `addtask`,
`deltask`, `include`, `require` and `inherit`, which take everything to end 
of line. The lexer now agrees with the parser in each case rather than
smoothing the difference away.

Four adaptations are needed, each because BitBake matches one 
already-assembled logical line where a lexer sees raw file text:

| Adaptation | Reason |
| --- | --- |
| `\s` → `(?:[ \t]\|\\[ \t]*\n)` | BitBake's `\s` never meets a newline, but must still accept a continuation: `FOO = \` with the value on the next line is an ordinary assignment |
| `.` → `(?:[^\n]\|\\[ \t]*\n)` | continuations are joined before BitBake sees them, and inline here instead |
| `$` → `[ \t]*$` | the line is `rstrip`ped before matching |
| `[^…]` → `[^…\n]` | a negated class can never cross a line in BitBake |

The last two are subtler than they look. `$` has to be adapted inside the 
assignment rule's two negative lookaheads as well, since those are what
decide whether the quotes balance. And a negated class left unadapted scans
forward through the file, finds a quote pair ending some later line, and 
rejects a valid assignment because of what is written below it. 

## Invalid metadata is now marked

2.21.0 reports nothing for any of the lines above. Its fallback rules
consume whatever no other rule matched as ordinary `Text`, so an invalid
assignment is not merely mis-highlighted, it is indistinguishable from a
valid one. These now produce an `Error` token.

That is safe for documentation which shows broken metadata on purpose:
Sphinx fails a `-W` build on an error token, but `:force:` skips its 
`raiseonerror` filter for a single block. So errors reach genuine mistakes
and are suppressed only where being wrong is the point.

Errors are now suppressed in exactly one place: a `${@...}` expression is
handed to the Python lexer in fragments, split around any `${VAR}`
expansions embedded in it, so a fragment routinely begins or ends
mid-string. That is an artefact of the splitting rather than a defect in the 
metadata being lexed.

## Evidence

| Check | Result |
| --- | --- |
| 19,922 BitBake files from 24 layers | 1 file with an `Error`, and it is a wic kickstart file that merely carries a `.inc` extension |
| differential against BitBake's parser, 59,399 cases | 0 too strict, 0 too loose |
| adapted patterns vs BitBake's verdict, 67,339 lines | 0 mismatches |
| Pygments test suite | 5344 passed, 7 skipped |
| pre-existing goldens | none modified |

`broken_input` and `unterminated_recovery` assert the property that matters
for recovery: the lines *after* a malformed one are lexed as assignments
again rather than being swallowed to the end of the file.
