### PR TITLE
Groff formatter: emit four to six hex digits for Unicode code points

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,9 @@ Version 2.22.0
 --------------
 (not released yet)
 
+- Groff formatter: write Unicode code points above U+FFFF with the four to six
+  hexadecimal digits groff accepts, instead of eight
+
 Version 2.21.0
 ---------------
 (released August 17th, 2026)

--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,7 @@ Version 2.22.0
 (not released yet)
 
 - Groff formatter: write Unicode code points above U+FFFF with the four to six
-  hexadecimal digits groff accepts, instead of eight
+  hexadecimal digits groff accepts, instead of eight (#3291)
 
 Version 2.21.0
 ---------------

--- a/pygments/formatters/groff.py
+++ b/pygments/formatters/groff.py
@@ -126,11 +126,9 @@ class GroffFormatter(Formatter):
 
         for char in copy:
             if len(char) != len(char.encode()):
-                uni = char.encode('unicode_escape') \
-                    .decode()[1:] \
-                    .replace('x', 'u00') \
-                    .upper()
-                text = text.replace(char, '\\[u' + uni[1:] + ']')
+                # groff_char(7): a Unicode code point is written with four to
+                # six uppercase hexadecimal digits.
+                text = text.replace(char, '\\[u%04X]' % ord(char))
 
         return text
 

--- a/tests/test_groff_formatter.py
+++ b/tests/test_groff_formatter.py
@@ -91,3 +91,22 @@ def test_wrap_does_not_duplicate_characters():
     # A piece that does end in a newline still keeps that trailing newline.
     fmt = GroffFormatter(wrap=4)
     assert fmt._wrap_line("123456\n") == "1234\n56\n"
+
+
+def test_escape_chars_astral_code_points():
+    # groff_char(7): a Unicode code point "can be accessed with four to six
+    # hexadecimal digits, with hexadecimal letters accepted in uppercase form
+    # only".  Code points above U+FFFF used to be written with eight digits,
+    # which groff rejects ("special character 'u0001F600' not defined") and
+    # drops the character from the output.
+    fmt = GroffFormatter()
+    assert fmt._escape_chars('\u00e9') == r'\[u00E9]'
+    assert fmt._escape_chars('\u20ac') == r'\[u20AC]'
+    assert fmt._escape_chars('\U0001f600') == r'\[u1F600]'
+    assert fmt._escape_chars('\U00020b9f') == r'\[u20B9F]'
+
+    for char in '\u00a0\u00e9\u0100\u20ac\U0001f600\U00020b9f\U0010fffd':
+        digits = fmt._escape_chars(char)[3:-1]
+        assert 4 <= len(digits) <= 6, (char, digits)
+        assert digits == digits.upper()
+        assert int(digits, 16) == ord(char)


### PR DESCRIPTION
`GroffFormatter._escape_chars` derives its `\[u...]` digits from `char.encode('unicode_escape')`. Above U+FFFF that yields eight digits: U+1F600 becomes `\[u0001F600]`.

groff_char(7): a code point "can be accessed with four to six hexadecimal digits, with hexadecimal letters accepted in uppercase form only." Eight is out of range, so groff warns `special character 'u0001F600' not defined` and drops the character.

Measured against GNU groff 1.24.1 over 3,928 assigned code points (Latin/Greek/Cyrillic/Indic/CJK/punctuation/math plus samples from planes 1 and 2) — same corpus, same groff invocation for each variant:

| escape | rendered | groff "not defined" |
|---|---|---|
| current | 2883 / 3928 | 1002 |
| `\[u%X]` | 2301 / 3928 | 1575 |
| `\[u%04X]` | 3851 / 3928 | 2 |

968 fixed, 0 regressed. Of the 77 still missed, 75 are groff emitting an NFD or canonical-equivalent form (my check looked for the literal code point); the other two are U+037E and U+212A, which groff has no glyph for either way.

The tempting one-liner is worse than today: without the zero padding (`'\[u%X]'`) U+0080-U+0FFF falls below four digits, `é` becomes `\[uE9]`, and 1,550 further code points fail. Hence the test asserts the digit count, not only the value.

`5330 passed, 16 skipped` on `tests/` (`--ignore=tests/contrast`, which needs `wcag_contrast_ratio`). Reverting only `groff.py` fails the new test.

Drafted with Claude Opus 5 (`claude-opus-5`); I ran and checked every number above myself.
