### PR TITLE
Register the standard Markdown MIME type

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Version 2.22.0
 --------------
 (not released yet)
 
+- Updated lexers:
+
+  * Markdown: Recognize the ``text/markdown`` MIME type (#3296)
+
 Version 2.21.0
 ---------------
 (released August 17th, 2026)

--- a/pygments/lexers/_mapping.py
+++ b/pygments/lexers/_mapping.py
@@ -313,7 +313,7 @@ LEXERS = {
     'MakoXmlLexer': ('pygments.lexers.templates', 'XML+Mako', ('xml+mako',), (), ('application/xml+mako',)),
     'MapleLexer': ('pygments.lexers.maple', 'Maple', ('maple',), ('*.mpl', '*.mi', '*.mm'), ('text/x-maple',)),
     'MaqlLexer': ('pygments.lexers.business', 'MAQL', ('maql',), ('*.maql',), ('text/x-gooddata-maql', 'application/x-gooddata-maql')),
-    'MarkdownLexer': ('pygments.lexers.markup', 'Markdown', ('markdown', 'md'), ('*.md', '*.markdown'), ('text/x-markdown',)),
+    'MarkdownLexer': ('pygments.lexers.markup', 'Markdown', ('markdown', 'md'), ('*.md', '*.markdown'), ('text/markdown', 'text/x-markdown')),
     'MaskLexer': ('pygments.lexers.javascript', 'Mask', ('mask',), ('*.mask',), ('text/x-mask',)),
     'MasonLexer': ('pygments.lexers.templates', 'Mason', ('mason',), ('*.m', '*.mhtml', '*.mc', '*.mi', 'autohandler', 'dhandler'), ('application/x-mason',)),
     'MathematicaLexer': ('pygments.lexers.algebra', 'Mathematica', ('mathematica', 'mma', 'nb', 'wl', 'wolfram'), ('*.nb', '*.cdf', '*.nbp', '*.ma', '*.wl', '*.wls'), ('application/mathematica', 'application/vnd.wolfram.mathematica', 'application/vnd.wolfram.mathematica.package', 'application/vnd.wolfram.cdf', 'application/vnd.wolfram.wl')),

--- a/pygments/lexers/markup.py
+++ b/pygments/lexers/markup.py
@@ -528,7 +528,7 @@ class MarkdownLexer(RegexLexer):
     url = 'https://daringfireball.net/projects/markdown/'
     aliases = ['markdown', 'md']
     filenames = ['*.md', '*.markdown']
-    mimetypes = ["text/x-markdown"]
+    mimetypes = ["text/markdown", "text/x-markdown"]
     version_added = '2.2'
     flags = re.MULTILINE
 

--- a/tests/test_basic_api.py
+++ b/tests/test_basic_api.py
@@ -185,6 +185,12 @@ def test_get_lexers():
         raise Exception
 
 
+@pytest.mark.parametrize('mimetype', ['text/markdown', 'text/x-markdown'])
+def test_get_markdown_lexer_for_mimetype(mimetype):
+    assert isinstance(lexers.get_lexer_for_mimetype(mimetype),
+                      lexers.MarkdownLexer)
+
+
 @pytest.mark.parametrize('cls', [getattr(formatters, name)
                                  for name in formatters.FORMATTERS])
 def test_formatter_public_api(cls):


### PR DESCRIPTION
`get_lexer_for_mimetype("text/markdown")` raises `ClassNotFound` because the Markdown lexer only registers `text/x-markdown`. Register the MIME type from [RFC 7763](https://www.rfc-editor.org/rfc/rfc7763.html), retain the existing alias, and regenerate the lexer mapping.

Add a regression test for both MIME types and a changelog entry. The new MIME case failed before the change; both cases pass afterward.

Validation on Python 3.13: `tox -e py313,check,regexlint -- -q -W error` (5,332 tests passed, 16 skipped; source checks and regex lint passed). `tox -e mapfiles` is repeatable with no additional changes.

Fixes #3296.